### PR TITLE
Releasing version 2.2.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+2.2.10 - 2019-05-21
+====================
+
+Added
+-----
+* Support for returning tags when listing instance configurations, instance pools, or autoscaling configurations in the Compute Autoscaling service
+* Support for getting the namespace of another tenancy than the caller's tenancy in the Object Storage service
+* Support for BGP dynamic routing and providing pre-shared secrets (PSKs) when establishing tunnels in the Networking service
+
+====================
 2.2.9 - 2019-05-14
 ====================
 

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -37,6 +37,7 @@ Core Services
     oci.core.models.AttachParavirtualizedVolumeDetails
     oci.core.models.AttachVnicDetails
     oci.core.models.AttachVolumeDetails
+    oci.core.models.BgpSessionInfo
     oci.core.models.BootVolume
     oci.core.models.BootVolumeAttachment
     oci.core.models.BootVolumeBackup
@@ -63,6 +64,8 @@ Core Services
     oci.core.models.CreateDrgAttachmentDetails
     oci.core.models.CreateDrgDetails
     oci.core.models.CreateIPSecConnectionDetails
+    oci.core.models.CreateIPSecConnectionTunnelDetails
+    oci.core.models.CreateIPSecTunnelBgpSessionDetails
     oci.core.models.CreateImageDetails
     oci.core.models.CreateInstanceConfigurationDetails
     oci.core.models.CreateInstanceConsoleConnectionDetails
@@ -113,6 +116,8 @@ Core Services
     oci.core.models.IPSecConnection
     oci.core.models.IPSecConnectionDeviceConfig
     oci.core.models.IPSecConnectionDeviceStatus
+    oci.core.models.IPSecConnectionTunnel
+    oci.core.models.IPSecConnectionTunnelSharedSecret
     oci.core.models.IScsiVolumeAttachment
     oci.core.models.IcmpOptions
     oci.core.models.Image
@@ -189,6 +194,9 @@ Core Services
     oci.core.models.UpdateDrgAttachmentDetails
     oci.core.models.UpdateDrgDetails
     oci.core.models.UpdateIPSecConnectionDetails
+    oci.core.models.UpdateIPSecConnectionTunnelDetails
+    oci.core.models.UpdateIPSecConnectionTunnelSharedSecretDetails
+    oci.core.models.UpdateIPSecTunnelBgpSessionDetails
     oci.core.models.UpdateImageDetails
     oci.core.models.UpdateInstanceAgentConfigDetails
     oci.core.models.UpdateInstanceConfigurationDetails

--- a/docs/api/core/models/oci.core.models.BgpSessionInfo.rst
+++ b/docs/api/core/models/oci.core.models.BgpSessionInfo.rst
@@ -1,0 +1,11 @@
+BgpSessionInfo
+==============
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: BgpSessionInfo
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.CreateIPSecConnectionTunnelDetails.rst
+++ b/docs/api/core/models/oci.core.models.CreateIPSecConnectionTunnelDetails.rst
@@ -1,0 +1,11 @@
+CreateIPSecConnectionTunnelDetails
+==================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: CreateIPSecConnectionTunnelDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.CreateIPSecTunnelBgpSessionDetails.rst
+++ b/docs/api/core/models/oci.core.models.CreateIPSecTunnelBgpSessionDetails.rst
@@ -1,0 +1,11 @@
+CreateIPSecTunnelBgpSessionDetails
+==================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: CreateIPSecTunnelBgpSessionDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.IPSecConnectionTunnel.rst
+++ b/docs/api/core/models/oci.core.models.IPSecConnectionTunnel.rst
@@ -1,0 +1,11 @@
+IPSecConnectionTunnel
+=====================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: IPSecConnectionTunnel
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.IPSecConnectionTunnelSharedSecret.rst
+++ b/docs/api/core/models/oci.core.models.IPSecConnectionTunnelSharedSecret.rst
@@ -1,0 +1,11 @@
+IPSecConnectionTunnelSharedSecret
+=================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: IPSecConnectionTunnelSharedSecret
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.UpdateIPSecConnectionTunnelDetails.rst
+++ b/docs/api/core/models/oci.core.models.UpdateIPSecConnectionTunnelDetails.rst
@@ -1,0 +1,11 @@
+UpdateIPSecConnectionTunnelDetails
+==================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: UpdateIPSecConnectionTunnelDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.UpdateIPSecConnectionTunnelSharedSecretDetails.rst
+++ b/docs/api/core/models/oci.core.models.UpdateIPSecConnectionTunnelSharedSecretDetails.rst
@@ -1,0 +1,11 @@
+UpdateIPSecConnectionTunnelSharedSecretDetails
+==============================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: UpdateIPSecConnectionTunnelSharedSecretDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.UpdateIPSecTunnelBgpSessionDetails.rst
+++ b/docs/api/core/models/oci.core.models.UpdateIPSecTunnelBgpSessionDetails.rst
@@ -1,0 +1,11 @@
+UpdateIPSecTunnelBgpSessionDetails
+==================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: UpdateIPSecTunnelBgpSessionDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/container_engine.py
+++ b/examples/container_engine.py
@@ -299,7 +299,9 @@ def create_vcn(vn_client, ads, number_of_worker_subnets=3, number_of_lb_subnets=
     print('Gateway Id: {}'.format(gateway_id))
 
     # Setup the route table
-    route_table_rule = oci.core.models.RouteRule(cidr_block='0.0.0.0/0',
+    route_table_rule = oci.core.models.RouteRule(cidr_block=None,
+                                                 destination='0.0.0.0/0',
+                                                 destination_type='CIDR_BLOCK',
                                                  network_entity_id=gateway_id)
 
     route_table_details = oci.core.models.CreateRouteTableDetails(compartment_id=compartment_id,

--- a/examples/launch_instance_example.py
+++ b/examples/launch_instance_example.py
@@ -151,7 +151,9 @@ def add_route_rule_to_default_route_table_for_internet_gateway(virtual_network, 
     # them back to the service as part of any update
     route_rules.append(
         oci.core.models.RouteRule(
-            cidr_block='0.0.0.0/0',
+            cidr_block=None,
+            destination='0.0.0.0/0',
+            destination_type='CIDR_BLOCK',
             network_entity_id=internet_gateway.id
         )
     )

--- a/examples/launch_instance_pv_encryption_intransit_example.py
+++ b/examples/launch_instance_pv_encryption_intransit_example.py
@@ -141,7 +141,9 @@ def add_route_rule_to_default_route_table_for_internet_gateway(virtual_network, 
     # them back to the service as part of any update
     route_rules.append(
         oci.core.models.RouteRule(
-            cidr_block='0.0.0.0/0',
+            cidr_block=None,
+            destination='0.0.0.0/0',
+            destination_type='CIDR_BLOCK',
             network_entity_id=internet_gateway.id
         )
     )

--- a/examples/object_storage_getnamespace_example.py
+++ b/examples/object_storage_getnamespace_example.py
@@ -1,0 +1,42 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+# This script provides a basic example of how to get Object Storage namespace of a tenancy that is not their own. This
+# is useful in cross-tenant Object Storage operations. Object Storage namespace can be retrieved using the
+# compartment id of the target tenancy if the user has necessary permissions to access that tenancy.
+#
+# For example if Tenant A wants to access Tenant B's object storage namespace then Tenant A has to define
+# a policy similar to following:
+#
+# DEFINE TENANCY TenantB AS <TenantB OCID>
+# ENDORSE GROUP <TenantA user group OCID> TO {TENANCY_INSPECT} IN TENANCY TenantB
+#
+# and Tenant B should add a policy similar to following:
+#
+# DEFINE TENANCY TenantA AS <TenantA OCID>
+# DEFINE GROUP TenantAGroup AS <TenantA user group OCID>
+# ADMIT GROUP TenantAGroup OF TENANCY TenantA TO {TENANCY_INSPECT} IN TENANCY
+#
+# This example covers only GetNamespace operation across tenants. Additional permissions
+# will be required to perform more Object Storage operations.
+#
+# This script accepts one argument:
+#
+#   * The OCID of the compartment for which namespace should be retrieved
+
+import oci
+import sys
+
+if len(sys.argv) != 2:
+    raise RuntimeError('Unexpected number of arguments received. Consult the script header comments for expected arguments')
+
+compartment_id = sys.argv[1]
+
+# Default config file and profile
+config = oci.config.from_file()
+object_storage_client = oci.object_storage.ObjectStorageClient(config)
+
+namespace = object_storage_client.get_namespace(compartment_id=compartment_id).data
+
+print('Object storage namespace for compartment id {} is: {}'.format(compartment_id, namespace))
+print('\n=========================\n')

--- a/examples/showoci/CHANGELOG.rst
+++ b/examples/showoci/CHANGELOG.rst
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+19.5.20 - 2019-05-20
+====================
+
+Added
+-----
+* Added Array check for service availability to support Seoul
+* Added run_daily_report.sh for daily crontab use
+
+====================
 19.5.13 - 2019-05-13
 ====================
 

--- a/examples/showoci/run_daily_report.sh
+++ b/examples/showoci/run_daily_report.sh
@@ -1,0 +1,52 @@
+#!/bin/ksh
+#############################################################################################################################
+# Author - Adi Zohar, May 15th 2019
+#
+# Run daily report for crontab use
+# Generates daily report including JSON file
+#
+# Amend APPDIR, PYTHONPATH and REPORT_DIR
+#
+# Crontab set:
+# 0 0 * * * timeout 6h /home/opc/showoci/run_daily_report.sh > /home/opc/showoci/run_daily_report_crontab_run.txt 2>&1
+#############################################################################################################################
+export DATE=`date '+%Y%m%d'`
+export APPDIR=$HOME/showoci
+export PYTHONPATH=$HOME/python
+export REPORT_DIR=${APPDIR}/report
+export PATH=${PYTHONPATH}/bin:$PATH
+mkdir -p ${REPORT_DIR}
+
+##################################
+# Run Report
+##################################
+OUTPUT_FILE=${REPORT_DIR}/${DATE}_showoci_report.txt
+JSON_FILE=${REPORT_DIR}/${DATE}_showoci_report.json.txt
+
+echo "###################################################################################"
+echo "# Start running showoci at `date`"
+echo "# Output File = $OUTPUT_FILE"
+echo "# JSON   File = $JSON_FILE"
+echo "###################################################################################"
+echo "Please Wait ..."
+python3 $APPDIR/showoci.py -ani -sjf $JSON_FILE > $OUTPUT_FILE 2>&1
+
+# Print Errors on screen
+grep -i Error $OUTPUT_FILE
+
+# Print Status
+ERROR=""
+WARNING=""
+(( `grep -i Error $OUTPUT_FILE | wc -l` > 0 )) && ERROR=", with **** Errors ****"
+(( `grep -i "Service Warning" $OUTPUT_FILE | wc -l` > 0 )) && WARNING=", with **** Warnings ****"
+
+echo ""
+echo "###################################################################################"
+echo "# Finished at `date` $ERROR $WARNING "
+echo "###################################################################################"
+
+####################################################
+# Cleanup - Gzip after 7 days, delete after 180
+####################################################
+/usr/bin/find ${REPORT_DIR} -name "*showoci_report*.txt" -mtime +7  -exec gzip '{}' \;
+/usr/bin/find ${REPORT_DIR} -name "*showoci_report*.txt" -mtime +180 -exec rm -f '{}' \;

--- a/examples/showoci/showoci.py
+++ b/examples/showoci/showoci.py
@@ -62,7 +62,7 @@ import sys
 import argparse
 import datetime
 
-version = "19.5.13"
+version = "19.5.20"
 
 ##########################################################################
 # execute_extract

--- a/examples/showoci/showoci_data.py
+++ b/examples/showoci/showoci_data.py
@@ -1942,7 +1942,7 @@ class ShowOCIData(object):
                     ssl_details = " - Cert: " + lo['ssl_configuration']
 
                 # add data
-                datalis.append(lo['id'] + " - " + str(lo['port']) + "/" + str(lo['protocol']) + " - Default BS: " + str(lo['default_backend_set_name']) + ssl_details)
+                datalis.append(lo['id'].ljust(20) + " - " + str(lo['port']) + "/" + str(lo['protocol']) + " - Default BS: " + str(lo['default_backend_set_name']) + ssl_details)
             data['listeners'] = datalis
 
             return data

--- a/examples/showoci/showoci_service.py
+++ b/examples/showoci/showoci_service.py
@@ -235,7 +235,13 @@ class ShowOCIService(object):
         {'ap-tokyo-1', C_MONITORING},
         {'ap-tokyo-1', C_COMPUTE_AUTOSCALING},
         {'ap-tokyo-1', C_STREAMS},
-        {'ap-tokyo-1', C_NOTIFICATIONS}
+        {'ap-tokyo-1', C_NOTIFICATIONS},
+        {'ap-seoul-1', C_EMAIL},
+        {'ap-seoul-1', C_EDGE},
+        {'ap-seoul-1', C_MONITORING},
+        {'ap-seoul-1', C_COMPUTE_AUTOSCALING},
+        {'ap-seoul-1', C_STREAMS},
+        {'ap-seoul-1', C_NOTIFICATIONS}
     ]
 
     ##########################################################################
@@ -1017,6 +1023,7 @@ class ShowOCIService(object):
         start_time = time.time()
 
         try:
+            tags = []
             try:
                 tags = oci.pagination.list_call_get_all_results(identity.list_cost_tracking_tags, tenancy_id).data
             except oci.exceptions.ServiceError as e:
@@ -3522,7 +3529,7 @@ class ShowOCIService(object):
                     datahosts = []
                     for hostname in arr.hostnames:
                         ho = arr.hostnames[hostname]
-                        datahosts.append(str(ho.name) + " - " + str(ho.hostname))
+                        datahosts.append(str(ho.name).ljust(20) + " - " + str(ho.hostname))
                     val['hostnames'] = datahosts
 
                     # check boot volume backup policy

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ requires = [
     "configparser>=3.5.0b1",
     "cryptography>=2.1.4",
     "pyOpenSSL>=17.5.0",
-    "python-dateutil>=2.5.3,<=2.7.3",
+    "python-dateutil>=2.5.3,<3.0.0",
     "pytz>=2016.10",
 ]
 

--- a/src/oci/autoscaling/auto_scaling_client.py
+++ b/src/oci/autoscaling/auto_scaling_client.py
@@ -17,7 +17,8 @@ missing = Sentinel("Missing")
 
 class AutoScalingClient(object):
     """
-    Auto Scaling API spec
+    APIs for dynamically scaling Compute resources to meet application requirements.
+    For information about the Compute service, see [Overview of the Compute Service](/Content/Compute/Concepts/computeoverview.htm).
     """
 
     def __init__(self, config, **kwargs):
@@ -83,11 +84,11 @@ class AutoScalingClient(object):
     def create_auto_scaling_configuration(self, create_auto_scaling_configuration_details, **kwargs):
         """
         CreateAutoScalingConfiguration
-        Create an AutoScalingConfiguration
+        Creates an autoscaling configuration.
 
 
         :param CreateAutoScalingConfigurationDetails create_auto_scaling_configuration_details: (required)
-            AutoScalingConfiguration creation details
+            Creation details for an autoscaling configuration.
 
         :param str opc_request_id: (optional)
 
@@ -156,14 +157,16 @@ class AutoScalingClient(object):
     def create_auto_scaling_policy(self, auto_scaling_configuration_id, create_auto_scaling_policy_details, **kwargs):
         """
         CreateAutoScalingPolicy
-        Create a Policy for AutoScalingConfiguration
+        Creates an autoscaling policy for the specified autoscaling configuration.
 
 
         :param str auto_scaling_configuration_id: (required)
-            The OCID of the auto scaling configuration.
+            The `OCID`__ of the autoscaling configuration.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param CreateAutoScalingPolicyDetails create_auto_scaling_policy_details: (required)
-            AutoScalingConfiguration Policy creation details
+            Creation details for an autoscaling policy.
 
         :param str opc_request_id: (optional)
 
@@ -244,11 +247,13 @@ class AutoScalingClient(object):
     def delete_auto_scaling_configuration(self, auto_scaling_configuration_id, **kwargs):
         """
         DeleteAutoScalingConfiguration
-        Deletes an AutoScalingConfiguration
+        Deletes an autoscaling configuration.
 
 
         :param str auto_scaling_configuration_id: (required)
-            The OCID of the auto scaling configuration.
+            The `OCID`__ of the autoscaling configuration.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
@@ -321,14 +326,16 @@ class AutoScalingClient(object):
     def delete_auto_scaling_policy(self, auto_scaling_configuration_id, auto_scaling_policy_id, **kwargs):
         """
         DeleteAutoScalingPolicy
-        Deletes an AutoScalingConfiguration Policy
+        Deletes an autoscaling policy for the specified autoscaling configuration.
 
 
         :param str auto_scaling_configuration_id: (required)
-            The OCID of the auto scaling configuration.
+            The `OCID`__ of the autoscaling configuration.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str auto_scaling_policy_id: (required)
-            The ID of the auto scaling configuration policy.
+            The ID of the autoscaling policy.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
@@ -402,11 +409,13 @@ class AutoScalingClient(object):
     def get_auto_scaling_configuration(self, auto_scaling_configuration_id, **kwargs):
         """
         GetAutoScalingConfiguration
-        Get AutoScalingConfiguration
+        Gets information about the specified autoscaling configuration.
 
 
         :param str auto_scaling_configuration_id: (required)
-            The OCID of the auto scaling configuration.
+            The `OCID`__ of the autoscaling configuration.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
 
@@ -474,14 +483,16 @@ class AutoScalingClient(object):
     def get_auto_scaling_policy(self, auto_scaling_configuration_id, auto_scaling_policy_id, **kwargs):
         """
         GetAutoScalingPolicy
-        Get Policy from a specific AutoScalingConfiguration
+        Gets information about the specified autoscaling policy in the specified autoscaling configuration.
 
 
         :param str auto_scaling_configuration_id: (required)
-            The OCID of the auto scaling configuration.
+            The `OCID`__ of the autoscaling configuration.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str auto_scaling_policy_id: (required)
-            The ID of the auto scaling configuration policy.
+            The ID of the autoscaling policy.
 
         :param str opc_request_id: (optional)
 
@@ -550,7 +561,7 @@ class AutoScalingClient(object):
     def list_auto_scaling_configurations(self, compartment_id, **kwargs):
         """
         ListAutoScalingConfigurations
-        Lists AutoScalingConfigurations in the specific compartment.
+        Lists autoscaling configurations in the specifed compartment.
 
 
         :param str compartment_id: (required)
@@ -566,16 +577,16 @@ class AutoScalingClient(object):
         :param str opc_request_id: (optional)
 
         :param int limit: (optional)
-            The maximum number of items to return in a paginated \"List\" call. For information about pagination, see
-            `List Pagination`__.
+            For list pagination. The maximum number of items to return in a paginated \"List\" call. For important details
+            about how pagination works, see `List Pagination`__.
 
-            __ https://docs.cloud.oracle.com/#API/Concepts/usingapi.htm#List_Pagination
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            The value of the `opc-next-page` response header from the previous \"List\" call. For information about
-            pagination, see `List Pagination`__.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+            details about how pagination works, see `List Pagination`__.
 
-            __ https://docs.cloud.oracle.com/#API/Concepts/usingapi.htm#List_Pagination
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_by: (optional)
             The field to sort by. You can provide one sort order (`sortOrder`). Default order for
@@ -673,11 +684,13 @@ class AutoScalingClient(object):
     def list_auto_scaling_policies(self, auto_scaling_configuration_id, **kwargs):
         """
         ListAutoScalingPolicies
-        Lists Policies in an AutoScalingConfiguration.
+        Lists the autoscaling policies in the specified autoscaling configuration.
 
 
         :param str auto_scaling_configuration_id: (required)
-            The OCID of the auto scaling configuration.
+            The `OCID`__ of the autoscaling configuration.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str display_name: (optional)
             A filter to return only resources that match the given display name exactly.
@@ -685,16 +698,16 @@ class AutoScalingClient(object):
         :param str opc_request_id: (optional)
 
         :param int limit: (optional)
-            The maximum number of items to return in a paginated \"List\" call. For information about pagination, see
-            `List Pagination`__.
+            For list pagination. The maximum number of items to return in a paginated \"List\" call. For important details
+            about how pagination works, see `List Pagination`__.
 
-            __ https://docs.cloud.oracle.com/#API/Concepts/usingapi.htm#List_Pagination
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            The value of the `opc-next-page` response header from the previous \"List\" call. For information about
-            pagination, see `List Pagination`__.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+            details about how pagination works, see `List Pagination`__.
 
-            __ https://docs.cloud.oracle.com/#API/Concepts/usingapi.htm#List_Pagination
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_by: (optional)
             The field to sort by. You can provide one sort order (`sortOrder`). Default order for
@@ -803,14 +816,17 @@ class AutoScalingClient(object):
     def update_auto_scaling_configuration(self, auto_scaling_configuration_id, update_auto_scaling_configuration_details, **kwargs):
         """
         UpdateAutoScalingConfiguration
-        Updates an AutoScalingConfiguration
+        Updates certain fields on the specified autoscaling configuration, such as the name, the cooldown period,
+        and whether the autoscaling configuration is enabled.
 
 
         :param str auto_scaling_configuration_id: (required)
-            The OCID of the auto scaling configuration.
+            The `OCID`__ of the autoscaling configuration.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param UpdateAutoScalingConfigurationDetails update_auto_scaling_configuration_details: (required)
-            AutoScalingConfiguration update details
+            Update details for an autoscaling configuration.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
@@ -898,17 +914,19 @@ class AutoScalingClient(object):
     def update_auto_scaling_policy(self, auto_scaling_configuration_id, auto_scaling_policy_id, update_auto_scaling_policy_details, **kwargs):
         """
         UpdateAutoScalingPolicy
-        Updates a Policy in the specific AutoScalingConfiguration
+        Updates an autoscaling policy in the specified autoscaling configuration.
 
 
         :param str auto_scaling_configuration_id: (required)
-            The OCID of the auto scaling configuration.
+            The `OCID`__ of the autoscaling configuration.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str auto_scaling_policy_id: (required)
-            The ID of the auto scaling configuration policy.
+            The ID of the autoscaling policy.
 
         :param UpdateAutoScalingPolicyDetails update_auto_scaling_policy_details: (required)
-            AutoScalingConfiguration Policy update details
+            Update details for an autoscaling policy.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`

--- a/src/oci/autoscaling/models/action.py
+++ b/src/oci/autoscaling/models/action.py
@@ -9,8 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Action(object):
     """
-    The action to take if a scale event has been triggered. Positive values indicate scale out
-    and negative value indicate scale in.
+    The action to take when autoscaling is triggered.
     """
 
     #: A constant which can be used with the type property of a Action.
@@ -50,7 +49,7 @@ class Action(object):
     def type(self):
         """
         **[Required]** Gets the type of this Action.
-        Action type to take
+        The type of action to take.
 
         Allowed values for this property are: "CHANGE_COUNT_BY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -65,7 +64,7 @@ class Action(object):
     def type(self, type):
         """
         Sets the type of this Action.
-        Action type to take
+        The type of action to take.
 
 
         :param type: The type of this Action.
@@ -80,6 +79,9 @@ class Action(object):
     def value(self):
         """
         **[Required]** Gets the value of this Action.
+        To scale out (increase the number of instances), provide a positive value. To scale in (decrease the number of
+        instances), provide a negative value.
+
 
         :return: The value of this Action.
         :rtype: int
@@ -90,6 +92,9 @@ class Action(object):
     def value(self, value):
         """
         Sets the value of this Action.
+        To scale out (increase the number of instances), provide a positive value. To scale in (decrease the number of
+        instances), provide a negative value.
+
 
         :param value: The value of this Action.
         :type: int

--- a/src/oci/autoscaling/models/auto_scaling_configuration.py
+++ b/src/oci/autoscaling/models/auto_scaling_configuration.py
@@ -9,7 +9,10 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class AutoScalingConfiguration(object):
     """
-    AutoScalingConfiguration model.
+    An autoscaling configuration allows you to dynamically scale the resources in a Compute instance pool.
+    For more information, see `Autoscaling`__.
+
+    __ https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/autoscalinginstancepools.htm
     """
 
     def __init__(self, **kwargs):
@@ -99,7 +102,9 @@ class AutoScalingConfiguration(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this AutoScalingConfiguration.
-        The OCID of the compartment containing the AutoScalingConfiguration.
+        The `OCID`__ of the compartment containing the autoscaling configuration.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this AutoScalingConfiguration.
@@ -111,7 +116,9 @@ class AutoScalingConfiguration(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this AutoScalingConfiguration.
-        The OCID of the compartment containing the AutoScalingConfiguration.
+        The `OCID`__ of the compartment containing the autoscaling configuration.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this AutoScalingConfiguration.
@@ -157,8 +164,7 @@ class AutoScalingConfiguration(object):
     def display_name(self):
         """
         Gets the display_name of this AutoScalingConfiguration.
-        A user-friendly name for the AutoScalingConfiguration. Does not have to be unique, and it's changeable.
-        Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :return: The display_name of this AutoScalingConfiguration.
@@ -170,8 +176,7 @@ class AutoScalingConfiguration(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this AutoScalingConfiguration.
-        A user-friendly name for the AutoScalingConfiguration. Does not have to be unique, and it's changeable.
-        Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this AutoScalingConfiguration.
@@ -217,7 +222,9 @@ class AutoScalingConfiguration(object):
     def id(self):
         """
         **[Required]** Gets the id of this AutoScalingConfiguration.
-        The OCID of the AutoScalingConfiguration
+        The `OCID`__ of the autoscaling configuration.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this AutoScalingConfiguration.
@@ -229,7 +236,9 @@ class AutoScalingConfiguration(object):
     def id(self, id):
         """
         Sets the id of this AutoScalingConfiguration.
-        The OCID of the AutoScalingConfiguration
+        The `OCID`__ of the autoscaling configuration.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this AutoScalingConfiguration.
@@ -241,7 +250,8 @@ class AutoScalingConfiguration(object):
     def cool_down_in_seconds(self):
         """
         Gets the cool_down_in_seconds of this AutoScalingConfiguration.
-        The minimum period of time between scaling actions. The default is 300 seconds.
+        The minimum period of time to wait between scaling actions. The cooldown period gives the system time to stabilize
+        before rescaling. The minimum value is 300 seconds, which is also the default.
 
 
         :return: The cool_down_in_seconds of this AutoScalingConfiguration.
@@ -253,7 +263,8 @@ class AutoScalingConfiguration(object):
     def cool_down_in_seconds(self, cool_down_in_seconds):
         """
         Sets the cool_down_in_seconds of this AutoScalingConfiguration.
-        The minimum period of time between scaling actions. The default is 300 seconds.
+        The minimum period of time to wait between scaling actions. The cooldown period gives the system time to stabilize
+        before rescaling. The minimum value is 300 seconds, which is also the default.
 
 
         :param cool_down_in_seconds: The cool_down_in_seconds of this AutoScalingConfiguration.
@@ -265,7 +276,7 @@ class AutoScalingConfiguration(object):
     def is_enabled(self):
         """
         Gets the is_enabled of this AutoScalingConfiguration.
-        If the AutoScalingConfiguration is enabled
+        Whether the autoscaling configuration is enabled.
 
 
         :return: The is_enabled of this AutoScalingConfiguration.
@@ -277,7 +288,7 @@ class AutoScalingConfiguration(object):
     def is_enabled(self, is_enabled):
         """
         Sets the is_enabled of this AutoScalingConfiguration.
-        If the AutoScalingConfiguration is enabled
+        Whether the autoscaling configuration is enabled.
 
 
         :param is_enabled: The is_enabled of this AutoScalingConfiguration.
@@ -309,7 +320,10 @@ class AutoScalingConfiguration(object):
     def policies(self):
         """
         **[Required]** Gets the policies of this AutoScalingConfiguration.
-        AutoScalingConfiguration policy definitions
+        Autoscaling policy definitions for the autoscaling configuration. An autoscaling policy defines the criteria that
+        trigger autoscaling actions and the actions to take.
+
+        Each autoscaling configuration can have one autoscaling policy.
 
 
         :return: The policies of this AutoScalingConfiguration.
@@ -321,7 +335,10 @@ class AutoScalingConfiguration(object):
     def policies(self, policies):
         """
         Sets the policies of this AutoScalingConfiguration.
-        AutoScalingConfiguration policy definitions
+        Autoscaling policy definitions for the autoscaling configuration. An autoscaling policy defines the criteria that
+        trigger autoscaling actions and the actions to take.
+
+        Each autoscaling configuration can have one autoscaling policy.
 
 
         :param policies: The policies of this AutoScalingConfiguration.
@@ -334,6 +351,7 @@ class AutoScalingConfiguration(object):
         """
         **[Required]** Gets the time_created of this AutoScalingConfiguration.
         The date and time the AutoScalingConfiguration was created, in the format defined by RFC3339.
+
         Example: `2016-08-25T21:10:29.600Z`
 
 
@@ -347,6 +365,7 @@ class AutoScalingConfiguration(object):
         """
         Sets the time_created of this AutoScalingConfiguration.
         The date and time the AutoScalingConfiguration was created, in the format defined by RFC3339.
+
         Example: `2016-08-25T21:10:29.600Z`
 
 

--- a/src/oci/autoscaling/models/auto_scaling_configuration_summary.py
+++ b/src/oci/autoscaling/models/auto_scaling_configuration_summary.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class AutoScalingConfigurationSummary(object):
     """
-    AutoScalingConfigurationSummary model.
+    Summary information for an autoscaling configuration.
     """
 
     def __init__(self, **kwargs):
@@ -41,6 +41,14 @@ class AutoScalingConfigurationSummary(object):
             The value to assign to the resource property of this AutoScalingConfigurationSummary.
         :type resource: Resource
 
+        :param defined_tags:
+            The value to assign to the defined_tags property of this AutoScalingConfigurationSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this AutoScalingConfigurationSummary.
+        :type freeform_tags: dict(str, str)
+
         :param time_created:
             The value to assign to the time_created property of this AutoScalingConfigurationSummary.
         :type time_created: datetime
@@ -53,6 +61,8 @@ class AutoScalingConfigurationSummary(object):
             'cool_down_in_seconds': 'int',
             'is_enabled': 'bool',
             'resource': 'Resource',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'freeform_tags': 'dict(str, str)',
             'time_created': 'datetime'
         }
 
@@ -63,6 +73,8 @@ class AutoScalingConfigurationSummary(object):
             'cool_down_in_seconds': 'coolDownInSeconds',
             'is_enabled': 'isEnabled',
             'resource': 'resource',
+            'defined_tags': 'definedTags',
+            'freeform_tags': 'freeformTags',
             'time_created': 'timeCreated'
         }
 
@@ -72,13 +84,17 @@ class AutoScalingConfigurationSummary(object):
         self._cool_down_in_seconds = None
         self._is_enabled = None
         self._resource = None
+        self._defined_tags = None
+        self._freeform_tags = None
         self._time_created = None
 
     @property
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this AutoScalingConfigurationSummary.
-        The OCID of the compartment containing the AutoScalingConfiguration.
+        The `OCID`__ of the compartment containing the autoscaling configuration.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this AutoScalingConfigurationSummary.
@@ -90,7 +106,9 @@ class AutoScalingConfigurationSummary(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this AutoScalingConfigurationSummary.
-        The OCID of the compartment containing the AutoScalingConfiguration.
+        The `OCID`__ of the compartment containing the autoscaling configuration.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this AutoScalingConfigurationSummary.
@@ -102,8 +120,7 @@ class AutoScalingConfigurationSummary(object):
     def display_name(self):
         """
         Gets the display_name of this AutoScalingConfigurationSummary.
-        A user-friendly name for the AutoScalingConfiguration. Does not have to be unique, and it's changeable.
-        Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :return: The display_name of this AutoScalingConfigurationSummary.
@@ -115,8 +132,7 @@ class AutoScalingConfigurationSummary(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this AutoScalingConfigurationSummary.
-        A user-friendly name for the AutoScalingConfiguration. Does not have to be unique, and it's changeable.
-        Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this AutoScalingConfigurationSummary.
@@ -128,7 +144,9 @@ class AutoScalingConfigurationSummary(object):
     def id(self):
         """
         **[Required]** Gets the id of this AutoScalingConfigurationSummary.
-        The OCID of the AutoScalingConfiguration
+        The `OCID`__ of the autoscaling configuration.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this AutoScalingConfigurationSummary.
@@ -140,7 +158,9 @@ class AutoScalingConfigurationSummary(object):
     def id(self, id):
         """
         Sets the id of this AutoScalingConfigurationSummary.
-        The OCID of the AutoScalingConfiguration
+        The `OCID`__ of the autoscaling configuration.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this AutoScalingConfigurationSummary.
@@ -152,7 +172,8 @@ class AutoScalingConfigurationSummary(object):
     def cool_down_in_seconds(self):
         """
         Gets the cool_down_in_seconds of this AutoScalingConfigurationSummary.
-        The minimum period of time between scaling actions. The default is 300 seconds.
+        The minimum period of time to wait between scaling actions. The cooldown period gives the system time to stabilize
+        before rescaling. The minimum value is 300 seconds, which is also the default.
 
 
         :return: The cool_down_in_seconds of this AutoScalingConfigurationSummary.
@@ -164,7 +185,8 @@ class AutoScalingConfigurationSummary(object):
     def cool_down_in_seconds(self, cool_down_in_seconds):
         """
         Sets the cool_down_in_seconds of this AutoScalingConfigurationSummary.
-        The minimum period of time between scaling actions. The default is 300 seconds.
+        The minimum period of time to wait between scaling actions. The cooldown period gives the system time to stabilize
+        before rescaling. The minimum value is 300 seconds, which is also the default.
 
 
         :param cool_down_in_seconds: The cool_down_in_seconds of this AutoScalingConfigurationSummary.
@@ -176,7 +198,7 @@ class AutoScalingConfigurationSummary(object):
     def is_enabled(self):
         """
         Gets the is_enabled of this AutoScalingConfigurationSummary.
-        If the AutoScalingConfiguration is enabled
+        Whether the autoscaling configuration is enabled.
 
 
         :return: The is_enabled of this AutoScalingConfigurationSummary.
@@ -188,7 +210,7 @@ class AutoScalingConfigurationSummary(object):
     def is_enabled(self, is_enabled):
         """
         Sets the is_enabled of this AutoScalingConfigurationSummary.
-        If the AutoScalingConfiguration is enabled
+        Whether the autoscaling configuration is enabled.
 
 
         :param is_enabled: The is_enabled of this AutoScalingConfigurationSummary.
@@ -217,10 +239,79 @@ class AutoScalingConfigurationSummary(object):
         self._resource = resource
 
     @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this AutoScalingConfigurationSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this AutoScalingConfigurationSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this AutoScalingConfigurationSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this AutoScalingConfigurationSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this AutoScalingConfigurationSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this AutoScalingConfigurationSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this AutoScalingConfigurationSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this AutoScalingConfigurationSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
     def time_created(self):
         """
         **[Required]** Gets the time_created of this AutoScalingConfigurationSummary.
         The date and time the AutoScalingConfiguration was created, in the format defined by RFC3339.
+
         Example: `2016-08-25T21:10:29.600Z`
 
 
@@ -234,6 +325,7 @@ class AutoScalingConfigurationSummary(object):
         """
         Sets the time_created of this AutoScalingConfigurationSummary.
         The date and time the AutoScalingConfiguration was created, in the format defined by RFC3339.
+
         Example: `2016-08-25T21:10:29.600Z`
 
 

--- a/src/oci/autoscaling/models/auto_scaling_policy.py
+++ b/src/oci/autoscaling/models/auto_scaling_policy.py
@@ -9,7 +9,12 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class AutoScalingPolicy(object):
     """
-    A Policy defines the rules and actions of an AutoScalingConfiguration. The only supported type is 'threshold'
+    Autoscaling policies define the criteria that trigger autoscaling actions and the actions to take.
+
+    An autoscaling policy is part of an autoscaling configuration. For more information, see
+    `Autoscaling`__.
+
+    __ https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/autoscalinginstancepools.htm
     """
 
     def __init__(self, **kwargs):
@@ -81,7 +86,7 @@ class AutoScalingPolicy(object):
     def capacity(self):
         """
         **[Required]** Gets the capacity of this AutoScalingPolicy.
-        The capacity requirements of the Policy
+        The capacity requirements of the autoscaling policy.
 
 
         :return: The capacity of this AutoScalingPolicy.
@@ -93,7 +98,7 @@ class AutoScalingPolicy(object):
     def capacity(self, capacity):
         """
         Sets the capacity of this AutoScalingPolicy.
-        The capacity requirements of the Policy
+        The capacity requirements of the autoscaling policy.
 
 
         :param capacity: The capacity of this AutoScalingPolicy.
@@ -105,7 +110,7 @@ class AutoScalingPolicy(object):
     def id(self):
         """
         Gets the id of this AutoScalingPolicy.
-        The ID of the policy that is assigned after creation
+        The ID of the autoscaling policy that is assigned after creation.
 
 
         :return: The id of this AutoScalingPolicy.
@@ -117,7 +122,7 @@ class AutoScalingPolicy(object):
     def id(self, id):
         """
         Sets the id of this AutoScalingPolicy.
-        The ID of the policy that is assigned after creation
+        The ID of the autoscaling policy that is assigned after creation.
 
 
         :param id: The id of this AutoScalingPolicy.
@@ -129,8 +134,7 @@ class AutoScalingPolicy(object):
     def display_name(self):
         """
         Gets the display_name of this AutoScalingPolicy.
-        A user-friendly name for the Policy. Does not have to be unique, and it's changeable. Avoid entering
-        confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :return: The display_name of this AutoScalingPolicy.
@@ -142,8 +146,7 @@ class AutoScalingPolicy(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this AutoScalingPolicy.
-        A user-friendly name for the Policy. Does not have to be unique, and it's changeable. Avoid entering
-        confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this AutoScalingPolicy.
@@ -155,7 +158,7 @@ class AutoScalingPolicy(object):
     def policy_type(self):
         """
         **[Required]** Gets the policy_type of this AutoScalingPolicy.
-        Indicates type of Policy
+        The type of autoscaling policy.
 
 
         :return: The policy_type of this AutoScalingPolicy.
@@ -167,7 +170,7 @@ class AutoScalingPolicy(object):
     def policy_type(self, policy_type):
         """
         Sets the policy_type of this AutoScalingPolicy.
-        Indicates type of Policy
+        The type of autoscaling policy.
 
 
         :param policy_type: The policy_type of this AutoScalingPolicy.
@@ -179,7 +182,8 @@ class AutoScalingPolicy(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this AutoScalingPolicy.
-        The date and time the AutoScalingConfiguration was created, in the format defined by RFC3339.
+        The date and time the autoscaling configuration was created, in the format defined by RFC3339.
+
         Example: `2016-08-25T21:10:29.600Z`
 
 
@@ -192,7 +196,8 @@ class AutoScalingPolicy(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this AutoScalingPolicy.
-        The date and time the AutoScalingConfiguration was created, in the format defined by RFC3339.
+        The date and time the autoscaling configuration was created, in the format defined by RFC3339.
+
         Example: `2016-08-25T21:10:29.600Z`
 
 

--- a/src/oci/autoscaling/models/auto_scaling_policy_summary.py
+++ b/src/oci/autoscaling/models/auto_scaling_policy_summary.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class AutoScalingPolicySummary(object):
     """
-    AutoScalingPolicySummary model.
+    Summary information for an autoscaling policy.
     """
 
     def __init__(self, **kwargs):
@@ -50,7 +50,7 @@ class AutoScalingPolicySummary(object):
     def id(self):
         """
         **[Required]** Gets the id of this AutoScalingPolicySummary.
-        The ID of the policy that is assigned after creation
+        The ID of the autoscaling policy that is assigned after creation.
 
 
         :return: The id of this AutoScalingPolicySummary.
@@ -62,7 +62,7 @@ class AutoScalingPolicySummary(object):
     def id(self, id):
         """
         Sets the id of this AutoScalingPolicySummary.
-        The ID of the policy that is assigned after creation
+        The ID of the autoscaling policy that is assigned after creation.
 
 
         :param id: The id of this AutoScalingPolicySummary.
@@ -74,8 +74,7 @@ class AutoScalingPolicySummary(object):
     def display_name(self):
         """
         Gets the display_name of this AutoScalingPolicySummary.
-        A user-friendly name for the Policy. Does not have to be unique, and it's changeable. Avoid entering
-        confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :return: The display_name of this AutoScalingPolicySummary.
@@ -87,8 +86,7 @@ class AutoScalingPolicySummary(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this AutoScalingPolicySummary.
-        A user-friendly name for the Policy. Does not have to be unique, and it's changeable. Avoid entering
-        confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this AutoScalingPolicySummary.
@@ -100,7 +98,7 @@ class AutoScalingPolicySummary(object):
     def policy_type(self):
         """
         **[Required]** Gets the policy_type of this AutoScalingPolicySummary.
-        Indicates type of Policy
+        The type of autoscaling policy.
 
 
         :return: The policy_type of this AutoScalingPolicySummary.
@@ -112,7 +110,7 @@ class AutoScalingPolicySummary(object):
     def policy_type(self, policy_type):
         """
         Sets the policy_type of this AutoScalingPolicySummary.
-        Indicates type of Policy
+        The type of autoscaling policy.
 
 
         :param policy_type: The policy_type of this AutoScalingPolicySummary.

--- a/src/oci/autoscaling/models/capacity.py
+++ b/src/oci/autoscaling/models/capacity.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Capacity(object):
     """
-    Capacity boundaries for the pool
+    Capacity limits for the instance pool.
     """
 
     def __init__(self, **kwargs):
@@ -50,7 +50,7 @@ class Capacity(object):
     def max(self):
         """
         **[Required]** Gets the max of this Capacity.
-        The maximum size the pool is allowed to increase to
+        The maximum number of instances the instance pool is allowed to increase to (scale out).
 
 
         :return: The max of this Capacity.
@@ -62,7 +62,7 @@ class Capacity(object):
     def max(self, max):
         """
         Sets the max of this Capacity.
-        The maximum size the pool is allowed to increase to
+        The maximum number of instances the instance pool is allowed to increase to (scale out).
 
 
         :param max: The max of this Capacity.
@@ -74,7 +74,7 @@ class Capacity(object):
     def min(self):
         """
         **[Required]** Gets the min of this Capacity.
-        The minimum size the pool is allowed to decrease to
+        The minimum number of instances the instance pool is allowed to decrease to (scale in).
 
 
         :return: The min of this Capacity.
@@ -86,7 +86,7 @@ class Capacity(object):
     def min(self, min):
         """
         Sets the min of this Capacity.
-        The minimum size the pool is allowed to decrease to
+        The minimum number of instances the instance pool is allowed to decrease to (scale in).
 
 
         :param min: The min of this Capacity.
@@ -98,7 +98,9 @@ class Capacity(object):
     def initial(self):
         """
         **[Required]** Gets the initial of this Capacity.
-        The initial size of the pool
+        The initial number of instances to launch in the instance pool immediately after autoscaling is
+        enabled. After autoscaling retrieves performance metrics, the number of instances is automatically adjusted from this
+        initial number to a number that is based on the limits that you set.
 
 
         :return: The initial of this Capacity.
@@ -110,7 +112,9 @@ class Capacity(object):
     def initial(self, initial):
         """
         Sets the initial of this Capacity.
-        The initial size of the pool
+        The initial number of instances to launch in the instance pool immediately after autoscaling is
+        enabled. After autoscaling retrieves performance metrics, the number of instances is automatically adjusted from this
+        initial number to a number that is based on the limits that you set.
 
 
         :param initial: The initial of this Capacity.

--- a/src/oci/autoscaling/models/condition.py
+++ b/src/oci/autoscaling/models/condition.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Condition(object):
     """
-    A container for metric and action details
+    A rule that defines a specific autoscaling action to take (scale in or scale out) and the metric that triggers that action.
     """
 
     def __init__(self, **kwargs):
@@ -77,8 +77,7 @@ class Condition(object):
     def display_name(self):
         """
         Gets the display_name of this Condition.
-        A user-friendly name for the AutoScalingConfiguration condition details. Does not have to be unique, and
-        it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :return: The display_name of this Condition.
@@ -90,8 +89,7 @@ class Condition(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this Condition.
-        A user-friendly name for the AutoScalingConfiguration condition details. Does not have to be unique, and
-        it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this Condition.
@@ -103,7 +101,7 @@ class Condition(object):
     def id(self):
         """
         Gets the id of this Condition.
-        Id of the condition that is assigned after creation
+        ID of the condition that is assigned after creation.
 
 
         :return: The id of this Condition.
@@ -115,7 +113,7 @@ class Condition(object):
     def id(self, id):
         """
         Sets the id of this Condition.
-        Id of the condition that is assigned after creation
+        ID of the condition that is assigned after creation.
 
 
         :param id: The id of this Condition.

--- a/src/oci/autoscaling/models/create_auto_scaling_configuration_details.py
+++ b/src/oci/autoscaling/models/create_auto_scaling_configuration_details.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateAutoScalingConfigurationDetails(object):
     """
-    An AutoScalingConfiguration creation details
+    Creation details for an autoscaling configuration.
     """
 
     def __init__(self, **kwargs):
@@ -85,7 +85,10 @@ class CreateAutoScalingConfigurationDetails(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this CreateAutoScalingConfigurationDetails.
-        The OCID of the compartment containing the AutoScalingConfiguration.
+        The `OCID`__ of the compartment containing the autoscaling configuration.
+        The autoscaling configuration and the instance pool that it manages must be in the same compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this CreateAutoScalingConfigurationDetails.
@@ -97,7 +100,10 @@ class CreateAutoScalingConfigurationDetails(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this CreateAutoScalingConfigurationDetails.
-        The OCID of the compartment containing the AutoScalingConfiguration.
+        The `OCID`__ of the compartment containing the autoscaling configuration.
+        The autoscaling configuration and the instance pool that it manages must be in the same compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this CreateAutoScalingConfigurationDetails.
@@ -143,8 +149,7 @@ class CreateAutoScalingConfigurationDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateAutoScalingConfigurationDetails.
-        A user-friendly name for the AutoScalingConfiguration. Does not have to be unique, and it's changeable.
-        Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :return: The display_name of this CreateAutoScalingConfigurationDetails.
@@ -156,8 +161,7 @@ class CreateAutoScalingConfigurationDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateAutoScalingConfigurationDetails.
-        A user-friendly name for the AutoScalingConfiguration. Does not have to be unique, and it's changeable.
-        Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateAutoScalingConfigurationDetails.
@@ -203,7 +207,8 @@ class CreateAutoScalingConfigurationDetails(object):
     def cool_down_in_seconds(self):
         """
         Gets the cool_down_in_seconds of this CreateAutoScalingConfigurationDetails.
-        The minimum period of time between scaling actions. The default is 300 seconds.
+        The minimum period of time to wait between scaling actions. The cooldown period gives the system time to stabilize
+        before rescaling. The minimum value is 300 seconds, which is also the default.
 
 
         :return: The cool_down_in_seconds of this CreateAutoScalingConfigurationDetails.
@@ -215,7 +220,8 @@ class CreateAutoScalingConfigurationDetails(object):
     def cool_down_in_seconds(self, cool_down_in_seconds):
         """
         Sets the cool_down_in_seconds of this CreateAutoScalingConfigurationDetails.
-        The minimum period of time between scaling actions. The default is 300 seconds.
+        The minimum period of time to wait between scaling actions. The cooldown period gives the system time to stabilize
+        before rescaling. The minimum value is 300 seconds, which is also the default.
 
 
         :param cool_down_in_seconds: The cool_down_in_seconds of this CreateAutoScalingConfigurationDetails.
@@ -227,7 +233,7 @@ class CreateAutoScalingConfigurationDetails(object):
     def is_enabled(self):
         """
         Gets the is_enabled of this CreateAutoScalingConfigurationDetails.
-        If the AutoScalingConfiguration is enabled
+        Whether the autoscaling configuration is enabled.
 
 
         :return: The is_enabled of this CreateAutoScalingConfigurationDetails.
@@ -239,7 +245,7 @@ class CreateAutoScalingConfigurationDetails(object):
     def is_enabled(self, is_enabled):
         """
         Sets the is_enabled of this CreateAutoScalingConfigurationDetails.
-        If the AutoScalingConfiguration is enabled
+        Whether the autoscaling configuration is enabled.
 
 
         :param is_enabled: The is_enabled of this CreateAutoScalingConfigurationDetails.

--- a/src/oci/autoscaling/models/create_auto_scaling_policy_details.py
+++ b/src/oci/autoscaling/models/create_auto_scaling_policy_details.py
@@ -9,7 +9,12 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateAutoScalingPolicyDetails(object):
     """
-    An AutoScalingConfiguration Policy creation details
+    Creation details for an autoscaling policy.
+
+    Each autoscaling configuration can have one autoscaling policy.
+
+    In a threshold-based autoscaling policy, an autoscaling action is triggered when a performance metric meets
+    or exceeds a threshold.
     """
 
     def __init__(self, **kwargs):
@@ -67,7 +72,7 @@ class CreateAutoScalingPolicyDetails(object):
     def capacity(self):
         """
         **[Required]** Gets the capacity of this CreateAutoScalingPolicyDetails.
-        The capacity requirements of the Policy
+        The capacity requirements of the autoscaling policy.
 
 
         :return: The capacity of this CreateAutoScalingPolicyDetails.
@@ -79,7 +84,7 @@ class CreateAutoScalingPolicyDetails(object):
     def capacity(self, capacity):
         """
         Sets the capacity of this CreateAutoScalingPolicyDetails.
-        The capacity requirements of the Policy
+        The capacity requirements of the autoscaling policy.
 
 
         :param capacity: The capacity of this CreateAutoScalingPolicyDetails.
@@ -91,8 +96,7 @@ class CreateAutoScalingPolicyDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateAutoScalingPolicyDetails.
-        A user-friendly name for the Policy. Does not have to be unique, and it's changeable. Avoid entering
-        confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :return: The display_name of this CreateAutoScalingPolicyDetails.
@@ -104,8 +108,7 @@ class CreateAutoScalingPolicyDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateAutoScalingPolicyDetails.
-        A user-friendly name for the Policy. Does not have to be unique, and it's changeable. Avoid entering
-        confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateAutoScalingPolicyDetails.
@@ -117,7 +120,7 @@ class CreateAutoScalingPolicyDetails(object):
     def policy_type(self):
         """
         **[Required]** Gets the policy_type of this CreateAutoScalingPolicyDetails.
-        Indicates type of Policy
+        The type of autoscaling policy.
 
 
         :return: The policy_type of this CreateAutoScalingPolicyDetails.
@@ -129,7 +132,7 @@ class CreateAutoScalingPolicyDetails(object):
     def policy_type(self, policy_type):
         """
         Sets the policy_type of this CreateAutoScalingPolicyDetails.
-        Indicates type of Policy
+        The type of autoscaling policy.
 
 
         :param policy_type: The policy_type of this CreateAutoScalingPolicyDetails.

--- a/src/oci/autoscaling/models/create_condition_details.py
+++ b/src/oci/autoscaling/models/create_condition_details.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateConditionDetails(object):
     """
-    Creation details for Condition in a ThresholdPolicy
+    Creation details for a condition in a threshold-based autoscaling policy.
     """
 
     def __init__(self, **kwargs):
@@ -70,8 +70,7 @@ class CreateConditionDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateConditionDetails.
-        A user-friendly name for the AutoScalingConfiguration condition details. Does not have to be unique, and
-        it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :return: The display_name of this CreateConditionDetails.
@@ -83,8 +82,7 @@ class CreateConditionDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateConditionDetails.
-        A user-friendly name for the AutoScalingConfiguration condition details. Does not have to be unique, and
-        it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateConditionDetails.

--- a/src/oci/autoscaling/models/create_threshold_policy_details.py
+++ b/src/oci/autoscaling/models/create_threshold_policy_details.py
@@ -9,7 +9,10 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateThresholdPolicyDetails(CreateAutoScalingPolicyDetails):
     """
-    An AutoScalingConfiguration ThresholdPolicy creation details
+    Creation details for a threshold-based autoscaling policy.
+
+    In a threshold-based autoscaling policy, an autoscaling action is triggered when a performance metric meets
+    or exceeds a threshold.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/autoscaling/models/instance_pool_resource.py
+++ b/src/oci/autoscaling/models/instance_pool_resource.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class InstancePoolResource(Resource):
     """
-    An Instance Pool resource
+    A Compute instance pool.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/autoscaling/models/metric.py
+++ b/src/oci/autoscaling/models/metric.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Metric(object):
     """
-    Metric threshold details
+    Metric and threshold details for triggering an autoscaling action.
     """
 
     #: A constant which can be used with the metric_type property of a Metric.

--- a/src/oci/autoscaling/models/resource.py
+++ b/src/oci/autoscaling/models/resource.py
@@ -9,7 +9,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Resource(object):
     """
-    A resource that the AutoScalingConfiguration manages. The only supported type is 'instancePool'
+    A resource that is managed by an autoscaling configuration. The only supported type is \"instancePool.\"
+
+    Each instance pool can have one autoscaling configuration.
     """
 
     def __init__(self, **kwargs):
@@ -60,7 +62,7 @@ class Resource(object):
     def type(self):
         """
         **[Required]** Gets the type of this Resource.
-        Indicates type of derived class
+        The type of resource.
 
 
         :return: The type of this Resource.
@@ -72,7 +74,7 @@ class Resource(object):
     def type(self, type):
         """
         Sets the type of this Resource.
-        Indicates type of derived class
+        The type of resource.
 
 
         :param type: The type of this Resource.
@@ -84,7 +86,9 @@ class Resource(object):
     def id(self):
         """
         **[Required]** Gets the id of this Resource.
-        The OCID of resource that the AutoScalingConfiguration will manage.
+        The `OCID`__ of the resource that is managed by the autoscaling configuration.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this Resource.
@@ -96,7 +100,9 @@ class Resource(object):
     def id(self, id):
         """
         Sets the id of this Resource.
-        The OCID of resource that the AutoScalingConfiguration will manage.
+        The `OCID`__ of the resource that is managed by the autoscaling configuration.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this Resource.

--- a/src/oci/autoscaling/models/threshold.py
+++ b/src/oci/autoscaling/models/threshold.py
@@ -61,11 +61,8 @@ class Threshold(object):
     def operator(self):
         """
         **[Required]** Gets the operator of this Threshold.
-        Support for the following operators
-        GT  - Greater than
-        GTE - Greater than equal to
-        LT  - Less than
-        LTE - Less than equal to
+        The comparison operator to use. Options are greater than (`GT`), greater than or equal to
+        (`GTE`), less than (`LT`), and less than or equal to (`LTE`).
 
         Allowed values for this property are: "GT", "GTE", "LT", "LTE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -80,11 +77,8 @@ class Threshold(object):
     def operator(self, operator):
         """
         Sets the operator of this Threshold.
-        Support for the following operators
-        GT  - Greater than
-        GTE - Greater than equal to
-        LT  - Less than
-        LTE - Less than equal to
+        The comparison operator to use. Options are greater than (`GT`), greater than or equal to
+        (`GTE`), less than (`LT`), and less than or equal to (`LTE`).
 
 
         :param operator: The operator of this Threshold.

--- a/src/oci/autoscaling/models/threshold_policy.py
+++ b/src/oci/autoscaling/models/threshold_policy.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ThresholdPolicy(AutoScalingPolicy):
     """
-    A Policy that defines threshold based rules for an AutoScalingConfiguration
+    An autoscaling policy that defines threshold-based rules for an autoscaling configuration.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/autoscaling/models/update_auto_scaling_configuration_details.py
+++ b/src/oci/autoscaling/models/update_auto_scaling_configuration_details.py
@@ -156,7 +156,7 @@ class UpdateAutoScalingConfigurationDetails(object):
     def is_enabled(self):
         """
         Gets the is_enabled of this UpdateAutoScalingConfigurationDetails.
-        If the AutoScalingConfiguration is enabled
+        Whether the autoscaling configuration is enabled.
 
 
         :return: The is_enabled of this UpdateAutoScalingConfigurationDetails.
@@ -168,7 +168,7 @@ class UpdateAutoScalingConfigurationDetails(object):
     def is_enabled(self, is_enabled):
         """
         Sets the is_enabled of this UpdateAutoScalingConfigurationDetails.
-        If the AutoScalingConfiguration is enabled
+        Whether the autoscaling configuration is enabled.
 
 
         :param is_enabled: The is_enabled of this UpdateAutoScalingConfigurationDetails.
@@ -180,7 +180,8 @@ class UpdateAutoScalingConfigurationDetails(object):
     def cool_down_in_seconds(self):
         """
         Gets the cool_down_in_seconds of this UpdateAutoScalingConfigurationDetails.
-        The minimum period of time between scaling actions. The default is 300 seconds.
+        The minimum period of time to wait between scaling actions. The cooldown period gives the system time
+        to stabilize before rescaling. The minimum value is 300 seconds, which is also the default.
 
 
         :return: The cool_down_in_seconds of this UpdateAutoScalingConfigurationDetails.
@@ -192,7 +193,8 @@ class UpdateAutoScalingConfigurationDetails(object):
     def cool_down_in_seconds(self, cool_down_in_seconds):
         """
         Sets the cool_down_in_seconds of this UpdateAutoScalingConfigurationDetails.
-        The minimum period of time between scaling actions. The default is 300 seconds.
+        The minimum period of time to wait between scaling actions. The cooldown period gives the system time
+        to stabilize before rescaling. The minimum value is 300 seconds, which is also the default.
 
 
         :param cool_down_in_seconds: The cool_down_in_seconds of this UpdateAutoScalingConfigurationDetails.

--- a/src/oci/autoscaling/models/update_auto_scaling_policy_details.py
+++ b/src/oci/autoscaling/models/update_auto_scaling_policy_details.py
@@ -91,7 +91,7 @@ class UpdateAutoScalingPolicyDetails(object):
     def capacity(self):
         """
         Gets the capacity of this UpdateAutoScalingPolicyDetails.
-        The capacity requirements of the Policy
+        The capacity requirements of the autoscaling policy.
 
 
         :return: The capacity of this UpdateAutoScalingPolicyDetails.
@@ -103,7 +103,7 @@ class UpdateAutoScalingPolicyDetails(object):
     def capacity(self, capacity):
         """
         Sets the capacity of this UpdateAutoScalingPolicyDetails.
-        The capacity requirements of the Policy
+        The capacity requirements of the autoscaling policy.
 
 
         :param capacity: The capacity of this UpdateAutoScalingPolicyDetails.
@@ -115,7 +115,7 @@ class UpdateAutoScalingPolicyDetails(object):
     def policy_type(self):
         """
         **[Required]** Gets the policy_type of this UpdateAutoScalingPolicyDetails.
-        Indicates type of Policy
+        Indicates the type of autoscaling policy.
 
 
         :return: The policy_type of this UpdateAutoScalingPolicyDetails.
@@ -127,7 +127,7 @@ class UpdateAutoScalingPolicyDetails(object):
     def policy_type(self, policy_type):
         """
         Sets the policy_type of this UpdateAutoScalingPolicyDetails.
-        Indicates type of Policy
+        Indicates the type of autoscaling policy.
 
 
         :param policy_type: The policy_type of this UpdateAutoScalingPolicyDetails.

--- a/src/oci/autoscaling/models/update_condition_details.py
+++ b/src/oci/autoscaling/models/update_condition_details.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateConditionDetails(object):
     """
-    Update details for Condition in a ThresholdPolicy
+    Update details for a condition in a threshold-based autoscaling policy.
     """
 
     def __init__(self, **kwargs):
@@ -70,8 +70,7 @@ class UpdateConditionDetails(object):
     def display_name(self):
         """
         Gets the display_name of this UpdateConditionDetails.
-        A user-friendly name for the AutoScalingConfiguration condition details. Does not have to be unique, and
-        it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :return: The display_name of this UpdateConditionDetails.
@@ -83,8 +82,7 @@ class UpdateConditionDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this UpdateConditionDetails.
-        A user-friendly name for the AutoScalingConfiguration condition details. Does not have to be unique, and
-        it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this UpdateConditionDetails.

--- a/src/oci/core/blockstorage_client.py
+++ b/src/oci/core/blockstorage_client.py
@@ -17,7 +17,11 @@ missing = Sentinel("Missing")
 
 class BlockstorageClient(object):
     """
-    APIs for Networking Service, Compute Service, and Block Volume Service.
+    API covering the [Networking](/iaas/Content/Network/Concepts/overview.htm),
+    [Compute](/iaas/Content/Compute/Concepts/computeoverview.htm), and
+    [Block Volume](/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+    to manage resources such as virtual cloud networks (VCNs), compute instances, and
+    block storage volumes.
     """
 
     def __init__(self, config, **kwargs):
@@ -844,7 +848,7 @@ class BlockstorageClient(object):
     def delete_boot_volume_kms_key(self, boot_volume_id, **kwargs):
         """
         DeleteBootVolumeKmsKey
-        Remove kms for the specific boot volume. If the volume doesn't use KMS, then do nothing.
+        Removes the KMS key for the specified boot volume.
 
 
         :param str boot_volume_id: (required)
@@ -1292,7 +1296,7 @@ class BlockstorageClient(object):
     def delete_volume_kms_key(self, volume_id, **kwargs):
         """
         DeleteVolumeKmsKey
-        Remove kms for the specific volume. If the volume doesn't use KMS, then do nothing.
+        Removes the KMS key for the specified volume.
 
 
         :param str volume_id: (required)
@@ -1493,7 +1497,7 @@ class BlockstorageClient(object):
     def get_boot_volume_kms_key(self, boot_volume_id, **kwargs):
         """
         GetBootVolumeKmsKey
-        Gets kms key id for the specified boot volume.
+        Gets the KMS key ID for the specified boot volume.
 
 
         :param str boot_volume_id: (required)
@@ -2040,7 +2044,7 @@ class BlockstorageClient(object):
     def get_volume_kms_key(self, volume_id, **kwargs):
         """
         GetVolumeKmsKey
-        Gets kms key id for the specified volume.
+        Gets the KMS key ID for the specified volume.
 
 
         :param str volume_id: (required)
@@ -3163,14 +3167,14 @@ class BlockstorageClient(object):
     def update_boot_volume_kms_key(self, boot_volume_id, update_boot_volume_kms_key_details, **kwargs):
         """
         UpdateBootVolumeKmsKey
-        Update kms key id for the specific volume.
+        Updates the KMS key ID for the specified volume.
 
 
         :param str boot_volume_id: (required)
             The OCID of the boot volume.
 
         :param UpdateBootVolumeKmsKeyDetails update_boot_volume_kms_key_details: (required)
-            Update kms key id for the specific boot volume.
+            Updates the KMS key ID for the specified boot volume.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
@@ -3574,14 +3578,14 @@ class BlockstorageClient(object):
     def update_volume_kms_key(self, volume_id, update_volume_kms_key_details, **kwargs):
         """
         UpdateVolumeKmsKey
-        Update kms key id for the specific volume.
+        Updates the KMS key ID for the specified volume.
 
 
         :param str volume_id: (required)
             The OCID of the volume.
 
         :param UpdateVolumeKmsKeyDetails update_volume_kms_key_details: (required)
-            Update kms key id for the specific volume.
+            Update the KMS key ID for the specified volume.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`

--- a/src/oci/core/compute_client.py
+++ b/src/oci/core/compute_client.py
@@ -17,7 +17,11 @@ missing = Sentinel("Missing")
 
 class ComputeClient(object):
     """
-    APIs for Networking Service, Compute Service, and Block Volume Service.
+    API covering the [Networking](/iaas/Content/Network/Concepts/overview.htm),
+    [Compute](/iaas/Content/Compute/Concepts/computeoverview.htm), and
+    [Block Volume](/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+    to manage resources such as virtual cloud networks (VCNs), compute instances, and
+    block storage volumes.
     """
 
     def __init__(self, config, **kwargs):

--- a/src/oci/core/compute_management_client.py
+++ b/src/oci/core/compute_management_client.py
@@ -17,7 +17,11 @@ missing = Sentinel("Missing")
 
 class ComputeManagementClient(object):
     """
-    APIs for Networking Service, Compute Service, and Block Volume Service.
+    API covering the [Networking](/iaas/Content/Network/Concepts/overview.htm),
+    [Compute](/iaas/Content/Compute/Concepts/computeoverview.htm), and
+    [Block Volume](/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+    to manage resources such as virtual cloud networks (VCNs), compute instances, and
+    block storage volumes.
     """
 
     def __init__(self, config, **kwargs):
@@ -247,7 +251,7 @@ class ComputeManagementClient(object):
 
 
         :param CreateInstancePoolDetails create_instance_pool_details: (required)
-            Instance Pool creation details
+            Instance pool creation details
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or

--- a/src/oci/core/compute_management_client_composite_operations.py
+++ b/src/oci/core/compute_management_client_composite_operations.py
@@ -69,7 +69,7 @@ class ComputeManagementClientCompositeOperations(object):
         to enter the given state(s).
 
         :param CreateInstancePoolDetails create_instance_pool_details: (required)
-            Instance Pool creation details
+            Instance pool creation details
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.core.models.InstancePool.lifecycle_state`

--- a/src/oci/core/models/__init__.py
+++ b/src/oci/core/models/__init__.py
@@ -16,6 +16,7 @@ from .attach_load_balancer_details import AttachLoadBalancerDetails
 from .attach_paravirtualized_volume_details import AttachParavirtualizedVolumeDetails
 from .attach_vnic_details import AttachVnicDetails
 from .attach_volume_details import AttachVolumeDetails
+from .bgp_session_info import BgpSessionInfo
 from .boot_volume import BootVolume
 from .boot_volume_attachment import BootVolumeAttachment
 from .boot_volume_backup import BootVolumeBackup
@@ -42,6 +43,8 @@ from .create_dhcp_details import CreateDhcpDetails
 from .create_drg_attachment_details import CreateDrgAttachmentDetails
 from .create_drg_details import CreateDrgDetails
 from .create_ip_sec_connection_details import CreateIPSecConnectionDetails
+from .create_ip_sec_connection_tunnel_details import CreateIPSecConnectionTunnelDetails
+from .create_ip_sec_tunnel_bgp_session_details import CreateIPSecTunnelBgpSessionDetails
 from .create_image_details import CreateImageDetails
 from .create_instance_configuration_details import CreateInstanceConfigurationDetails
 from .create_instance_console_connection_details import CreateInstanceConsoleConnectionDetails
@@ -92,6 +95,8 @@ from .get_public_ip_by_private_ip_id_details import GetPublicIpByPrivateIpIdDeta
 from .ip_sec_connection import IPSecConnection
 from .ip_sec_connection_device_config import IPSecConnectionDeviceConfig
 from .ip_sec_connection_device_status import IPSecConnectionDeviceStatus
+from .ip_sec_connection_tunnel import IPSecConnectionTunnel
+from .ip_sec_connection_tunnel_shared_secret import IPSecConnectionTunnelSharedSecret
 from .i_scsi_volume_attachment import IScsiVolumeAttachment
 from .icmp_options import IcmpOptions
 from .image import Image
@@ -168,6 +173,9 @@ from .update_dhcp_details import UpdateDhcpDetails
 from .update_drg_attachment_details import UpdateDrgAttachmentDetails
 from .update_drg_details import UpdateDrgDetails
 from .update_ip_sec_connection_details import UpdateIPSecConnectionDetails
+from .update_ip_sec_connection_tunnel_details import UpdateIPSecConnectionTunnelDetails
+from .update_ip_sec_connection_tunnel_shared_secret_details import UpdateIPSecConnectionTunnelSharedSecretDetails
+from .update_ip_sec_tunnel_bgp_session_details import UpdateIPSecTunnelBgpSessionDetails
 from .update_image_details import UpdateImageDetails
 from .update_instance_agent_config_details import UpdateInstanceAgentConfigDetails
 from .update_instance_configuration_details import UpdateInstanceConfigurationDetails
@@ -230,6 +238,7 @@ core_type_mapping = {
     "AttachParavirtualizedVolumeDetails": AttachParavirtualizedVolumeDetails,
     "AttachVnicDetails": AttachVnicDetails,
     "AttachVolumeDetails": AttachVolumeDetails,
+    "BgpSessionInfo": BgpSessionInfo,
     "BootVolume": BootVolume,
     "BootVolumeAttachment": BootVolumeAttachment,
     "BootVolumeBackup": BootVolumeBackup,
@@ -256,6 +265,8 @@ core_type_mapping = {
     "CreateDrgAttachmentDetails": CreateDrgAttachmentDetails,
     "CreateDrgDetails": CreateDrgDetails,
     "CreateIPSecConnectionDetails": CreateIPSecConnectionDetails,
+    "CreateIPSecConnectionTunnelDetails": CreateIPSecConnectionTunnelDetails,
+    "CreateIPSecTunnelBgpSessionDetails": CreateIPSecTunnelBgpSessionDetails,
     "CreateImageDetails": CreateImageDetails,
     "CreateInstanceConfigurationDetails": CreateInstanceConfigurationDetails,
     "CreateInstanceConsoleConnectionDetails": CreateInstanceConsoleConnectionDetails,
@@ -306,6 +317,8 @@ core_type_mapping = {
     "IPSecConnection": IPSecConnection,
     "IPSecConnectionDeviceConfig": IPSecConnectionDeviceConfig,
     "IPSecConnectionDeviceStatus": IPSecConnectionDeviceStatus,
+    "IPSecConnectionTunnel": IPSecConnectionTunnel,
+    "IPSecConnectionTunnelSharedSecret": IPSecConnectionTunnelSharedSecret,
     "IScsiVolumeAttachment": IScsiVolumeAttachment,
     "IcmpOptions": IcmpOptions,
     "Image": Image,
@@ -382,6 +395,9 @@ core_type_mapping = {
     "UpdateDrgAttachmentDetails": UpdateDrgAttachmentDetails,
     "UpdateDrgDetails": UpdateDrgDetails,
     "UpdateIPSecConnectionDetails": UpdateIPSecConnectionDetails,
+    "UpdateIPSecConnectionTunnelDetails": UpdateIPSecConnectionTunnelDetails,
+    "UpdateIPSecConnectionTunnelSharedSecretDetails": UpdateIPSecConnectionTunnelSharedSecretDetails,
+    "UpdateIPSecTunnelBgpSessionDetails": UpdateIPSecTunnelBgpSessionDetails,
     "UpdateImageDetails": UpdateImageDetails,
     "UpdateInstanceAgentConfigDetails": UpdateInstanceAgentConfigDetails,
     "UpdateInstanceConfigurationDetails": UpdateInstanceConfigurationDetails,

--- a/src/oci/core/models/bgp_session_info.py
+++ b/src/oci/core/models/bgp_session_info.py
@@ -1,0 +1,267 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class BgpSessionInfo(object):
+    """
+    Information for establishing a BGP session for the IPSec tunnel.
+    """
+
+    #: A constant which can be used with the bgp_state property of a BgpSessionInfo.
+    #: This constant has a value of "UP"
+    BGP_STATE_UP = "UP"
+
+    #: A constant which can be used with the bgp_state property of a BgpSessionInfo.
+    #: This constant has a value of "DOWN"
+    BGP_STATE_DOWN = "DOWN"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new BgpSessionInfo object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param oracle_interface_ip:
+            The value to assign to the oracle_interface_ip property of this BgpSessionInfo.
+        :type oracle_interface_ip: str
+
+        :param customer_interface_ip:
+            The value to assign to the customer_interface_ip property of this BgpSessionInfo.
+        :type customer_interface_ip: str
+
+        :param oracle_bgp_asn:
+            The value to assign to the oracle_bgp_asn property of this BgpSessionInfo.
+        :type oracle_bgp_asn: str
+
+        :param customer_bgp_asn:
+            The value to assign to the customer_bgp_asn property of this BgpSessionInfo.
+        :type customer_bgp_asn: str
+
+        :param bgp_state:
+            The value to assign to the bgp_state property of this BgpSessionInfo.
+            Allowed values for this property are: "UP", "DOWN", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type bgp_state: str
+
+        """
+        self.swagger_types = {
+            'oracle_interface_ip': 'str',
+            'customer_interface_ip': 'str',
+            'oracle_bgp_asn': 'str',
+            'customer_bgp_asn': 'str',
+            'bgp_state': 'str'
+        }
+
+        self.attribute_map = {
+            'oracle_interface_ip': 'oracleInterfaceIp',
+            'customer_interface_ip': 'customerInterfaceIp',
+            'oracle_bgp_asn': 'oracleBgpAsn',
+            'customer_bgp_asn': 'customerBgpAsn',
+            'bgp_state': 'bgpState'
+        }
+
+        self._oracle_interface_ip = None
+        self._customer_interface_ip = None
+        self._oracle_bgp_asn = None
+        self._customer_bgp_asn = None
+        self._bgp_state = None
+
+    @property
+    def oracle_interface_ip(self):
+        """
+        Gets the oracle_interface_ip of this BgpSessionInfo.
+        The IP address for the Oracle end of the inside tunnel interface.
+
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :class:`IPSecConnectionTunnel`), this IP address
+        is required and used for the tunnel's BGP session.
+
+        If `routing` is instead set to `STATIC`, this IP address is optional. You can set this IP
+        address so you can troubleshoot or monitor the tunnel.
+
+        The value must be a /30 or /31.
+
+        Example: `10.0.0.4/31`
+
+
+        :return: The oracle_interface_ip of this BgpSessionInfo.
+        :rtype: str
+        """
+        return self._oracle_interface_ip
+
+    @oracle_interface_ip.setter
+    def oracle_interface_ip(self, oracle_interface_ip):
+        """
+        Sets the oracle_interface_ip of this BgpSessionInfo.
+        The IP address for the Oracle end of the inside tunnel interface.
+
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :class:`IPSecConnectionTunnel`), this IP address
+        is required and used for the tunnel's BGP session.
+
+        If `routing` is instead set to `STATIC`, this IP address is optional. You can set this IP
+        address so you can troubleshoot or monitor the tunnel.
+
+        The value must be a /30 or /31.
+
+        Example: `10.0.0.4/31`
+
+
+        :param oracle_interface_ip: The oracle_interface_ip of this BgpSessionInfo.
+        :type: str
+        """
+        self._oracle_interface_ip = oracle_interface_ip
+
+    @property
+    def customer_interface_ip(self):
+        """
+        Gets the customer_interface_ip of this BgpSessionInfo.
+        The IP address for the CPE end of the inside tunnel interface.
+
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :class:`IPSecConnectionTunnel`), this IP address
+        is required and used for the tunnel's BGP session.
+
+        If `routing` is instead set to `STATIC`, this IP address is optional. You can set this IP
+        address so you can troubleshoot or monitor the tunnel.
+
+        The value must be a /30 or /31.
+
+        Example: `10.0.0.5/31`
+
+
+        :return: The customer_interface_ip of this BgpSessionInfo.
+        :rtype: str
+        """
+        return self._customer_interface_ip
+
+    @customer_interface_ip.setter
+    def customer_interface_ip(self, customer_interface_ip):
+        """
+        Sets the customer_interface_ip of this BgpSessionInfo.
+        The IP address for the CPE end of the inside tunnel interface.
+
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :class:`IPSecConnectionTunnel`), this IP address
+        is required and used for the tunnel's BGP session.
+
+        If `routing` is instead set to `STATIC`, this IP address is optional. You can set this IP
+        address so you can troubleshoot or monitor the tunnel.
+
+        The value must be a /30 or /31.
+
+        Example: `10.0.0.5/31`
+
+
+        :param customer_interface_ip: The customer_interface_ip of this BgpSessionInfo.
+        :type: str
+        """
+        self._customer_interface_ip = customer_interface_ip
+
+    @property
+    def oracle_bgp_asn(self):
+        """
+        Gets the oracle_bgp_asn of this BgpSessionInfo.
+        The Oracle BGP ASN.
+
+
+        :return: The oracle_bgp_asn of this BgpSessionInfo.
+        :rtype: str
+        """
+        return self._oracle_bgp_asn
+
+    @oracle_bgp_asn.setter
+    def oracle_bgp_asn(self, oracle_bgp_asn):
+        """
+        Sets the oracle_bgp_asn of this BgpSessionInfo.
+        The Oracle BGP ASN.
+
+
+        :param oracle_bgp_asn: The oracle_bgp_asn of this BgpSessionInfo.
+        :type: str
+        """
+        self._oracle_bgp_asn = oracle_bgp_asn
+
+    @property
+    def customer_bgp_asn(self):
+        """
+        Gets the customer_bgp_asn of this BgpSessionInfo.
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :class:`IPSecConnectionTunnel`), this ASN
+        is required and used for the tunnel's BGP session. This is the ASN of the network on the
+        CPE end of the BGP session. Can be a 2-byte or 4-byte ASN. Uses \"asplain\" format.
+
+        If the tunnel uses static routing, the `customerBgpAsn` must be null.
+
+        Example: `12345` (2-byte) or `1587232876` (4-byte)
+
+
+        :return: The customer_bgp_asn of this BgpSessionInfo.
+        :rtype: str
+        """
+        return self._customer_bgp_asn
+
+    @customer_bgp_asn.setter
+    def customer_bgp_asn(self, customer_bgp_asn):
+        """
+        Sets the customer_bgp_asn of this BgpSessionInfo.
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :class:`IPSecConnectionTunnel`), this ASN
+        is required and used for the tunnel's BGP session. This is the ASN of the network on the
+        CPE end of the BGP session. Can be a 2-byte or 4-byte ASN. Uses \"asplain\" format.
+
+        If the tunnel uses static routing, the `customerBgpAsn` must be null.
+
+        Example: `12345` (2-byte) or `1587232876` (4-byte)
+
+
+        :param customer_bgp_asn: The customer_bgp_asn of this BgpSessionInfo.
+        :type: str
+        """
+        self._customer_bgp_asn = customer_bgp_asn
+
+    @property
+    def bgp_state(self):
+        """
+        Gets the bgp_state of this BgpSessionInfo.
+        The state of the BGP session.
+
+        Allowed values for this property are: "UP", "DOWN", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The bgp_state of this BgpSessionInfo.
+        :rtype: str
+        """
+        return self._bgp_state
+
+    @bgp_state.setter
+    def bgp_state(self, bgp_state):
+        """
+        Sets the bgp_state of this BgpSessionInfo.
+        The state of the BGP session.
+
+
+        :param bgp_state: The bgp_state of this BgpSessionInfo.
+        :type: str
+        """
+        allowed_values = ["UP", "DOWN"]
+        if not value_allowed_none_or_none_sentinel(bgp_state, allowed_values):
+            bgp_state = 'UNKNOWN_ENUM_VALUE'
+        self._bgp_state = bgp_state
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/boot_volume_kms_key.py
+++ b/src/oci/core/models/boot_volume_kms_key.py
@@ -36,7 +36,7 @@ class BootVolumeKmsKey(object):
     def kms_key_id(self):
         """
         Gets the kms_key_id of this BootVolumeKmsKey.
-        Kms key id associated with this volume. If volume is not using KMS, then kmsKeyId will be null string.
+        The OCID of the KMS key associated with this volume. If volume is not using KMS, then the `kmsKeyId` will be a null string.
 
 
         :return: The kms_key_id of this BootVolumeKmsKey.
@@ -48,7 +48,7 @@ class BootVolumeKmsKey(object):
     def kms_key_id(self, kms_key_id):
         """
         Sets the kms_key_id of this BootVolumeKmsKey.
-        Kms key id associated with this volume. If volume is not using KMS, then kmsKeyId will be null string.
+        The OCID of the KMS key associated with this volume. If volume is not using KMS, then the `kmsKeyId` will be a null string.
 
 
         :param kms_key_id: The kms_key_id of this BootVolumeKmsKey.

--- a/src/oci/core/models/create_instance_pool_details.py
+++ b/src/oci/core/models/create_instance_pool_details.py
@@ -203,7 +203,7 @@ class CreateInstancePoolDetails(object):
     def instance_configuration_id(self):
         """
         **[Required]** Gets the instance_configuration_id of this CreateInstancePoolDetails.
-        The OCID of the instance configuration associated to the instance pool.
+        The OCID of the instance configuration associated with the instance pool.
 
 
         :return: The instance_configuration_id of this CreateInstancePoolDetails.
@@ -215,7 +215,7 @@ class CreateInstancePoolDetails(object):
     def instance_configuration_id(self, instance_configuration_id):
         """
         Sets the instance_configuration_id of this CreateInstancePoolDetails.
-        The OCID of the instance configuration associated to the instance pool.
+        The OCID of the instance configuration associated with the instance pool.
 
 
         :param instance_configuration_id: The instance_configuration_id of this CreateInstancePoolDetails.
@@ -227,8 +227,12 @@ class CreateInstancePoolDetails(object):
     def placement_configurations(self):
         """
         **[Required]** Gets the placement_configurations of this CreateInstancePoolDetails.
-        The placement configurations for the instance pool.
-        There should be 1 placement configuration for each desired AD.
+        The placement configurations for the instance pool. Provide one placement configuration for
+        each availability domain.
+
+        To use the instance pool with a regional subnet, provide a placement configuration for
+        each availability domain, and include the regional subnet in each placement
+        configuration.
 
 
         :return: The placement_configurations of this CreateInstancePoolDetails.
@@ -240,8 +244,12 @@ class CreateInstancePoolDetails(object):
     def placement_configurations(self, placement_configurations):
         """
         Sets the placement_configurations of this CreateInstancePoolDetails.
-        The placement configurations for the instance pool.
-        There should be 1 placement configuration for each desired AD.
+        The placement configurations for the instance pool. Provide one placement configuration for
+        each availability domain.
+
+        To use the instance pool with a regional subnet, provide a placement configuration for
+        each availability domain, and include the regional subnet in each placement
+        configuration.
 
 
         :param placement_configurations: The placement_configurations of this CreateInstancePoolDetails.

--- a/src/oci/core/models/create_ip_sec_connection_details.py
+++ b/src/oci/core/models/create_ip_sec_connection_details.py
@@ -62,6 +62,10 @@ class CreateIPSecConnectionDetails(object):
             The value to assign to the static_routes property of this CreateIPSecConnectionDetails.
         :type static_routes: list[str]
 
+        :param tunnel_configuration:
+            The value to assign to the tunnel_configuration property of this CreateIPSecConnectionDetails.
+        :type tunnel_configuration: list[CreateIPSecConnectionTunnelDetails]
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
@@ -72,7 +76,8 @@ class CreateIPSecConnectionDetails(object):
             'freeform_tags': 'dict(str, str)',
             'cpe_local_identifier': 'str',
             'cpe_local_identifier_type': 'str',
-            'static_routes': 'list[str]'
+            'static_routes': 'list[str]',
+            'tunnel_configuration': 'list[CreateIPSecConnectionTunnelDetails]'
         }
 
         self.attribute_map = {
@@ -84,7 +89,8 @@ class CreateIPSecConnectionDetails(object):
             'freeform_tags': 'freeformTags',
             'cpe_local_identifier': 'cpeLocalIdentifier',
             'cpe_local_identifier_type': 'cpeLocalIdentifierType',
-            'static_routes': 'staticRoutes'
+            'static_routes': 'staticRoutes',
+            'tunnel_configuration': 'tunnelConfiguration'
         }
 
         self._compartment_id = None
@@ -96,6 +102,7 @@ class CreateIPSecConnectionDetails(object):
         self._cpe_local_identifier = None
         self._cpe_local_identifier_type = None
         self._static_routes = None
+        self._tunnel_configuration = None
 
     @property
     def compartment_id(self):
@@ -343,8 +350,15 @@ class CreateIPSecConnectionDetails(object):
     def static_routes(self):
         """
         **[Required]** Gets the static_routes of this CreateIPSecConnectionDetails.
-        Static routes to the CPE. At least one route must be included. A static route's CIDR must not be a
+        Static routes to the CPE. A static route's CIDR must not be a
         multicast address or class E address.
+
+        Used for routing a given IPSec tunnel's traffic only if the tunnel
+        is using static routing. If you configure at least one tunnel to use static routing, then
+        you must provide at least one valid static route. If you configure both
+        tunnels to use BGP dynamic routing, you can provide an empty list for the static routes.
+        For more information, see the important note in :class:`IPSecConnection`.
+
 
         Example: `10.0.1.0/24`
 
@@ -358,8 +372,15 @@ class CreateIPSecConnectionDetails(object):
     def static_routes(self, static_routes):
         """
         Sets the static_routes of this CreateIPSecConnectionDetails.
-        Static routes to the CPE. At least one route must be included. A static route's CIDR must not be a
+        Static routes to the CPE. A static route's CIDR must not be a
         multicast address or class E address.
+
+        Used for routing a given IPSec tunnel's traffic only if the tunnel
+        is using static routing. If you configure at least one tunnel to use static routing, then
+        you must provide at least one valid static route. If you configure both
+        tunnels to use BGP dynamic routing, you can provide an empty list for the static routes.
+        For more information, see the important note in :class:`IPSecConnection`.
+
 
         Example: `10.0.1.0/24`
 
@@ -368,6 +389,34 @@ class CreateIPSecConnectionDetails(object):
         :type: list[str]
         """
         self._static_routes = static_routes
+
+    @property
+    def tunnel_configuration(self):
+        """
+        Gets the tunnel_configuration of this CreateIPSecConnectionDetails.
+        Information for creating the individual tunnels in the IPSec connection. You can provide a
+        maximum of 2 `tunnelConfiguration` objects in the array (one for each of the
+        two tunnels).
+
+
+        :return: The tunnel_configuration of this CreateIPSecConnectionDetails.
+        :rtype: list[CreateIPSecConnectionTunnelDetails]
+        """
+        return self._tunnel_configuration
+
+    @tunnel_configuration.setter
+    def tunnel_configuration(self, tunnel_configuration):
+        """
+        Sets the tunnel_configuration of this CreateIPSecConnectionDetails.
+        Information for creating the individual tunnels in the IPSec connection. You can provide a
+        maximum of 2 `tunnelConfiguration` objects in the array (one for each of the
+        two tunnels).
+
+
+        :param tunnel_configuration: The tunnel_configuration of this CreateIPSecConnectionDetails.
+        :type: list[CreateIPSecConnectionTunnelDetails]
+        """
+        self._tunnel_configuration = tunnel_configuration
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/create_ip_sec_connection_tunnel_details.py
+++ b/src/oci/core/models/create_ip_sec_connection_tunnel_details.py
@@ -1,0 +1,199 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateIPSecConnectionTunnelDetails(object):
+    """
+    CreateIPSecConnectionTunnelDetails model.
+    """
+
+    #: A constant which can be used with the routing property of a CreateIPSecConnectionTunnelDetails.
+    #: This constant has a value of "BGP"
+    ROUTING_BGP = "BGP"
+
+    #: A constant which can be used with the routing property of a CreateIPSecConnectionTunnelDetails.
+    #: This constant has a value of "STATIC"
+    ROUTING_STATIC = "STATIC"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateIPSecConnectionTunnelDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateIPSecConnectionTunnelDetails.
+        :type display_name: str
+
+        :param routing:
+            The value to assign to the routing property of this CreateIPSecConnectionTunnelDetails.
+            Allowed values for this property are: "BGP", "STATIC"
+        :type routing: str
+
+        :param shared_secret:
+            The value to assign to the shared_secret property of this CreateIPSecConnectionTunnelDetails.
+        :type shared_secret: str
+
+        :param bgp_session_config:
+            The value to assign to the bgp_session_config property of this CreateIPSecConnectionTunnelDetails.
+        :type bgp_session_config: CreateIPSecTunnelBgpSessionDetails
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'routing': 'str',
+            'shared_secret': 'str',
+            'bgp_session_config': 'CreateIPSecTunnelBgpSessionDetails'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'routing': 'routing',
+            'shared_secret': 'sharedSecret',
+            'bgp_session_config': 'bgpSessionConfig'
+        }
+
+        self._display_name = None
+        self._routing = None
+        self._shared_secret = None
+        self._bgp_session_config = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateIPSecConnectionTunnelDetails.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid
+        entering confidential information.
+
+
+        :return: The display_name of this CreateIPSecConnectionTunnelDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateIPSecConnectionTunnelDetails.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid
+        entering confidential information.
+
+
+        :param display_name: The display_name of this CreateIPSecConnectionTunnelDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def routing(self):
+        """
+        Gets the routing of this CreateIPSecConnectionTunnelDetails.
+        The type of routing to use for this tunnel (either BGP dynamic routing or static routing).
+
+        Allowed values for this property are: "BGP", "STATIC"
+
+
+        :return: The routing of this CreateIPSecConnectionTunnelDetails.
+        :rtype: str
+        """
+        return self._routing
+
+    @routing.setter
+    def routing(self, routing):
+        """
+        Sets the routing of this CreateIPSecConnectionTunnelDetails.
+        The type of routing to use for this tunnel (either BGP dynamic routing or static routing).
+
+
+        :param routing: The routing of this CreateIPSecConnectionTunnelDetails.
+        :type: str
+        """
+        allowed_values = ["BGP", "STATIC"]
+        if not value_allowed_none_or_none_sentinel(routing, allowed_values):
+            raise ValueError(
+                "Invalid value for `routing`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._routing = routing
+
+    @property
+    def shared_secret(self):
+        """
+        Gets the shared_secret of this CreateIPSecConnectionTunnelDetails.
+        The shared secret (pre-shared key) to use for the IPSec tunnel. If you don't provide a value,
+        Oracle generates a value for you. You can specify your own shared secret later if
+        you like with :func:`update_ip_sec_connection_tunnel_shared_secret`.
+
+        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+
+
+        :return: The shared_secret of this CreateIPSecConnectionTunnelDetails.
+        :rtype: str
+        """
+        return self._shared_secret
+
+    @shared_secret.setter
+    def shared_secret(self, shared_secret):
+        """
+        Sets the shared_secret of this CreateIPSecConnectionTunnelDetails.
+        The shared secret (pre-shared key) to use for the IPSec tunnel. If you don't provide a value,
+        Oracle generates a value for you. You can specify your own shared secret later if
+        you like with :func:`update_ip_sec_connection_tunnel_shared_secret`.
+
+        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+
+
+        :param shared_secret: The shared_secret of this CreateIPSecConnectionTunnelDetails.
+        :type: str
+        """
+        self._shared_secret = shared_secret
+
+    @property
+    def bgp_session_config(self):
+        """
+        Gets the bgp_session_config of this CreateIPSecConnectionTunnelDetails.
+        Information for establishing a BGP session for the IPSec tunnel. Required if the tunnel uses
+        BGP dynamic routing.
+
+        If the tunnel instead uses static routing, you may optionally provide
+        this object and set an IP address for one or both ends of the IPSec tunnel for the purposes
+        of troubleshooting or monitoring the tunnel.
+
+
+        :return: The bgp_session_config of this CreateIPSecConnectionTunnelDetails.
+        :rtype: CreateIPSecTunnelBgpSessionDetails
+        """
+        return self._bgp_session_config
+
+    @bgp_session_config.setter
+    def bgp_session_config(self, bgp_session_config):
+        """
+        Sets the bgp_session_config of this CreateIPSecConnectionTunnelDetails.
+        Information for establishing a BGP session for the IPSec tunnel. Required if the tunnel uses
+        BGP dynamic routing.
+
+        If the tunnel instead uses static routing, you may optionally provide
+        this object and set an IP address for one or both ends of the IPSec tunnel for the purposes
+        of troubleshooting or monitoring the tunnel.
+
+
+        :param bgp_session_config: The bgp_session_config of this CreateIPSecConnectionTunnelDetails.
+        :type: CreateIPSecTunnelBgpSessionDetails
+        """
+        self._bgp_session_config = bgp_session_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/create_ip_sec_tunnel_bgp_session_details.py
+++ b/src/oci/core/models/create_ip_sec_tunnel_bgp_session_details.py
@@ -1,0 +1,189 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateIPSecTunnelBgpSessionDetails(object):
+    """
+    CreateIPSecTunnelBgpSessionDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateIPSecTunnelBgpSessionDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param oracle_interface_ip:
+            The value to assign to the oracle_interface_ip property of this CreateIPSecTunnelBgpSessionDetails.
+        :type oracle_interface_ip: str
+
+        :param customer_interface_ip:
+            The value to assign to the customer_interface_ip property of this CreateIPSecTunnelBgpSessionDetails.
+        :type customer_interface_ip: str
+
+        :param customer_bgp_asn:
+            The value to assign to the customer_bgp_asn property of this CreateIPSecTunnelBgpSessionDetails.
+        :type customer_bgp_asn: str
+
+        """
+        self.swagger_types = {
+            'oracle_interface_ip': 'str',
+            'customer_interface_ip': 'str',
+            'customer_bgp_asn': 'str'
+        }
+
+        self.attribute_map = {
+            'oracle_interface_ip': 'oracleInterfaceIp',
+            'customer_interface_ip': 'customerInterfaceIp',
+            'customer_bgp_asn': 'customerBgpAsn'
+        }
+
+        self._oracle_interface_ip = None
+        self._customer_interface_ip = None
+        self._customer_bgp_asn = None
+
+    @property
+    def oracle_interface_ip(self):
+        """
+        Gets the oracle_interface_ip of this CreateIPSecTunnelBgpSessionDetails.
+        The IP address for the Oracle end of the inside tunnel interface.
+
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :class:`IPSecConnectionTunnel`), this IP address
+        is required and used for the tunnel's BGP session.
+
+        If `routing` is instead set to `STATIC`, this IP address is optional. You can set this IP
+        address to troubleshoot or monitor the tunnel.
+
+        The value must be a /30 or /31.
+
+        Example: `10.0.0.4/31`
+
+
+        :return: The oracle_interface_ip of this CreateIPSecTunnelBgpSessionDetails.
+        :rtype: str
+        """
+        return self._oracle_interface_ip
+
+    @oracle_interface_ip.setter
+    def oracle_interface_ip(self, oracle_interface_ip):
+        """
+        Sets the oracle_interface_ip of this CreateIPSecTunnelBgpSessionDetails.
+        The IP address for the Oracle end of the inside tunnel interface.
+
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :class:`IPSecConnectionTunnel`), this IP address
+        is required and used for the tunnel's BGP session.
+
+        If `routing` is instead set to `STATIC`, this IP address is optional. You can set this IP
+        address to troubleshoot or monitor the tunnel.
+
+        The value must be a /30 or /31.
+
+        Example: `10.0.0.4/31`
+
+
+        :param oracle_interface_ip: The oracle_interface_ip of this CreateIPSecTunnelBgpSessionDetails.
+        :type: str
+        """
+        self._oracle_interface_ip = oracle_interface_ip
+
+    @property
+    def customer_interface_ip(self):
+        """
+        Gets the customer_interface_ip of this CreateIPSecTunnelBgpSessionDetails.
+        The IP address for the CPE end of the inside tunnel interface.
+
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :class:`IPSecConnectionTunnel`), this IP address
+        is required and used for the tunnel's BGP session.
+
+        If `routing` is instead set to `STATIC`, this IP address is optional. You can set this IP
+        address to troubleshoot or monitor the tunnel.
+
+        The value must be a /30 or /31.
+
+        Example: `10.0.0.5/31`
+
+
+        :return: The customer_interface_ip of this CreateIPSecTunnelBgpSessionDetails.
+        :rtype: str
+        """
+        return self._customer_interface_ip
+
+    @customer_interface_ip.setter
+    def customer_interface_ip(self, customer_interface_ip):
+        """
+        Sets the customer_interface_ip of this CreateIPSecTunnelBgpSessionDetails.
+        The IP address for the CPE end of the inside tunnel interface.
+
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :class:`IPSecConnectionTunnel`), this IP address
+        is required and used for the tunnel's BGP session.
+
+        If `routing` is instead set to `STATIC`, this IP address is optional. You can set this IP
+        address to troubleshoot or monitor the tunnel.
+
+        The value must be a /30 or /31.
+
+        Example: `10.0.0.5/31`
+
+
+        :param customer_interface_ip: The customer_interface_ip of this CreateIPSecTunnelBgpSessionDetails.
+        :type: str
+        """
+        self._customer_interface_ip = customer_interface_ip
+
+    @property
+    def customer_bgp_asn(self):
+        """
+        Gets the customer_bgp_asn of this CreateIPSecTunnelBgpSessionDetails.
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :class:`IPSecConnectionTunnel`), this ASN
+        is required and used for the tunnel's BGP session. This is the ASN of the network on the
+        CPE end of the BGP session. Can be a 2-byte or 4-byte ASN. Uses \"asplain\" format.
+
+        If the tunnel's `routing` attribute is set to `STATIC`, the `customerBgpAsn` must be null.
+
+        Example: `12345` (2-byte) or `1587232876` (4-byte)
+
+
+        :return: The customer_bgp_asn of this CreateIPSecTunnelBgpSessionDetails.
+        :rtype: str
+        """
+        return self._customer_bgp_asn
+
+    @customer_bgp_asn.setter
+    def customer_bgp_asn(self, customer_bgp_asn):
+        """
+        Sets the customer_bgp_asn of this CreateIPSecTunnelBgpSessionDetails.
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :class:`IPSecConnectionTunnel`), this ASN
+        is required and used for the tunnel's BGP session. This is the ASN of the network on the
+        CPE end of the BGP session. Can be a 2-byte or 4-byte ASN. Uses \"asplain\" format.
+
+        If the tunnel's `routing` attribute is set to `STATIC`, the `customerBgpAsn` must be null.
+
+        Example: `12345` (2-byte) or `1587232876` (4-byte)
+
+
+        :param customer_bgp_asn: The customer_bgp_asn of this CreateIPSecTunnelBgpSessionDetails.
+        :type: str
+        """
+        self._customer_bgp_asn = customer_bgp_asn
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/create_service_gateway_details.py
+++ b/src/oci/core/models/create_service_gateway_details.py
@@ -71,7 +71,7 @@ class CreateServiceGatewayDetails(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this CreateServiceGatewayDetails.
-        The `OCID]`__  of the compartment to contain the service gateway.
+        The `OCID]`__ of the compartment to contain the service gateway.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -85,7 +85,7 @@ class CreateServiceGatewayDetails(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this CreateServiceGatewayDetails.
-        The `OCID]`__  of the compartment to contain the service gateway.
+        The `OCID]`__ of the compartment to contain the service gateway.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -195,7 +195,15 @@ class CreateServiceGatewayDetails(object):
     def services(self):
         """
         **[Required]** Gets the services of this CreateServiceGatewayDetails.
-        List of the service OCIDs. These are the services that will be enabled on the service gateway. This list can be empty.
+        List of the OCIDs of the :class:`Service` objects to
+        enable for the service gateway. This list can be empty if you don't want to enable any
+        `Service` objects when you create the gateway. You can enable a `Service`
+        object later by using either :func:`attach_service_id`
+        or :func:`update_service_gateway`.
+
+        For each enabled `Service`, make sure there's a route rule with the `Service` object's `cidrBlock`
+        as the rule's destination and the service gateway as the rule's target. See
+        :class:`RouteTable`.
 
 
         :return: The services of this CreateServiceGatewayDetails.
@@ -207,7 +215,15 @@ class CreateServiceGatewayDetails(object):
     def services(self, services):
         """
         Sets the services of this CreateServiceGatewayDetails.
-        List of the service OCIDs. These are the services that will be enabled on the service gateway. This list can be empty.
+        List of the OCIDs of the :class:`Service` objects to
+        enable for the service gateway. This list can be empty if you don't want to enable any
+        `Service` objects when you create the gateway. You can enable a `Service`
+        object later by using either :func:`attach_service_id`
+        or :func:`update_service_gateway`.
+
+        For each enabled `Service`, make sure there's a route rule with the `Service` object's `cidrBlock`
+        as the rule's destination and the service gateway as the rule's target. See
+        :class:`RouteTable`.
 
 
         :param services: The services of this CreateServiceGatewayDetails.

--- a/src/oci/core/models/cross_connect_group.py
+++ b/src/oci/core/models/cross_connect_group.py
@@ -135,7 +135,7 @@ class CrossConnectGroup(object):
     def display_name(self):
         """
         Gets the display_name of this CrossConnectGroup.
-        The display name of A user-friendly name. Does not have to be unique, and it's changeable.
+        The display name of a user-friendly name. Does not have to be unique, and it's changeable.
         Avoid entering confidential information.
 
 
@@ -148,7 +148,7 @@ class CrossConnectGroup(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CrossConnectGroup.
-        The display name of A user-friendly name. Does not have to be unique, and it's changeable.
+        The display name of a user-friendly name. Does not have to be unique, and it's changeable.
         Avoid entering confidential information.
 
 

--- a/src/oci/core/models/egress_security_rule.py
+++ b/src/oci/core/models/egress_security_rule.py
@@ -96,8 +96,8 @@ class EgressSecurityRule(object):
           * IP address range in CIDR notation. For example: `192.168.1.0/24`
 
           * The `cidrBlock` value for a :class:`Service`, if you're
-            setting up a security list rule for traffic destined for a particular service through
-            a service gateway. For example: `oci-phx-objectstorage`
+            setting up a security list rule for traffic destined for a particular `Service` through
+            a service gateway. For example: `oci-phx-objectstorage`.
 
 
         :return: The destination of this EgressSecurityRule.
@@ -117,8 +117,8 @@ class EgressSecurityRule(object):
           * IP address range in CIDR notation. For example: `192.168.1.0/24`
 
           * The `cidrBlock` value for a :class:`Service`, if you're
-            setting up a security list rule for traffic destined for a particular service through
-            a service gateway. For example: `oci-phx-objectstorage`
+            setting up a security list rule for traffic destined for a particular `Service` through
+            a service gateway. For example: `oci-phx-objectstorage`.
 
 
         :param destination: The destination of this EgressSecurityRule.
@@ -138,7 +138,7 @@ class EgressSecurityRule(object):
 
           * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
             :class:`Service` (the rule is for traffic destined for a
-            particular service through a service gateway).
+            particular `Service` through a service gateway).
 
         Allowed values for this property are: "CIDR_BLOCK", "SERVICE_CIDR_BLOCK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -161,7 +161,7 @@ class EgressSecurityRule(object):
 
           * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
             :class:`Service` (the rule is for traffic destined for a
-            particular service through a service gateway).
+            particular `Service` through a service gateway).
 
 
         :param destination_type: The destination_type of this EgressSecurityRule.

--- a/src/oci/core/models/ingress_security_rule.py
+++ b/src/oci/core/models/ingress_security_rule.py
@@ -204,8 +204,8 @@ class IngressSecurityRule(object):
           * IP address range in CIDR notation. For example: `192.168.1.0/24`
 
           * The `cidrBlock` value for a :class:`Service`, if you're
-            setting up a security list rule for traffic coming from a particular service through
-            a service gateway. For example: `oci-phx-objectstorage`
+            setting up a security list rule for traffic coming from a particular `Service` through
+            a service gateway. For example: `oci-phx-objectstorage`.
 
 
         :return: The source of this IngressSecurityRule.
@@ -225,8 +225,8 @@ class IngressSecurityRule(object):
           * IP address range in CIDR notation. For example: `192.168.1.0/24`
 
           * The `cidrBlock` value for a :class:`Service`, if you're
-            setting up a security list rule for traffic coming from a particular service through
-            a service gateway. For example: `oci-phx-objectstorage`
+            setting up a security list rule for traffic coming from a particular `Service` through
+            a service gateway. For example: `oci-phx-objectstorage`.
 
 
         :param source: The source of this IngressSecurityRule.
@@ -244,7 +244,7 @@ class IngressSecurityRule(object):
 
           * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
             :class:`Service` (the rule is for traffic coming from a
-            particular service through a service gateway).
+            particular `Service` through a service gateway).
 
         Allowed values for this property are: "CIDR_BLOCK", "SERVICE_CIDR_BLOCK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -265,7 +265,7 @@ class IngressSecurityRule(object):
 
           * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
             :class:`Service` (the rule is for traffic coming from a
-            particular service through a service gateway).
+            particular `Service` through a service gateway).
 
 
         :param source_type: The source_type of this IngressSecurityRule.

--- a/src/oci/core/models/instance_configuration.py
+++ b/src/oci/core/models/instance_configuration.py
@@ -247,6 +247,9 @@ class InstanceConfiguration(object):
     def deferred_fields(self):
         """
         Gets the deferred_fields of this InstanceConfiguration.
+        The required details when using the :func:`launch_instance_configuration` operation.
+        These attributes are optional when using the :func:`create_instance_configuration` operation.
+
 
         :return: The deferred_fields of this InstanceConfiguration.
         :rtype: list[str]
@@ -257,6 +260,9 @@ class InstanceConfiguration(object):
     def deferred_fields(self, deferred_fields):
         """
         Sets the deferred_fields of this InstanceConfiguration.
+        The required details when using the :func:`launch_instance_configuration` operation.
+        These attributes are optional when using the :func:`create_instance_configuration` operation.
+
 
         :param deferred_fields: The deferred_fields of this InstanceConfiguration.
         :type: list[str]

--- a/src/oci/core/models/instance_configuration_create_vnic_details.py
+++ b/src/oci/core/models/instance_configuration_create_vnic_details.py
@@ -9,7 +9,10 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class InstanceConfigurationCreateVnicDetails(object):
     """
-    Please see :class:`CreateVnicDetails`
+    Contains the properties of the VNIC for an instance configuration. See :class:`CreateVnicDetails`
+    and `Instance Configurations`__ for more information.
+
+    __ https://docs.cloud.oracle.com/Content/Compute/Concepts/instancemanagement.htm#config
     """
 
     def __init__(self, **kwargs):
@@ -71,6 +74,9 @@ class InstanceConfigurationCreateVnicDetails(object):
     def assign_public_ip(self):
         """
         Gets the assign_public_ip of this InstanceConfigurationCreateVnicDetails.
+        Whether the VNIC should be assigned a public IP address. See the `assignPublicIp` attribute of :class:`CreateVnicDetails`
+        for more information.
+
 
         :return: The assign_public_ip of this InstanceConfigurationCreateVnicDetails.
         :rtype: bool
@@ -81,6 +87,9 @@ class InstanceConfigurationCreateVnicDetails(object):
     def assign_public_ip(self, assign_public_ip):
         """
         Sets the assign_public_ip of this InstanceConfigurationCreateVnicDetails.
+        Whether the VNIC should be assigned a public IP address. See the `assignPublicIp` attribute of :class:`CreateVnicDetails`
+        for more information.
+
 
         :param assign_public_ip: The assign_public_ip of this InstanceConfigurationCreateVnicDetails.
         :type: bool
@@ -117,6 +126,9 @@ class InstanceConfigurationCreateVnicDetails(object):
     def hostname_label(self):
         """
         Gets the hostname_label of this InstanceConfigurationCreateVnicDetails.
+        The hostname for the VNIC's primary private IP.
+        See the `hostnameLabel` attribute of :class:`CreateVnicDetails` for more information.
+
 
         :return: The hostname_label of this InstanceConfigurationCreateVnicDetails.
         :rtype: str
@@ -127,6 +139,9 @@ class InstanceConfigurationCreateVnicDetails(object):
     def hostname_label(self, hostname_label):
         """
         Sets the hostname_label of this InstanceConfigurationCreateVnicDetails.
+        The hostname for the VNIC's primary private IP.
+        See the `hostnameLabel` attribute of :class:`CreateVnicDetails` for more information.
+
 
         :param hostname_label: The hostname_label of this InstanceConfigurationCreateVnicDetails.
         :type: str
@@ -137,6 +152,9 @@ class InstanceConfigurationCreateVnicDetails(object):
     def private_ip(self):
         """
         Gets the private_ip of this InstanceConfigurationCreateVnicDetails.
+        A private IP address of your choice to assign to the VNIC.
+        See the `privateIp` attribute of :class:`CreateVnicDetails` for more information.
+
 
         :return: The private_ip of this InstanceConfigurationCreateVnicDetails.
         :rtype: str
@@ -147,6 +165,9 @@ class InstanceConfigurationCreateVnicDetails(object):
     def private_ip(self, private_ip):
         """
         Sets the private_ip of this InstanceConfigurationCreateVnicDetails.
+        A private IP address of your choice to assign to the VNIC.
+        See the `privateIp` attribute of :class:`CreateVnicDetails` for more information.
+
 
         :param private_ip: The private_ip of this InstanceConfigurationCreateVnicDetails.
         :type: str
@@ -157,6 +178,9 @@ class InstanceConfigurationCreateVnicDetails(object):
     def skip_source_dest_check(self):
         """
         Gets the skip_source_dest_check of this InstanceConfigurationCreateVnicDetails.
+        Whether the source/destination check is disabled on the VNIC.
+        See the `skipSourceDestCheck` attribute of :class:`CreateVnicDetails` for more information.
+
 
         :return: The skip_source_dest_check of this InstanceConfigurationCreateVnicDetails.
         :rtype: bool
@@ -167,6 +191,9 @@ class InstanceConfigurationCreateVnicDetails(object):
     def skip_source_dest_check(self, skip_source_dest_check):
         """
         Sets the skip_source_dest_check of this InstanceConfigurationCreateVnicDetails.
+        Whether the source/destination check is disabled on the VNIC.
+        See the `skipSourceDestCheck` attribute of :class:`CreateVnicDetails` for more information.
+
 
         :param skip_source_dest_check: The skip_source_dest_check of this InstanceConfigurationCreateVnicDetails.
         :type: bool
@@ -177,6 +204,9 @@ class InstanceConfigurationCreateVnicDetails(object):
     def subnet_id(self):
         """
         Gets the subnet_id of this InstanceConfigurationCreateVnicDetails.
+        The OCID of the subnet to create the VNIC in.
+        See the `subnetId` attribute of :class:`CreateVnicDetails` for more information.
+
 
         :return: The subnet_id of this InstanceConfigurationCreateVnicDetails.
         :rtype: str
@@ -187,6 +217,9 @@ class InstanceConfigurationCreateVnicDetails(object):
     def subnet_id(self, subnet_id):
         """
         Sets the subnet_id of this InstanceConfigurationCreateVnicDetails.
+        The OCID of the subnet to create the VNIC in.
+        See the `subnetId` attribute of :class:`CreateVnicDetails` for more information.
+
 
         :param subnet_id: The subnet_id of this InstanceConfigurationCreateVnicDetails.
         :type: str

--- a/src/oci/core/models/instance_configuration_summary.py
+++ b/src/oci/core/models/instance_configuration_summary.py
@@ -33,25 +33,39 @@ class InstanceConfigurationSummary(object):
             The value to assign to the time_created property of this InstanceConfigurationSummary.
         :type time_created: datetime
 
+        :param defined_tags:
+            The value to assign to the defined_tags property of this InstanceConfigurationSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this InstanceConfigurationSummary.
+        :type freeform_tags: dict(str, str)
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
             'display_name': 'str',
             'id': 'str',
-            'time_created': 'datetime'
+            'time_created': 'datetime',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'freeform_tags': 'dict(str, str)'
         }
 
         self.attribute_map = {
             'compartment_id': 'compartmentId',
             'display_name': 'displayName',
             'id': 'id',
-            'time_created': 'timeCreated'
+            'time_created': 'timeCreated',
+            'defined_tags': 'definedTags',
+            'freeform_tags': 'freeformTags'
         }
 
         self._compartment_id = None
         self._display_name = None
         self._id = None
         self._time_created = None
+        self._defined_tags = None
+        self._freeform_tags = None
 
     @property
     def compartment_id(self):
@@ -150,6 +164,76 @@ class InstanceConfigurationSummary(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this InstanceConfigurationSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this InstanceConfigurationSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this InstanceConfigurationSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this InstanceConfigurationSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this InstanceConfigurationSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this InstanceConfigurationSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this InstanceConfigurationSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this InstanceConfigurationSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/instance_pool_summary.py
+++ b/src/oci/core/models/instance_pool_summary.py
@@ -83,6 +83,14 @@ class InstancePoolSummary(object):
             The value to assign to the time_created property of this InstancePoolSummary.
         :type time_created: datetime
 
+        :param defined_tags:
+            The value to assign to the defined_tags property of this InstancePoolSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this InstancePoolSummary.
+        :type freeform_tags: dict(str, str)
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -92,7 +100,9 @@ class InstancePoolSummary(object):
             'lifecycle_state': 'str',
             'availability_domains': 'list[str]',
             'size': 'int',
-            'time_created': 'datetime'
+            'time_created': 'datetime',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'freeform_tags': 'dict(str, str)'
         }
 
         self.attribute_map = {
@@ -103,7 +113,9 @@ class InstancePoolSummary(object):
             'lifecycle_state': 'lifecycleState',
             'availability_domains': 'availabilityDomains',
             'size': 'size',
-            'time_created': 'timeCreated'
+            'time_created': 'timeCreated',
+            'defined_tags': 'definedTags',
+            'freeform_tags': 'freeformTags'
         }
 
         self._id = None
@@ -114,6 +126,8 @@ class InstancePoolSummary(object):
         self._availability_domains = None
         self._size = None
         self._time_created = None
+        self._defined_tags = None
+        self._freeform_tags = None
 
     @property
     def id(self):
@@ -314,6 +328,76 @@ class InstancePoolSummary(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this InstancePoolSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this InstancePoolSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this InstancePoolSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this InstancePoolSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this InstancePoolSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this InstancePoolSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this InstancePoolSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this InstancePoolSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/ip_sec_connection.py
+++ b/src/oci/core/models/ip_sec_connection.py
@@ -11,7 +11,20 @@ class IPSecConnection(object):
     """
     A connection between a DRG and CPE. This connection consists of multiple IPSec
     tunnels. Creating this connection is one of the steps required when setting up
-    an IPSec VPN. For more information, see
+    an IPSec VPN.
+
+    **Important:**  Each tunnel in an IPSec connection can use either static routing or BGP dynamic
+    routing (see the :class:`IPSecConnectionTunnel` object's
+    `routing` attribute). Originally only static routing was supported and
+    every IPSec connection was required to have at least one static route configured.
+    To maintain backward compatibility in the API when support for BPG dynamic routing was introduced,
+    the API accepts an empty list of static routes if you configure both of the IPSec tunnels to use
+    BGP dynamic routing. If you switch a tunnel's routing from `BGP` to `STATIC`, you must first
+    ensure that the IPSec connection is configured with at least one valid CIDR block static route.
+    Oracle uses the IPSec connection's static routes when routing a tunnel's traffic *only*
+    if that tunnel's `routing` attribute = `STATIC`. Otherwise the static routes are ignored.
+
+    For more information about the workflow for setting up an IPSec connection, see
     `IPSec VPN`__.
 
     To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
@@ -450,8 +463,14 @@ class IPSecConnection(object):
     def static_routes(self):
         """
         **[Required]** Gets the static_routes of this IPSecConnection.
-        Static routes to the CPE. At least one route must be included. The CIDR must not be a
+        Static routes to the CPE. The CIDR must not be a
         multicast address or class E address.
+
+        Used for routing a given IPSec tunnel's traffic only if the tunnel
+        is using static routing. If you configure at least one tunnel to use static routing, then
+        you must provide at least one valid static route. If you configure both
+        tunnels to use BGP dynamic routing, you can provide an empty list for the static routes.
+
 
         Example: `10.0.1.0/24`
 
@@ -465,8 +484,14 @@ class IPSecConnection(object):
     def static_routes(self, static_routes):
         """
         Sets the static_routes of this IPSecConnection.
-        Static routes to the CPE. At least one route must be included. The CIDR must not be a
+        Static routes to the CPE. The CIDR must not be a
         multicast address or class E address.
+
+        Used for routing a given IPSec tunnel's traffic only if the tunnel
+        is using static routing. If you configure at least one tunnel to use static routing, then
+        you must provide at least one valid static route. If you configure both
+        tunnels to use BGP dynamic routing, you can provide an empty list for the static routes.
+
 
         Example: `10.0.1.0/24`
 

--- a/src/oci/core/models/ip_sec_connection_device_config.py
+++ b/src/oci/core/models/ip_sec_connection_device_config.py
@@ -9,7 +9,10 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class IPSecConnectionDeviceConfig(object):
     """
-    Information about the IPSecConnection device configuration.
+    Deprecated. For tunnel information, instead see:
+
+    * :class:`IPSecConnectionTunnel`
+    * :class:`IPSecConnectionTunnelSharedSecret`
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/core/models/ip_sec_connection_device_status.py
+++ b/src/oci/core/models/ip_sec_connection_device_status.py
@@ -9,7 +9,8 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class IPSecConnectionDeviceStatus(object):
     """
-    Status of the IPSec connection.
+    Deprecated. For tunnel information, instead see
+    :class:`IPSecConnectionTunnel`.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/core/models/ip_sec_connection_tunnel.py
+++ b/src/oci/core/models/ip_sec_connection_tunnel.py
@@ -1,0 +1,467 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class IPSecConnectionTunnel(object):
+    """
+    Information about a single tunnel in an IPSec connection. This object does not include the tunnel's
+    shared secret (pre-shared key). That is in the
+    :class:`IPSecConnectionTunnelSharedSecret` object.
+    """
+
+    #: A constant which can be used with the status property of a IPSecConnectionTunnel.
+    #: This constant has a value of "UP"
+    STATUS_UP = "UP"
+
+    #: A constant which can be used with the status property of a IPSecConnectionTunnel.
+    #: This constant has a value of "DOWN"
+    STATUS_DOWN = "DOWN"
+
+    #: A constant which can be used with the status property of a IPSecConnectionTunnel.
+    #: This constant has a value of "DOWN_FOR_MAINTENANCE"
+    STATUS_DOWN_FOR_MAINTENANCE = "DOWN_FOR_MAINTENANCE"
+
+    #: A constant which can be used with the lifecycle_state property of a IPSecConnectionTunnel.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a IPSecConnectionTunnel.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a IPSecConnectionTunnel.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a IPSecConnectionTunnel.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the routing property of a IPSecConnectionTunnel.
+    #: This constant has a value of "BGP"
+    ROUTING_BGP = "BGP"
+
+    #: A constant which can be used with the routing property of a IPSecConnectionTunnel.
+    #: This constant has a value of "STATIC"
+    ROUTING_STATIC = "STATIC"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new IPSecConnectionTunnel object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this IPSecConnectionTunnel.
+        :type compartment_id: str
+
+        :param id:
+            The value to assign to the id property of this IPSecConnectionTunnel.
+        :type id: str
+
+        :param vpn_ip:
+            The value to assign to the vpn_ip property of this IPSecConnectionTunnel.
+        :type vpn_ip: str
+
+        :param cpe_ip:
+            The value to assign to the cpe_ip property of this IPSecConnectionTunnel.
+        :type cpe_ip: str
+
+        :param status:
+            The value to assign to the status property of this IPSecConnectionTunnel.
+            Allowed values for this property are: "UP", "DOWN", "DOWN_FOR_MAINTENANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this IPSecConnectionTunnel.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param display_name:
+            The value to assign to the display_name property of this IPSecConnectionTunnel.
+        :type display_name: str
+
+        :param bgp_session_info:
+            The value to assign to the bgp_session_info property of this IPSecConnectionTunnel.
+        :type bgp_session_info: BgpSessionInfo
+
+        :param routing:
+            The value to assign to the routing property of this IPSecConnectionTunnel.
+            Allowed values for this property are: "BGP", "STATIC", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type routing: str
+
+        :param time_created:
+            The value to assign to the time_created property of this IPSecConnectionTunnel.
+        :type time_created: datetime
+
+        :param time_status_updated:
+            The value to assign to the time_status_updated property of this IPSecConnectionTunnel.
+        :type time_status_updated: datetime
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'id': 'str',
+            'vpn_ip': 'str',
+            'cpe_ip': 'str',
+            'status': 'str',
+            'lifecycle_state': 'str',
+            'display_name': 'str',
+            'bgp_session_info': 'BgpSessionInfo',
+            'routing': 'str',
+            'time_created': 'datetime',
+            'time_status_updated': 'datetime'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'id': 'id',
+            'vpn_ip': 'vpnIp',
+            'cpe_ip': 'cpeIp',
+            'status': 'status',
+            'lifecycle_state': 'lifecycleState',
+            'display_name': 'displayName',
+            'bgp_session_info': 'bgpSessionInfo',
+            'routing': 'routing',
+            'time_created': 'timeCreated',
+            'time_status_updated': 'timeStatusUpdated'
+        }
+
+        self._compartment_id = None
+        self._id = None
+        self._vpn_ip = None
+        self._cpe_ip = None
+        self._status = None
+        self._lifecycle_state = None
+        self._display_name = None
+        self._bgp_session_info = None
+        self._routing = None
+        self._time_created = None
+        self._time_status_updated = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this IPSecConnectionTunnel.
+        The `OCID`__ of the compartment containing the tunnel.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this IPSecConnectionTunnel.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this IPSecConnectionTunnel.
+        The `OCID`__ of the compartment containing the tunnel.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this IPSecConnectionTunnel.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this IPSecConnectionTunnel.
+        The `OCID`__ of the tunnel.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this IPSecConnectionTunnel.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this IPSecConnectionTunnel.
+        The `OCID`__ of the tunnel.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this IPSecConnectionTunnel.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def vpn_ip(self):
+        """
+        Gets the vpn_ip of this IPSecConnectionTunnel.
+        The IP address of Oracle's VPN headend.
+
+        Example: `192.0.2.5`
+
+
+        :return: The vpn_ip of this IPSecConnectionTunnel.
+        :rtype: str
+        """
+        return self._vpn_ip
+
+    @vpn_ip.setter
+    def vpn_ip(self, vpn_ip):
+        """
+        Sets the vpn_ip of this IPSecConnectionTunnel.
+        The IP address of Oracle's VPN headend.
+
+        Example: `192.0.2.5`
+
+
+        :param vpn_ip: The vpn_ip of this IPSecConnectionTunnel.
+        :type: str
+        """
+        self._vpn_ip = vpn_ip
+
+    @property
+    def cpe_ip(self):
+        """
+        Gets the cpe_ip of this IPSecConnectionTunnel.
+        The IP address of the CPE's VPN headend.
+
+        Example: `192.0.2.157`
+
+
+        :return: The cpe_ip of this IPSecConnectionTunnel.
+        :rtype: str
+        """
+        return self._cpe_ip
+
+    @cpe_ip.setter
+    def cpe_ip(self, cpe_ip):
+        """
+        Sets the cpe_ip of this IPSecConnectionTunnel.
+        The IP address of the CPE's VPN headend.
+
+        Example: `192.0.2.157`
+
+
+        :param cpe_ip: The cpe_ip of this IPSecConnectionTunnel.
+        :type: str
+        """
+        self._cpe_ip = cpe_ip
+
+    @property
+    def status(self):
+        """
+        Gets the status of this IPSecConnectionTunnel.
+        The status of the tunnel based on IPSec protocol characteristics.
+
+        Allowed values for this property are: "UP", "DOWN", "DOWN_FOR_MAINTENANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this IPSecConnectionTunnel.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this IPSecConnectionTunnel.
+        The status of the tunnel based on IPSec protocol characteristics.
+
+
+        :param status: The status of this IPSecConnectionTunnel.
+        :type: str
+        """
+        allowed_values = ["UP", "DOWN", "DOWN_FOR_MAINTENANCE"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this IPSecConnectionTunnel.
+        The tunnel's lifecycle state.
+
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this IPSecConnectionTunnel.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this IPSecConnectionTunnel.
+        The tunnel's lifecycle state.
+
+
+        :param lifecycle_state: The lifecycle_state of this IPSecConnectionTunnel.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this IPSecConnectionTunnel.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid
+        entering confidential information.
+
+
+        :return: The display_name of this IPSecConnectionTunnel.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this IPSecConnectionTunnel.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid
+        entering confidential information.
+
+
+        :param display_name: The display_name of this IPSecConnectionTunnel.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def bgp_session_info(self):
+        """
+        Gets the bgp_session_info of this IPSecConnectionTunnel.
+        Information for establishing the tunnel's BGP session.
+
+
+        :return: The bgp_session_info of this IPSecConnectionTunnel.
+        :rtype: BgpSessionInfo
+        """
+        return self._bgp_session_info
+
+    @bgp_session_info.setter
+    def bgp_session_info(self, bgp_session_info):
+        """
+        Sets the bgp_session_info of this IPSecConnectionTunnel.
+        Information for establishing the tunnel's BGP session.
+
+
+        :param bgp_session_info: The bgp_session_info of this IPSecConnectionTunnel.
+        :type: BgpSessionInfo
+        """
+        self._bgp_session_info = bgp_session_info
+
+    @property
+    def routing(self):
+        """
+        Gets the routing of this IPSecConnectionTunnel.
+        The type of routing used for this tunnel (either BGP dynamic routing or static routing).
+
+        Allowed values for this property are: "BGP", "STATIC", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The routing of this IPSecConnectionTunnel.
+        :rtype: str
+        """
+        return self._routing
+
+    @routing.setter
+    def routing(self, routing):
+        """
+        Sets the routing of this IPSecConnectionTunnel.
+        The type of routing used for this tunnel (either BGP dynamic routing or static routing).
+
+
+        :param routing: The routing of this IPSecConnectionTunnel.
+        :type: str
+        """
+        allowed_values = ["BGP", "STATIC"]
+        if not value_allowed_none_or_none_sentinel(routing, allowed_values):
+            routing = 'UNKNOWN_ENUM_VALUE'
+        self._routing = routing
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this IPSecConnectionTunnel.
+        The date and time the IPSec connection tunnel was created, in the format defined by RFC3339.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+
+        :return: The time_created of this IPSecConnectionTunnel.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this IPSecConnectionTunnel.
+        The date and time the IPSec connection tunnel was created, in the format defined by RFC3339.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+
+        :param time_created: The time_created of this IPSecConnectionTunnel.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_status_updated(self):
+        """
+        Gets the time_status_updated of this IPSecConnectionTunnel.
+        When the status of the tunnel last changed, in the format defined by RFC3339.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+
+        :return: The time_status_updated of this IPSecConnectionTunnel.
+        :rtype: datetime
+        """
+        return self._time_status_updated
+
+    @time_status_updated.setter
+    def time_status_updated(self, time_status_updated):
+        """
+        Sets the time_status_updated of this IPSecConnectionTunnel.
+        When the status of the tunnel last changed, in the format defined by RFC3339.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+
+        :param time_status_updated: The time_status_updated of this IPSecConnectionTunnel.
+        :type: datetime
+        """
+        self._time_status_updated = time_status_updated
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/ip_sec_connection_tunnel_shared_secret.py
+++ b/src/oci/core/models/ip_sec_connection_tunnel_shared_secret.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class IPSecConnectionTunnelSharedSecret(object):
+    """
+    The tunnel's shared secret (pre-shared key).
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new IPSecConnectionTunnelSharedSecret object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param shared_secret:
+            The value to assign to the shared_secret property of this IPSecConnectionTunnelSharedSecret.
+        :type shared_secret: str
+
+        """
+        self.swagger_types = {
+            'shared_secret': 'str'
+        }
+
+        self.attribute_map = {
+            'shared_secret': 'sharedSecret'
+        }
+
+        self._shared_secret = None
+
+    @property
+    def shared_secret(self):
+        """
+        **[Required]** Gets the shared_secret of this IPSecConnectionTunnelSharedSecret.
+        The tunnel's shared secret (pre-shared key).
+
+        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+
+
+        :return: The shared_secret of this IPSecConnectionTunnelSharedSecret.
+        :rtype: str
+        """
+        return self._shared_secret
+
+    @shared_secret.setter
+    def shared_secret(self, shared_secret):
+        """
+        Sets the shared_secret of this IPSecConnectionTunnelSharedSecret.
+        The tunnel's shared secret (pre-shared key).
+
+        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+
+
+        :param shared_secret: The shared_secret of this IPSecConnectionTunnelSharedSecret.
+        :type: str
+        """
+        self._shared_secret = shared_secret
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/private_ip.py
+++ b/src/oci/core/models/private_ip.py
@@ -9,8 +9,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class PrivateIp(object):
     """
-    A *private IP* is a conceptual term that refers to a private IP address and related properties.
+    A *private IP* is a conceptual term that refers to an IPv4 private IP address and related properties.
     The `privateIp` object is the API representation of a private IP.
+
 
     Each instance has a *primary private IP* that is automatically created and
     assigned to the primary VNIC during instance launch. If you add a secondary

--- a/src/oci/core/models/route_rule.py
+++ b/src/oci/core/models/route_rule.py
@@ -74,6 +74,7 @@ class RouteRule(object):
         A destination IP address range in CIDR notation. Matching packets will
         be routed to the indicated network entity (the target).
 
+
         Example: `0.0.0.0/0`
 
 
@@ -91,6 +92,7 @@ class RouteRule(object):
 
         A destination IP address range in CIDR notation. Matching packets will
         be routed to the indicated network entity (the target).
+
 
         Example: `0.0.0.0/0`
 
@@ -112,8 +114,8 @@ class RouteRule(object):
           * IP address range in CIDR notation. For example: `192.168.1.0/24`
 
           * The `cidrBlock` value for a :class:`Service`, if you're
-            setting up a route rule for traffic destined for a particular service through
-            a service gateway. For example: `oci-phx-objectstorage`
+            setting up a route rule for traffic destined for a particular `Service` through
+            a service gateway. For example: `oci-phx-objectstorage`.
 
 
         :return: The destination of this RouteRule.
@@ -133,8 +135,8 @@ class RouteRule(object):
           * IP address range in CIDR notation. For example: `192.168.1.0/24`
 
           * The `cidrBlock` value for a :class:`Service`, if you're
-            setting up a route rule for traffic destined for a particular service through
-            a service gateway. For example: `oci-phx-objectstorage`
+            setting up a route rule for traffic destined for a particular `Service` through
+            a service gateway. For example: `oci-phx-objectstorage`.
 
 
         :param destination: The destination of this RouteRule.
@@ -152,7 +154,7 @@ class RouteRule(object):
 
           * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
             :class:`Service` (the rule is for traffic destined for a
-            particular service through a service gateway).
+            particular `Service` through a service gateway).
 
         Allowed values for this property are: "CIDR_BLOCK", "SERVICE_CIDR_BLOCK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -173,7 +175,7 @@ class RouteRule(object):
 
           * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
             :class:`Service` (the rule is for traffic destined for a
-            particular service through a service gateway).
+            particular `Service` through a service gateway).
 
 
         :param destination_type: The destination_type of this RouteRule.

--- a/src/oci/core/models/service.py
+++ b/src/oci/core/models/service.py
@@ -9,7 +9,14 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Service(object):
     """
-    Information about a service that is accessible through a service gateway.
+    An object that represents one or multiple Oracle services that you can enable for a
+    :class:`ServiceGateway`. In the User Guide topic
+    `Access to Oracle Services: Service Gateway`__, the
+    term *service CIDR label* is used to refer to the string that represents the regional public
+    IP address ranges of the Oracle service or services covered by a given `Service` object. That
+    unique string is the value of the `Service` object's `cidrBlock` attribute.
+
+    __ https://docs.cloud.oracle.com/Content/Network/Tasks/servicegateway.htm
     """
 
     def __init__(self, **kwargs):
@@ -57,9 +64,17 @@ class Service(object):
     def cidr_block(self):
         """
         **[Required]** Gets the cidr_block of this Service.
-        A string that represents the public endpoints for the service. When you set up a route rule
-        to route traffic to the service gateway, use this value as the destination CIDR block for
-        the rule. See :class:`RouteTable`.
+        A string that represents the regional public IP address ranges for the Oracle service or
+        services covered by this `Service` object. Also known as the `Service` object's *service
+        CIDR label*.
+
+        When you set up a route rule to route traffic to the service gateway, use this value as the
+        rule's destination. See :class:`RouteTable`. Also, when you set up
+        a security list rule to cover traffic with the service gateway, use the `cidrBlock` value
+        as the rule's destination (for an egress rule) or the source (for an ingress rule).
+        See :class:`SecurityList`.
+
+        Example: `oci-phx-objectstorage`
 
 
         :return: The cidr_block of this Service.
@@ -71,9 +86,17 @@ class Service(object):
     def cidr_block(self, cidr_block):
         """
         Sets the cidr_block of this Service.
-        A string that represents the public endpoints for the service. When you set up a route rule
-        to route traffic to the service gateway, use this value as the destination CIDR block for
-        the rule. See :class:`RouteTable`.
+        A string that represents the regional public IP address ranges for the Oracle service or
+        services covered by this `Service` object. Also known as the `Service` object's *service
+        CIDR label*.
+
+        When you set up a route rule to route traffic to the service gateway, use this value as the
+        rule's destination. See :class:`RouteTable`. Also, when you set up
+        a security list rule to cover traffic with the service gateway, use the `cidrBlock` value
+        as the rule's destination (for an egress rule) or the source (for an ingress rule).
+        See :class:`SecurityList`.
+
+        Example: `oci-phx-objectstorage`
 
 
         :param cidr_block: The cidr_block of this Service.
@@ -85,7 +108,9 @@ class Service(object):
     def description(self):
         """
         **[Required]** Gets the description of this Service.
-        Description of the service.
+        Description of the Oracle service or services covered by this `Service` object.
+
+        Example: `OCI PHX Object Storage`
 
 
         :return: The description of this Service.
@@ -97,7 +122,9 @@ class Service(object):
     def description(self, description):
         """
         Sets the description of this Service.
-        Description of the service.
+        Description of the Oracle service or services covered by this `Service` object.
+
+        Example: `OCI PHX Object Storage`
 
 
         :param description: The description of this Service.
@@ -109,7 +136,7 @@ class Service(object):
     def id(self):
         """
         **[Required]** Gets the id of this Service.
-        The service's `OCID`__.
+        The `Service` object's `OCID`__.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -123,7 +150,7 @@ class Service(object):
     def id(self, id):
         """
         Sets the id of this Service.
-        The service's `OCID`__.
+        The `Service` object's `OCID`__.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -137,7 +164,9 @@ class Service(object):
     def name(self):
         """
         **[Required]** Gets the name of this Service.
-        Name of the service. This name can change and is not guaranteed to be unique.
+        Name of the `Service` object. This name can change and is not guaranteed to be unique.
+
+        Example: `OCI PHX Object Storage`
 
 
         :return: The name of this Service.
@@ -149,7 +178,9 @@ class Service(object):
     def name(self, name):
         """
         Sets the name of this Service.
-        Name of the service. This name can change and is not guaranteed to be unique.
+        Name of the `Service` object. This name can change and is not guaranteed to be unique.
+
+        Example: `OCI PHX Object Storage`
 
 
         :param name: The name of this Service.

--- a/src/oci/core/models/service_gateway.py
+++ b/src/oci/core/models/service_gateway.py
@@ -9,13 +9,13 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ServiceGateway(object):
     """
-    Represents a router that connects the edge of a VCN with public Oracle Cloud Infrastructure
-    services such as Object Storage. Traffic leaving the VCN and destined for a supported public
-    service (see :func:`list_services`) is routed through the
-    service gateway and does not traverse the internet. The instances in the VCN do not need to
-    have public IP addresses nor be in a public subnet. The VCN does not need an internet gateway
+    Represents a router that lets your VCN privately access specific Oracle services such as Object
+    Storage without exposing the VCN to the public internet. Traffic leaving the VCN and destined
+    for a supported Oracle service (see :func:`list_services`) is
+    routed through the service gateway and does not traverse the internet. The instances in the VCN
+    do not need to have public IP addresses nor be in a public subnet. The VCN does not need an internet gateway
     for this traffic. For more information, see
-    `Access to Object Storage: Service Gateway`__.
+    `Access to Oracle Services: Service Gateway`__.
 
     To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
@@ -347,9 +347,10 @@ class ServiceGateway(object):
     def services(self):
         """
         **[Required]** Gets the services of this ServiceGateway.
-        List of the services enabled on this service gateway. The list can be empty.
-        You can enable a particular service by using
-        :func:`attach_service_id`.
+        List of the :class:`Service` objects enabled for this service gateway.
+        The list can be empty. You can enable a particular `Service` by using
+        :func:`attach_service_id` or
+        :func:`update_service_gateway`.
 
 
         :return: The services of this ServiceGateway.
@@ -361,9 +362,10 @@ class ServiceGateway(object):
     def services(self, services):
         """
         Sets the services of this ServiceGateway.
-        List of the services enabled on this service gateway. The list can be empty.
-        You can enable a particular service by using
-        :func:`attach_service_id`.
+        List of the :class:`Service` objects enabled for this service gateway.
+        The list can be empty. You can enable a particular `Service` by using
+        :func:`attach_service_id` or
+        :func:`update_service_gateway`.
 
 
         :param services: The services of this ServiceGateway.

--- a/src/oci/core/models/service_id_request_details.py
+++ b/src/oci/core/models/service_id_request_details.py
@@ -36,7 +36,7 @@ class ServiceIdRequestDetails(object):
     def service_id(self):
         """
         **[Required]** Gets the service_id of this ServiceIdRequestDetails.
-        The `OCID`__ of the service.
+        The `OCID`__ of the :class:`Service`.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -50,7 +50,7 @@ class ServiceIdRequestDetails(object):
     def service_id(self, service_id):
         """
         Sets the service_id of this ServiceIdRequestDetails.
-        The `OCID`__ of the service.
+        The `OCID`__ of the :class:`Service`.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 

--- a/src/oci/core/models/tunnel_config.py
+++ b/src/oci/core/models/tunnel_config.py
@@ -9,7 +9,10 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class TunnelConfig(object):
     """
-    Specific connection details for an IPSec tunnel.
+    Deprecated. For tunnel information, instead see:
+
+    * :class:`IPSecConnectionTunnel`
+    * :class:`IPSecConnectionTunnelSharedSecret`
     """
 
     def __init__(self, **kwargs):
@@ -80,7 +83,7 @@ class TunnelConfig(object):
         **[Required]** Gets the shared_secret of this TunnelConfig.
         The shared secret of the IPSec tunnel.
 
-        Example: `vFG2IF6TWq4UToUiLSRDoJEUs6j1c.p8G.dVQxiMfMO0yXMLi.lZTbYIWhGu4V8o`
+        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
 
 
         :return: The shared_secret of this TunnelConfig.
@@ -94,7 +97,7 @@ class TunnelConfig(object):
         Sets the shared_secret of this TunnelConfig.
         The shared secret of the IPSec tunnel.
 
-        Example: `vFG2IF6TWq4UToUiLSRDoJEUs6j1c.p8G.dVQxiMfMO0yXMLi.lZTbYIWhGu4V8o`
+        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
 
 
         :param shared_secret: The shared_secret of this TunnelConfig.

--- a/src/oci/core/models/tunnel_status.py
+++ b/src/oci/core/models/tunnel_status.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class TunnelStatus(object):
     """
-    Specific connection details for an IPSec tunnel.
+    Deprecated. For tunnel information, instead see :class:`IPSecConnectionTunnel`.
     """
 
     #: A constant which can be used with the lifecycle_state property of a TunnelStatus.

--- a/src/oci/core/models/update_boot_volume_kms_key_details.py
+++ b/src/oci/core/models/update_boot_volume_kms_key_details.py
@@ -36,10 +36,9 @@ class UpdateBootVolumeKmsKeyDetails(object):
     def kms_key_id(self):
         """
         Gets the kms_key_id of this UpdateBootVolumeKmsKeyDetails.
-        The new kms key which will be used to protect the specific volume.
-        This key has to be a valid kms key ocid, and user must have key delegation policy to allow them to access this key.
-        Even if this new kms key is the same as the previous kms key id, block storage service will use it to regenerate a new volume encryption key.
-        Example: `{\"kmsKeyId\": \"ocid1.key.region1.sea.afnl2n7daag4s.abzwkljs6uevhlgcznhmh7oiatyrxngrywc3tje3uk3g77hzmewqiieuk75f\"}`
+        The OCID of the new KMS key which will be used to protect the specified volume.
+        This key has to be a valid KMS key OCID, and the user must have key delegation policy to allow them to access this key.
+        Even if the new KMS key is the same as the previous KMS key ID, the Block Volume service will use it to regenerate a new volume encryption key.
 
 
         :return: The kms_key_id of this UpdateBootVolumeKmsKeyDetails.
@@ -51,10 +50,9 @@ class UpdateBootVolumeKmsKeyDetails(object):
     def kms_key_id(self, kms_key_id):
         """
         Sets the kms_key_id of this UpdateBootVolumeKmsKeyDetails.
-        The new kms key which will be used to protect the specific volume.
-        This key has to be a valid kms key ocid, and user must have key delegation policy to allow them to access this key.
-        Even if this new kms key is the same as the previous kms key id, block storage service will use it to regenerate a new volume encryption key.
-        Example: `{\"kmsKeyId\": \"ocid1.key.region1.sea.afnl2n7daag4s.abzwkljs6uevhlgcznhmh7oiatyrxngrywc3tje3uk3g77hzmewqiieuk75f\"}`
+        The OCID of the new KMS key which will be used to protect the specified volume.
+        This key has to be a valid KMS key OCID, and the user must have key delegation policy to allow them to access this key.
+        Even if the new KMS key is the same as the previous KMS key ID, the Block Volume service will use it to regenerate a new volume encryption key.
 
 
         :param kms_key_id: The kms_key_id of this UpdateBootVolumeKmsKeyDetails.

--- a/src/oci/core/models/update_instance_pool_details.py
+++ b/src/oci/core/models/update_instance_pool_details.py
@@ -189,8 +189,12 @@ class UpdateInstancePoolDetails(object):
     def placement_configurations(self):
         """
         Gets the placement_configurations of this UpdateInstancePoolDetails.
-        The placement configurations for the instance pool.
-        There should be 1 placement configuration for each desired AD.
+        The placement configurations for the instance pool. Provide one placement configuration for
+        each availability domain.
+
+        To use the instance pool with a regional subnet, provide a placement configuration for
+        each availability domain, and include the regional subnet in each placement
+        configuration.
 
 
         :return: The placement_configurations of this UpdateInstancePoolDetails.
@@ -202,8 +206,12 @@ class UpdateInstancePoolDetails(object):
     def placement_configurations(self, placement_configurations):
         """
         Sets the placement_configurations of this UpdateInstancePoolDetails.
-        The placement configurations for the instance pool.
-        There should be 1 placement configuration for each desired AD.
+        The placement configurations for the instance pool. Provide one placement configuration for
+        each availability domain.
+
+        To use the instance pool with a regional subnet, provide a placement configuration for
+        each availability domain, and include the regional subnet in each placement
+        configuration.
 
 
         :param placement_configurations: The placement_configurations of this UpdateInstancePoolDetails.

--- a/src/oci/core/models/update_ip_sec_connection_tunnel_details.py
+++ b/src/oci/core/models/update_ip_sec_connection_tunnel_details.py
@@ -1,0 +1,150 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateIPSecConnectionTunnelDetails(object):
+    """
+    UpdateIPSecConnectionTunnelDetails model.
+    """
+
+    #: A constant which can be used with the routing property of a UpdateIPSecConnectionTunnelDetails.
+    #: This constant has a value of "BGP"
+    ROUTING_BGP = "BGP"
+
+    #: A constant which can be used with the routing property of a UpdateIPSecConnectionTunnelDetails.
+    #: This constant has a value of "STATIC"
+    ROUTING_STATIC = "STATIC"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateIPSecConnectionTunnelDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateIPSecConnectionTunnelDetails.
+        :type display_name: str
+
+        :param routing:
+            The value to assign to the routing property of this UpdateIPSecConnectionTunnelDetails.
+            Allowed values for this property are: "BGP", "STATIC"
+        :type routing: str
+
+        :param bgp_session_config:
+            The value to assign to the bgp_session_config property of this UpdateIPSecConnectionTunnelDetails.
+        :type bgp_session_config: UpdateIPSecTunnelBgpSessionDetails
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'routing': 'str',
+            'bgp_session_config': 'UpdateIPSecTunnelBgpSessionDetails'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'routing': 'routing',
+            'bgp_session_config': 'bgpSessionConfig'
+        }
+
+        self._display_name = None
+        self._routing = None
+        self._bgp_session_config = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateIPSecConnectionTunnelDetails.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid
+        entering confidential information.
+
+
+        :return: The display_name of this UpdateIPSecConnectionTunnelDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateIPSecConnectionTunnelDetails.
+        A user-friendly name. Does not have to be unique, and it's changeable. Avoid
+        entering confidential information.
+
+
+        :param display_name: The display_name of this UpdateIPSecConnectionTunnelDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def routing(self):
+        """
+        Gets the routing of this UpdateIPSecConnectionTunnelDetails.
+        The type of routing to use for this tunnel (either BGP dynamic routing or static routing).
+
+        Allowed values for this property are: "BGP", "STATIC"
+
+
+        :return: The routing of this UpdateIPSecConnectionTunnelDetails.
+        :rtype: str
+        """
+        return self._routing
+
+    @routing.setter
+    def routing(self, routing):
+        """
+        Sets the routing of this UpdateIPSecConnectionTunnelDetails.
+        The type of routing to use for this tunnel (either BGP dynamic routing or static routing).
+
+
+        :param routing: The routing of this UpdateIPSecConnectionTunnelDetails.
+        :type: str
+        """
+        allowed_values = ["BGP", "STATIC"]
+        if not value_allowed_none_or_none_sentinel(routing, allowed_values):
+            raise ValueError(
+                "Invalid value for `routing`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._routing = routing
+
+    @property
+    def bgp_session_config(self):
+        """
+        Gets the bgp_session_config of this UpdateIPSecConnectionTunnelDetails.
+        Information for establishing a BGP session for the IPSec tunnel.
+
+
+        :return: The bgp_session_config of this UpdateIPSecConnectionTunnelDetails.
+        :rtype: UpdateIPSecTunnelBgpSessionDetails
+        """
+        return self._bgp_session_config
+
+    @bgp_session_config.setter
+    def bgp_session_config(self, bgp_session_config):
+        """
+        Sets the bgp_session_config of this UpdateIPSecConnectionTunnelDetails.
+        Information for establishing a BGP session for the IPSec tunnel.
+
+
+        :param bgp_session_config: The bgp_session_config of this UpdateIPSecConnectionTunnelDetails.
+        :type: UpdateIPSecTunnelBgpSessionDetails
+        """
+        self._bgp_session_config = bgp_session_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/update_ip_sec_connection_tunnel_shared_secret_details.py
+++ b/src/oci/core/models/update_ip_sec_connection_tunnel_shared_secret_details.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateIPSecConnectionTunnelSharedSecretDetails(object):
+    """
+    UpdateIPSecConnectionTunnelSharedSecretDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateIPSecConnectionTunnelSharedSecretDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param shared_secret:
+            The value to assign to the shared_secret property of this UpdateIPSecConnectionTunnelSharedSecretDetails.
+        :type shared_secret: str
+
+        """
+        self.swagger_types = {
+            'shared_secret': 'str'
+        }
+
+        self.attribute_map = {
+            'shared_secret': 'sharedSecret'
+        }
+
+        self._shared_secret = None
+
+    @property
+    def shared_secret(self):
+        """
+        Gets the shared_secret of this UpdateIPSecConnectionTunnelSharedSecretDetails.
+        The shared secret (pre-shared key) to use for the tunnel.
+
+        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+
+
+        :return: The shared_secret of this UpdateIPSecConnectionTunnelSharedSecretDetails.
+        :rtype: str
+        """
+        return self._shared_secret
+
+    @shared_secret.setter
+    def shared_secret(self, shared_secret):
+        """
+        Sets the shared_secret of this UpdateIPSecConnectionTunnelSharedSecretDetails.
+        The shared secret (pre-shared key) to use for the tunnel.
+
+        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+
+
+        :param shared_secret: The shared_secret of this UpdateIPSecConnectionTunnelSharedSecretDetails.
+        :type: str
+        """
+        self._shared_secret = shared_secret
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/update_ip_sec_tunnel_bgp_session_details.py
+++ b/src/oci/core/models/update_ip_sec_tunnel_bgp_session_details.py
@@ -1,0 +1,199 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateIPSecTunnelBgpSessionDetails(object):
+    """
+    UpdateIPSecTunnelBgpSessionDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateIPSecTunnelBgpSessionDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param oracle_interface_ip:
+            The value to assign to the oracle_interface_ip property of this UpdateIPSecTunnelBgpSessionDetails.
+        :type oracle_interface_ip: str
+
+        :param customer_interface_ip:
+            The value to assign to the customer_interface_ip property of this UpdateIPSecTunnelBgpSessionDetails.
+        :type customer_interface_ip: str
+
+        :param customer_bgp_asn:
+            The value to assign to the customer_bgp_asn property of this UpdateIPSecTunnelBgpSessionDetails.
+        :type customer_bgp_asn: str
+
+        """
+        self.swagger_types = {
+            'oracle_interface_ip': 'str',
+            'customer_interface_ip': 'str',
+            'customer_bgp_asn': 'str'
+        }
+
+        self.attribute_map = {
+            'oracle_interface_ip': 'oracleInterfaceIp',
+            'customer_interface_ip': 'customerInterfaceIp',
+            'customer_bgp_asn': 'customerBgpAsn'
+        }
+
+        self._oracle_interface_ip = None
+        self._customer_interface_ip = None
+        self._customer_bgp_asn = None
+
+    @property
+    def oracle_interface_ip(self):
+        """
+        Gets the oracle_interface_ip of this UpdateIPSecTunnelBgpSessionDetails.
+        The IP address for the Oracle end of the inside tunnel interface.
+
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :func:`update_ip_sec_connection_tunnel_details`), this IP address
+        is used for the tunnel's BGP session.
+
+        If `routing` is instead set to `STATIC`, you can set this IP address to troubleshoot or
+        monitor the tunnel.
+
+        The value must be a /30 or /31.
+
+        If you are switching the tunnel from using BGP dynamic routing to static routing and want
+        to remove the value for `oracleInterfaceIp`, you can set the value to an empty string.
+
+        Example: `10.0.0.4/31`
+
+
+        :return: The oracle_interface_ip of this UpdateIPSecTunnelBgpSessionDetails.
+        :rtype: str
+        """
+        return self._oracle_interface_ip
+
+    @oracle_interface_ip.setter
+    def oracle_interface_ip(self, oracle_interface_ip):
+        """
+        Sets the oracle_interface_ip of this UpdateIPSecTunnelBgpSessionDetails.
+        The IP address for the Oracle end of the inside tunnel interface.
+
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :func:`update_ip_sec_connection_tunnel_details`), this IP address
+        is used for the tunnel's BGP session.
+
+        If `routing` is instead set to `STATIC`, you can set this IP address to troubleshoot or
+        monitor the tunnel.
+
+        The value must be a /30 or /31.
+
+        If you are switching the tunnel from using BGP dynamic routing to static routing and want
+        to remove the value for `oracleInterfaceIp`, you can set the value to an empty string.
+
+        Example: `10.0.0.4/31`
+
+
+        :param oracle_interface_ip: The oracle_interface_ip of this UpdateIPSecTunnelBgpSessionDetails.
+        :type: str
+        """
+        self._oracle_interface_ip = oracle_interface_ip
+
+    @property
+    def customer_interface_ip(self):
+        """
+        Gets the customer_interface_ip of this UpdateIPSecTunnelBgpSessionDetails.
+        The IP address for the CPE end of the inside tunnel interface.
+
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :func:`update_ip_sec_connection_tunnel_details`), this IP address
+        is used for the tunnel's BGP session.
+
+        If `routing` is instead set to `STATIC`, you can set this IP address to troubleshoot or
+        monitor the tunnel.
+
+        The value must be a /30 or /31.
+
+        If you are switching the tunnel from using BGP dynamic routing to static routing and want
+        to remove the value for `customerInterfaceIp`, you can set the value to an empty string.
+
+        Example: `10.0.0.5/31`
+
+
+        :return: The customer_interface_ip of this UpdateIPSecTunnelBgpSessionDetails.
+        :rtype: str
+        """
+        return self._customer_interface_ip
+
+    @customer_interface_ip.setter
+    def customer_interface_ip(self, customer_interface_ip):
+        """
+        Sets the customer_interface_ip of this UpdateIPSecTunnelBgpSessionDetails.
+        The IP address for the CPE end of the inside tunnel interface.
+
+        If the tunnel's `routing` attribute is set to `BGP`
+        (see :func:`update_ip_sec_connection_tunnel_details`), this IP address
+        is used for the tunnel's BGP session.
+
+        If `routing` is instead set to `STATIC`, you can set this IP address to troubleshoot or
+        monitor the tunnel.
+
+        The value must be a /30 or /31.
+
+        If you are switching the tunnel from using BGP dynamic routing to static routing and want
+        to remove the value for `customerInterfaceIp`, you can set the value to an empty string.
+
+        Example: `10.0.0.5/31`
+
+
+        :param customer_interface_ip: The customer_interface_ip of this UpdateIPSecTunnelBgpSessionDetails.
+        :type: str
+        """
+        self._customer_interface_ip = customer_interface_ip
+
+    @property
+    def customer_bgp_asn(self):
+        """
+        Gets the customer_bgp_asn of this UpdateIPSecTunnelBgpSessionDetails.
+        The BGP ASN of the network on the CPE end of the BGP session. Can be a 2-byte or 4-byte ASN.
+        Uses \"asplain\" format.
+
+        If you are switching the tunnel from using BGP dynamic routing to static routing, the
+        `customerBgpAsn` must be null.
+
+        Example: `12345` (2-byte) or `1587232876` (4-byte)
+
+
+        :return: The customer_bgp_asn of this UpdateIPSecTunnelBgpSessionDetails.
+        :rtype: str
+        """
+        return self._customer_bgp_asn
+
+    @customer_bgp_asn.setter
+    def customer_bgp_asn(self, customer_bgp_asn):
+        """
+        Sets the customer_bgp_asn of this UpdateIPSecTunnelBgpSessionDetails.
+        The BGP ASN of the network on the CPE end of the BGP session. Can be a 2-byte or 4-byte ASN.
+        Uses \"asplain\" format.
+
+        If you are switching the tunnel from using BGP dynamic routing to static routing, the
+        `customerBgpAsn` must be null.
+
+        Example: `12345` (2-byte) or `1587232876` (4-byte)
+
+
+        :param customer_bgp_asn: The customer_bgp_asn of this UpdateIPSecTunnelBgpSessionDetails.
+        :type: str
+        """
+        self._customer_bgp_asn = customer_bgp_asn
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/update_service_gateway_details.py
+++ b/src/oci/core/models/update_service_gateway_details.py
@@ -190,16 +190,16 @@ class UpdateServiceGatewayDetails(object):
     def services(self):
         """
         Gets the services of this UpdateServiceGatewayDetails.
-        List of all the services you want enabled on this service gateway. Sending an empty list
+        List of all the `Service` objects you want enabled on this service gateway. Sending an empty list
         means you want to disable all services. Omitting this parameter entirely keeps the
         existing list of services intact.
 
-        You can also enable or disable a particular service by using
-        :func:`attach_service_id` and
+        You can also enable or disable a particular `Service` by using
+        :func:`attach_service_id` or
         :func:`detach_service_id`.
 
-        For each enabled service, make sure there's a route rule with the service's `cidrBlock`
-        as the rule's destination CIDR and the service gateway as the rule's target. See
+        For each enabled `Service`, make sure there's a route rule with the `Service` object's `cidrBlock`
+        as the rule's destination and the service gateway as the rule's target. See
         :class:`RouteTable`.
 
 
@@ -212,16 +212,16 @@ class UpdateServiceGatewayDetails(object):
     def services(self, services):
         """
         Sets the services of this UpdateServiceGatewayDetails.
-        List of all the services you want enabled on this service gateway. Sending an empty list
+        List of all the `Service` objects you want enabled on this service gateway. Sending an empty list
         means you want to disable all services. Omitting this parameter entirely keeps the
         existing list of services intact.
 
-        You can also enable or disable a particular service by using
-        :func:`attach_service_id` and
+        You can also enable or disable a particular `Service` by using
+        :func:`attach_service_id` or
         :func:`detach_service_id`.
 
-        For each enabled service, make sure there's a route rule with the service's `cidrBlock`
-        as the rule's destination CIDR and the service gateway as the rule's target. See
+        For each enabled `Service`, make sure there's a route rule with the `Service` object's `cidrBlock`
+        as the rule's destination and the service gateway as the rule's target. See
         :class:`RouteTable`.
 
 

--- a/src/oci/core/models/update_volume_kms_key_details.py
+++ b/src/oci/core/models/update_volume_kms_key_details.py
@@ -36,10 +36,9 @@ class UpdateVolumeKmsKeyDetails(object):
     def kms_key_id(self):
         """
         Gets the kms_key_id of this UpdateVolumeKmsKeyDetails.
-        The new kms key which will be used to protect the specific volume.
-        This key has to be a valid kms key ocid, and user must have key delegation policy to allow them to access this key.
-        Even if this new kms key is the same as the previous kms key id, block storage service will use it to regenerate a new volume encryption key.
-        Example: `{\"kmsKeyId\": \"ocid1.key.region1.sea.afnl2n7daag4s.abzwkljs6uevhlgcznhmh7oiatyrxngrywc3tje3uk3g77hzmewqiieuk75f\"}`
+        The OCID of the new KMS key which will be used to protect the specified volume.
+        This key has to be a valid KMS key OCID, and the user must have key delegation policy to allow them to access this key.
+        Even if the new KMS key is the same as the previous KMS key ID, the Block Volume service will use it to regenerate a new volume encryption key.
 
 
         :return: The kms_key_id of this UpdateVolumeKmsKeyDetails.
@@ -51,10 +50,9 @@ class UpdateVolumeKmsKeyDetails(object):
     def kms_key_id(self, kms_key_id):
         """
         Sets the kms_key_id of this UpdateVolumeKmsKeyDetails.
-        The new kms key which will be used to protect the specific volume.
-        This key has to be a valid kms key ocid, and user must have key delegation policy to allow them to access this key.
-        Even if this new kms key is the same as the previous kms key id, block storage service will use it to regenerate a new volume encryption key.
-        Example: `{\"kmsKeyId\": \"ocid1.key.region1.sea.afnl2n7daag4s.abzwkljs6uevhlgcznhmh7oiatyrxngrywc3tje3uk3g77hzmewqiieuk75f\"}`
+        The OCID of the new KMS key which will be used to protect the specified volume.
+        This key has to be a valid KMS key OCID, and the user must have key delegation policy to allow them to access this key.
+        Even if the new KMS key is the same as the previous KMS key ID, the Block Volume service will use it to regenerate a new volume encryption key.
 
 
         :param kms_key_id: The kms_key_id of this UpdateVolumeKmsKeyDetails.

--- a/src/oci/core/models/volume_kms_key.py
+++ b/src/oci/core/models/volume_kms_key.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class VolumeKmsKey(object):
     """
-    Kms key id associated with this volume.
+    The KMS key OCID associated with this volume.
     """
 
     def __init__(self, **kwargs):
@@ -36,7 +36,7 @@ class VolumeKmsKey(object):
     def kms_key_id(self):
         """
         Gets the kms_key_id of this VolumeKmsKey.
-        Kms key id associated with this volume. If volume is not using KMS, then kmsKeyId will be null string.
+        The KMS key OCID associated with this volume. If the volume is not using KMS, then the `kmsKeyId` will be a null string.
 
 
         :return: The kms_key_id of this VolumeKmsKey.
@@ -48,7 +48,7 @@ class VolumeKmsKey(object):
     def kms_key_id(self, kms_key_id):
         """
         Sets the kms_key_id of this VolumeKmsKey.
-        Kms key id associated with this volume. If volume is not using KMS, then kmsKeyId will be null string.
+        The KMS key OCID associated with this volume. If the volume is not using KMS, then the `kmsKeyId` will be a null string.
 
 
         :param kms_key_id: The kms_key_id of this VolumeKmsKey.

--- a/src/oci/core/virtual_network_client.py
+++ b/src/oci/core/virtual_network_client.py
@@ -17,7 +17,11 @@ missing = Sentinel("Missing")
 
 class VirtualNetworkClient(object):
     """
-    APIs for Networking Service, Compute Service, and Block Volume Service.
+    API covering the [Networking](/iaas/Content/Network/Concepts/overview.htm),
+    [Compute](/iaas/Content/Compute/Concepts/computeoverview.htm), and
+    [Block Volume](/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+    to manage resources such as virtual cloud networks (VCNs), compute instances, and
+    block storage volumes.
     """
 
     def __init__(self, config, **kwargs):
@@ -83,16 +87,16 @@ class VirtualNetworkClient(object):
     def attach_service_id(self, service_gateway_id, attach_service_details, **kwargs):
         """
         AttachService
-        Enables the specified service on the specified gateway. In other words, enables the service
-        gateway to send traffic to the specified service. You must also set up a route rule with the
-        service's `cidrBlock` as the rule's destination CIDR and the gateway as the rule's target.
-        See :class:`RouteTable`.
+        Adds the specified :class:`Service` to the list of enabled
+        `Service` objects for the specified gateway. You must also set up a route rule with the
+        `cidrBlock` of the `Service` as the rule's destination and the service gateway as the rule's
+        target. See :class:`RouteTable`.
 
-        **Note:** The `AttachServiceId` operation is an easy way to enable an individual service on
+        **Note:** The `AttachServiceId` operation is an easy way to add an individual `Service` to
         the service gateway. Compare it with
-        :func:`update_service_gateway`, which also
-        lets you enable an individual service. However, with `UpdateServiceGateway`, you must specify
-        the *entire* list of services you want enabled on the service gateway.
+        :func:`update_service_gateway`, which replaces
+        the entire existing list of enabled `Service` objects with the list that you provide in the
+        `Update` call.
 
 
         :param str service_gateway_id: (required)
@@ -1077,8 +1081,11 @@ class VirtualNetworkClient(object):
         Creates a new IPSec connection between the specified DRG and CPE. For more information, see
         `IPSec VPNs`__.
 
-        In the request, you must include at least one static route to the CPE object (you're allowed a maximum
-        of 10). For example: 10.0.8.0/16.
+        If you configure at least one tunnel to use static routing, then in the request you must provide
+        at least one valid static route (you're allowed a maximum of 10). For example: 10.0.0.0/16.
+        If you configure both tunnels to use BGP dynamic routing, you can provide an empty list for
+        the static routes. For more information, see the important note in
+        :class:`IPSecConnection`.
 
         For the purposes of access control, you must provide the OCID of the compartment where you want the
         IPSec connection to reside. Notice that the IPSec connection doesn't have to be in the same compartment
@@ -1092,14 +1099,14 @@ class VirtualNetworkClient(object):
         It does not have to be unique, and you can change it. Avoid entering confidential information.
 
         After creating the IPSec connection, you need to configure your on-premises router
-        with tunnel-specific information returned by
-        :func:`get_ip_sec_connection_device_config`.
-        For each tunnel, that operation gives you the IP address of Oracle's VPN headend and the shared secret
+        with tunnel-specific information. For tunnel status and the required configuration information, see:
+
+          * :class:`IPSecConnectionTunnel`
+          * :class:`IPSecConnectionTunnelSharedSecret`
+
+        For each tunnel, you need the IP address of Oracle's VPN headend and the shared secret
         (that is, the pre-shared key). For more information, see
         `Configuring Your On-Premises Router for an IPSec VPN`__.
-
-        To get the status of the tunnels (whether they're up or down), use
-        :func:`get_ip_sec_connection_device_status`.
 
         __ https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPsec.htm
         __ https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm
@@ -3575,19 +3582,18 @@ class VirtualNetworkClient(object):
     def detach_service_id(self, service_gateway_id, detach_service_details, **kwargs):
         """
         DetachService
-        Disables the specified service on the specified gateway. In other words, stops the service
-        gateway from sending traffic to the specified service. You do not need to remove any route
-        rules that specify this service's `cidrBlock` as the destination CIDR. However, consider
-        removing the rules if your intent is to permanently disable use of the service through this
+        Removes the specified :class:`Service` from the list of enabled
+        `Service` objects for the specified gateway. You do not need to remove any route
+        rules that specify this `Service` object's `cidrBlock` as the destination CIDR. However, consider
+        removing the rules if your intent is to permanently disable use of the `Service` through this
         service gateway.
 
-        **Note:** The `DetachServiceId` operation is an easy way to disable an individual service on
+        **Note:** The `DetachServiceId` operation is an easy way to remove an individual `Service` from
         the service gateway. Compare it with
-        :func:`update_service_gateway`, which also
-        lets you disable an individual service. However, with `UpdateServiceGateway`, you must specify
-        the *entire* list of services you want enabled on the service gateway. `UpdateServiceGateway`
-        also lets you block all traffic through the service gateway without having to disable each of
-        the individual services.
+        :func:`update_service_gateway`, which replaces
+        the entire existing list of enabled `Service` objects with the list that you provide in the
+        `Update` call. `UpdateServiceGateway` also lets you block all traffic through the service
+        gateway without having to remove each of the individual `Service` objects.
 
 
         :param str service_gateway_id: (required)
@@ -4386,7 +4392,7 @@ class VirtualNetworkClient(object):
         GetIPSecConnection
         Gets the specified IPSec connection's basic information, including the static routes for the
         on-premises router. If you want the status of the connection (whether it's up or down), use
-        :func:`get_ip_sec_connection_device_status`.
+        :func:`get_ip_sec_connection_tunnel`.
 
 
         :param str ipsc_id: (required)
@@ -4450,8 +4456,10 @@ class VirtualNetworkClient(object):
     def get_ip_sec_connection_device_config(self, ipsc_id, **kwargs):
         """
         GetIPSecConnectionDeviceConfig
-        Gets the configuration information for the specified IPSec connection. For each tunnel, the
-        response includes the IP address of Oracle's VPN headend and the shared secret.
+        Deprecated. To get tunnel information, instead use:
+
+        * :func:`get_ip_sec_connection_tunnel`
+        * :func:`get_ip_sec_connection_tunnel_shared_secret`
 
 
         :param str ipsc_id: (required)
@@ -4515,7 +4523,8 @@ class VirtualNetworkClient(object):
     def get_ip_sec_connection_device_status(self, ipsc_id, **kwargs):
         """
         GetIPSecConnectionDeviceStatus
-        Gets the status of the specified IPSec connection (whether it's up or down).
+        Deprecated. To get the tunnel status, instead use
+        :func:`get_ip_sec_connection_tunnel`.
 
 
         :param str ipsc_id: (required)
@@ -4575,6 +4584,149 @@ class VirtualNetworkClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 response_type="IPSecConnectionDeviceStatus")
+
+    def get_ip_sec_connection_tunnel(self, ipsc_id, tunnel_id, **kwargs):
+        """
+        GetIPSecConnectionTunnel
+        Gets the specified tunnel's information. The resulting object does not include the tunnel's
+        shared secret (pre-shared key). To retrieve that, use
+        :func:`get_ip_sec_connection_tunnel_shared_secret`.
+
+
+        :param str ipsc_id: (required)
+            The OCID of the IPSec connection.
+
+        :param str tunnel_id: (required)
+            The `OCID`__ of the tunnel.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.IPSecConnectionTunnel`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/ipsecConnections/{ipscId}/tunnels/{tunnelId}"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_ip_sec_connection_tunnel got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "ipscId": ipsc_id,
+            "tunnelId": tunnel_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="IPSecConnectionTunnel")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="IPSecConnectionTunnel")
+
+    def get_ip_sec_connection_tunnel_shared_secret(self, ipsc_id, tunnel_id, **kwargs):
+        """
+        GetIPSecConnectionTunnelSharedSecret
+        Gets the specified tunnel's shared secret (pre-shared key). To get other information
+        about the tunnel, use :func:`get_ip_sec_connection_tunnel`.
+
+
+        :param str ipsc_id: (required)
+            The OCID of the IPSec connection.
+
+        :param str tunnel_id: (required)
+            The `OCID`__ of the tunnel.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.IPSecConnectionTunnelSharedSecret`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/ipsecConnections/{ipscId}/tunnels/{tunnelId}/sharedSecret"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_ip_sec_connection_tunnel_shared_secret got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "ipscId": ipsc_id,
+            "tunnelId": tunnel_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="IPSecConnectionTunnelSharedSecret")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="IPSecConnectionTunnelSharedSecret")
 
     def get_local_peering_gateway(self, local_peering_gateway_id, **kwargs):
         """
@@ -5164,7 +5316,7 @@ class VirtualNetworkClient(object):
     def get_service(self, service_id, **kwargs):
         """
         GetService
-        Gets the specified service's information.
+        Gets the specified :class:`Service` object.
 
 
         :param str service_id: (required)
@@ -6780,6 +6932,99 @@ class VirtualNetworkClient(object):
                 header_params=header_params,
                 response_type="list[InternetGateway]")
 
+    def list_ip_sec_connection_tunnels(self, ipsc_id, **kwargs):
+        """
+        ListIPSecConnectionTunnels
+        Lists the tunnel information for the specified IPSec connection.
+
+
+        :param str ipsc_id: (required)
+            The OCID of the IPSec connection.
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            Example: `50`
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+            call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.core.models.IPSecConnectionTunnel`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/ipsecConnections/{ipscId}/tunnels"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_ip_sec_connection_tunnels got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "ipscId": ipsc_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[IPSecConnectionTunnel]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[IPSecConnectionTunnel]")
+
     def list_ip_sec_connections(self, compartment_id, **kwargs):
         """
         ListIPSecConnections
@@ -7865,7 +8110,8 @@ class VirtualNetworkClient(object):
     def list_services(self, **kwargs):
         """
         ListServices
-        Lists the available services that you can access through a service gateway in this region.
+        Lists the available :class:`Service` objects that you can enable for a
+        service gateway in this region.
 
 
         :param int limit: (optional)
@@ -9099,8 +9345,10 @@ class VirtualNetworkClient(object):
     def update_ip_sec_connection(self, ipsc_id, update_ip_sec_connection_details, **kwargs):
         """
         UpdateIPSecConnection
-        Updates the display name or tags for the specified IPSec connection.
-        Avoid entering confidential information.
+        Updates the specified IPSec connection.
+
+        To update an individual IPSec tunnel's attributes, use
+        :func:`update_ip_sec_connection_tunnel`.
 
 
         :param str ipsc_id: (required)
@@ -9176,6 +9424,197 @@ class VirtualNetworkClient(object):
                 header_params=header_params,
                 body=update_ip_sec_connection_details,
                 response_type="IPSecConnection")
+
+    def update_ip_sec_connection_tunnel(self, ipsc_id, tunnel_id, update_ip_sec_connection_tunnel_details, **kwargs):
+        """
+        UpdateIPSecConnectionTunnelDetails
+        Updates the specified tunnel. This operation lets you change tunnel attributes such as the
+        routing type (BGP dynamic routing or static routing). Here are some important notes:
+
+          * If you change the tunnel's routing type or BGP session configuration, the tunnel will go
+            down while it's reprovisioned.
+
+          * If you want to switch the tunnel's `routing` from `STATIC` to `BGP`, make sure the tunnel's
+            BGP session configuration attributes have been set (:func:`bgp_session_info`).
+
+          * If you want to switch the tunnel's `routing` from `BGP` to `STATIC`, make sure the
+            :class:`IPSecConnection` already has at least one valid CIDR
+            static route.
+
+
+        :param str ipsc_id: (required)
+            The OCID of the IPSec connection.
+
+        :param str tunnel_id: (required)
+            The `OCID`__ of the tunnel.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateIPSecConnectionTunnelDetails update_ip_sec_connection_tunnel_details: (required)
+            Details object for updating a IPSecConnection tunnel's details.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.IPSecConnectionTunnel`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/ipsecConnections/{ipscId}/tunnels/{tunnelId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_ip_sec_connection_tunnel got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "ipscId": ipsc_id,
+            "tunnelId": tunnel_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_ip_sec_connection_tunnel_details,
+                response_type="IPSecConnectionTunnel")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_ip_sec_connection_tunnel_details,
+                response_type="IPSecConnectionTunnel")
+
+    def update_ip_sec_connection_tunnel_shared_secret(self, ipsc_id, tunnel_id, update_ip_sec_connection_tunnel_shared_secret_details, **kwargs):
+        """
+        UpdateIPSecConnectionTunnelSharedSecret
+        Updates the shared secret (pre-shared key) for the specified tunnel.
+
+        **Important:** If you change the shared secret, the tunnel will go down while it's reprovisioned.
+
+
+        :param str ipsc_id: (required)
+            The OCID of the IPSec connection.
+
+        :param str tunnel_id: (required)
+            The `OCID`__ of the tunnel.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateIPSecConnectionTunnelSharedSecretDetails update_ip_sec_connection_tunnel_shared_secret_details: (required)
+            Details object for updating a IPSec connection tunnel's sharedSecret.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.IPSecConnectionTunnelSharedSecret`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/ipsecConnections/{ipscId}/tunnels/{tunnelId}/sharedSecret"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_ip_sec_connection_tunnel_shared_secret got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "ipscId": ipsc_id,
+            "tunnelId": tunnel_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_ip_sec_connection_tunnel_shared_secret_details,
+                response_type="IPSecConnectionTunnelSharedSecret")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_ip_sec_connection_tunnel_shared_secret_details,
+                response_type="IPSecConnectionTunnelSharedSecret")
 
     def update_local_peering_gateway(self, local_peering_gateway_id, update_local_peering_gateway_details, **kwargs):
         """

--- a/src/oci/core/virtual_network_client_composite_operations.py
+++ b/src/oci/core/virtual_network_client_composite_operations.py
@@ -1844,6 +1844,52 @@ class VirtualNetworkClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def update_ip_sec_connection_tunnel_and_wait_for_state(self, ipsc_id, tunnel_id, update_ip_sec_connection_tunnel_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.core.VirtualNetworkClient.update_ip_sec_connection_tunnel` and waits for the :py:class:`~oci.core.models.IPSecConnectionTunnel` acted upon
+        to enter the given state(s).
+
+        :param str ipsc_id: (required)
+            The OCID of the IPSec connection.
+
+        :param str tunnel_id: (required)
+            The `OCID`__ of the tunnel.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateIPSecConnectionTunnelDetails update_ip_sec_connection_tunnel_details: (required)
+            Details object for updating a IPSecConnection tunnel's details.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.core.models.IPSecConnectionTunnel.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.core.VirtualNetworkClient.update_ip_sec_connection_tunnel`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_ip_sec_connection_tunnel(ipsc_id, tunnel_id, update_ip_sec_connection_tunnel_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_ip_sec_connection_tunnel(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def update_local_peering_gateway_and_wait_for_state(self, local_peering_gateway_id, update_local_peering_gateway_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.core.VirtualNetworkClient.update_local_peering_gateway` and waits for the :py:class:`~oci.core.models.LocalPeeringGateway` acted upon

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "2.2.9"
+__version__ = "2.2.10"

--- a/tests/integ/test_launch_instance_tutorial.py
+++ b/tests/integ/test_launch_instance_tutorial.py
@@ -173,7 +173,9 @@ def delete_internet_gateway(virtual_network, gateway_id):
 def update_route_table(virtual_network, test_id, vcn, gateway):
     # print('Updating route table')
     route_rule = oci.core.models.RouteRule()
-    route_rule.cidr_block = '0.0.0.0/0'
+    route_rule.cidr_block = None
+    route_rule.destination = '0.0.0.0/0'
+    route_rule.destination_type = 'CIDR_BLOCK'
     route_rule.display_name = 'pythonsdk_route_rule_' + test_id
     route_rule.network_entity_id = gateway.id
     route_rule.network_entity_type = 'INTERNET_GATEWAY'


### PR DESCRIPTION
## Added

- Support for returning tags when listing instance configurations, instance pools, or autoscaling configurations in the Compute Autoscaling service

- Support for getting the namespace of another tenancy than the caller's tenancy in the Object Storage service

- Support for BGP dynamic routing and providing pre-shared secrets (PSKs) when establishing tunnels in the Networking service


