### PR TITLE
Reduce dependencies Readthedocs has to retrieve

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,3 +9,6 @@ python:
 # Just the HTML and indexing
 formats:
     - none
+
+# Limit the requirements to building the docs
+requirements_file: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx-rtd-theme==0.2.5b2
+sphinx==1.6.4


### PR DESCRIPTION
Following the guidelines here https://docs.readthedocs.io/en/latest/guides/build-using-too-many-resources.html for reducing the resources needed for building the docs