### PR TITLE
Added idna to the requirements in setup.py as cryptography 2.5 does n…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ requires = [
     "pyOpenSSL>=17.5.0",
     "python-dateutil>=2.5.3,<=2.7.3",
     "pytz>=2016.10",
+    "idna>=2.8",
 ]
 
 setup(


### PR DESCRIPTION
cryptography 2.5 does not provide `idna` anymore and one of our microservices fails as oci 2.1.4 still needs it.

Signed-off-by: Florian Wiesner <florian.wiesner@oracle.com>