### PR TITLE
fix argument typo in delete_node_pool() arguments

### DIFF
--- a/examples/container_engine.py
+++ b/examples/container_engine.py
@@ -210,7 +210,7 @@ def update_node_pool(ce_client, node_pool_id):
     return
 
 
-def delete_node_pool(ca_client, node_pool_id):
+def delete_node_pool(ce_client, node_pool_id):
     """
     delete_node_pool
 


### PR DESCRIPTION
Signed-off-by: Ken Caruso <ken.caruso@oracle.com>

The `delete_node_pool()` signature has `ca_client` but the method uses `ce_client`.  This change fixes the typo changing `ca_client` to `ce_client`