### PR TITLE
Bump python-dateutil to new version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ PyJWT==1.5.3
 pyOpenSSL==17.4.0
 pytest==3.2.3
 pytest-catchlog==1.2.2
-python-dateutil==2.5.3
+python-dateutil==2.7.3
 pytz==2016.10
 requests==2.18.4
 sphinx-rtd-theme==0.2.5b2

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ requires = [
     "cryptography==2.1.3",
     "PyJWT==1.5.3",
     "pyOpenSSL<=17.4.0",
-    "python-dateutil==2.5.3",
+    "python-dateutil==2.7.3",
     "pytz==2016.10",
     "requests==2.18.4",
     "six==1.11.0",


### PR DESCRIPTION
To resolve issue #57 (relating primarily to issues parsing Date headers from servers in the OCI CLI)