### PR TITLE
Releasing version 2.2.9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+2.2.9 - 2019-05-14
+====================
+
+Added
+-----
+* Support for the Seoul (ICN) region
+* Support for logging context fields on data-plane APIs of the Key Management Service
+* Support for reverse pagination on list operations of the Email service
+* Support for configuring backup retention windows on database backups in the Database service
+* Support for subscribed regions in stop_untagged_instances.py on `GitHub <https://github.com/oracle/oci-python-sdk/blob/master/examples/stop_untagged_instances.py>`__.
+* New services to showoci.py on `GitHub <https://github.com/oracle/oci-python-sdk/blob/master/examples/showoci/showoci.py>`__.
+
+====================
 2.2.8 - 2019-05-07
 ====================
 

--- a/README-development.rst
+++ b/README-development.rst
@@ -64,6 +64,23 @@ variables to be set:
 
     * ``OCI_PYSDK_PUBLIC_SSH_KEY_FILE``: path to a public SSH key (.pub file) that will be given access to the instance launched in ``test_launch_instance_tutorial.py``.
 
+
+Checking Style
+==============
+The Python SDK adheres to PEP8 style guilds and uses Flake8 to validate style.  There are some exceptions and they can
+be viewed in the ``setup.cfg`` file.
+
+If you run tox with no environment specified Flake8 will be run.  You can also run flake8 with no arguments to check
+the style consistency for the whole project.  If you want to check a single file you can run flake8 with a path to the
+file to check.
+
+.. code-block:: sh
+    flake8 path/to/python_file_to_check.py
+
+If flake8 is not found, make sure you have ``requirements.txt`` installed into your virtualenv.  See the
+"Getting Started" section.
+
+
 Generating Documentation
 ========================
 Sphinx is used for documentation. You can generate HTML locally with the following:

--- a/examples/add_API_key.py
+++ b/examples/add_API_key.py
@@ -1,3 +1,6 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
 import oci
 import sys
 import os.path

--- a/examples/showoci/CHANGELOG.rst
+++ b/examples/showoci/CHANGELOG.rst
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+19.5.13 - 2019-05-13
+====================
+
+Added
+-----
+* Option to print nice to screen + JSON file using -sjf switch
+* Added summary to JSON output file or screen
+* Added Monitoring Service
+* Added Notifications Service
+* Added Edge Services (Healthcheck)
+* Added Announcement
+* Added Array check for service availability to support Tokyo
+
+====================
 19.4.23 - 2019-04-23
 ====================
 

--- a/examples/stop_untagged_instances.py
+++ b/examples/stop_untagged_instances.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
 # This example demonstrates how to find, stop and report on instances that have
@@ -54,12 +55,12 @@ def stop_resource(instance_id, region):
 
 
 # determines the list of subscribed regions for the tenancy
-def list_of_regions():
+def list_of_regions(tenancy_id):
     identity = oci.identity.IdentityClient(config)
     list_of_regions = []
-    list_regions_response = identity.list_regions()
+    list_regions_response = identity.list_region_subscriptions(tenancy_id)
     for r in list_regions_response.data:
-        list_of_regions.append(r.name)
+        list_of_regions.append(r.region_name)
     return list_of_regions
 
 
@@ -67,7 +68,7 @@ def list_of_regions():
 # from the find_resources_wo_tags function.  The LaunchInstance events give it the principal (usually email) of the
 # 'person' who started the resource and joins it to the exisitng instances_to_stop so it now contains the email of who
 # started it.
-def find_audit_events(instances_to_stop, instance_stop_list, compartment_id_stop_list):
+def find_audit_events(instances_to_stop, instance_stop_list, compartment_id_stop_list, tenancy_id):
     end_time = datetime.datetime.utcnow()
     start_time = end_time + datetime.timedelta(hours=-int(audit_hours))
     list_of_audit_events = []
@@ -76,7 +77,7 @@ def find_audit_events(instances_to_stop, instance_stop_list, compartment_id_stop
     print('\nGetting list of audit events for the last {0} hour(s).' .format(audit_hours))
 
     # Finding all Resources in a region
-    region_list = list_of_regions()
+    region_list = list_of_regions(tenancy_id)
     for region in region_list:
         audit.base_client.set_region(region)
 
@@ -109,14 +110,14 @@ def find_audit_events(instances_to_stop, instance_stop_list, compartment_id_stop
 # For any resources that are in the correct state and that are either missing tags entirely or not tag correctly.
 # It records those which are going to be stopped and calls stop_resource with a list of all compute instances to be
 # stopped.
-def find_resources_wo_tags(instances_to_stop_list, search_string):
+def find_resources_wo_tags(instances_to_stop_list, search_string, tenancy_id):
     instances_stop_list = []
     compartment_id_stop_list = []
     search_client = oci.resource_search.ResourceSearchClient(config)
     compute_client = oci.core.ComputeClient(config)
 
     # Finding all Resources in a region
-    region_list = list_of_regions()
+    region_list = list_of_regions(tenancy_id)
     for region in region_list:
         print('Searching RQS to find mis-tagged resources in Region:{0}' .format(region))
         try:
@@ -161,7 +162,7 @@ def find_resources_wo_tags(instances_to_stop_list, search_string):
 
     # Only find audit events for  those compartments with a stopped instance
     if len(instances_to_stop_list) != 0:
-        find_audit_events(instances_to_stop_list, instances_stop_list, compartment_id_stop_list)
+        find_audit_events(instances_to_stop_list, instances_stop_list, compartment_id_stop_list, tenancy_id)
 
 
 # A helper function that processes the two arguments for this program.  Tag_string is the string that is searched for.
@@ -176,13 +177,14 @@ def prep_arguments():
 
 if __name__ == "__main__":
     # Starts a timer for the execution time.
-    print('Stop the Untagged v0.6')
+    print('Stop the Untagged v0.61')
     start_time = datetime.datetime.now()
     print('Start Time: {0}'.format(start_time.replace(microsecond=0).isoformat()))
 
     config = oci.config.from_file()
     identity_client = oci.identity.IdentityClient(config)
 
+    tenancy_id = config['tenancy']
     # Set the search_string and audit_hours from arguments
     args = prep_arguments()
     search_string = args.tag_string
@@ -197,7 +199,7 @@ if __name__ == "__main__":
     instances_to_stop.append(instance_line)
 
     # This is the main function that finds any instance that's not tagged with the search_string
-    find_resources_wo_tags(instances_to_stop, search_string)
+    find_resources_wo_tags(instances_to_stop, search_string, tenancy_id)
 
     # Completes the program and shows the duration of the run
     end_time = datetime.datetime.now()

--- a/src/oci/database/models/db_backup_config.py
+++ b/src/oci/database/models/db_backup_config.py
@@ -24,16 +24,23 @@ class DbBackupConfig(object):
             The value to assign to the auto_backup_enabled property of this DbBackupConfig.
         :type auto_backup_enabled: bool
 
+        :param recovery_window_in_days:
+            The value to assign to the recovery_window_in_days property of this DbBackupConfig.
+        :type recovery_window_in_days: int
+
         """
         self.swagger_types = {
-            'auto_backup_enabled': 'bool'
+            'auto_backup_enabled': 'bool',
+            'recovery_window_in_days': 'int'
         }
 
         self.attribute_map = {
-            'auto_backup_enabled': 'autoBackupEnabled'
+            'auto_backup_enabled': 'autoBackupEnabled',
+            'recovery_window_in_days': 'recoveryWindowInDays'
         }
 
         self._auto_backup_enabled = None
+        self._recovery_window_in_days = None
 
     @property
     def auto_backup_enabled(self):
@@ -58,6 +65,34 @@ class DbBackupConfig(object):
         :type: bool
         """
         self._auto_backup_enabled = auto_backup_enabled
+
+    @property
+    def recovery_window_in_days(self):
+        """
+        Gets the recovery_window_in_days of this DbBackupConfig.
+        Number of days between the current and the earliest point of recoverability covered by automatic backups.
+        This value applies to automatic backups only. After a new automatic backup has been created, Oracle removes old automatic backups that are created before the window.
+        When the value is updated, it is applied to all existing automatic backups.
+
+
+        :return: The recovery_window_in_days of this DbBackupConfig.
+        :rtype: int
+        """
+        return self._recovery_window_in_days
+
+    @recovery_window_in_days.setter
+    def recovery_window_in_days(self, recovery_window_in_days):
+        """
+        Sets the recovery_window_in_days of this DbBackupConfig.
+        Number of days between the current and the earliest point of recoverability covered by automatic backups.
+        This value applies to automatic backups only. After a new automatic backup has been created, Oracle removes old automatic backups that are created before the window.
+        When the value is updated, it is applied to all existing automatic backups.
+
+
+        :param recovery_window_in_days: The recovery_window_in_days of this DbBackupConfig.
+        :type: int
+        """
+        self._recovery_window_in_days = recovery_window_in_days
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/email/email_client.py
+++ b/src/oci/email/email_client.py
@@ -529,8 +529,11 @@ class EmailClient(object):
             The email address of the approved sender.
 
         :param str page: (optional)
-            The value of the `opc-next-page` response header from the previous
-            GET request.
+            For list pagination. The value of the opc-next-page response header from the previous \"List\" call.
+            For important details about how pagination works,
+            see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a
@@ -679,8 +682,11 @@ class EmailClient(object):
             **Example:** 2016-12-19T16:39:57.600Z
 
         :param str page: (optional)
-            The value of the `opc-next-page` response header from the previous
-            GET request.
+            For list pagination. The value of the opc-next-page response header from the previous \"List\" call.
+            For important details about how pagination works,
+            see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a

--- a/src/oci/key_management/kms_crypto_client.py
+++ b/src/oci/key_management/kms_crypto_client.py
@@ -71,7 +71,7 @@ class KmsCryptoClient(object):
             'regional_client': False,
             'service_endpoint': service_endpoint,
             'timeout': kwargs.get('timeout'),
-            'base_path': '/',
+            'base_path': '/20180608',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("kms_crypto", config, signer, key_management_type_mapping, **base_client_init_kwargs)
@@ -102,7 +102,7 @@ class KmsCryptoClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.DecryptedData`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/decrypt"
+        resource_path = "/decrypt"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -169,7 +169,7 @@ class KmsCryptoClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.EncryptedData`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/encrypt"
+        resource_path = "/encrypt"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -234,7 +234,7 @@ class KmsCryptoClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.GeneratedKey`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/generateDataEncryptionKey"
+        resource_path = "/generateDataEncryptionKey"
         method = "POST"
 
         # Don't accept unknown kwargs

--- a/src/oci/key_management/kms_management_client.py
+++ b/src/oci/key_management/kms_management_client.py
@@ -71,7 +71,7 @@ class KmsManagementClient(object):
             'regional_client': False,
             'service_endpoint': service_endpoint,
             'timeout': kwargs.get('timeout'),
-            'base_path': '/',
+            'base_path': '/20180608',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("kms_management", config, signer, key_management_type_mapping, **base_client_init_kwargs)
@@ -110,7 +110,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Key`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/keys"
+        resource_path = "/keys"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -188,7 +188,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.KeyVersion`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/keys/{keyId}/keyVersions"
+        resource_path = "/keys/{keyId}/keyVersions"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -283,7 +283,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Key`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/keys/{keyId}/actions/disable"
+        resource_path = "/keys/{keyId}/actions/disable"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -380,7 +380,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Key`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/keys/{keyId}/actions/enable"
+        resource_path = "/keys/{keyId}/actions/enable"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -461,7 +461,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Key`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/keys/{keyId}"
+        resource_path = "/keys/{keyId}"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -539,7 +539,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.KeyVersion`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/keys/{keyId}/keyVersions/{keyVersionId}"
+        resource_path = "/keys/{keyId}/keyVersions/{keyVersionId}"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -634,7 +634,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.key_management.models.KeyVersionSummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/keys/{keyId}/keyVersions"
+        resource_path = "/keys/{keyId}/keyVersions"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -756,7 +756,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.key_management.models.KeySummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/keys"
+        resource_path = "/keys"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -860,7 +860,7 @@ class KmsManagementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Key`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/keys/{keyId}"
+        resource_path = "/keys/{keyId}"
         method = "PUT"
 
         # Don't accept unknown kwargs

--- a/src/oci/key_management/kms_vault_client.py
+++ b/src/oci/key_management/kms_vault_client.py
@@ -73,7 +73,7 @@ class KmsVaultClient(object):
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
-            'base_path': '/',
+            'base_path': '/20180608',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("kms_vault", config, signer, key_management_type_mapping, **base_client_init_kwargs)
@@ -121,7 +121,7 @@ class KmsVaultClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Vault`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/vaults/{vaultId}/actions/cancelDeletion"
+        resource_path = "/vaults/{vaultId}/actions/cancelDeletion"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -213,7 +213,7 @@ class KmsVaultClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Vault`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/vaults"
+        resource_path = "/vaults"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -282,7 +282,7 @@ class KmsVaultClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Vault`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/vaults/{vaultId}"
+        resource_path = "/vaults/{vaultId}"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -376,7 +376,7 @@ class KmsVaultClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.key_management.models.VaultSummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/vaults"
+        resource_path = "/vaults"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -487,7 +487,7 @@ class KmsVaultClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Vault`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/vaults/{vaultId}/actions/scheduleDeletion"
+        resource_path = "/vaults/{vaultId}/actions/scheduleDeletion"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -582,7 +582,7 @@ class KmsVaultClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.key_management.models.Vault`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20180608/vaults/{vaultId}"
+        resource_path = "/vaults/{vaultId}"
         method = "PUT"
 
         # Don't accept unknown kwargs

--- a/src/oci/key_management/models/decrypt_data_details.py
+++ b/src/oci/key_management/models/decrypt_data_details.py
@@ -29,22 +29,29 @@ class DecryptDataDetails(object):
             The value to assign to the key_id property of this DecryptDataDetails.
         :type key_id: str
 
+        :param logging_context:
+            The value to assign to the logging_context property of this DecryptDataDetails.
+        :type logging_context: dict(str, str)
+
         """
         self.swagger_types = {
             'associated_data': 'dict(str, str)',
             'ciphertext': 'str',
-            'key_id': 'str'
+            'key_id': 'str',
+            'logging_context': 'dict(str, str)'
         }
 
         self.attribute_map = {
             'associated_data': 'associatedData',
             'ciphertext': 'ciphertext',
-            'key_id': 'keyId'
+            'key_id': 'keyId',
+            'logging_context': 'loggingContext'
         }
 
         self._associated_data = None
         self._ciphertext = None
         self._key_id = None
+        self._logging_context = None
 
     @property
     def associated_data(self):
@@ -121,6 +128,32 @@ class DecryptDataDetails(object):
         :type: str
         """
         self._key_id = key_id
+
+    @property
+    def logging_context(self):
+        """
+        Gets the logging_context of this DecryptDataDetails.
+        Information that can be used to provide context for audit logging. It is a map that contains any addtional
+        data the users may have and will be added to the audit logs (if audit logging is enabled)
+
+
+        :return: The logging_context of this DecryptDataDetails.
+        :rtype: dict(str, str)
+        """
+        return self._logging_context
+
+    @logging_context.setter
+    def logging_context(self, logging_context):
+        """
+        Sets the logging_context of this DecryptDataDetails.
+        Information that can be used to provide context for audit logging. It is a map that contains any addtional
+        data the users may have and will be added to the audit logs (if audit logging is enabled)
+
+
+        :param logging_context: The logging_context of this DecryptDataDetails.
+        :type: dict(str, str)
+        """
+        self._logging_context = logging_context
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/key_management/models/encrypt_data_details.py
+++ b/src/oci/key_management/models/encrypt_data_details.py
@@ -25,6 +25,10 @@ class EncryptDataDetails(object):
             The value to assign to the key_id property of this EncryptDataDetails.
         :type key_id: str
 
+        :param logging_context:
+            The value to assign to the logging_context property of this EncryptDataDetails.
+        :type logging_context: dict(str, str)
+
         :param plaintext:
             The value to assign to the plaintext property of this EncryptDataDetails.
         :type plaintext: str
@@ -33,17 +37,20 @@ class EncryptDataDetails(object):
         self.swagger_types = {
             'associated_data': 'dict(str, str)',
             'key_id': 'str',
+            'logging_context': 'dict(str, str)',
             'plaintext': 'str'
         }
 
         self.attribute_map = {
             'associated_data': 'associatedData',
             'key_id': 'keyId',
+            'logging_context': 'loggingContext',
             'plaintext': 'plaintext'
         }
 
         self._associated_data = None
         self._key_id = None
+        self._logging_context = None
         self._plaintext = None
 
     @property
@@ -97,6 +104,32 @@ class EncryptDataDetails(object):
         :type: str
         """
         self._key_id = key_id
+
+    @property
+    def logging_context(self):
+        """
+        Gets the logging_context of this EncryptDataDetails.
+        Information that can be used to provide context for audit logging. It is a map that contains any addtional
+        data the users may have and will be added to the audit logs (if audit logging is enabled)
+
+
+        :return: The logging_context of this EncryptDataDetails.
+        :rtype: dict(str, str)
+        """
+        return self._logging_context
+
+    @logging_context.setter
+    def logging_context(self, logging_context):
+        """
+        Sets the logging_context of this EncryptDataDetails.
+        Information that can be used to provide context for audit logging. It is a map that contains any addtional
+        data the users may have and will be added to the audit logs (if audit logging is enabled)
+
+
+        :param logging_context: The logging_context of this EncryptDataDetails.
+        :type: dict(str, str)
+        """
+        self._logging_context = logging_context
 
     @property
     def plaintext(self):

--- a/src/oci/key_management/models/generate_key_details.py
+++ b/src/oci/key_management/models/generate_key_details.py
@@ -33,25 +33,32 @@ class GenerateKeyDetails(object):
             The value to assign to the key_shape property of this GenerateKeyDetails.
         :type key_shape: KeyShape
 
+        :param logging_context:
+            The value to assign to the logging_context property of this GenerateKeyDetails.
+        :type logging_context: dict(str, str)
+
         """
         self.swagger_types = {
             'associated_data': 'dict(str, str)',
             'include_plaintext_key': 'bool',
             'key_id': 'str',
-            'key_shape': 'KeyShape'
+            'key_shape': 'KeyShape',
+            'logging_context': 'dict(str, str)'
         }
 
         self.attribute_map = {
             'associated_data': 'associatedData',
             'include_plaintext_key': 'includePlaintextKey',
             'key_id': 'keyId',
-            'key_shape': 'keyShape'
+            'key_shape': 'keyShape',
+            'logging_context': 'loggingContext'
         }
 
         self._associated_data = None
         self._include_plaintext_key = None
         self._key_id = None
         self._key_shape = None
+        self._logging_context = None
 
     @property
     def associated_data(self):
@@ -148,6 +155,32 @@ class GenerateKeyDetails(object):
         :type: KeyShape
         """
         self._key_shape = key_shape
+
+    @property
+    def logging_context(self):
+        """
+        Gets the logging_context of this GenerateKeyDetails.
+        Information that can be used to provide context for audit logging. It is a map that contains any addtional
+        data the users may have and will be added to the audit logs (if audit logging is enabled)
+
+
+        :return: The logging_context of this GenerateKeyDetails.
+        :rtype: dict(str, str)
+        """
+        return self._logging_context
+
+    @logging_context.setter
+    def logging_context(self, logging_context):
+        """
+        Sets the logging_context of this GenerateKeyDetails.
+        Information that can be used to provide context for audit logging. It is a map that contains any addtional
+        data the users may have and will be added to the audit logs (if audit logging is enabled)
+
+
+        :param logging_context: The logging_context of this GenerateKeyDetails.
+        :type: dict(str, str)
+        """
+        self._logging_context = logging_context
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/regions.py
+++ b/src/oci/regions.py
@@ -11,6 +11,7 @@ REGIONS_SHORT_NAMES = {
     'yyz': 'ca-toronto-1'
 }
 REGION_REALMS = {
+    'ap-seoul-1': 'oc1',
     'ap-tokyo-1': 'oc1',
     'us-phoenix-1': 'oc1',
     'us-ashburn-1': 'oc1',
@@ -31,6 +32,7 @@ REALMS = {
     'oc3': 'oraclegovcloud.com'
 }
 REGIONS = [
+    "ap-seoul-1",
     "ap-tokyo-1",
     "us-phoenix-1",
     "us-ashburn-1",

--- a/src/oci/resource_search/resource_search_client.py
+++ b/src/oci/resource_search/resource_search_client.py
@@ -74,6 +74,7 @@ class ResourceSearchClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20180409',
+            'service_endpoint_template': 'https://query.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("resource_search", config, signer, resource_search_type_mapping, **base_client_init_kwargs)

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "2.2.8"
+__version__ = "2.2.9"

--- a/tests/util.py
+++ b/tests/util.py
@@ -220,4 +220,5 @@ def test_config_to_python_config(test_config):
     converted_config['tenancy'] = converted_config.pop('tenant_id')
     converted_config['user'] = converted_config.pop('user_id')
     converted_config['key_content'] = converted_config.pop('key_file_content')
+    converted_config['service_endpoint'] = converted_config.pop('endpoint')
     return converted_config


### PR DESCRIPTION
Added
-----
* Support for the Seoul (ICN) region
* Support for logging context fields on data-plane APIs of the Key Management Service
* Support for reverse pagination on list operations of the Email service
* Support for configuring backup retention windows on database backups in the Database service
* Support for subscribed regions in stop_untagged_instances.py on `GitHub <https://github.com/oracle/oci-python-sdk/blob/master/examples/stop_untagged_instances.py>`__.
* New services to showoci.py on `GitHub <https://github.com/oracle/oci-python-sdk/blob/master/examples/showoci/showoci.py>`__.
