### PR TITLE
Releasing version 2.2.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+2.2.5 - 2019-04-02
+====================
+
+Added
+-----
+* Support for provider service key names on virtual circuits in the FastConnect service
+* Support for customer reference names on cross connects and cross connect groups in the FastConnect service
+* A sample showing how to use Streaming service from the SDK is available on `GitHub <https://github.com/oracle/oci-python-sdk/blob/master/examples/stream_example.py>`__.
+
+====================
 2.2.4 - 2019-03-26
 ====================
 

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -107,6 +107,7 @@ Core Services
     oci.core.models.ExportImageViaObjectStorageTupleDetails
     oci.core.models.ExportImageViaObjectStorageUriDetails
     oci.core.models.FastConnectProviderService
+    oci.core.models.FastConnectProviderServiceKey
     oci.core.models.GetPublicIpByIpAddressDetails
     oci.core.models.GetPublicIpByPrivateIpIdDetails
     oci.core.models.IPSecConnection

--- a/docs/api/core/models/oci.core.models.FastConnectProviderServiceKey.rst
+++ b/docs/api/core/models/oci.core.models.FastConnectProviderServiceKey.rst
@@ -1,0 +1,11 @@
+FastConnectProviderServiceKey
+=============================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: FastConnectProviderServiceKey
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/stream_example.py
+++ b/examples/stream_example.py
@@ -1,0 +1,161 @@
+import oci
+import sys
+import base64
+import time
+
+# ==========================================================
+# This file provides an example of basic streaming usage
+# * - List streams
+# * - Get a Stream
+# * - Create a Stream
+# * - Delete a Stream
+# * - Publish to a Stream
+# * - Consume from a stream partition using cursor
+# * - Consume from a stream using a group cursor
+# Documentation : https://docs.cloud.oracle.com/iaas/Content/Streaming/Concepts/streamingoverview.htm
+
+# Usage : python stream_example.py <compartment id>
+
+STREAM_NAME = "SdkExampleStream"
+PARTITIONS = 1
+
+
+def publish_example_messages(client, stream_id):
+    # Build up a PutMessagesDetails and publish some messages to the stream
+    message_list = []
+    for i in range(100):
+        key = "key" + str(i)
+        value = "value" + str(i)
+        encoded_key = base64.b64encode(key)
+        encoded_value = base64.b64encode(value)
+        message_list.append(oci.streaming.models.PutMessagesDetailsEntry(key=encoded_key, value=encoded_value))
+
+    print ("Publishing {} messages to the stream {} ".format(len(message_list), stream_id))
+    messages = oci.streaming.models.PutMessagesDetails(messages=message_list)
+    put_message_result = client.put_messages(stream_id, messages)
+
+    # The put_message_result can contain some useful metadata for handling failures
+    for entry in put_message_result.data.entries:
+        if entry.error:
+            print ("Error ({}) : {}".format(entry.error, entry.error_message))
+        else:
+            print ("Published message to partition {} , offset {}".format(entry.partition, entry.offset))
+
+
+def get_or_create_stream(client, compartment_id, stream_name, partition, sac_composite):
+
+    list_streams = client.list_streams(compartment_id, name=stream_name,
+                                       lifecycle_state=oci.streaming.models.StreamSummary.LIFECYCLE_STATE_ACTIVE)
+    if list_streams.data:
+        # If we find an active stream with the correct name, we'll use it.
+        print ("An active stream {} has been found".format(stream_name))
+        sid = list_streams.data[0].id
+        return get_stream(sac_composite.client, sid)
+
+    print (" No Active stream  {} has been found; Creating it now. ".format(stream_name))
+    print (" Creating stream {} with {} partitions.".format(stream_name, partition))
+
+    # Create stream_details object that need to be passed while creating stream.
+    stream_details = oci.streaming.models.CreateStreamDetails(name=stream_name, partitions=partition,
+                                                              compartment_id=compartment, retention_in_hours=24)
+
+    # Since stream creation is asynchronous; we need to wait for the stream to become active.
+    response = sac_composite.create_stream_and_wait_for_state(
+        stream_details, wait_for_states=[oci.streaming.models.StreamSummary.LIFECYCLE_STATE_ACTIVE])
+    return response
+
+
+def get_stream(admin_client, stream_id):
+    return admin_client.get_stream(stream_id)
+
+
+def delete_stream(client, stream_id):
+    print (" Deleting Stream {}".format(stream_id))
+    # Stream deletion is an asynchronous operation, give it some time to complete.
+    client.delete_stream_and_wait_for_state(stream_id, oci.streaming.models.StreamSummary.LIFECYCLE_STATE_DELETED)
+
+
+def get_cursor_by_partition(client, stream_id, partition):
+    print("Creating a cursor for partition {}".format(partition))
+    cursor_details = oci.streaming.models.CreateCursorDetails(
+        partition=partition,
+        type=oci.streaming.models.CreateCursorDetails.TYPE_TRIM_HORIZON)
+    response = client.create_cursor(stream_id, cursor_details)
+    cursor = response.data.value
+    return cursor
+
+
+def simple_message_loop(client, stream_id, initial_cursor):
+    cursor = initial_cursor
+    while True:
+        get_response = client.get_messages(stream_id, cursor, limit=10)
+        # No messages to process. return.
+        if not get_response.data:
+            return
+
+        # Process the messages
+        print(" Read {} messages".format(len(get_response.data)))
+        for message in get_response.data:
+            print("{}: {}".format(base64.b64decode(message.key), base64.b64decode(message.value)))
+
+        # get_messages is a throttled method; clients should retrieve sufficiently large message
+        # batches, as to avoid too many http requests.
+        time.sleep(1)
+        # use the next-cursor for iteration
+        cursor = get_response.headers["opc-next-cursor"]
+
+
+def get_cursor_by_group(sc, sid, group_name, instance_name):
+    print(" Creating a cursor for group {}, instance {}".format(group_name, instance_name))
+    cursor_details = oci.streaming.models.CreateGroupCursorDetails(group_name=group_name, instance_name=instance_name,
+                                                                   type=oci.streaming.models.
+                                                                   CreateGroupCursorDetails.TYPE_TRIM_HORIZON,
+                                                                   commit_on_get=True)
+    response = sc.create_group_cursor(sid, cursor_details)
+    return response.data.value
+
+
+# Load the default configuration
+config = oci.config.from_file()
+
+# Create a StreamAdminClientCompositeOperations for composite operations.
+stream_admin_client = oci.streaming.StreamAdminClient(config)
+stream_admin_client_composite = oci.streaming.StreamAdminClientCompositeOperations(stream_admin_client)
+
+if len(sys.argv) != 2:
+    raise RuntimeError('This example expects an ocid for the compartment in which streams should be created.')
+
+compartment = sys.argv[1]
+
+# We  will reuse a stream if its already created.
+# This will utilize list_streams() to determine if a stream exists and return it, or create a new one.
+stream = get_or_create_stream(stream_admin_client, compartment, STREAM_NAME,
+                              PARTITIONS, stream_admin_client_composite).data
+
+print (" Created Stream {} with id : {}".format(stream.name, stream.id))
+
+# Streams are assigned a specific endpoint url based on where they are provisioned.
+# Create a stream client using the provided message endpoint.
+stream_client = oci.streaming.StreamClient(config, service_endpoint=stream.messages_endpoint)
+s_id = stream.id
+
+# Publish some messages to the stream
+publish_example_messages(stream_client, s_id)
+
+# Use a cursor for getting messages; each get_messages call will return a next-cursor for iteration.
+# There are a couple kinds of cursors.
+# A cursor can be created at a given partition/offset.
+# This gives explicit offset management control to the consumer.
+
+print("Starting a simple message loop with a partition cursor")
+partition_cursor = get_cursor_by_partition(stream_client, s_id, partition="0")
+simple_message_loop(stream_client, s_id, partition_cursor)
+
+# A cursor can be created as part of a consumer group.
+# Committed offsets are managed for the group, and partitions
+# are dynamically balanced amongst consumers in the group.
+group_cursor = get_cursor_by_group(stream_client, s_id, "example-group", "example-instance-1")
+simple_message_loop(stream_client, s_id, group_cursor)
+
+# Cleanup; remember to delete streams which are not in use.
+delete_stream(stream_admin_client_composite, s_id)

--- a/src/oci/announcements_service/announcement_client_composite_operations.py
+++ b/src/oci/announcements_service/announcement_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class AnnouncementClientCompositeOperations(object):

--- a/src/oci/audit/audit_client_composite_operations.py
+++ b/src/oci/audit/audit_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class AuditClientCompositeOperations(object):

--- a/src/oci/auth/federation_client.py
+++ b/src/oci/auth/federation_client.py
@@ -143,10 +143,7 @@ class X509FederationClient(object):
         fingerprint = crypto.load_certificate(crypto.FILETYPE_PEM, self.leaf_certificate_retriever.get_certificate_raw()).digest('sha1').decode('utf-8')
         signer = AuthTokenRequestSigner(self.tenancy_id, fingerprint, self.leaf_certificate_retriever)
 
-        if self.cert_bundle_verify:
-            response = self.requests_session.post(self.federation_endpoint, json=request_payload, auth=signer, verify=self.cert_bundle_verify, timeout=(10, 60))
-        else:
-            response = self.requests_session.post(self.federation_endpoint, json=request_payload, auth=signer, timeout=(10, 60))
+        response = self.requests_session.post(self.federation_endpoint, json=request_payload, auth=signer, verify=self.cert_bundle_verify, timeout=(10, 60))
 
         parsed_response = None
         try:

--- a/src/oci/autoscaling/auto_scaling_client_composite_operations.py
+++ b/src/oci/autoscaling/auto_scaling_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class AutoScalingClientCompositeOperations(object):

--- a/src/oci/budget/budget_client_composite_operations.py
+++ b/src/oci/budget/budget_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class BudgetClientCompositeOperations(object):
@@ -119,7 +120,15 @@ class BudgetClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_budget(budget_id)
-        operation_result = self.client.delete_budget(budget_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_budget(budget_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/container_engine/container_engine_client_composite_operations.py
+++ b/src/oci/container_engine/container_engine_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class ContainerEngineClientCompositeOperations(object):
@@ -115,7 +116,15 @@ class ContainerEngineClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        operation_result = self.client.delete_cluster(cluster_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_cluster(cluster_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -153,7 +162,15 @@ class ContainerEngineClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        operation_result = self.client.delete_node_pool(node_pool_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_node_pool(node_pool_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/core/blockstorage_client_composite_operations.py
+++ b/src/oci/core/blockstorage_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class BlockstorageClientCompositeOperations(object):
@@ -309,7 +310,15 @@ class BlockstorageClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_boot_volume(boot_volume_id)
-        operation_result = self.client.delete_boot_volume(boot_volume_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_boot_volume(boot_volume_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -348,7 +357,15 @@ class BlockstorageClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_boot_volume_backup(boot_volume_backup_id)
-        operation_result = self.client.delete_boot_volume_backup(boot_volume_backup_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_boot_volume_backup(boot_volume_backup_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -387,7 +404,15 @@ class BlockstorageClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_volume(volume_id)
-        operation_result = self.client.delete_volume(volume_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_volume(volume_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -426,7 +451,15 @@ class BlockstorageClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_volume_backup(volume_backup_id)
-        operation_result = self.client.delete_volume_backup(volume_backup_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_volume_backup(volume_backup_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -465,7 +498,15 @@ class BlockstorageClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_volume_group(volume_group_id)
-        operation_result = self.client.delete_volume_group(volume_group_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_volume_group(volume_group_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -504,7 +545,15 @@ class BlockstorageClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_volume_group_backup(volume_group_backup_id)
-        operation_result = self.client.delete_volume_group_backup(volume_group_backup_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_volume_group_backup(volume_group_backup_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/core/compute_client.py
+++ b/src/oci/core/compute_client.py
@@ -462,7 +462,7 @@ class ComputeClient(object):
 
         When importing an image based on the Object Storage URL, use
         :func:`image_source_via_object_storage_uri_details`.
-        See `Object Storage URLs`__ and `pre-authenticated requests`__
+        See `Object Storage URLs`__ and `Using Pre-Authenticated Requests`__
         for constructing URLs for image import/export.
 
         For more information about importing exported images, see
@@ -474,7 +474,7 @@ class ComputeClient(object):
 
         __ https://docs.cloud.oracle.com/Content/Compute/Tasks/managingcustomimages.htm
         __ https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs
-        __ https://docs.cloud.oracle.com/Content/Object/Tasks/managingaccess.htm#pre-auth
+        __ https://docs.cloud.oracle.com/Content/Object/Tasks/usingpreauthenticatedrequests.htm
         __ https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm
 
 
@@ -1147,13 +1147,13 @@ class ComputeClient(object):
         To perform an image export, you need write access to the Object Storage bucket for the image,
         see `Let Users Write Objects to Object Storage Buckets`__.
 
-        See `Object Storage URLs`__ and `pre-authenticated requests`__
+        See `Object Storage URLs`__ and `Using Pre-Authenticated Requests`__
         for constructing URLs for image import/export.
 
         __ https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm
         __ https://docs.cloud.oracle.com/Content/Identity/Concepts/commonpolicies.htm#Let4
         __ https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs
-        __ https://docs.cloud.oracle.com/Content/Object/Tasks/managingaccess.htm#pre-auth
+        __ https://docs.cloud.oracle.com/Content/Object/Tasks/usingpreauthenticatedrequests.htm
 
 
         :param str image_id: (required)

--- a/src/oci/core/compute_client_composite_operations.py
+++ b/src/oci/core/compute_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class ComputeClientCompositeOperations(object):
@@ -268,7 +269,15 @@ class ComputeClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_console_history(instance_console_history_id)
-        operation_result = self.client.delete_console_history(instance_console_history_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_console_history(instance_console_history_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -307,7 +316,15 @@ class ComputeClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_image(image_id)
-        operation_result = self.client.delete_image(image_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_image(image_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -346,7 +363,15 @@ class ComputeClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_instance_console_connection(instance_console_connection_id)
-        operation_result = self.client.delete_instance_console_connection(instance_console_connection_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_instance_console_connection(instance_console_connection_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -385,7 +410,15 @@ class ComputeClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_boot_volume_attachment(boot_volume_attachment_id)
-        operation_result = self.client.detach_boot_volume(boot_volume_attachment_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.detach_boot_volume(boot_volume_attachment_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -424,7 +457,15 @@ class ComputeClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_vnic_attachment(vnic_attachment_id)
-        operation_result = self.client.detach_vnic(vnic_attachment_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.detach_vnic(vnic_attachment_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -463,7 +504,15 @@ class ComputeClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_volume_attachment(volume_attachment_id)
-        operation_result = self.client.detach_volume(volume_attachment_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.detach_volume(volume_attachment_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -624,7 +673,15 @@ class ComputeClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_instance(instance_id)
-        operation_result = self.client.terminate_instance(instance_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.terminate_instance(instance_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/core/compute_management_client_composite_operations.py
+++ b/src/oci/core/compute_management_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class ComputeManagementClientCompositeOperations(object):
@@ -312,7 +313,15 @@ class ComputeManagementClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_instance_pool(instance_pool_id)
-        operation_result = self.client.terminate_instance_pool(instance_pool_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.terminate_instance_pool(instance_pool_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/core/models/__init__.py
+++ b/src/oci/core/models/__init__.py
@@ -86,6 +86,7 @@ from .export_image_details import ExportImageDetails
 from .export_image_via_object_storage_tuple_details import ExportImageViaObjectStorageTupleDetails
 from .export_image_via_object_storage_uri_details import ExportImageViaObjectStorageUriDetails
 from .fast_connect_provider_service import FastConnectProviderService
+from .fast_connect_provider_service_key import FastConnectProviderServiceKey
 from .get_public_ip_by_ip_address_details import GetPublicIpByIpAddressDetails
 from .get_public_ip_by_private_ip_id_details import GetPublicIpByPrivateIpIdDetails
 from .ip_sec_connection import IPSecConnection
@@ -299,6 +300,7 @@ core_type_mapping = {
     "ExportImageViaObjectStorageTupleDetails": ExportImageViaObjectStorageTupleDetails,
     "ExportImageViaObjectStorageUriDetails": ExportImageViaObjectStorageUriDetails,
     "FastConnectProviderService": FastConnectProviderService,
+    "FastConnectProviderServiceKey": FastConnectProviderServiceKey,
     "GetPublicIpByIpAddressDetails": GetPublicIpByIpAddressDetails,
     "GetPublicIpByPrivateIpIdDetails": GetPublicIpByPrivateIpIdDetails,
     "IPSecConnection": IPSecConnection,

--- a/src/oci/core/models/attach_paravirtualized_volume_details.py
+++ b/src/oci/core/models/attach_paravirtualized_volume_details.py
@@ -80,7 +80,7 @@ class AttachParavirtualizedVolumeDetails(AttachVolumeDetails):
     def is_pv_encryption_in_transit_enabled(self):
         """
         Gets the is_pv_encryption_in_transit_enabled of this AttachParavirtualizedVolumeDetails.
-        Whether to enable encryption in transit for the PV data volume attachment. Defaults to false.
+        Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false.
 
 
         :return: The is_pv_encryption_in_transit_enabled of this AttachParavirtualizedVolumeDetails.
@@ -92,7 +92,7 @@ class AttachParavirtualizedVolumeDetails(AttachVolumeDetails):
     def is_pv_encryption_in_transit_enabled(self, is_pv_encryption_in_transit_enabled):
         """
         Sets the is_pv_encryption_in_transit_enabled of this AttachParavirtualizedVolumeDetails.
-        Whether to enable encryption in transit for the PV data volume attachment. Defaults to false.
+        Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false.
 
 
         :param is_pv_encryption_in_transit_enabled: The is_pv_encryption_in_transit_enabled of this AttachParavirtualizedVolumeDetails.

--- a/src/oci/core/models/boot_volume_attachment.py
+++ b/src/oci/core/models/boot_volume_attachment.py
@@ -325,7 +325,7 @@ class BootVolumeAttachment(object):
     def is_pv_encryption_in_transit_enabled(self):
         """
         Gets the is_pv_encryption_in_transit_enabled of this BootVolumeAttachment.
-        Whether the enable encryption in transit for the PV volume attachment is on or not.
+        Whether in-transit encryption for the boot volume's paravirtualized attachment is enabled or not.
 
 
         :return: The is_pv_encryption_in_transit_enabled of this BootVolumeAttachment.
@@ -337,7 +337,7 @@ class BootVolumeAttachment(object):
     def is_pv_encryption_in_transit_enabled(self, is_pv_encryption_in_transit_enabled):
         """
         Sets the is_pv_encryption_in_transit_enabled of this BootVolumeAttachment.
-        Whether the enable encryption in transit for the PV volume attachment is on or not.
+        Whether in-transit encryption for the boot volume's paravirtualized attachment is enabled or not.
 
 
         :param is_pv_encryption_in_transit_enabled: The is_pv_encryption_in_transit_enabled of this BootVolumeAttachment.

--- a/src/oci/core/models/create_cross_connect_details.py
+++ b/src/oci/core/models/create_cross_connect_details.py
@@ -45,6 +45,10 @@ class CreateCrossConnectDetails(object):
             The value to assign to the port_speed_shape_name property of this CreateCrossConnectDetails.
         :type port_speed_shape_name: str
 
+        :param customer_reference_name:
+            The value to assign to the customer_reference_name property of this CreateCrossConnectDetails.
+        :type customer_reference_name: str
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
@@ -53,7 +57,8 @@ class CreateCrossConnectDetails(object):
             'far_cross_connect_or_cross_connect_group_id': 'str',
             'location_name': 'str',
             'near_cross_connect_or_cross_connect_group_id': 'str',
-            'port_speed_shape_name': 'str'
+            'port_speed_shape_name': 'str',
+            'customer_reference_name': 'str'
         }
 
         self.attribute_map = {
@@ -63,7 +68,8 @@ class CreateCrossConnectDetails(object):
             'far_cross_connect_or_cross_connect_group_id': 'farCrossConnectOrCrossConnectGroupId',
             'location_name': 'locationName',
             'near_cross_connect_or_cross_connect_group_id': 'nearCrossConnectOrCrossConnectGroupId',
-            'port_speed_shape_name': 'portSpeedShapeName'
+            'port_speed_shape_name': 'portSpeedShapeName',
+            'customer_reference_name': 'customerReferenceName'
         }
 
         self._compartment_id = None
@@ -73,6 +79,7 @@ class CreateCrossConnectDetails(object):
         self._location_name = None
         self._near_cross_connect_or_cross_connect_group_id = None
         self._port_speed_shape_name = None
+        self._customer_reference_name = None
 
     @property
     def compartment_id(self):
@@ -267,6 +274,32 @@ class CreateCrossConnectDetails(object):
         :type: str
         """
         self._port_speed_shape_name = port_speed_shape_name
+
+    @property
+    def customer_reference_name(self):
+        """
+        Gets the customer_reference_name of this CreateCrossConnectDetails.
+        A reference name or identifier for the physical fiber connection that this cross-connect
+        uses.
+
+
+        :return: The customer_reference_name of this CreateCrossConnectDetails.
+        :rtype: str
+        """
+        return self._customer_reference_name
+
+    @customer_reference_name.setter
+    def customer_reference_name(self, customer_reference_name):
+        """
+        Sets the customer_reference_name of this CreateCrossConnectDetails.
+        A reference name or identifier for the physical fiber connection that this cross-connect
+        uses.
+
+
+        :param customer_reference_name: The customer_reference_name of this CreateCrossConnectDetails.
+        :type: str
+        """
+        self._customer_reference_name = customer_reference_name
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/create_cross_connect_group_details.py
+++ b/src/oci/core/models/create_cross_connect_group_details.py
@@ -25,19 +25,26 @@ class CreateCrossConnectGroupDetails(object):
             The value to assign to the display_name property of this CreateCrossConnectGroupDetails.
         :type display_name: str
 
+        :param customer_reference_name:
+            The value to assign to the customer_reference_name property of this CreateCrossConnectGroupDetails.
+        :type customer_reference_name: str
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
-            'display_name': 'str'
+            'display_name': 'str',
+            'customer_reference_name': 'str'
         }
 
         self.attribute_map = {
             'compartment_id': 'compartmentId',
-            'display_name': 'displayName'
+            'display_name': 'displayName',
+            'customer_reference_name': 'customerReferenceName'
         }
 
         self._compartment_id = None
         self._display_name = None
+        self._customer_reference_name = None
 
     @property
     def compartment_id(self):
@@ -88,6 +95,32 @@ class CreateCrossConnectGroupDetails(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def customer_reference_name(self):
+        """
+        Gets the customer_reference_name of this CreateCrossConnectGroupDetails.
+        A reference name or identifier for the physical fiber connection that this cross-connect
+        group uses.
+
+
+        :return: The customer_reference_name of this CreateCrossConnectGroupDetails.
+        :rtype: str
+        """
+        return self._customer_reference_name
+
+    @customer_reference_name.setter
+    def customer_reference_name(self, customer_reference_name):
+        """
+        Sets the customer_reference_name of this CreateCrossConnectGroupDetails.
+        A reference name or identifier for the physical fiber connection that this cross-connect
+        group uses.
+
+
+        :param customer_reference_name: The customer_reference_name of this CreateCrossConnectGroupDetails.
+        :type: str
+        """
+        self._customer_reference_name = customer_reference_name
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/create_image_details.py
+++ b/src/oci/core/models/create_image_details.py
@@ -272,7 +272,7 @@ class CreateImageDetails(object):
         """
         Gets the launch_mode of this CreateImageDetails.
         Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
-        * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
+        * `NATIVE` - VM instances launch with paravirtualized boot and VFIO devices. The default value for Oracle-provided images.
         * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
         * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
         * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
@@ -290,7 +290,7 @@ class CreateImageDetails(object):
         """
         Sets the launch_mode of this CreateImageDetails.
         Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
-        * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
+        * `NATIVE` - VM instances launch with paravirtualized boot and VFIO devices. The default value for Oracle-provided images.
         * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
         * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
         * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.

--- a/src/oci/core/models/create_virtual_circuit_details.py
+++ b/src/oci/core/models/create_virtual_circuit_details.py
@@ -57,6 +57,10 @@ class CreateVirtualCircuitDetails(object):
             The value to assign to the provider_service_id property of this CreateVirtualCircuitDetails.
         :type provider_service_id: str
 
+        :param provider_service_key_name:
+            The value to assign to the provider_service_key_name property of this CreateVirtualCircuitDetails.
+        :type provider_service_key_name: str
+
         :param provider_service_name:
             The value to assign to the provider_service_name property of this CreateVirtualCircuitDetails.
         :type provider_service_name: str
@@ -84,6 +88,7 @@ class CreateVirtualCircuitDetails(object):
             'gateway_id': 'str',
             'provider_name': 'str',
             'provider_service_id': 'str',
+            'provider_service_key_name': 'str',
             'provider_service_name': 'str',
             'public_prefixes': 'list[CreateVirtualCircuitPublicPrefixDetails]',
             'region': 'str',
@@ -99,6 +104,7 @@ class CreateVirtualCircuitDetails(object):
             'gateway_id': 'gatewayId',
             'provider_name': 'providerName',
             'provider_service_id': 'providerServiceId',
+            'provider_service_key_name': 'providerServiceKeyName',
             'provider_service_name': 'providerServiceName',
             'public_prefixes': 'publicPrefixes',
             'region': 'region',
@@ -113,6 +119,7 @@ class CreateVirtualCircuitDetails(object):
         self._gateway_id = None
         self._provider_name = None
         self._provider_service_id = None
+        self._provider_service_key_name = None
         self._provider_service_name = None
         self._public_prefixes = None
         self._region = None
@@ -333,6 +340,30 @@ class CreateVirtualCircuitDetails(object):
         :type: str
         """
         self._provider_service_id = provider_service_id
+
+    @property
+    def provider_service_key_name(self):
+        """
+        Gets the provider_service_key_name of this CreateVirtualCircuitDetails.
+        The service key name offered by the provider (if the customer is connecting via a provider).
+
+
+        :return: The provider_service_key_name of this CreateVirtualCircuitDetails.
+        :rtype: str
+        """
+        return self._provider_service_key_name
+
+    @provider_service_key_name.setter
+    def provider_service_key_name(self, provider_service_key_name):
+        """
+        Sets the provider_service_key_name of this CreateVirtualCircuitDetails.
+        The service key name offered by the provider (if the customer is connecting via a provider).
+
+
+        :param provider_service_key_name: The provider_service_key_name of this CreateVirtualCircuitDetails.
+        :type: str
+        """
+        self._provider_service_key_name = provider_service_key_name
 
     @property
     def provider_service_name(self):

--- a/src/oci/core/models/cross_connect.py
+++ b/src/oci/core/models/cross_connect.py
@@ -96,6 +96,10 @@ class CrossConnect(object):
             The value to assign to the port_speed_shape_name property of this CrossConnect.
         :type port_speed_shape_name: str
 
+        :param customer_reference_name:
+            The value to assign to the customer_reference_name property of this CrossConnect.
+        :type customer_reference_name: str
+
         :param time_created:
             The value to assign to the time_created property of this CrossConnect.
         :type time_created: datetime
@@ -110,6 +114,7 @@ class CrossConnect(object):
             'location_name': 'str',
             'port_name': 'str',
             'port_speed_shape_name': 'str',
+            'customer_reference_name': 'str',
             'time_created': 'datetime'
         }
 
@@ -122,6 +127,7 @@ class CrossConnect(object):
             'location_name': 'locationName',
             'port_name': 'portName',
             'port_speed_shape_name': 'portSpeedShapeName',
+            'customer_reference_name': 'customerReferenceName',
             'time_created': 'timeCreated'
         }
 
@@ -133,6 +139,7 @@ class CrossConnect(object):
         self._location_name = None
         self._port_name = None
         self._port_speed_shape_name = None
+        self._customer_reference_name = None
         self._time_created = None
 
     @property
@@ -338,6 +345,32 @@ class CrossConnect(object):
         :type: str
         """
         self._port_speed_shape_name = port_speed_shape_name
+
+    @property
+    def customer_reference_name(self):
+        """
+        Gets the customer_reference_name of this CrossConnect.
+        A reference name or identifier for the physical fiber connection that this cross-connect
+        uses.
+
+
+        :return: The customer_reference_name of this CrossConnect.
+        :rtype: str
+        """
+        return self._customer_reference_name
+
+    @customer_reference_name.setter
+    def customer_reference_name(self, customer_reference_name):
+        """
+        Sets the customer_reference_name of this CrossConnect.
+        A reference name or identifier for the physical fiber connection that this cross-connect
+        uses.
+
+
+        :param customer_reference_name: The customer_reference_name of this CrossConnect.
+        :type: str
+        """
+        self._customer_reference_name = customer_reference_name
 
     @property
     def time_created(self):

--- a/src/oci/core/models/cross_connect_group.py
+++ b/src/oci/core/models/cross_connect_group.py
@@ -73,6 +73,10 @@ class CrossConnectGroup(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
+        :param customer_reference_name:
+            The value to assign to the customer_reference_name property of this CrossConnectGroup.
+        :type customer_reference_name: str
+
         :param time_created:
             The value to assign to the time_created property of this CrossConnectGroup.
         :type time_created: datetime
@@ -83,6 +87,7 @@ class CrossConnectGroup(object):
             'display_name': 'str',
             'id': 'str',
             'lifecycle_state': 'str',
+            'customer_reference_name': 'str',
             'time_created': 'datetime'
         }
 
@@ -91,6 +96,7 @@ class CrossConnectGroup(object):
             'display_name': 'displayName',
             'id': 'id',
             'lifecycle_state': 'lifecycleState',
+            'customer_reference_name': 'customerReferenceName',
             'time_created': 'timeCreated'
         }
 
@@ -98,6 +104,7 @@ class CrossConnectGroup(object):
         self._display_name = None
         self._id = None
         self._lifecycle_state = None
+        self._customer_reference_name = None
         self._time_created = None
 
     @property
@@ -203,6 +210,32 @@ class CrossConnectGroup(object):
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
+
+    @property
+    def customer_reference_name(self):
+        """
+        Gets the customer_reference_name of this CrossConnectGroup.
+        A reference name or identifier for the physical fiber connection that this cross-connect
+        group uses.
+
+
+        :return: The customer_reference_name of this CrossConnectGroup.
+        :rtype: str
+        """
+        return self._customer_reference_name
+
+    @customer_reference_name.setter
+    def customer_reference_name(self, customer_reference_name):
+        """
+        Sets the customer_reference_name of this CrossConnectGroup.
+        A reference name or identifier for the physical fiber connection that this cross-connect
+        group uses.
+
+
+        :param customer_reference_name: The customer_reference_name of this CrossConnectGroup.
+        :type: str
+        """
+        self._customer_reference_name = customer_reference_name
 
     @property
     def time_created(self):

--- a/src/oci/core/models/export_image_via_object_storage_tuple_details.py
+++ b/src/oci/core/models/export_image_via_object_storage_tuple_details.py
@@ -58,7 +58,7 @@ class ExportImageViaObjectStorageTupleDetails(ExportImageDetails):
     @property
     def bucket_name(self):
         """
-        Gets the bucket_name of this ExportImageViaObjectStorageTupleDetails.
+        **[Required]** Gets the bucket_name of this ExportImageViaObjectStorageTupleDetails.
         The Object Storage bucket to export the image to.
 
 
@@ -82,7 +82,7 @@ class ExportImageViaObjectStorageTupleDetails(ExportImageDetails):
     @property
     def namespace_name(self):
         """
-        Gets the namespace_name of this ExportImageViaObjectStorageTupleDetails.
+        **[Required]** Gets the namespace_name of this ExportImageViaObjectStorageTupleDetails.
         The Object Storage namespace to export the image to.
 
 
@@ -106,7 +106,7 @@ class ExportImageViaObjectStorageTupleDetails(ExportImageDetails):
     @property
     def object_name(self):
         """
-        Gets the object_name of this ExportImageViaObjectStorageTupleDetails.
+        **[Required]** Gets the object_name of this ExportImageViaObjectStorageTupleDetails.
         The Object Storage object name for the exported image.
 
 

--- a/src/oci/core/models/export_image_via_object_storage_uri_details.py
+++ b/src/oci/core/models/export_image_via_object_storage_uri_details.py
@@ -46,10 +46,10 @@ class ExportImageViaObjectStorageUriDetails(ExportImageDetails):
         """
         **[Required]** Gets the destination_uri of this ExportImageViaObjectStorageUriDetails.
         The Object Storage URL to export the image to. See `Object Storage URLs`__
-        and `pre-authenticated requests`__ for constructing URLs for image import/export.
+        and `Using Pre-Authenticated Requests`__ for constructing URLs for image import/export.
 
         __ https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs
-        __ https://docs.cloud.oracle.com/Content/Object/Tasks/managingaccess.htm#pre-auth
+        __ https://docs.cloud.oracle.com/Content/Object/Tasks/usingpreauthenticatedrequests.htm
 
 
         :return: The destination_uri of this ExportImageViaObjectStorageUriDetails.
@@ -62,10 +62,10 @@ class ExportImageViaObjectStorageUriDetails(ExportImageDetails):
         """
         Sets the destination_uri of this ExportImageViaObjectStorageUriDetails.
         The Object Storage URL to export the image to. See `Object Storage URLs`__
-        and `pre-authenticated requests`__ for constructing URLs for image import/export.
+        and `Using Pre-Authenticated Requests`__ for constructing URLs for image import/export.
 
         __ https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs
-        __ https://docs.cloud.oracle.com/Content/Object/Tasks/managingaccess.htm#pre-auth
+        __ https://docs.cloud.oracle.com/Content/Object/Tasks/usingpreauthenticatedrequests.htm
 
 
         :param destination_uri: The destination_uri of this ExportImageViaObjectStorageUriDetails.

--- a/src/oci/core/models/fast_connect_provider_service.py
+++ b/src/oci/core/models/fast_connect_provider_service.py
@@ -47,6 +47,42 @@ class FastConnectProviderService(object):
     #: This constant has a value of "PRIVATE"
     SUPPORTED_VIRTUAL_CIRCUIT_TYPES_PRIVATE = "PRIVATE"
 
+    #: A constant which can be used with the customer_asn_management property of a FastConnectProviderService.
+    #: This constant has a value of "CUSTOMER_MANAGED"
+    CUSTOMER_ASN_MANAGEMENT_CUSTOMER_MANAGED = "CUSTOMER_MANAGED"
+
+    #: A constant which can be used with the customer_asn_management property of a FastConnectProviderService.
+    #: This constant has a value of "PROVIDER_MANAGED"
+    CUSTOMER_ASN_MANAGEMENT_PROVIDER_MANAGED = "PROVIDER_MANAGED"
+
+    #: A constant which can be used with the customer_asn_management property of a FastConnectProviderService.
+    #: This constant has a value of "ORACLE_MANAGED"
+    CUSTOMER_ASN_MANAGEMENT_ORACLE_MANAGED = "ORACLE_MANAGED"
+
+    #: A constant which can be used with the provider_service_key_management property of a FastConnectProviderService.
+    #: This constant has a value of "CUSTOMER_MANAGED"
+    PROVIDER_SERVICE_KEY_MANAGEMENT_CUSTOMER_MANAGED = "CUSTOMER_MANAGED"
+
+    #: A constant which can be used with the provider_service_key_management property of a FastConnectProviderService.
+    #: This constant has a value of "PROVIDER_MANAGED"
+    PROVIDER_SERVICE_KEY_MANAGEMENT_PROVIDER_MANAGED = "PROVIDER_MANAGED"
+
+    #: A constant which can be used with the provider_service_key_management property of a FastConnectProviderService.
+    #: This constant has a value of "ORACLE_MANAGED"
+    PROVIDER_SERVICE_KEY_MANAGEMENT_ORACLE_MANAGED = "ORACLE_MANAGED"
+
+    #: A constant which can be used with the bandwith_shape_management property of a FastConnectProviderService.
+    #: This constant has a value of "CUSTOMER_MANAGED"
+    BANDWITH_SHAPE_MANAGEMENT_CUSTOMER_MANAGED = "CUSTOMER_MANAGED"
+
+    #: A constant which can be used with the bandwith_shape_management property of a FastConnectProviderService.
+    #: This constant has a value of "PROVIDER_MANAGED"
+    BANDWITH_SHAPE_MANAGEMENT_PROVIDER_MANAGED = "PROVIDER_MANAGED"
+
+    #: A constant which can be used with the bandwith_shape_management property of a FastConnectProviderService.
+    #: This constant has a value of "ORACLE_MANAGED"
+    BANDWITH_SHAPE_MANAGEMENT_ORACLE_MANAGED = "ORACLE_MANAGED"
+
     #: A constant which can be used with the type property of a FastConnectProviderService.
     #: This constant has a value of "LAYER2"
     TYPE_LAYER2 = "LAYER2"
@@ -94,6 +130,28 @@ class FastConnectProviderService(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type supported_virtual_circuit_types: list[str]
 
+        :param customer_asn_management:
+            The value to assign to the customer_asn_management property of this FastConnectProviderService.
+            Allowed values for this property are: "CUSTOMER_MANAGED", "PROVIDER_MANAGED", "ORACLE_MANAGED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type customer_asn_management: str
+
+        :param provider_service_key_management:
+            The value to assign to the provider_service_key_management property of this FastConnectProviderService.
+            Allowed values for this property are: "CUSTOMER_MANAGED", "PROVIDER_MANAGED", "ORACLE_MANAGED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type provider_service_key_management: str
+
+        :param bandwith_shape_management:
+            The value to assign to the bandwith_shape_management property of this FastConnectProviderService.
+            Allowed values for this property are: "CUSTOMER_MANAGED", "PROVIDER_MANAGED", "ORACLE_MANAGED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type bandwith_shape_management: str
+
+        :param required_total_cross_connects:
+            The value to assign to the required_total_cross_connects property of this FastConnectProviderService.
+        :type required_total_cross_connects: int
+
         :param type:
             The value to assign to the type property of this FastConnectProviderService.
             Allowed values for this property are: "LAYER2", "LAYER3", 'UNKNOWN_ENUM_VALUE'.
@@ -109,6 +167,10 @@ class FastConnectProviderService(object):
             'provider_service_name': 'str',
             'public_peering_bgp_management': 'str',
             'supported_virtual_circuit_types': 'list[str]',
+            'customer_asn_management': 'str',
+            'provider_service_key_management': 'str',
+            'bandwith_shape_management': 'str',
+            'required_total_cross_connects': 'int',
             'type': 'str'
         }
 
@@ -120,6 +182,10 @@ class FastConnectProviderService(object):
             'provider_service_name': 'providerServiceName',
             'public_peering_bgp_management': 'publicPeeringBgpManagement',
             'supported_virtual_circuit_types': 'supportedVirtualCircuitTypes',
+            'customer_asn_management': 'customerAsnManagement',
+            'provider_service_key_management': 'providerServiceKeyManagement',
+            'bandwith_shape_management': 'bandwithShapeManagement',
+            'required_total_cross_connects': 'requiredTotalCrossConnects',
             'type': 'type'
         }
 
@@ -130,6 +196,10 @@ class FastConnectProviderService(object):
         self._provider_service_name = None
         self._public_peering_bgp_management = None
         self._supported_virtual_circuit_types = None
+        self._customer_asn_management = None
+        self._provider_service_key_management = None
+        self._bandwith_shape_management = None
+        self._required_total_cross_connects = None
         self._type = None
 
     @property
@@ -317,6 +387,122 @@ class FastConnectProviderService(object):
         if supported_virtual_circuit_types:
             supported_virtual_circuit_types[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in supported_virtual_circuit_types]
         self._supported_virtual_circuit_types = supported_virtual_circuit_types
+
+    @property
+    def customer_asn_management(self):
+        """
+        **[Required]** Gets the customer_asn_management of this FastConnectProviderService.
+        Who is responsible for managing the ASN information for the network at the other end
+        of the connection from Oracle.
+
+        Allowed values for this property are: "CUSTOMER_MANAGED", "PROVIDER_MANAGED", "ORACLE_MANAGED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The customer_asn_management of this FastConnectProviderService.
+        :rtype: str
+        """
+        return self._customer_asn_management
+
+    @customer_asn_management.setter
+    def customer_asn_management(self, customer_asn_management):
+        """
+        Sets the customer_asn_management of this FastConnectProviderService.
+        Who is responsible for managing the ASN information for the network at the other end
+        of the connection from Oracle.
+
+
+        :param customer_asn_management: The customer_asn_management of this FastConnectProviderService.
+        :type: str
+        """
+        allowed_values = ["CUSTOMER_MANAGED", "PROVIDER_MANAGED", "ORACLE_MANAGED"]
+        if not value_allowed_none_or_none_sentinel(customer_asn_management, allowed_values):
+            customer_asn_management = 'UNKNOWN_ENUM_VALUE'
+        self._customer_asn_management = customer_asn_management
+
+    @property
+    def provider_service_key_management(self):
+        """
+        **[Required]** Gets the provider_service_key_management of this FastConnectProviderService.
+        Who is responsible for managing the provider service key.
+
+        Allowed values for this property are: "CUSTOMER_MANAGED", "PROVIDER_MANAGED", "ORACLE_MANAGED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The provider_service_key_management of this FastConnectProviderService.
+        :rtype: str
+        """
+        return self._provider_service_key_management
+
+    @provider_service_key_management.setter
+    def provider_service_key_management(self, provider_service_key_management):
+        """
+        Sets the provider_service_key_management of this FastConnectProviderService.
+        Who is responsible for managing the provider service key.
+
+
+        :param provider_service_key_management: The provider_service_key_management of this FastConnectProviderService.
+        :type: str
+        """
+        allowed_values = ["CUSTOMER_MANAGED", "PROVIDER_MANAGED", "ORACLE_MANAGED"]
+        if not value_allowed_none_or_none_sentinel(provider_service_key_management, allowed_values):
+            provider_service_key_management = 'UNKNOWN_ENUM_VALUE'
+        self._provider_service_key_management = provider_service_key_management
+
+    @property
+    def bandwith_shape_management(self):
+        """
+        **[Required]** Gets the bandwith_shape_management of this FastConnectProviderService.
+        Who is responsible for managing the virtual circuit bandwidth.
+
+        Allowed values for this property are: "CUSTOMER_MANAGED", "PROVIDER_MANAGED", "ORACLE_MANAGED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The bandwith_shape_management of this FastConnectProviderService.
+        :rtype: str
+        """
+        return self._bandwith_shape_management
+
+    @bandwith_shape_management.setter
+    def bandwith_shape_management(self, bandwith_shape_management):
+        """
+        Sets the bandwith_shape_management of this FastConnectProviderService.
+        Who is responsible for managing the virtual circuit bandwidth.
+
+
+        :param bandwith_shape_management: The bandwith_shape_management of this FastConnectProviderService.
+        :type: str
+        """
+        allowed_values = ["CUSTOMER_MANAGED", "PROVIDER_MANAGED", "ORACLE_MANAGED"]
+        if not value_allowed_none_or_none_sentinel(bandwith_shape_management, allowed_values):
+            bandwith_shape_management = 'UNKNOWN_ENUM_VALUE'
+        self._bandwith_shape_management = bandwith_shape_management
+
+    @property
+    def required_total_cross_connects(self):
+        """
+        **[Required]** Gets the required_total_cross_connects of this FastConnectProviderService.
+        Total number of cross-connect or cross-connect groups required for the virtual circuit.
+
+
+        :return: The required_total_cross_connects of this FastConnectProviderService.
+        :rtype: int
+        """
+        return self._required_total_cross_connects
+
+    @required_total_cross_connects.setter
+    def required_total_cross_connects(self, required_total_cross_connects):
+        """
+        Sets the required_total_cross_connects of this FastConnectProviderService.
+        Total number of cross-connect or cross-connect groups required for the virtual circuit.
+
+
+        :param required_total_cross_connects: The required_total_cross_connects of this FastConnectProviderService.
+        :type: int
+        """
+        self._required_total_cross_connects = required_total_cross_connects
 
     @property
     def type(self):

--- a/src/oci/core/models/fast_connect_provider_service_key.py
+++ b/src/oci/core/models/fast_connect_provider_service_key.py
@@ -1,0 +1,140 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class FastConnectProviderServiceKey(object):
+    """
+    A provider service key and its details. A provider service key is an identifier for a provider's
+    virtual circuit.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new FastConnectProviderServiceKey object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this FastConnectProviderServiceKey.
+        :type name: str
+
+        :param bandwidth_shape_name:
+            The value to assign to the bandwidth_shape_name property of this FastConnectProviderServiceKey.
+        :type bandwidth_shape_name: str
+
+        :param peering_location:
+            The value to assign to the peering_location property of this FastConnectProviderServiceKey.
+        :type peering_location: str
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'bandwidth_shape_name': 'str',
+            'peering_location': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'bandwidth_shape_name': 'bandwidthShapeName',
+            'peering_location': 'peeringLocation'
+        }
+
+        self._name = None
+        self._bandwidth_shape_name = None
+        self._peering_location = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this FastConnectProviderServiceKey.
+        The name of the service key offered by the provider.
+
+
+        :return: The name of this FastConnectProviderServiceKey.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this FastConnectProviderServiceKey.
+        The name of the service key offered by the provider.
+
+
+        :param name: The name of this FastConnectProviderServiceKey.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def bandwidth_shape_name(self):
+        """
+        Gets the bandwidth_shape_name of this FastConnectProviderServiceKey.
+        The provisioned data rate of the connection.  To get a list of the
+        available bandwidth levels (that is, shapes), see
+        :func:`list_fast_connect_provider_virtual_circuit_bandwidth_shapes`.
+
+        Example: `10 Gbps`
+
+
+        :return: The bandwidth_shape_name of this FastConnectProviderServiceKey.
+        :rtype: str
+        """
+        return self._bandwidth_shape_name
+
+    @bandwidth_shape_name.setter
+    def bandwidth_shape_name(self, bandwidth_shape_name):
+        """
+        Sets the bandwidth_shape_name of this FastConnectProviderServiceKey.
+        The provisioned data rate of the connection.  To get a list of the
+        available bandwidth levels (that is, shapes), see
+        :func:`list_fast_connect_provider_virtual_circuit_bandwidth_shapes`.
+
+        Example: `10 Gbps`
+
+
+        :param bandwidth_shape_name: The bandwidth_shape_name of this FastConnectProviderServiceKey.
+        :type: str
+        """
+        self._bandwidth_shape_name = bandwidth_shape_name
+
+    @property
+    def peering_location(self):
+        """
+        Gets the peering_location of this FastConnectProviderServiceKey.
+        The provider's peering location.
+
+
+        :return: The peering_location of this FastConnectProviderServiceKey.
+        :rtype: str
+        """
+        return self._peering_location
+
+    @peering_location.setter
+    def peering_location(self, peering_location):
+        """
+        Sets the peering_location of this FastConnectProviderServiceKey.
+        The provider's peering location.
+
+
+        :param peering_location: The peering_location of this FastConnectProviderServiceKey.
+        :type: str
+        """
+        self._peering_location = peering_location
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/image_source_details.py
+++ b/src/oci/core/models/image_source_details.py
@@ -73,8 +73,8 @@ class ImageSourceDetails(object):
     def source_image_type(self):
         """
         Gets the source_image_type of this ImageSourceDetails.
-        The format of the image to be imported.  Exported Oracle images are QCOW2.  Only monolithic
-        images are supported.
+        The format of the image to be imported.  Only monolithic
+        images are supported. This attribute is not used for exported Oracle images with the OCI image format.
 
         Allowed values for this property are: "QCOW2", "VMDK"
 
@@ -88,8 +88,8 @@ class ImageSourceDetails(object):
     def source_image_type(self, source_image_type):
         """
         Sets the source_image_type of this ImageSourceDetails.
-        The format of the image to be imported.  Exported Oracle images are QCOW2.  Only monolithic
-        images are supported.
+        The format of the image to be imported.  Only monolithic
+        images are supported. This attribute is not used for exported Oracle images with the OCI image format.
 
 
         :param source_image_type: The source_image_type of this ImageSourceDetails.

--- a/src/oci/core/models/launch_instance_details.py
+++ b/src/oci/core/models/launch_instance_details.py
@@ -781,7 +781,7 @@ class LaunchInstanceDetails(object):
     def is_pv_encryption_in_transit_enabled(self):
         """
         Gets the is_pv_encryption_in_transit_enabled of this LaunchInstanceDetails.
-        Whether to enable encryption in transit for the PV boot volume attachment. Defaults to false.
+        Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false.
 
 
         :return: The is_pv_encryption_in_transit_enabled of this LaunchInstanceDetails.
@@ -793,7 +793,7 @@ class LaunchInstanceDetails(object):
     def is_pv_encryption_in_transit_enabled(self, is_pv_encryption_in_transit_enabled):
         """
         Sets the is_pv_encryption_in_transit_enabled of this LaunchInstanceDetails.
-        Whether to enable encryption in transit for the PV boot volume attachment. Defaults to false.
+        Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false.
 
 
         :param is_pv_encryption_in_transit_enabled: The is_pv_encryption_in_transit_enabled of this LaunchInstanceDetails.

--- a/src/oci/core/models/launch_options.py
+++ b/src/oci/core/models/launch_options.py
@@ -301,7 +301,7 @@ class LaunchOptions(object):
     def is_pv_encryption_in_transit_enabled(self):
         """
         Gets the is_pv_encryption_in_transit_enabled of this LaunchOptions.
-        Whether to enable encryption in transit for the PV boot volume attachment. Defaults to false.
+        Whether to enable in-transit encryption for the boot volume's paravirtualized attachment. The default value is false.
 
 
         :return: The is_pv_encryption_in_transit_enabled of this LaunchOptions.
@@ -313,7 +313,7 @@ class LaunchOptions(object):
     def is_pv_encryption_in_transit_enabled(self, is_pv_encryption_in_transit_enabled):
         """
         Sets the is_pv_encryption_in_transit_enabled of this LaunchOptions.
-        Whether to enable encryption in transit for the PV boot volume attachment. Defaults to false.
+        Whether to enable in-transit encryption for the boot volume's paravirtualized attachment. The default value is false.
 
 
         :param is_pv_encryption_in_transit_enabled: The is_pv_encryption_in_transit_enabled of this LaunchOptions.

--- a/src/oci/core/models/update_cross_connect_details.py
+++ b/src/oci/core/models/update_cross_connect_details.py
@@ -25,19 +25,26 @@ class UpdateCrossConnectDetails(object):
             The value to assign to the is_active property of this UpdateCrossConnectDetails.
         :type is_active: bool
 
+        :param customer_reference_name:
+            The value to assign to the customer_reference_name property of this UpdateCrossConnectDetails.
+        :type customer_reference_name: str
+
         """
         self.swagger_types = {
             'display_name': 'str',
-            'is_active': 'bool'
+            'is_active': 'bool',
+            'customer_reference_name': 'str'
         }
 
         self.attribute_map = {
             'display_name': 'displayName',
-            'is_active': 'isActive'
+            'is_active': 'isActive',
+            'customer_reference_name': 'customerReferenceName'
         }
 
         self._display_name = None
         self._is_active = None
+        self._customer_reference_name = None
 
     @property
     def display_name(self):
@@ -96,6 +103,32 @@ class UpdateCrossConnectDetails(object):
         :type: bool
         """
         self._is_active = is_active
+
+    @property
+    def customer_reference_name(self):
+        """
+        Gets the customer_reference_name of this UpdateCrossConnectDetails.
+        A reference name or identifier for the physical fiber connection that this cross-connect
+        uses.
+
+
+        :return: The customer_reference_name of this UpdateCrossConnectDetails.
+        :rtype: str
+        """
+        return self._customer_reference_name
+
+    @customer_reference_name.setter
+    def customer_reference_name(self, customer_reference_name):
+        """
+        Sets the customer_reference_name of this UpdateCrossConnectDetails.
+        A reference name or identifier for the physical fiber connection that this cross-connect
+        uses.
+
+
+        :param customer_reference_name: The customer_reference_name of this UpdateCrossConnectDetails.
+        :type: str
+        """
+        self._customer_reference_name = customer_reference_name
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/update_cross_connect_group_details.py
+++ b/src/oci/core/models/update_cross_connect_group_details.py
@@ -21,16 +21,23 @@ class UpdateCrossConnectGroupDetails(object):
             The value to assign to the display_name property of this UpdateCrossConnectGroupDetails.
         :type display_name: str
 
+        :param customer_reference_name:
+            The value to assign to the customer_reference_name property of this UpdateCrossConnectGroupDetails.
+        :type customer_reference_name: str
+
         """
         self.swagger_types = {
-            'display_name': 'str'
+            'display_name': 'str',
+            'customer_reference_name': 'str'
         }
 
         self.attribute_map = {
-            'display_name': 'displayName'
+            'display_name': 'displayName',
+            'customer_reference_name': 'customerReferenceName'
         }
 
         self._display_name = None
+        self._customer_reference_name = None
 
     @property
     def display_name(self):
@@ -57,6 +64,32 @@ class UpdateCrossConnectGroupDetails(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def customer_reference_name(self):
+        """
+        Gets the customer_reference_name of this UpdateCrossConnectGroupDetails.
+        A reference name or identifier for the physical fiber connection that this cross-connect
+        group uses.
+
+
+        :return: The customer_reference_name of this UpdateCrossConnectGroupDetails.
+        :rtype: str
+        """
+        return self._customer_reference_name
+
+    @customer_reference_name.setter
+    def customer_reference_name(self, customer_reference_name):
+        """
+        Sets the customer_reference_name of this UpdateCrossConnectGroupDetails.
+        A reference name or identifier for the physical fiber connection that this cross-connect
+        group uses.
+
+
+        :param customer_reference_name: The customer_reference_name of this UpdateCrossConnectGroupDetails.
+        :type: str
+        """
+        self._customer_reference_name = customer_reference_name
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/update_virtual_circuit_details.py
+++ b/src/oci/core/models/update_virtual_circuit_details.py
@@ -50,6 +50,10 @@ class UpdateVirtualCircuitDetails(object):
             Allowed values for this property are: "ACTIVE", "INACTIVE"
         :type provider_state: str
 
+        :param provider_service_key_name:
+            The value to assign to the provider_service_key_name property of this UpdateVirtualCircuitDetails.
+        :type provider_service_key_name: str
+
         :param reference_comment:
             The value to assign to the reference_comment property of this UpdateVirtualCircuitDetails.
         :type reference_comment: str
@@ -62,6 +66,7 @@ class UpdateVirtualCircuitDetails(object):
             'display_name': 'str',
             'gateway_id': 'str',
             'provider_state': 'str',
+            'provider_service_key_name': 'str',
             'reference_comment': 'str'
         }
 
@@ -72,6 +77,7 @@ class UpdateVirtualCircuitDetails(object):
             'display_name': 'displayName',
             'gateway_id': 'gatewayId',
             'provider_state': 'providerState',
+            'provider_service_key_name': 'providerServiceKeyName',
             'reference_comment': 'referenceComment'
         }
 
@@ -81,6 +87,7 @@ class UpdateVirtualCircuitDetails(object):
         self._display_name = None
         self._gateway_id = None
         self._provider_state = None
+        self._provider_service_key_name = None
         self._reference_comment = None
 
     @property
@@ -292,6 +299,30 @@ class UpdateVirtualCircuitDetails(object):
                 .format(allowed_values)
             )
         self._provider_state = provider_state
+
+    @property
+    def provider_service_key_name(self):
+        """
+        Gets the provider_service_key_name of this UpdateVirtualCircuitDetails.
+        The service key name offered by the provider (if the customer is connecting via a provider).
+
+
+        :return: The provider_service_key_name of this UpdateVirtualCircuitDetails.
+        :rtype: str
+        """
+        return self._provider_service_key_name
+
+    @provider_service_key_name.setter
+    def provider_service_key_name(self, provider_service_key_name):
+        """
+        Sets the provider_service_key_name of this UpdateVirtualCircuitDetails.
+        The service key name offered by the provider (if the customer is connecting via a provider).
+
+
+        :param provider_service_key_name: The provider_service_key_name of this UpdateVirtualCircuitDetails.
+        :type: str
+        """
+        self._provider_service_key_name = provider_service_key_name
 
     @property
     def reference_comment(self):

--- a/src/oci/core/models/virtual_circuit.py
+++ b/src/oci/core/models/virtual_circuit.py
@@ -179,6 +179,10 @@ class VirtualCircuit(object):
             The value to assign to the provider_service_id property of this VirtualCircuit.
         :type provider_service_id: str
 
+        :param provider_service_key_name:
+            The value to assign to the provider_service_key_name property of this VirtualCircuit.
+        :type provider_service_key_name: str
+
         :param provider_service_name:
             The value to assign to the provider_service_name property of this VirtualCircuit.
         :type provider_service_name: str
@@ -232,6 +236,7 @@ class VirtualCircuit(object):
             'oracle_bgp_asn': 'int',
             'provider_name': 'str',
             'provider_service_id': 'str',
+            'provider_service_key_name': 'str',
             'provider_service_name': 'str',
             'provider_state': 'str',
             'public_prefixes': 'list[str]',
@@ -256,6 +261,7 @@ class VirtualCircuit(object):
             'oracle_bgp_asn': 'oracleBgpAsn',
             'provider_name': 'providerName',
             'provider_service_id': 'providerServiceId',
+            'provider_service_key_name': 'providerServiceKeyName',
             'provider_service_name': 'providerServiceName',
             'provider_state': 'providerState',
             'public_prefixes': 'publicPrefixes',
@@ -279,6 +285,7 @@ class VirtualCircuit(object):
         self._oracle_bgp_asn = None
         self._provider_name = None
         self._provider_service_id = None
+        self._provider_service_key_name = None
         self._provider_service_name = None
         self._provider_state = None
         self._public_prefixes = None
@@ -324,7 +331,8 @@ class VirtualCircuit(object):
     def bgp_management(self):
         """
         Gets the bgp_management of this VirtualCircuit.
-        BGP management option.
+        Deprecated. Instead use the information in
+        :class:`FastConnectProviderService`.
 
         Allowed values for this property are: "CUSTOMER_MANAGED", "PROVIDER_MANAGED", "ORACLE_MANAGED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -339,7 +347,8 @@ class VirtualCircuit(object):
     def bgp_management(self, bgp_management):
         """
         Sets the bgp_management of this VirtualCircuit.
-        BGP management option.
+        Deprecated. Instead use the information in
+        :class:`FastConnectProviderService`.
 
 
         :param bgp_management: The bgp_management of this VirtualCircuit.
@@ -649,6 +658,30 @@ class VirtualCircuit(object):
         :type: str
         """
         self._provider_service_id = provider_service_id
+
+    @property
+    def provider_service_key_name(self):
+        """
+        Gets the provider_service_key_name of this VirtualCircuit.
+        The service key name offered by the provider (if the customer is connecting via a provider).
+
+
+        :return: The provider_service_key_name of this VirtualCircuit.
+        :rtype: str
+        """
+        return self._provider_service_key_name
+
+    @provider_service_key_name.setter
+    def provider_service_key_name(self, provider_service_key_name):
+        """
+        Sets the provider_service_key_name of this VirtualCircuit.
+        The service key name offered by the provider (if the customer is connecting via a provider).
+
+
+        :param provider_service_key_name: The provider_service_key_name of this VirtualCircuit.
+        :type: str
+        """
+        self._provider_service_key_name = provider_service_key_name
 
     @property
     def provider_service_name(self):

--- a/src/oci/core/models/volume_attachment.py
+++ b/src/oci/core/models/volume_attachment.py
@@ -446,7 +446,7 @@ class VolumeAttachment(object):
     def is_pv_encryption_in_transit_enabled(self):
         """
         Gets the is_pv_encryption_in_transit_enabled of this VolumeAttachment.
-        Whether the enable encryption in transit for the PV volume attachment is on or not.
+        Whether in-transit encryption for the data volume's paravirtualized attachment is enabled or not.
 
 
         :return: The is_pv_encryption_in_transit_enabled of this VolumeAttachment.
@@ -458,7 +458,7 @@ class VolumeAttachment(object):
     def is_pv_encryption_in_transit_enabled(self, is_pv_encryption_in_transit_enabled):
         """
         Sets the is_pv_encryption_in_transit_enabled of this VolumeAttachment.
-        Whether the enable encryption in transit for the PV volume attachment is on or not.
+        Whether in-transit encryption for the data volume's paravirtualized attachment is enabled or not.
 
 
         :param is_pv_encryption_in_transit_enabled: The is_pv_encryption_in_transit_enabled of this VolumeAttachment.

--- a/src/oci/core/virtual_network_client.py
+++ b/src/oci/core/virtual_network_client.py
@@ -4245,6 +4245,74 @@ class VirtualNetworkClient(object):
                 header_params=header_params,
                 response_type="FastConnectProviderService")
 
+    def get_fast_connect_provider_service_key(self, provider_service_id, provider_service_key_name, **kwargs):
+        """
+        GetFastConnectProviderServiceKey
+        Gets the specified provider service key's information.
+
+
+        :param str provider_service_id: (required)
+            The OCID of the provider service.
+
+        :param str provider_service_key_name: (required)
+            The provider service key name.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.FastConnectProviderServiceKey`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/fastConnectProviderServices/{providerServiceId}/providerServiceKeys/{providerServiceKeyName}"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_fast_connect_provider_service_key got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "providerServiceId": provider_service_id,
+            "providerServiceKeyName": provider_service_key_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="FastConnectProviderServiceKey")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="FastConnectProviderServiceKey")
+
     def get_internet_gateway(self, ig_id, **kwargs):
         """
         GetInternetGateway

--- a/src/oci/core/virtual_network_client_composite_operations.py
+++ b/src/oci/core/virtual_network_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class VirtualNetworkClientCompositeOperations(object):
@@ -729,7 +730,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_cross_connect(cross_connect_id)
-        operation_result = self.client.delete_cross_connect(cross_connect_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_cross_connect(cross_connect_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -768,7 +777,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_cross_connect_group(cross_connect_group_id)
-        operation_result = self.client.delete_cross_connect_group(cross_connect_group_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_cross_connect_group(cross_connect_group_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -807,7 +824,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_dhcp_options(dhcp_id)
-        operation_result = self.client.delete_dhcp_options(dhcp_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_dhcp_options(dhcp_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -846,7 +871,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_drg(drg_id)
-        operation_result = self.client.delete_drg(drg_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_drg(drg_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -885,7 +918,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_drg_attachment(drg_attachment_id)
-        operation_result = self.client.delete_drg_attachment(drg_attachment_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_drg_attachment(drg_attachment_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -924,7 +965,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_internet_gateway(ig_id)
-        operation_result = self.client.delete_internet_gateway(ig_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_internet_gateway(ig_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -963,7 +1012,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_ip_sec_connection(ipsc_id)
-        operation_result = self.client.delete_ip_sec_connection(ipsc_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_ip_sec_connection(ipsc_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -1002,7 +1059,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_local_peering_gateway(local_peering_gateway_id)
-        operation_result = self.client.delete_local_peering_gateway(local_peering_gateway_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_local_peering_gateway(local_peering_gateway_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -1043,7 +1108,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_nat_gateway(nat_gateway_id)
-        operation_result = self.client.delete_nat_gateway(nat_gateway_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_nat_gateway(nat_gateway_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -1082,7 +1155,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_public_ip(public_ip_id)
-        operation_result = self.client.delete_public_ip(public_ip_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_public_ip(public_ip_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -1121,7 +1202,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_remote_peering_connection(remote_peering_connection_id)
-        operation_result = self.client.delete_remote_peering_connection(remote_peering_connection_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_remote_peering_connection(remote_peering_connection_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -1160,7 +1249,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_route_table(rt_id)
-        operation_result = self.client.delete_route_table(rt_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_route_table(rt_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -1199,7 +1296,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_security_list(security_list_id)
-        operation_result = self.client.delete_security_list(security_list_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_security_list(security_list_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -1240,7 +1345,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_service_gateway(service_gateway_id)
-        operation_result = self.client.delete_service_gateway(service_gateway_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_service_gateway(service_gateway_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -1279,7 +1392,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_subnet(subnet_id)
-        operation_result = self.client.delete_subnet(subnet_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_subnet(subnet_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -1318,7 +1439,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_vcn(vcn_id)
-        operation_result = self.client.delete_vcn(vcn_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_vcn(vcn_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -1357,7 +1486,15 @@ class VirtualNetworkClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_virtual_circuit(virtual_circuit_id)
-        operation_result = self.client.delete_virtual_circuit(virtual_circuit_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_virtual_circuit(virtual_circuit_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/database/database_client_composite_operations.py
+++ b/src/oci/database/database_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class DatabaseClientCompositeOperations(object):
@@ -358,7 +359,15 @@ class DatabaseClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_autonomous_data_warehouse(autonomous_data_warehouse_id)
-        operation_result = self.client.delete_autonomous_data_warehouse(autonomous_data_warehouse_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_autonomous_data_warehouse(autonomous_data_warehouse_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -399,7 +408,15 @@ class DatabaseClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_autonomous_database(autonomous_database_id)
-        operation_result = self.client.delete_autonomous_database(autonomous_database_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_autonomous_database(autonomous_database_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -440,7 +457,15 @@ class DatabaseClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_backup(backup_id)
-        operation_result = self.client.delete_backup(backup_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_backup(backup_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -481,7 +506,15 @@ class DatabaseClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_db_home(db_home_id)
-        operation_result = self.client.delete_db_home(db_home_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_db_home(db_home_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -993,7 +1026,15 @@ class DatabaseClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_db_system(db_system_id)
-        operation_result = self.client.terminate_db_system(db_system_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.terminate_db_system(db_system_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/dns/dns_client_composite_operations.py
+++ b/src/oci/dns/dns_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class DnsClientCompositeOperations(object):
@@ -154,7 +155,15 @@ class DnsClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_steering_policy(steering_policy_id)
-        operation_result = self.client.delete_steering_policy(steering_policy_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_steering_policy(steering_policy_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -193,7 +202,15 @@ class DnsClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_steering_policy_attachment(steering_policy_attachment_id)
-        operation_result = self.client.delete_steering_policy_attachment(steering_policy_attachment_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_steering_policy_attachment(steering_policy_attachment_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -232,7 +249,15 @@ class DnsClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_zone(zone_name_or_id)
-        operation_result = self.client.delete_zone(zone_name_or_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_zone(zone_name_or_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/email/email_client_composite_operations.py
+++ b/src/oci/email/email_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class EmailClientCompositeOperations(object):
@@ -78,7 +79,15 @@ class EmailClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_sender(sender_id)
-        operation_result = self.client.delete_sender(sender_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_sender(sender_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/file_storage/file_storage_client_composite_operations.py
+++ b/src/oci/file_storage/file_storage_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class FileStorageClientCompositeOperations(object):
@@ -192,7 +193,15 @@ class FileStorageClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_export(export_id)
-        operation_result = self.client.delete_export(export_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_export(export_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -231,7 +240,15 @@ class FileStorageClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_file_system(file_system_id)
-        operation_result = self.client.delete_file_system(file_system_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_file_system(file_system_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -270,7 +287,15 @@ class FileStorageClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_mount_target(mount_target_id)
-        operation_result = self.client.delete_mount_target(mount_target_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_mount_target(mount_target_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -309,7 +334,15 @@ class FileStorageClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_snapshot(snapshot_id)
-        operation_result = self.client.delete_snapshot(snapshot_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_snapshot(snapshot_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/healthchecks/health_checks_client_composite_operations.py
+++ b/src/oci/healthchecks/health_checks_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class HealthChecksClientCompositeOperations(object):

--- a/src/oci/identity/identity_client_composite_operations.py
+++ b/src/oci/identity/identity_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class IdentityClientCompositeOperations(object):
@@ -422,7 +423,15 @@ class IdentityClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        operation_result = self.client.delete_compartment(compartment_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_compartment(compartment_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -461,7 +470,15 @@ class IdentityClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_dynamic_group(dynamic_group_id)
-        operation_result = self.client.delete_dynamic_group(dynamic_group_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_dynamic_group(dynamic_group_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -500,7 +517,15 @@ class IdentityClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_group(group_id)
-        operation_result = self.client.delete_group(group_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_group(group_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -539,7 +564,15 @@ class IdentityClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_identity_provider(identity_provider_id)
-        operation_result = self.client.delete_identity_provider(identity_provider_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_identity_provider(identity_provider_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -578,7 +611,15 @@ class IdentityClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_policy(policy_id)
-        operation_result = self.client.delete_policy(policy_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_policy(policy_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -617,7 +658,15 @@ class IdentityClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_tag_default(tag_default_id)
-        operation_result = self.client.delete_tag_default(tag_default_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_tag_default(tag_default_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -656,7 +705,15 @@ class IdentityClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_user(user_id)
-        operation_result = self.client.delete_user(user_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_user(user_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/key_management/kms_crypto_client.py
+++ b/src/oci/key_management/kms_crypto_client.py
@@ -71,7 +71,7 @@ class KmsCryptoClient(object):
             'regional_client': False,
             'service_endpoint': service_endpoint,
             'timeout': kwargs.get('timeout'),
-            'base_path': '/20180608',
+            'base_path': '/',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("kms_crypto", config, signer, key_management_type_mapping, **base_client_init_kwargs)
@@ -102,7 +102,7 @@ class KmsCryptoClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.DecryptedData`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/decrypt"
+        resource_path = "/20180608/decrypt"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -169,7 +169,7 @@ class KmsCryptoClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.EncryptedData`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/encrypt"
+        resource_path = "/20180608/encrypt"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -234,7 +234,7 @@ class KmsCryptoClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.GeneratedKey`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/generateDataEncryptionKey"
+        resource_path = "/20180608/generateDataEncryptionKey"
         method = "POST"
 
         # Don't accept unknown kwargs

--- a/src/oci/key_management/kms_crypto_client_composite_operations.py
+++ b/src/oci/key_management/kms_crypto_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class KmsCryptoClientCompositeOperations(object):

--- a/src/oci/key_management/kms_management_client.py
+++ b/src/oci/key_management/kms_management_client.py
@@ -71,7 +71,7 @@ class KmsManagementClient(object):
             'regional_client': False,
             'service_endpoint': service_endpoint,
             'timeout': kwargs.get('timeout'),
-            'base_path': '/20180608',
+            'base_path': '/',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("kms_management", config, signer, key_management_type_mapping, **base_client_init_kwargs)
@@ -79,7 +79,7 @@ class KmsManagementClient(object):
 
     def create_key(self, create_key_details, **kwargs):
         """
-        CreateKey
+        Creates a new key.
         Creates a new key.
 
 
@@ -110,7 +110,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Key`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/keys"
+        resource_path = "/20180608/keys"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -156,8 +156,8 @@ class KmsManagementClient(object):
 
     def create_key_version(self, key_id, **kwargs):
         """
-        Create new KeyVersion and rotate the key to use it for encryption.
-        Generates new cryptographic material for a key. Key must be in an `ENABLED` state to be
+        Creates a new KeyVersion resource and rotates the key to use it for encryption.
+        Generates new cryptographic material for a key. The key must be in an `ENABLED` state to be
         rotated.
 
 
@@ -188,7 +188,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.KeyVersion`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/keys/{keyId}/keyVersions"
+        resource_path = "/20180608/keys/{keyId}/keyVersions"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -244,7 +244,7 @@ class KmsManagementClient(object):
 
     def disable_key(self, key_id, **kwargs):
         """
-        DisableKey
+        Disables a key so it cannot be used for cryptographic operations.
         Disables a key to make it unavailable for encryption
         or decryption.
 
@@ -283,7 +283,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Key`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/keys/{keyId}/actions/disable"
+        resource_path = "/20180608/keys/{keyId}/actions/disable"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -341,7 +341,7 @@ class KmsManagementClient(object):
 
     def enable_key(self, key_id, **kwargs):
         """
-        EnableKey
+        Enables a key so it can be used for cryptographic operations.
         Enables a key to make it available for encryption or
         decryption.
 
@@ -380,7 +380,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Key`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/keys/{keyId}/actions/enable"
+        resource_path = "/20180608/keys/{keyId}/actions/enable"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -438,7 +438,7 @@ class KmsManagementClient(object):
 
     def get_key(self, key_id, **kwargs):
         """
-        GetKey
+        Gets details about a key.
         Gets information about the specified key.
 
 
@@ -461,7 +461,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Key`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/keys/{keyId}"
+        resource_path = "/20180608/keys/{keyId}"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -513,7 +513,7 @@ class KmsManagementClient(object):
 
     def get_key_version(self, key_id, key_version_id, **kwargs):
         """
-        GetKeyVersion
+        Gets details about a key version.
         Gets information about the specified key version.
 
 
@@ -539,7 +539,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.KeyVersion`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/keys/{keyId}/keyVersions/{keyVersionId}"
+        resource_path = "/20180608/keys/{keyId}/keyVersions/{keyVersionId}"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -592,7 +592,7 @@ class KmsManagementClient(object):
 
     def list_key_versions(self, key_id, **kwargs):
         """
-        ListKeyVersions
+        Lists the KeyVersion resources for a key.
         Lists all key versions for the specified key.
 
 
@@ -634,7 +634,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.key_management.models.KeyVersionSummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/keys/{keyId}/keyVersions"
+        resource_path = "/20180608/keys/{keyId}/keyVersions"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -714,7 +714,7 @@ class KmsManagementClient(object):
 
     def list_keys(self, compartment_id, **kwargs):
         """
-        ListKeys
+        Lists keys in the specified vault and compartment.
         Lists the keys in the specified vault and compartment.
 
 
@@ -756,7 +756,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.key_management.models.KeySummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/keys"
+        resource_path = "/20180608/keys"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -825,10 +825,10 @@ class KmsManagementClient(object):
 
     def update_key(self, key_id, update_key_details, **kwargs):
         """
-        UpdateKey
+        Updates a key's properties.
         Updates the properties of a key. Specifically, you can update the
-        `displayName` , `freeformTags`, and `definedTags` properties. Furthermore,
-        the key must in an `ACTIVE` or `CREATING` state.
+        `displayName`, `freeformTags`, and `definedTags` properties. Furthermore,
+        the key must in an `ACTIVE` or `CREATING` state to be updated.
 
 
         :param str key_id: (required)
@@ -860,7 +860,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Key`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/keys/{keyId}"
+        resource_path = "/20180608/keys/{keyId}"
         method = "PUT"
 
         # Don't accept unknown kwargs

--- a/src/oci/key_management/kms_management_client_composite_operations.py
+++ b/src/oci/key_management/kms_management_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class KmsManagementClientCompositeOperations(object):

--- a/src/oci/key_management/kms_vault_client.py
+++ b/src/oci/key_management/kms_vault_client.py
@@ -73,7 +73,7 @@ class KmsVaultClient(object):
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
-            'base_path': '/20180608',
+            'base_path': '/',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("kms_vault", config, signer, key_management_type_mapping, **base_client_init_kwargs)
@@ -81,9 +81,9 @@ class KmsVaultClient(object):
 
     def cancel_vault_deletion(self, vault_id, **kwargs):
         """
-        CancelVaultDeletion
-        Cancels the scheduled deletion of the specified Vault, which must be in PendingDeletion
-        state. The Vault and all Keys in it will be moved back to their previous states before
+        Cancels the scheduled deletion of a vault.
+        Cancels the scheduled deletion of the specified vault. Canceling a scheduled deletion
+        restores the vault and all keys in it to the respective states they were in before
         the deletion was scheduled.
 
 
@@ -121,7 +121,7 @@ class KmsVaultClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Vault`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/vaults/{vaultId}/actions/cancelDeletion"
+        resource_path = "/20180608/vaults/{vaultId}/actions/cancelDeletion"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -179,11 +179,11 @@ class KmsVaultClient(object):
 
     def create_vault(self, create_vault_details, **kwargs):
         """
-        CreateVault
+        Creates a new vault.
         Creates a new vault. The type of vault you create determines key
         placement, pricing, and available options. Options include storage
         isolation, a dedicated service endpoint instead of a shared service
-        endpoint for API calls, and a dedicated HSM or a multitenant HSM.
+        endpoint for API calls, and a dedicated hardware security module (HSM) or a multitenant HSM.
 
 
         :param CreateVaultDetails create_vault_details: (required)
@@ -213,7 +213,7 @@ class KmsVaultClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Vault`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/vaults"
+        resource_path = "/20180608/vaults"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -259,7 +259,7 @@ class KmsVaultClient(object):
 
     def get_vault(self, vault_id, **kwargs):
         """
-        GetVault
+        Gets details about a vault.
         Gets the specified vault's configuration information.
 
 
@@ -282,7 +282,7 @@ class KmsVaultClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Vault`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/vaults/{vaultId}"
+        resource_path = "/20180608/vaults/{vaultId}"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -334,8 +334,8 @@ class KmsVaultClient(object):
 
     def list_vaults(self, compartment_id, **kwargs):
         """
-        ListVaults
-        Lists vaults in the specified compartment.
+        Lists vaults in the compartment.
+        Lists the vaults in the specified compartment.
 
 
         :param str compartment_id: (required)
@@ -376,7 +376,7 @@ class KmsVaultClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.key_management.models.VaultSummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/vaults"
+        resource_path = "/20180608/vaults"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -445,9 +445,9 @@ class KmsVaultClient(object):
 
     def schedule_vault_deletion(self, vault_id, schedule_vault_deletion_details, **kwargs):
         """
-        ScheduleVaultDeletion
-        Schedules the deletion of the specified Vault. The Vault and all Keys in it
-        will be moved to PendingDeletion state and deleted after the retention period.
+        Schedules the deletion of a vault.
+        Schedules the deletion of the specified vault. This sets the state of the vault and all keys in it
+        to `PENDING_DELETION` and then deletes them after the retention period ends.
 
 
         :param str vault_id: (required)
@@ -487,7 +487,7 @@ class KmsVaultClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Vault`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/vaults/{vaultId}/actions/scheduleDeletion"
+        resource_path = "/20180608/vaults/{vaultId}/actions/scheduleDeletion"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -547,10 +547,10 @@ class KmsVaultClient(object):
 
     def update_vault(self, vault_id, update_vault_details, **kwargs):
         """
-        UpdateVault
+        Updates the properties of a vault.
         Updates the properties of a vault. Specifically, you can update the
-        `displayName` , `freeformTags`, and `definedTags` properties. Furthermore,
-        the vault must be in an `ACTIVE` or `CREATING` state.
+        `displayName`, `freeformTags`, and `definedTags` properties. Furthermore,
+        the vault must be in an `ACTIVE` or `CREATING` state to be updated.
 
 
         :param str vault_id: (required)
@@ -582,7 +582,7 @@ class KmsVaultClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Vault`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/vaults/{vaultId}"
+        resource_path = "/20180608/vaults/{vaultId}"
         method = "PUT"
 
         # Don't accept unknown kwargs

--- a/src/oci/key_management/kms_vault_client_composite_operations.py
+++ b/src/oci/key_management/kms_vault_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class KmsVaultClientCompositeOperations(object):

--- a/src/oci/key_management/models/decrypted_data.py
+++ b/src/oci/key_management/models/decrypted_data.py
@@ -43,7 +43,7 @@ class DecryptedData(object):
     def plaintext(self):
         """
         **[Required]** Gets the plaintext of this DecryptedData.
-        The decrypted data, in the form of a base64-encoded value.
+        The decrypted data, expressed as a base64-encoded value.
 
 
         :return: The plaintext of this DecryptedData.
@@ -55,7 +55,7 @@ class DecryptedData(object):
     def plaintext(self, plaintext):
         """
         Sets the plaintext of this DecryptedData.
-        The decrypted data, in the form of a base64-encoded value.
+        The decrypted data, expressed as a base64-encoded value.
 
 
         :param plaintext: The plaintext of this DecryptedData.

--- a/src/oci/key_management/models/key.py
+++ b/src/oci/key_management/models/key.py
@@ -165,9 +165,9 @@ class Key(object):
     def current_key_version(self):
         """
         **[Required]** Gets the current_key_version of this Key.
-        The OCID of the KeyVersion resource used in cryptographic operations. During key rotation, service may be in transitional state
-        where this or a newer KeyVersion are used intermittently, and currentKeyVersion field is updated once service is guaranteed to
-        use new KeyVersion for all consequent encrypt operations.
+        The OCID of the KeyVersion resource used in cryptographic operations. During key rotation, service might be in a transitional state
+        where this or a newer KeyVersion are used intermittently. The currentKeyVersion field is updated when the service is guaranteed to
+        use the new KeyVersion for all subsequent encryption operations.
 
 
         :return: The current_key_version of this Key.
@@ -179,9 +179,9 @@ class Key(object):
     def current_key_version(self, current_key_version):
         """
         Sets the current_key_version of this Key.
-        The OCID of the KeyVersion resource used in cryptographic operations. During key rotation, service may be in transitional state
-        where this or a newer KeyVersion are used intermittently, and currentKeyVersion field is updated once service is guaranteed to
-        use new KeyVersion for all consequent encrypt operations.
+        The OCID of the KeyVersion resource used in cryptographic operations. During key rotation, service might be in a transitional state
+        where this or a newer KeyVersion are used intermittently. The currentKeyVersion field is updated when the service is guaranteed to
+        use the new KeyVersion for all subsequent encryption operations.
 
 
         :param current_key_version: The current_key_version of this Key.

--- a/src/oci/key_management/models/schedule_vault_deletion_details.py
+++ b/src/oci/key_management/models/schedule_vault_deletion_details.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ScheduleVaultDeletionDetails(object):
     """
-    Details for scheduling Vault deletion
+    Details for scheduling vault deletion
     """
 
     def __init__(self, **kwargs):
@@ -36,9 +36,11 @@ class ScheduleVaultDeletionDetails(object):
     def time_of_deletion(self):
         """
         Gets the time_of_deletion of this ScheduleVaultDeletionDetails.
-        An optional property to indicate the deletion time of the Vault.
-        The time format should comply with RFC-3339 standards. This time must be between 7 to 30 days from the time
-        when the request is received. If the property is missing, it will be set to 30 days from request time by default.
+        An optional property to indicate the deletion time of the vault, expressed in `RFC 3339`__
+        timestamp format. The specified time must be between 7 and 30 days from the time
+        when the request is received. If this property is missing, it will be set to 30 days from the time of the request by default.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_of_deletion of this ScheduleVaultDeletionDetails.
@@ -50,9 +52,11 @@ class ScheduleVaultDeletionDetails(object):
     def time_of_deletion(self, time_of_deletion):
         """
         Sets the time_of_deletion of this ScheduleVaultDeletionDetails.
-        An optional property to indicate the deletion time of the Vault.
-        The time format should comply with RFC-3339 standards. This time must be between 7 to 30 days from the time
-        when the request is received. If the property is missing, it will be set to 30 days from request time by default.
+        An optional property to indicate the deletion time of the vault, expressed in `RFC 3339`__
+        timestamp format. The specified time must be between 7 and 30 days from the time
+        when the request is received. If this property is missing, it will be set to 30 days from the time of the request by default.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_of_deletion: The time_of_deletion of this ScheduleVaultDeletionDetails.

--- a/src/oci/key_management/models/vault.py
+++ b/src/oci/key_management/models/vault.py
@@ -384,7 +384,7 @@ class Vault(object):
     def time_of_deletion(self):
         """
         Gets the time_of_deletion of this Vault.
-        An optional property for the deletion time of the Vault expressed in `RFC 3339`__ timestamp format.
+        An optional property for the deletion time of the vault, expressed in `RFC 3339`__ timestamp format.
         Example: `2018-04-03T21:10:29.600Z`
 
         __ https://tools.ietf.org/html/rfc3339
@@ -399,7 +399,7 @@ class Vault(object):
     def time_of_deletion(self, time_of_deletion):
         """
         Sets the time_of_deletion of this Vault.
-        An optional property for the deletion time of the Vault expressed in `RFC 3339`__ timestamp format.
+        An optional property for the deletion time of the vault, expressed in `RFC 3339`__ timestamp format.
         Example: `2018-04-03T21:10:29.600Z`
 
         __ https://tools.ietf.org/html/rfc3339

--- a/src/oci/key_management/models/vault_summary.py
+++ b/src/oci/key_management/models/vault_summary.py
@@ -135,7 +135,7 @@ class VaultSummary(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this VaultSummary.
-        The OCID of the compartment that contains this vault.
+        The OCID of the compartment that contains a particular vault.
 
 
         :return: The compartment_id of this VaultSummary.
@@ -147,7 +147,7 @@ class VaultSummary(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this VaultSummary.
-        The OCID of the compartment that contains this vault.
+        The OCID of the compartment that contains a particular vault.
 
 
         :param compartment_id: The compartment_id of this VaultSummary.

--- a/src/oci/load_balancer/load_balancer_client_composite_operations.py
+++ b/src/oci/load_balancer/load_balancer_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class LoadBalancerClientCompositeOperations(object):
@@ -395,7 +396,15 @@ class LoadBalancerClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        operation_result = self.client.delete_backend(load_balancer_id, backend_set_name, backend_name, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_backend(load_balancer_id, backend_set_name, backend_name, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -440,7 +449,15 @@ class LoadBalancerClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        operation_result = self.client.delete_backend_set(load_balancer_id, backend_set_name, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_backend_set(load_balancer_id, backend_set_name, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -486,7 +503,15 @@ class LoadBalancerClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        operation_result = self.client.delete_certificate(load_balancer_id, certificate_name, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_certificate(load_balancer_id, certificate_name, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -531,7 +556,15 @@ class LoadBalancerClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        operation_result = self.client.delete_hostname(load_balancer_id, name, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_hostname(load_balancer_id, name, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -576,7 +609,15 @@ class LoadBalancerClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        operation_result = self.client.delete_listener(load_balancer_id, listener_name, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_listener(load_balancer_id, listener_name, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -616,7 +657,15 @@ class LoadBalancerClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        operation_result = self.client.delete_load_balancer(load_balancer_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_load_balancer(load_balancer_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -661,7 +710,15 @@ class LoadBalancerClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        operation_result = self.client.delete_path_route_set(load_balancer_id, path_route_set_name, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_path_route_set(load_balancer_id, path_route_set_name, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -706,7 +763,15 @@ class LoadBalancerClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        operation_result = self.client.delete_rule_set(load_balancer_id, rule_set_name, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_rule_set(load_balancer_id, rule_set_name, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/monitoring/monitoring_client_composite_operations.py
+++ b/src/oci/monitoring/monitoring_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class MonitoringClientCompositeOperations(object):
@@ -80,7 +81,15 @@ class MonitoringClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_alarm(alarm_id)
-        operation_result = self.client.delete_alarm(alarm_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_alarm(alarm_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/object_storage/models/multipart_upload.py
+++ b/src/oci/object_storage/models/multipart_upload.py
@@ -19,7 +19,7 @@ class MultipartUpload(object):
     talk to an administrator. If you are an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    __ https://docs.cloud.oracle.com/Content/Object/Tasks/managingmultipartuploads.htm
+    __ https://docs.cloud.oracle.com/Content/Object/Tasks/usingmultipartuploads.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """
 

--- a/src/oci/object_storage/models/preauthenticated_request.py
+++ b/src/oci/object_storage/models/preauthenticated_request.py
@@ -18,7 +18,7 @@ class PreauthenticatedRequest(object):
     administrator. If you are an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    __ https://docs.cloud.oracle.com/Content/Object/Tasks/managingaccess.htm
+    __ https://docs.cloud.oracle.com/Content/Object/Tasks/usingpreauthenticatedrequests.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """
 

--- a/src/oci/object_storage/models/work_request_error.py
+++ b/src/oci/object_storage/models/work_request_error.py
@@ -53,7 +53,7 @@ class WorkRequestError(object):
         A machine-usable code for the error that occurred. For the list of error codes,
         see `API Errors`__.
 
-        __ https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
+        __ https://docs.cloud.oracle.com/Content/API/References/apierrors.htm
 
 
         :return: The code of this WorkRequestError.
@@ -68,7 +68,7 @@ class WorkRequestError(object):
         A machine-usable code for the error that occurred. For the list of error codes,
         see `API Errors`__.
 
-        __ https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
+        __ https://docs.cloud.oracle.com/Content/API/References/apierrors.htm
 
 
         :param code: The code of this WorkRequestError.

--- a/src/oci/object_storage/object_storage_client.py
+++ b/src/oci/object_storage/object_storage_client.py
@@ -2605,7 +2605,7 @@ class ObjectStorageClient(object):
         Creates a new object or overwrites an existing one. See `Special Instructions for Object Storage
         PUT`__ for request signature requirements.
 
-        __ https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/signingrequests.htm#ObjectStoragePut
+        __ https://docs.cloud.oracle.com/Content/API/Concepts/signingrequests.htm#ObjectStoragePut
 
 
         :param str namespace_name: (required)

--- a/src/oci/object_storage/object_storage_client_composite_operations.py
+++ b/src/oci/object_storage/object_storage_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class ObjectStorageClientCompositeOperations(object):

--- a/src/oci/ons/notification_control_plane_client_composite_operations.py
+++ b/src/oci/ons/notification_control_plane_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class NotificationControlPlaneClientCompositeOperations(object):

--- a/src/oci/ons/notification_data_plane_client_composite_operations.py
+++ b/src/oci/ons/notification_data_plane_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class NotificationDataPlaneClientCompositeOperations(object):
@@ -80,7 +81,15 @@ class NotificationDataPlaneClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_subscription(subscription_id)
-        operation_result = self.client.delete_subscription(subscription_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_subscription(subscription_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/resource_manager/resource_manager_client_composite_operations.py
+++ b/src/oci/resource_manager/resource_manager_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class ResourceManagerClientCompositeOperations(object):
@@ -40,7 +41,15 @@ class ResourceManagerClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_job(job_id)
-        operation_result = self.client.cancel_job(job_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.cancel_job(job_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -155,7 +164,15 @@ class ResourceManagerClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_stack(stack_id)
-        operation_result = self.client.delete_stack(stack_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_stack(stack_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/resource_search/resource_search_client_composite_operations.py
+++ b/src/oci/resource_search/resource_search_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class ResourceSearchClientCompositeOperations(object):

--- a/src/oci/streaming/stream_admin_client_composite_operations.py
+++ b/src/oci/streaming/stream_admin_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class StreamAdminClientCompositeOperations(object):
@@ -78,7 +79,15 @@ class StreamAdminClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_stream(stream_id)
-        operation_result = self.client.delete_stream(stream_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_stream(stream_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/streaming/stream_client_composite_operations.py
+++ b/src/oci/streaming/stream_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class StreamClientCompositeOperations(object):

--- a/src/oci/util.py
+++ b/src/oci/util.py
@@ -130,3 +130,5 @@ class Sentinel(object):
 
 
 NONE_SENTINEL = Sentinel(name='None', truthy=False)
+
+WAIT_RESOURCE_NOT_FOUND = Sentinel(name='WaitResourceNotFound', truthy=False)

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"

--- a/src/oci/waas/waas_client_composite_operations.py
+++ b/src/oci/waas/waas_client_composite_operations.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-import oci   # noqa: F401
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
 
 
 class WaasClientCompositeOperations(object):
@@ -160,7 +161,15 @@ class WaasClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         initial_get_result = self.client.get_certificate(certificate_id)
-        operation_result = self.client.delete_certificate(certificate_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_certificate(certificate_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 
@@ -200,7 +209,15 @@ class WaasClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        operation_result = self.client.delete_waas_policy(waas_policy_id, **operation_kwargs)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_waas_policy(waas_policy_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/waiter.py
+++ b/src/oci/waiter.py
@@ -4,10 +4,8 @@
 import time
 
 from .exceptions import MaximumWaitTimeExceeded, WaitUntilNotSupported, ServiceError
-from .util import Sentinel
+from .util import WAIT_RESOURCE_NOT_FOUND
 from . import retry
-
-WAIT_RESOURCE_NOT_FOUND = Sentinel(name='WaitResourceNotFound', truthy=False)
 
 
 def wait_until(client, response, property=None, state=None, max_interval_seconds=30, max_wait_seconds=1200, succeed_on_not_found=False, **kwargs):


### PR DESCRIPTION
## Added

- Support for provider service key names on virtual circuits in the FastConnect service

- Support for customer reference names on cross connects and cross connect groups in the FastConnect service

- A sample showing how to use Streaming service from the SDK is available on `GitHub <https://github.com/oracle/oci-python-sdk/blob/master/examples/stream_example.py>`__.
