### PR TITLE
Allow class creation via kwargs

### DIFF
--- a/oraclebmc/core/models/attach_i_scsi_volume_details.py
+++ b/oraclebmc/core/models/attach_i_scsi_volume_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 from .attach_volume_details import AttachVolumeDetails
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class AttachIScsiVolumeDetails(AttachVolumeDetails):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/attach_volume_details.py
+++ b/oraclebmc/core/models/attach_volume_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class AttachVolumeDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/capture_console_history_details.py
+++ b/oraclebmc/core/models/capture_console_history_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CaptureConsoleHistoryDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/console_history.py
+++ b/oraclebmc/core/models/console_history.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class ConsoleHistory(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/cpe.py
+++ b/oraclebmc/core/models/cpe.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class Cpe(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/create_cpe_details.py
+++ b/oraclebmc/core/models/create_cpe_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateCpeDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/create_dhcp_details.py
+++ b/oraclebmc/core/models/create_dhcp_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateDhcpDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/create_drg_attachment_details.py
+++ b/oraclebmc/core/models/create_drg_attachment_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateDrgAttachmentDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/create_drg_details.py
+++ b/oraclebmc/core/models/create_drg_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateDrgDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/create_image_details.py
+++ b/oraclebmc/core/models/create_image_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateImageDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/create_internet_gateway_details.py
+++ b/oraclebmc/core/models/create_internet_gateway_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateInternetGatewayDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/create_ip_sec_connection_details.py
+++ b/oraclebmc/core/models/create_ip_sec_connection_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateIPSecConnectionDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/create_route_table_details.py
+++ b/oraclebmc/core/models/create_route_table_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateRouteTableDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/create_security_list_details.py
+++ b/oraclebmc/core/models/create_security_list_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateSecurityListDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/create_subnet_details.py
+++ b/oraclebmc/core/models/create_subnet_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateSubnetDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/create_vcn_details.py
+++ b/oraclebmc/core/models/create_vcn_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateVcnDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/create_volume_backup_details.py
+++ b/oraclebmc/core/models/create_volume_backup_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateVolumeBackupDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/create_volume_details.py
+++ b/oraclebmc/core/models/create_volume_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateVolumeDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/dhcp_dns_option.py
+++ b/oraclebmc/core/models/dhcp_dns_option.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 from .dhcp_option import DhcpOption
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class DhcpDnsOption(DhcpOption):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/dhcp_option.py
+++ b/oraclebmc/core/models/dhcp_option.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class DhcpOption(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/dhcp_options.py
+++ b/oraclebmc/core/models/dhcp_options.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class DhcpOptions(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/drg.py
+++ b/oraclebmc/core/models/drg.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class Drg(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/drg_attachment.py
+++ b/oraclebmc/core/models/drg_attachment.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class DrgAttachment(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/egress_security_rule.py
+++ b/oraclebmc/core/models/egress_security_rule.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class EgressSecurityRule(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/i_scsi_volume_attachment.py
+++ b/oraclebmc/core/models/i_scsi_volume_attachment.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 from .volume_attachment import VolumeAttachment
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class IScsiVolumeAttachment(VolumeAttachment):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/icmp_options.py
+++ b/oraclebmc/core/models/icmp_options.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class IcmpOptions(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/image.py
+++ b/oraclebmc/core/models/image.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class Image(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/ingress_security_rule.py
+++ b/oraclebmc/core/models/ingress_security_rule.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class IngressSecurityRule(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/instance.py
+++ b/oraclebmc/core/models/instance.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class Instance(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/internet_gateway.py
+++ b/oraclebmc/core/models/internet_gateway.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class InternetGateway(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/ip_sec_connection.py
+++ b/oraclebmc/core/models/ip_sec_connection.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class IPSecConnection(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/ip_sec_connection_device_config.py
+++ b/oraclebmc/core/models/ip_sec_connection_device_config.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class IPSecConnectionDeviceConfig(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/ip_sec_connection_device_status.py
+++ b/oraclebmc/core/models/ip_sec_connection_device_status.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class IPSecConnectionDeviceStatus(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/launch_instance_details.py
+++ b/oraclebmc/core/models/launch_instance_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class LaunchInstanceDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/port_range.py
+++ b/oraclebmc/core/models/port_range.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class PortRange(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/route_rule.py
+++ b/oraclebmc/core/models/route_rule.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class RouteRule(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/route_table.py
+++ b/oraclebmc/core/models/route_table.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class RouteTable(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/security_list.py
+++ b/oraclebmc/core/models/security_list.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class SecurityList(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/shape.py
+++ b/oraclebmc/core/models/shape.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class Shape(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/subnet.py
+++ b/oraclebmc/core/models/subnet.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class Subnet(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/tcp_options.py
+++ b/oraclebmc/core/models/tcp_options.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class TcpOptions(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/tunnel_config.py
+++ b/oraclebmc/core/models/tunnel_config.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class TunnelConfig(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/tunnel_status.py
+++ b/oraclebmc/core/models/tunnel_status.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class TunnelStatus(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/udp_options.py
+++ b/oraclebmc/core/models/udp_options.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UdpOptions(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_cpe_details.py
+++ b/oraclebmc/core/models/update_cpe_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateCpeDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_dhcp_details.py
+++ b/oraclebmc/core/models/update_dhcp_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateDhcpDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_drg_attachment_details.py
+++ b/oraclebmc/core/models/update_drg_attachment_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateDrgAttachmentDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_drg_details.py
+++ b/oraclebmc/core/models/update_drg_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateDrgDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_image_details.py
+++ b/oraclebmc/core/models/update_image_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateImageDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_instance_details.py
+++ b/oraclebmc/core/models/update_instance_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateInstanceDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_internet_gateway_details.py
+++ b/oraclebmc/core/models/update_internet_gateway_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateInternetGatewayDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_ip_sec_connection_details.py
+++ b/oraclebmc/core/models/update_ip_sec_connection_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateIPSecConnectionDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_route_table_details.py
+++ b/oraclebmc/core/models/update_route_table_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateRouteTableDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_security_list_details.py
+++ b/oraclebmc/core/models/update_security_list_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateSecurityListDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_subnet_details.py
+++ b/oraclebmc/core/models/update_subnet_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateSubnetDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_vcn_details.py
+++ b/oraclebmc/core/models/update_vcn_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateVcnDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_volume_backup_details.py
+++ b/oraclebmc/core/models/update_volume_backup_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateVolumeBackupDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/update_volume_details.py
+++ b/oraclebmc/core/models/update_volume_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateVolumeDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/vcn.py
+++ b/oraclebmc/core/models/vcn.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class Vcn(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/vnic.py
+++ b/oraclebmc/core/models/vnic.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class Vnic(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/vnic_attachment.py
+++ b/oraclebmc/core/models/vnic_attachment.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class VnicAttachment(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/volume.py
+++ b/oraclebmc/core/models/volume.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class Volume(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/volume_attachment.py
+++ b/oraclebmc/core/models/volume_attachment.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class VolumeAttachment(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/core/models/volume_backup.py
+++ b/oraclebmc/core/models/volume_backup.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class VolumeBackup(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/add_user_to_group_details.py
+++ b/oraclebmc/identity/models/add_user_to_group_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class AddUserToGroupDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/api_key.py
+++ b/oraclebmc/identity/models/api_key.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class ApiKey(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/availability_domain.py
+++ b/oraclebmc/identity/models/availability_domain.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class AvailabilityDomain(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/compartment.py
+++ b/oraclebmc/identity/models/compartment.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class Compartment(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/create_api_key_details.py
+++ b/oraclebmc/identity/models/create_api_key_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateApiKeyDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/create_compartment_details.py
+++ b/oraclebmc/identity/models/create_compartment_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateCompartmentDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/create_group_details.py
+++ b/oraclebmc/identity/models/create_group_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateGroupDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/create_policy_details.py
+++ b/oraclebmc/identity/models/create_policy_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreatePolicyDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/create_swift_password_details.py
+++ b/oraclebmc/identity/models/create_swift_password_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateSwiftPasswordDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/create_user_details.py
+++ b/oraclebmc/identity/models/create_user_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateUserDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/group.py
+++ b/oraclebmc/identity/models/group.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class Group(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/policy.py
+++ b/oraclebmc/identity/models/policy.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class Policy(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/swift_password.py
+++ b/oraclebmc/identity/models/swift_password.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class SwiftPassword(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/ui_password.py
+++ b/oraclebmc/identity/models/ui_password.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UIPassword(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/update_compartment_details.py
+++ b/oraclebmc/identity/models/update_compartment_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateCompartmentDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/update_group_details.py
+++ b/oraclebmc/identity/models/update_group_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateGroupDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/update_policy_details.py
+++ b/oraclebmc/identity/models/update_policy_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdatePolicyDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/update_state_details.py
+++ b/oraclebmc/identity/models/update_state_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateStateDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/update_swift_password_details.py
+++ b/oraclebmc/identity/models/update_swift_password_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateSwiftPasswordDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/update_user_details.py
+++ b/oraclebmc/identity/models/update_user_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateUserDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/user.py
+++ b/oraclebmc/identity/models/user.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class User(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/identity/models/user_group_membership.py
+++ b/oraclebmc/identity/models/user_group_membership.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UserGroupMembership(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/object_storage/models/bucket.py
+++ b/oraclebmc/object_storage/models/bucket.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class Bucket(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/object_storage/models/bucket_summary.py
+++ b/oraclebmc/object_storage/models/bucket_summary.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class BucketSummary(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/object_storage/models/create_bucket_details.py
+++ b/oraclebmc/object_storage/models/create_bucket_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class CreateBucketDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/object_storage/models/list_objects.py
+++ b/oraclebmc/object_storage/models/list_objects.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class ListObjects(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/object_storage/models/object_summary.py
+++ b/oraclebmc/object_storage/models/object_summary.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class ObjectSummary(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/object_storage/models/update_bucket_details.py
+++ b/oraclebmc/object_storage/models/update_bucket_details.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 
-from ...util import formatted_flat_dict
+from ...util import formatted_flat_dict, initkwargs
 
 
 class UpdateBucketDetails(object):
 
+    @initkwargs
     def __init__(self):
 
         self.swagger_types = {

--- a/oraclebmc/util.py
+++ b/oraclebmc/util.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
 import datetime
+import functools
 import json
 import pytz
 import six
@@ -99,3 +100,14 @@ class Sentinel(object):
         return self.truthy
     # PY2 Compatibility
     __nonzero__ = __bool__
+
+def initkwargs(fn):
+    @functools.wraps(fn)
+    def init(self, **kwargs):
+        fn(self)
+        for kw, value in kwargs.items():
+            if kw not in self.swagger_types:
+                raise TypeError("%s doesn't have atribute %s" %(self.__class__, kw))
+            else:
+                setattr(self, kw, value)
+    return init


### PR DESCRIPTION
Class creation is tedious
```
    ingress = IngressSecurityRule()
    ingress.protocol = 'all'
    ingress.source = '10.0.0.0/16'

    egress =  EgressSecurityRule()
    egress.protocol = 6
    egress.destination = '0.0.0.0/0'
    
    
    seclistdetails = CreateSecurityListDetails()
    seclistdetails.compartment_id = config["compartment_id"]
    seclistdetails.egress_security_rules = [egress]
    seclistdetails.ingress_security_rules = [ingress]
    seclistdetails.display_name = 'build'
    seclistdetails.vcn_id = vcnid
    vcn_client = VirtualNetworkClient(config)
    seclist = vcn_client.create_security_list(seclistdetails)
```
Using kwargs is much better

```
    seclistdetails = CreateSecurityListDetails(compartment_id=config["compartment_id"],
                                               egress_security_rules = [EgressSecurityRule(protocol=6,
                                                                                           destination='0.0.0.0/0')
                                               ],
                                               ingress_security_rules = [IngressSecurityRule(protocol='all',
                                                                                             source='10.0.0.0/16')],
                                               display_name = 'build',
                                               vcn_id = vcnid)
```
Signed-off-by: Garth Bushell <garth@garthy.com>