### PR TITLE
Releasing version 2.2.12

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+2.2.12 - 2019-06-04
+====================
+
+Added
+-----
+* Support for autoscaling autonomous databases and autonomous data warehouses in the Database service
+* Support for specifying fault domains as part of instance configurations in the Compute Autoscaling service
+* Support for deleting tag definitions and tag namespaces in the Identity service
+
+Fixed
+-----
+* Support for regions in realms other than oraclecloud.com in the Load Balancing service
+
+====================
 2.2.11 - 2019-05-28
 ====================
 

--- a/examples/database/adb_example.py
+++ b/examples/database/adb_example.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci
+
+# Overview of Autonomous Data Warehouse
+# https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/adboverview.htm
+
+# Load the default configuration
+config = oci.config.from_file()
+
+# Set the compartment_id. You can use any compartment in your tenancy which
+# has privileges for creating an Autonomous Database
+compartment_id = config["tenancy"]
+
+
+def create_adb(db_client):
+    # Create the model and populate the values
+    # See: https://docs.cloud.oracle.com/iaas/Content/Database/Tasks/adbcreating.htm
+    adb_request = oci.database.models.CreateAutonomousDatabaseDetails()
+
+    adb_request.compartment_id = compartment_id
+    adb_request.cpu_core_count = 1
+    adb_request.data_storage_size_in_tbs = 1
+    adb_request.db_name = "adbexample2"
+    adb_request.display_name = "PYSDK-ADB-EXAMPLE"
+    adb_request.db_workload = "OLTP"
+    adb_request.license_model = adb_request.LICENSE_MODEL_BRING_YOUR_OWN_LICENSE
+    adb_request.admin_password = "Welcome1!SDK"
+    adb_request.is_auto_scaling_enabled = True
+
+    adb_response = db_client.create_autonomous_database(
+        create_autonomous_database_details=adb_request,
+        retry_strategy=oci.retry.DEFAULT_RETRY_STRATEGY)
+
+    print("Created Automated Database {}".format(adb_response.data.id))
+
+    return adb_response.data.id
+
+
+def delete_adb(db_client, adb_id):
+    # Delete the autonomous database
+    response = db_client.delete_autonomous_database(adb_id)
+    print(response)
+
+
+def update_adb(db_client, adb_id):
+    # Create the model and populate the values
+    # See: https://docs.cloud.oracle.com/iaas/Content/Database/Tasks/adbcreating.htm
+    adb_request = oci.database.models.UpdateAutonomousDatabaseDetails()
+
+    adb_request.cpu_core_count = 2
+    adb_request.data_storage_size_in_tbs = 2
+    adb_request.is_auto_scaling_enabled = True
+
+    adb_response = db_client.update_autonomous_database(adb_id,
+                                                        update_autonomous_database_details=adb_request,
+                                                        retry_strategy=oci.retry.DEFAULT_RETRY_STRATEGY)
+
+    print("Created Automated Data Warehouse {}".format(adb_response.data.id))
+
+    return adb_response.data.id
+
+
+if __name__ == "__main__":
+    # Initialize the client
+    db_client = oci.database.DatabaseClient(config)
+    adb_id = create_adb(db_client)
+    delete_adb(db_client, adb_id)

--- a/examples/showoci/CHANGELOG.rst
+++ b/examples/showoci/CHANGELOG.rst
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+19.6.3 - 2019-06-03
+====================
+
+Added
+-----
+* Added support for ipsec dynamic routing (bgp)
+
+====================
 19.5.27 - 2019-05-27
 ====================
 

--- a/examples/showoci/showoci.py
+++ b/examples/showoci/showoci.py
@@ -62,7 +62,7 @@ import sys
 import argparse
 import datetime
 
-version = "19.5.27"
+version = "19.6.3"
 
 ##########################################################################
 # execute_extract

--- a/examples/showoci/showoci_output.py
+++ b/examples/showoci/showoci_output.py
@@ -494,8 +494,12 @@ class ShowOCIOutput(object):
                 print(self.tabs + "CPE    : " + ips['cpe'])
                 # get tunnel status
                 for t in ips['tunnels']:
-                    print(self.tabs + "Tunnel : " + t['ip_address'] + " - " + t['status'] + " - " + t['status_date'])
-                print(self.tabs + "Routes : " + "\n    Routes : ".join(ips['routes']))
+                    print(self.tabs + "Tunnel : " + t['display_name'].ljust(12) + " - " + t['status'] + ", " + t['routing'] + ", VPN: " + t['vpn_ip'] + ", CPE: " + t['cpe_ip'] + ", " + t['status_date'])
+                    if t['bgp_info']:
+                        print(self.tabs + "       : " + t['bgp_info'])
+
+                if ips['routes']:
+                    print(self.tabs + "Routes : " + "\n    Static : ".join(ips['routes']))
                 print("")
 
         except Exception as e:

--- a/src/oci/core/blockstorage_client.py
+++ b/src/oci/core/blockstorage_client.py
@@ -2123,7 +2123,9 @@ class BlockstorageClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str boot_volume_id: (optional)
             The OCID of the boot volume.
@@ -2270,7 +2272,9 @@ class BlockstorageClient(object):
             Example: `Uocm:PHX-AD-1`
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -2436,7 +2440,9 @@ class BlockstorageClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str volume_id: (optional)
             The OCID of the volume.
@@ -2586,7 +2592,9 @@ class BlockstorageClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str volume_group_id: (optional)
             The OCID of the volume group.
@@ -2717,7 +2725,9 @@ class BlockstorageClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str availability_domain: (optional)
             The name of the availability domain.
@@ -2861,7 +2871,9 @@ class BlockstorageClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str availability_domain: (optional)
             The name of the availability domain.

--- a/src/oci/core/compute_client.py
+++ b/src/oci/core/compute_client.py
@@ -630,7 +630,9 @@ class ComputeClient(object):
             The OCID of the listing.
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str resource_version: (required)
             Listing Resource Version.
@@ -2484,7 +2486,9 @@ class ComputeClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -2613,7 +2617,9 @@ class ComputeClient(object):
             Example: `Uocm:PHX-AD-1`
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -2706,7 +2712,9 @@ class ComputeClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str availability_domain: (optional)
             The name of the availability domain.
@@ -2859,7 +2867,9 @@ class ComputeClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str display_name: (optional)
             A filter to return only resources that match the given display name exactly.
@@ -3019,7 +3029,9 @@ class ComputeClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str instance_id: (optional)
             The OCID of the instance.
@@ -3254,7 +3266,9 @@ class ComputeClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str availability_domain: (optional)
             The name of the availability domain.
@@ -3399,7 +3413,9 @@ class ComputeClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str availability_domain: (optional)
             The name of the availability domain.
@@ -3495,7 +3511,9 @@ class ComputeClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str availability_domain: (optional)
             The name of the availability domain.
@@ -3598,7 +3616,9 @@ class ComputeClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str availability_domain: (optional)
             The name of the availability domain.

--- a/src/oci/core/compute_management_client.py
+++ b/src/oci/core/compute_management_client.py
@@ -696,7 +696,9 @@ class ComputeManagementClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -814,7 +816,9 @@ class ComputeManagementClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str instance_pool_id: (required)
             The OCID of the instance pool.
@@ -952,7 +956,9 @@ class ComputeManagementClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str display_name: (optional)
             A filter to return only resources that match the given display name exactly.

--- a/src/oci/core/models/boot_volume.py
+++ b/src/oci/core/models/boot_volume.py
@@ -223,8 +223,8 @@ class BootVolume(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this BootVolume.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -240,8 +240,8 @@ class BootVolume(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this BootVolume.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -284,8 +284,7 @@ class BootVolume(object):
         """
         Gets the freeform_tags of this BootVolume.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -302,8 +301,7 @@ class BootVolume(object):
         """
         Sets the freeform_tags of this BootVolume.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/boot_volume_backup.py
+++ b/src/oci/core/models/boot_volume_backup.py
@@ -240,8 +240,8 @@ class BootVolumeBackup(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this BootVolumeBackup.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -257,8 +257,8 @@ class BootVolumeBackup(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this BootVolumeBackup.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -333,8 +333,7 @@ class BootVolumeBackup(object):
         """
         Gets the freeform_tags of this BootVolumeBackup.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -351,8 +350,7 @@ class BootVolumeBackup(object):
         """
         Sets the freeform_tags of this BootVolumeBackup.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/capture_console_history_details.py
+++ b/src/oci/core/models/capture_console_history_details.py
@@ -57,8 +57,8 @@ class CaptureConsoleHistoryDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CaptureConsoleHistoryDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -74,8 +74,8 @@ class CaptureConsoleHistoryDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CaptureConsoleHistoryDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -116,8 +116,7 @@ class CaptureConsoleHistoryDetails(object):
         """
         Gets the freeform_tags of this CaptureConsoleHistoryDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -134,8 +133,7 @@ class CaptureConsoleHistoryDetails(object):
         """
         Sets the freeform_tags of this CaptureConsoleHistoryDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/console_history.py
+++ b/src/oci/core/models/console_history.py
@@ -167,8 +167,8 @@ class ConsoleHistory(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this ConsoleHistory.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -184,8 +184,8 @@ class ConsoleHistory(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this ConsoleHistory.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -232,8 +232,7 @@ class ConsoleHistory(object):
         """
         Gets the freeform_tags of this ConsoleHistory.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -250,8 +249,7 @@ class ConsoleHistory(object):
         """
         Sets the freeform_tags of this ConsoleHistory.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/cpe.py
+++ b/src/oci/core/models/cpe.py
@@ -116,8 +116,8 @@ class Cpe(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this Cpe.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -133,8 +133,8 @@ class Cpe(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this Cpe.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -177,8 +177,7 @@ class Cpe(object):
         """
         Gets the freeform_tags of this Cpe.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -195,8 +194,7 @@ class Cpe(object):
         """
         Sets the freeform_tags of this Cpe.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_boot_volume_backup_details.py
+++ b/src/oci/core/models/create_boot_volume_backup_details.py
@@ -97,8 +97,8 @@ class CreateBootVolumeBackupDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateBootVolumeBackupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -114,8 +114,8 @@ class CreateBootVolumeBackupDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateBootVolumeBackupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -158,8 +158,7 @@ class CreateBootVolumeBackupDetails(object):
         """
         Gets the freeform_tags of this CreateBootVolumeBackupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -176,8 +175,7 @@ class CreateBootVolumeBackupDetails(object):
         """
         Sets the freeform_tags of this CreateBootVolumeBackupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_boot_volume_details.py
+++ b/src/oci/core/models/create_boot_volume_details.py
@@ -170,8 +170,8 @@ class CreateBootVolumeDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateBootVolumeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -187,8 +187,8 @@ class CreateBootVolumeDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateBootVolumeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -231,8 +231,7 @@ class CreateBootVolumeDetails(object):
         """
         Gets the freeform_tags of this CreateBootVolumeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -249,8 +248,7 @@ class CreateBootVolumeDetails(object):
         """
         Sets the freeform_tags of this CreateBootVolumeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_cpe_details.py
+++ b/src/oci/core/models/create_cpe_details.py
@@ -88,8 +88,8 @@ class CreateCpeDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateCpeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -105,8 +105,8 @@ class CreateCpeDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateCpeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -147,8 +147,7 @@ class CreateCpeDetails(object):
         """
         Gets the freeform_tags of this CreateCpeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -165,8 +164,7 @@ class CreateCpeDetails(object):
         """
         Sets the freeform_tags of this CreateCpeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_dhcp_details.py
+++ b/src/oci/core/models/create_dhcp_details.py
@@ -95,8 +95,8 @@ class CreateDhcpDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateDhcpDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -112,8 +112,8 @@ class CreateDhcpDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateDhcpDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -154,8 +154,7 @@ class CreateDhcpDetails(object):
         """
         Gets the freeform_tags of this CreateDhcpDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -172,8 +171,7 @@ class CreateDhcpDetails(object):
         """
         Sets the freeform_tags of this CreateDhcpDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_drg_details.py
+++ b/src/oci/core/models/create_drg_details.py
@@ -81,8 +81,8 @@ class CreateDrgDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateDrgDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -98,8 +98,8 @@ class CreateDrgDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateDrgDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -140,8 +140,7 @@ class CreateDrgDetails(object):
         """
         Gets the freeform_tags of this CreateDrgDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -158,8 +157,7 @@ class CreateDrgDetails(object):
         """
         Sets the freeform_tags of this CreateDrgDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_image_details.py
+++ b/src/oci/core/models/create_image_details.py
@@ -119,8 +119,8 @@ class CreateImageDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateImageDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -136,8 +136,8 @@ class CreateImageDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateImageDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -188,8 +188,7 @@ class CreateImageDetails(object):
         """
         Gets the freeform_tags of this CreateImageDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -206,8 +205,7 @@ class CreateImageDetails(object):
         """
         Sets the freeform_tags of this CreateImageDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_instance_configuration_details.py
+++ b/src/oci/core/models/create_instance_configuration_details.py
@@ -88,8 +88,8 @@ class CreateInstanceConfigurationDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateInstanceConfigurationDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -105,8 +105,8 @@ class CreateInstanceConfigurationDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateInstanceConfigurationDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -147,8 +147,7 @@ class CreateInstanceConfigurationDetails(object):
         """
         Gets the freeform_tags of this CreateInstanceConfigurationDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -165,8 +164,7 @@ class CreateInstanceConfigurationDetails(object):
         """
         Sets the freeform_tags of this CreateInstanceConfigurationDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_instance_console_connection_details.py
+++ b/src/oci/core/models/create_instance_console_connection_details.py
@@ -58,8 +58,8 @@ class CreateInstanceConsoleConnectionDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateInstanceConsoleConnectionDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -75,8 +75,8 @@ class CreateInstanceConsoleConnectionDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateInstanceConsoleConnectionDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -93,8 +93,7 @@ class CreateInstanceConsoleConnectionDetails(object):
         """
         Gets the freeform_tags of this CreateInstanceConsoleConnectionDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -111,8 +110,7 @@ class CreateInstanceConsoleConnectionDetails(object):
         """
         Sets the freeform_tags of this CreateInstanceConsoleConnectionDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_instance_pool_details.py
+++ b/src/oci/core/models/create_instance_pool_details.py
@@ -109,8 +109,8 @@ class CreateInstancePoolDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateInstancePoolDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -126,8 +126,8 @@ class CreateInstancePoolDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateInstancePoolDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -168,8 +168,7 @@ class CreateInstancePoolDetails(object):
         """
         Gets the freeform_tags of this CreateInstancePoolDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -186,8 +185,7 @@ class CreateInstancePoolDetails(object):
         """
         Sets the freeform_tags of this CreateInstancePoolDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_internet_gateway_details.py
+++ b/src/oci/core/models/create_internet_gateway_details.py
@@ -95,8 +95,8 @@ class CreateInternetGatewayDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateInternetGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -112,8 +112,8 @@ class CreateInternetGatewayDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateInternetGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -154,8 +154,7 @@ class CreateInternetGatewayDetails(object):
         """
         Gets the freeform_tags of this CreateInternetGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -172,8 +171,7 @@ class CreateInternetGatewayDetails(object):
         """
         Sets the freeform_tags of this CreateInternetGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_ip_sec_connection_details.py
+++ b/src/oci/core/models/create_ip_sec_connection_details.py
@@ -156,8 +156,8 @@ class CreateIPSecConnectionDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateIPSecConnectionDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -173,8 +173,8 @@ class CreateIPSecConnectionDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateIPSecConnectionDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -239,8 +239,7 @@ class CreateIPSecConnectionDetails(object):
         """
         Gets the freeform_tags of this CreateIPSecConnectionDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -257,8 +256,7 @@ class CreateIPSecConnectionDetails(object):
         """
         Sets the freeform_tags of this CreateIPSecConnectionDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -281,9 +279,14 @@ class CreateIPSecConnectionDetails(object):
         If you don't provide a value, the `ipAddress` attribute for the :class:`Cpe`
         object specified by `cpeId` is used as the `cpeLocalIdentifier`.
 
+        For information about why you'd provide this value, see
+        `If Your CPE Is Behind a NAT Device`__.
+
         Example IP address: `10.0.3.3`
 
         Example hostname: `cpe.example.com`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Tasks/overviewIPsec.htm#nat
 
 
         :return: The cpe_local_identifier of this CreateIPSecConnectionDetails.
@@ -302,9 +305,14 @@ class CreateIPSecConnectionDetails(object):
         If you don't provide a value, the `ipAddress` attribute for the :class:`Cpe`
         object specified by `cpeId` is used as the `cpeLocalIdentifier`.
 
+        For information about why you'd provide this value, see
+        `If Your CPE Is Behind a NAT Device`__.
+
         Example IP address: `10.0.3.3`
 
         Example hostname: `cpe.example.com`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Tasks/overviewIPsec.htm#nat
 
 
         :param cpe_local_identifier: The cpe_local_identifier of this CreateIPSecConnectionDetails.

--- a/src/oci/core/models/create_ip_sec_connection_tunnel_details.py
+++ b/src/oci/core/models/create_ip_sec_connection_tunnel_details.py
@@ -124,11 +124,12 @@ class CreateIPSecConnectionTunnelDetails(object):
     def shared_secret(self):
         """
         Gets the shared_secret of this CreateIPSecConnectionTunnelDetails.
-        The shared secret (pre-shared key) to use for the IPSec tunnel. If you don't provide a value,
+        The shared secret (pre-shared key) to use for the IPSec tunnel. Only numbers, letters, and
+        spaces are allowed. If you don't provide a value,
         Oracle generates a value for you. You can specify your own shared secret later if
         you like with :func:`update_ip_sec_connection_tunnel_shared_secret`.
 
-        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 
 
         :return: The shared_secret of this CreateIPSecConnectionTunnelDetails.
@@ -140,11 +141,12 @@ class CreateIPSecConnectionTunnelDetails(object):
     def shared_secret(self, shared_secret):
         """
         Sets the shared_secret of this CreateIPSecConnectionTunnelDetails.
-        The shared secret (pre-shared key) to use for the IPSec tunnel. If you don't provide a value,
+        The shared secret (pre-shared key) to use for the IPSec tunnel. Only numbers, letters, and
+        spaces are allowed. If you don't provide a value,
         Oracle generates a value for you. You can specify your own shared secret later if
         you like with :func:`update_ip_sec_connection_tunnel_shared_secret`.
 
-        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 
 
         :param shared_secret: The shared_secret of this CreateIPSecConnectionTunnelDetails.

--- a/src/oci/core/models/create_local_peering_gateway_details.py
+++ b/src/oci/core/models/create_local_peering_gateway_details.py
@@ -95,8 +95,8 @@ class CreateLocalPeeringGatewayDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateLocalPeeringGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -112,8 +112,8 @@ class CreateLocalPeeringGatewayDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateLocalPeeringGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -156,8 +156,7 @@ class CreateLocalPeeringGatewayDetails(object):
         """
         Gets the freeform_tags of this CreateLocalPeeringGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -174,8 +173,7 @@ class CreateLocalPeeringGatewayDetails(object):
         """
         Sets the freeform_tags of this CreateLocalPeeringGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_nat_gateway_details.py
+++ b/src/oci/core/models/create_nat_gateway_details.py
@@ -101,8 +101,8 @@ class CreateNatGatewayDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateNatGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -118,8 +118,8 @@ class CreateNatGatewayDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateNatGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -162,8 +162,7 @@ class CreateNatGatewayDetails(object):
         """
         Gets the freeform_tags of this CreateNatGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -180,8 +179,7 @@ class CreateNatGatewayDetails(object):
         """
         Sets the freeform_tags of this CreateNatGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_private_ip_details.py
+++ b/src/oci/core/models/create_private_ip_details.py
@@ -71,8 +71,8 @@ class CreatePrivateIpDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreatePrivateIpDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -88,8 +88,8 @@ class CreatePrivateIpDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreatePrivateIpDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -132,8 +132,7 @@ class CreatePrivateIpDetails(object):
         """
         Gets the freeform_tags of this CreatePrivateIpDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -150,8 +149,7 @@ class CreatePrivateIpDetails(object):
         """
         Sets the freeform_tags of this CreatePrivateIpDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_public_ip_details.py
+++ b/src/oci/core/models/create_public_ip_details.py
@@ -106,8 +106,8 @@ class CreatePublicIpDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreatePublicIpDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -123,8 +123,8 @@ class CreatePublicIpDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreatePublicIpDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -167,8 +167,7 @@ class CreatePublicIpDetails(object):
         """
         Gets the freeform_tags of this CreatePublicIpDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -185,8 +184,7 @@ class CreatePublicIpDetails(object):
         """
         Sets the freeform_tags of this CreatePublicIpDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_route_table_details.py
+++ b/src/oci/core/models/create_route_table_details.py
@@ -95,8 +95,8 @@ class CreateRouteTableDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateRouteTableDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -112,8 +112,8 @@ class CreateRouteTableDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateRouteTableDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -154,8 +154,7 @@ class CreateRouteTableDetails(object):
         """
         Gets the freeform_tags of this CreateRouteTableDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -172,8 +171,7 @@ class CreateRouteTableDetails(object):
         """
         Sets the freeform_tags of this CreateRouteTableDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_security_list_details.py
+++ b/src/oci/core/models/create_security_list_details.py
@@ -102,8 +102,8 @@ class CreateSecurityListDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateSecurityListDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -119,8 +119,8 @@ class CreateSecurityListDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateSecurityListDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -185,8 +185,7 @@ class CreateSecurityListDetails(object):
         """
         Gets the freeform_tags of this CreateSecurityListDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -203,8 +202,7 @@ class CreateSecurityListDetails(object):
         """
         Sets the freeform_tags of this CreateSecurityListDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_service_gateway_details.py
+++ b/src/oci/core/models/create_service_gateway_details.py
@@ -99,8 +99,8 @@ class CreateServiceGatewayDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateServiceGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -116,8 +116,8 @@ class CreateServiceGatewayDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateServiceGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -160,8 +160,7 @@ class CreateServiceGatewayDetails(object):
         """
         Gets the freeform_tags of this CreateServiceGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -178,8 +177,7 @@ class CreateServiceGatewayDetails(object):
         """
         Sets the freeform_tags of this CreateServiceGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_subnet_details.py
+++ b/src/oci/core/models/create_subnet_details.py
@@ -213,8 +213,8 @@ class CreateSubnetDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateSubnetDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -230,8 +230,8 @@ class CreateSubnetDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateSubnetDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -352,8 +352,7 @@ class CreateSubnetDetails(object):
         """
         Gets the freeform_tags of this CreateSubnetDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -370,8 +369,7 @@ class CreateSubnetDetails(object):
         """
         Sets the freeform_tags of this CreateSubnetDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_vcn_details.py
+++ b/src/oci/core/models/create_vcn_details.py
@@ -123,8 +123,8 @@ class CreateVcnDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateVcnDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -140,8 +140,8 @@ class CreateVcnDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateVcnDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -238,8 +238,7 @@ class CreateVcnDetails(object):
         """
         Gets the freeform_tags of this CreateVcnDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -256,8 +255,7 @@ class CreateVcnDetails(object):
         """
         Sets the freeform_tags of this CreateVcnDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_vnic_details.py
+++ b/src/oci/core/models/create_vnic_details.py
@@ -158,8 +158,8 @@ class CreateVnicDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateVnicDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -175,8 +175,8 @@ class CreateVnicDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateVnicDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -219,8 +219,7 @@ class CreateVnicDetails(object):
         """
         Gets the freeform_tags of this CreateVnicDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -237,8 +236,7 @@ class CreateVnicDetails(object):
         """
         Sets the freeform_tags of this CreateVnicDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_volume_backup_details.py
+++ b/src/oci/core/models/create_volume_backup_details.py
@@ -73,8 +73,8 @@ class CreateVolumeBackupDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateVolumeBackupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -90,8 +90,8 @@ class CreateVolumeBackupDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateVolumeBackupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -134,8 +134,7 @@ class CreateVolumeBackupDetails(object):
         """
         Gets the freeform_tags of this CreateVolumeBackupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -152,8 +151,7 @@ class CreateVolumeBackupDetails(object):
         """
         Sets the freeform_tags of this CreateVolumeBackupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_volume_details.py
+++ b/src/oci/core/models/create_volume_details.py
@@ -184,8 +184,8 @@ class CreateVolumeDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateVolumeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -201,8 +201,8 @@ class CreateVolumeDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateVolumeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -245,8 +245,7 @@ class CreateVolumeDetails(object):
         """
         Gets the freeform_tags of this CreateVolumeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -263,8 +262,7 @@ class CreateVolumeDetails(object):
         """
         Sets the freeform_tags of this CreateVolumeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_volume_group_backup_details.py
+++ b/src/oci/core/models/create_volume_group_backup_details.py
@@ -104,8 +104,8 @@ class CreateVolumeGroupBackupDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateVolumeGroupBackupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -121,8 +121,8 @@ class CreateVolumeGroupBackupDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateVolumeGroupBackupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -163,8 +163,7 @@ class CreateVolumeGroupBackupDetails(object):
         """
         Gets the freeform_tags of this CreateVolumeGroupBackupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -181,8 +180,7 @@ class CreateVolumeGroupBackupDetails(object):
         """
         Sets the freeform_tags of this CreateVolumeGroupBackupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/create_volume_group_details.py
+++ b/src/oci/core/models/create_volume_group_details.py
@@ -119,8 +119,8 @@ class CreateVolumeGroupDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateVolumeGroupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -136,8 +136,8 @@ class CreateVolumeGroupDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateVolumeGroupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -178,8 +178,7 @@ class CreateVolumeGroupDetails(object):
         """
         Gets the freeform_tags of this CreateVolumeGroupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -196,8 +195,7 @@ class CreateVolumeGroupDetails(object):
         """
         Sets the freeform_tags of this CreateVolumeGroupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/dhcp_options.py
+++ b/src/oci/core/models/dhcp_options.py
@@ -155,8 +155,8 @@ class DhcpOptions(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this DhcpOptions.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -172,8 +172,8 @@ class DhcpOptions(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this DhcpOptions.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -216,8 +216,7 @@ class DhcpOptions(object):
         """
         Gets the freeform_tags of this DhcpOptions.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -234,8 +233,7 @@ class DhcpOptions(object):
         """
         Sets the freeform_tags of this DhcpOptions.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/drg.py
+++ b/src/oci/core/models/drg.py
@@ -134,8 +134,8 @@ class Drg(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this Drg.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -151,8 +151,8 @@ class Drg(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this Drg.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -195,8 +195,7 @@ class Drg(object):
         """
         Gets the freeform_tags of this Drg.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -213,8 +212,7 @@ class Drg(object):
         """
         Sets the freeform_tags of this Drg.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/image.py
+++ b/src/oci/core/models/image.py
@@ -265,8 +265,8 @@ class Image(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this Image.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -282,8 +282,8 @@ class Image(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this Image.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -332,8 +332,7 @@ class Image(object):
         """
         Gets the freeform_tags of this Image.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -350,8 +349,7 @@ class Image(object):
         """
         Sets the freeform_tags of this Image.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/image_source_details.py
+++ b/src/oci/core/models/image_source_details.py
@@ -30,6 +30,14 @@ class ImageSourceDetails(object):
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param operating_system:
+            The value to assign to the operating_system property of this ImageSourceDetails.
+        :type operating_system: str
+
+        :param operating_system_version:
+            The value to assign to the operating_system_version property of this ImageSourceDetails.
+        :type operating_system_version: str
+
         :param source_image_type:
             The value to assign to the source_image_type property of this ImageSourceDetails.
             Allowed values for this property are: "QCOW2", "VMDK"
@@ -41,15 +49,21 @@ class ImageSourceDetails(object):
 
         """
         self.swagger_types = {
+            'operating_system': 'str',
+            'operating_system_version': 'str',
             'source_image_type': 'str',
             'source_type': 'str'
         }
 
         self.attribute_map = {
+            'operating_system': 'operatingSystem',
+            'operating_system_version': 'operatingSystemVersion',
             'source_image_type': 'sourceImageType',
             'source_type': 'sourceType'
         }
 
+        self._operating_system = None
+        self._operating_system_version = None
         self._source_image_type = None
         self._source_type = None
 
@@ -68,6 +82,46 @@ class ImageSourceDetails(object):
             return 'ImageSourceViaObjectStorageUriDetails'
         else:
             return 'ImageSourceDetails'
+
+    @property
+    def operating_system(self):
+        """
+        Gets the operating_system of this ImageSourceDetails.
+
+        :return: The operating_system of this ImageSourceDetails.
+        :rtype: str
+        """
+        return self._operating_system
+
+    @operating_system.setter
+    def operating_system(self, operating_system):
+        """
+        Sets the operating_system of this ImageSourceDetails.
+
+        :param operating_system: The operating_system of this ImageSourceDetails.
+        :type: str
+        """
+        self._operating_system = operating_system
+
+    @property
+    def operating_system_version(self):
+        """
+        Gets the operating_system_version of this ImageSourceDetails.
+
+        :return: The operating_system_version of this ImageSourceDetails.
+        :rtype: str
+        """
+        return self._operating_system_version
+
+    @operating_system_version.setter
+    def operating_system_version(self, operating_system_version):
+        """
+        Sets the operating_system_version of this ImageSourceDetails.
+
+        :param operating_system_version: The operating_system_version of this ImageSourceDetails.
+        :type: str
+        """
+        self._operating_system_version = operating_system_version
 
     @property
     def source_image_type(self):

--- a/src/oci/core/models/image_source_via_object_storage_tuple_details.py
+++ b/src/oci/core/models/image_source_via_object_storage_tuple_details.py
@@ -18,6 +18,14 @@ class ImageSourceViaObjectStorageTupleDetails(ImageSourceDetails):
         of this class is ``objectStorageTuple`` and it should not be changed.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param operating_system:
+            The value to assign to the operating_system property of this ImageSourceViaObjectStorageTupleDetails.
+        :type operating_system: str
+
+        :param operating_system_version:
+            The value to assign to the operating_system_version property of this ImageSourceViaObjectStorageTupleDetails.
+        :type operating_system_version: str
+
         :param source_image_type:
             The value to assign to the source_image_type property of this ImageSourceViaObjectStorageTupleDetails.
             Allowed values for this property are: "QCOW2", "VMDK"
@@ -41,6 +49,8 @@ class ImageSourceViaObjectStorageTupleDetails(ImageSourceDetails):
 
         """
         self.swagger_types = {
+            'operating_system': 'str',
+            'operating_system_version': 'str',
             'source_image_type': 'str',
             'source_type': 'str',
             'bucket_name': 'str',
@@ -49,6 +59,8 @@ class ImageSourceViaObjectStorageTupleDetails(ImageSourceDetails):
         }
 
         self.attribute_map = {
+            'operating_system': 'operatingSystem',
+            'operating_system_version': 'operatingSystemVersion',
             'source_image_type': 'sourceImageType',
             'source_type': 'sourceType',
             'bucket_name': 'bucketName',
@@ -56,6 +68,8 @@ class ImageSourceViaObjectStorageTupleDetails(ImageSourceDetails):
             'object_name': 'objectName'
         }
 
+        self._operating_system = None
+        self._operating_system_version = None
         self._source_image_type = None
         self._source_type = None
         self._bucket_name = None

--- a/src/oci/core/models/image_source_via_object_storage_uri_details.py
+++ b/src/oci/core/models/image_source_via_object_storage_uri_details.py
@@ -18,6 +18,14 @@ class ImageSourceViaObjectStorageUriDetails(ImageSourceDetails):
         of this class is ``objectStorageUri`` and it should not be changed.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param operating_system:
+            The value to assign to the operating_system property of this ImageSourceViaObjectStorageUriDetails.
+        :type operating_system: str
+
+        :param operating_system_version:
+            The value to assign to the operating_system_version property of this ImageSourceViaObjectStorageUriDetails.
+        :type operating_system_version: str
+
         :param source_image_type:
             The value to assign to the source_image_type property of this ImageSourceViaObjectStorageUriDetails.
             Allowed values for this property are: "QCOW2", "VMDK"
@@ -33,17 +41,23 @@ class ImageSourceViaObjectStorageUriDetails(ImageSourceDetails):
 
         """
         self.swagger_types = {
+            'operating_system': 'str',
+            'operating_system_version': 'str',
             'source_image_type': 'str',
             'source_type': 'str',
             'source_uri': 'str'
         }
 
         self.attribute_map = {
+            'operating_system': 'operatingSystem',
+            'operating_system_version': 'operatingSystemVersion',
             'source_image_type': 'sourceImageType',
             'source_type': 'sourceType',
             'source_uri': 'sourceUri'
         }
 
+        self._operating_system = None
+        self._operating_system_version = None
         self._source_image_type = None
         self._source_type = None
         self._source_uri = None

--- a/src/oci/core/models/instance.py
+++ b/src/oci/core/models/instance.py
@@ -286,8 +286,8 @@ class Instance(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this Instance.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -303,8 +303,8 @@ class Instance(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this Instance.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -425,8 +425,7 @@ class Instance(object):
         """
         Gets the freeform_tags of this Instance.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -443,8 +442,7 @@ class Instance(object):
         """
         Sets the freeform_tags of this Instance.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/instance_configuration.py
+++ b/src/oci/core/models/instance_configuration.py
@@ -109,8 +109,8 @@ class InstanceConfiguration(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this InstanceConfiguration.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -126,8 +126,8 @@ class InstanceConfiguration(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this InstanceConfiguration.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -168,8 +168,7 @@ class InstanceConfiguration(object):
         """
         Gets the freeform_tags of this InstanceConfiguration.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -186,8 +185,7 @@ class InstanceConfiguration(object):
         """
         Sets the freeform_tags of this InstanceConfiguration.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/instance_configuration_create_volume_details.py
+++ b/src/oci/core/models/instance_configuration_create_volume_details.py
@@ -163,8 +163,8 @@ class InstanceConfigurationCreateVolumeDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this InstanceConfigurationCreateVolumeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -180,8 +180,8 @@ class InstanceConfigurationCreateVolumeDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this InstanceConfigurationCreateVolumeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -224,8 +224,7 @@ class InstanceConfigurationCreateVolumeDetails(object):
         """
         Gets the freeform_tags of this InstanceConfigurationCreateVolumeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -242,8 +241,7 @@ class InstanceConfigurationCreateVolumeDetails(object):
         """
         Sets the freeform_tags of this InstanceConfigurationCreateVolumeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/instance_configuration_launch_instance_details.py
+++ b/src/oci/core/models/instance_configuration_launch_instance_details.py
@@ -61,6 +61,10 @@ class InstanceConfigurationLaunchInstanceDetails(object):
             The value to assign to the source_details property of this InstanceConfigurationLaunchInstanceDetails.
         :type source_details: InstanceConfigurationInstanceSourceDetails
 
+        :param fault_domain:
+            The value to assign to the fault_domain property of this InstanceConfigurationLaunchInstanceDetails.
+        :type fault_domain: str
+
         """
         self.swagger_types = {
             'availability_domain': 'str',
@@ -73,7 +77,8 @@ class InstanceConfigurationLaunchInstanceDetails(object):
             'ipxe_script': 'str',
             'metadata': 'dict(str, str)',
             'shape': 'str',
-            'source_details': 'InstanceConfigurationInstanceSourceDetails'
+            'source_details': 'InstanceConfigurationInstanceSourceDetails',
+            'fault_domain': 'str'
         }
 
         self.attribute_map = {
@@ -87,7 +92,8 @@ class InstanceConfigurationLaunchInstanceDetails(object):
             'ipxe_script': 'ipxeScript',
             'metadata': 'metadata',
             'shape': 'shape',
-            'source_details': 'sourceDetails'
+            'source_details': 'sourceDetails',
+            'fault_domain': 'faultDomain'
         }
 
         self._availability_domain = None
@@ -101,6 +107,7 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         self._metadata = None
         self._shape = None
         self._source_details = None
+        self._fault_domain = None
 
     @property
     def availability_domain(self):
@@ -184,8 +191,8 @@ class InstanceConfigurationLaunchInstanceDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this InstanceConfigurationLaunchInstanceDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -201,8 +208,8 @@ class InstanceConfigurationLaunchInstanceDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this InstanceConfigurationLaunchInstanceDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -277,8 +284,7 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         """
         Gets the freeform_tags of this InstanceConfigurationLaunchInstanceDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -295,8 +301,7 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         """
         Sets the freeform_tags of this InstanceConfigurationLaunchInstanceDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -581,6 +586,56 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         :type: InstanceConfigurationInstanceSourceDetails
         """
         self._source_details = source_details
+
+    @property
+    def fault_domain(self):
+        """
+        Gets the fault_domain of this InstanceConfigurationLaunchInstanceDetails.
+        A fault domain is a grouping of hardware and infrastructure within an availability domain.
+        Each availability domain contains three fault domains. Fault domains let you distribute your
+        instances so that they are not on the same physical hardware within a single availability domain.
+        A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
+        instances in other fault domains.
+
+        If you do not specify the fault domain, the system selects one for you. To change the fault
+        domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+
+        To get a list of fault domains, use the
+        :func:`list_fault_domains` operation in the
+        Identity and Access Management Service API.
+
+        Example: `FAULT-DOMAIN-1`
+
+
+        :return: The fault_domain of this InstanceConfigurationLaunchInstanceDetails.
+        :rtype: str
+        """
+        return self._fault_domain
+
+    @fault_domain.setter
+    def fault_domain(self, fault_domain):
+        """
+        Sets the fault_domain of this InstanceConfigurationLaunchInstanceDetails.
+        A fault domain is a grouping of hardware and infrastructure within an availability domain.
+        Each availability domain contains three fault domains. Fault domains let you distribute your
+        instances so that they are not on the same physical hardware within a single availability domain.
+        A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
+        instances in other fault domains.
+
+        If you do not specify the fault domain, the system selects one for you. To change the fault
+        domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+
+        To get a list of fault domains, use the
+        :func:`list_fault_domains` operation in the
+        Identity and Access Management Service API.
+
+        Example: `FAULT-DOMAIN-1`
+
+
+        :param fault_domain: The fault_domain of this InstanceConfigurationLaunchInstanceDetails.
+        :type: str
+        """
+        self._fault_domain = fault_domain
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/instance_configuration_summary.py
+++ b/src/oci/core/models/instance_configuration_summary.py
@@ -169,8 +169,8 @@ class InstanceConfigurationSummary(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this InstanceConfigurationSummary.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -186,8 +186,8 @@ class InstanceConfigurationSummary(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this InstanceConfigurationSummary.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -204,8 +204,7 @@ class InstanceConfigurationSummary(object):
         """
         Gets the freeform_tags of this InstanceConfigurationSummary.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -222,8 +221,7 @@ class InstanceConfigurationSummary(object):
         """
         Sets the freeform_tags of this InstanceConfigurationSummary.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/instance_console_connection.py
+++ b/src/oci/core/models/instance_console_connection.py
@@ -168,8 +168,8 @@ class InstanceConsoleConnection(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this InstanceConsoleConnection.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -185,8 +185,8 @@ class InstanceConsoleConnection(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this InstanceConsoleConnection.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -227,8 +227,7 @@ class InstanceConsoleConnection(object):
         """
         Gets the freeform_tags of this InstanceConsoleConnection.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -245,8 +244,7 @@ class InstanceConsoleConnection(object):
         """
         Sets the freeform_tags of this InstanceConsoleConnection.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/instance_pool.py
+++ b/src/oci/core/models/instance_pool.py
@@ -188,8 +188,8 @@ class InstancePool(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this InstancePool.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -205,8 +205,8 @@ class InstancePool(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this InstancePool.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -247,8 +247,7 @@ class InstancePool(object):
         """
         Gets the freeform_tags of this InstancePool.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -265,8 +264,7 @@ class InstancePool(object):
         """
         Sets the freeform_tags of this InstancePool.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/instance_pool_summary.py
+++ b/src/oci/core/models/instance_pool_summary.py
@@ -333,8 +333,8 @@ class InstancePoolSummary(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this InstancePoolSummary.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -350,8 +350,8 @@ class InstancePoolSummary(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this InstancePoolSummary.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -368,8 +368,7 @@ class InstancePoolSummary(object):
         """
         Gets the freeform_tags of this InstancePoolSummary.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -386,8 +385,7 @@ class InstancePoolSummary(object):
         """
         Sets the freeform_tags of this InstancePoolSummary.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/internet_gateway.py
+++ b/src/oci/core/models/internet_gateway.py
@@ -146,8 +146,8 @@ class InternetGateway(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this InternetGateway.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -163,8 +163,8 @@ class InternetGateway(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this InternetGateway.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -207,8 +207,7 @@ class InternetGateway(object):
         """
         Gets the freeform_tags of this InternetGateway.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -225,8 +224,7 @@ class InternetGateway(object):
         """
         Sets the freeform_tags of this InternetGateway.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/ip_sec_connection.py
+++ b/src/oci/core/models/ip_sec_connection.py
@@ -215,8 +215,8 @@ class IPSecConnection(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this IPSecConnection.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -232,8 +232,8 @@ class IPSecConnection(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this IPSecConnection.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -300,8 +300,7 @@ class IPSecConnection(object):
         """
         Gets the freeform_tags of this IPSecConnection.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -318,8 +317,7 @@ class IPSecConnection(object):
         """
         Sets the freeform_tags of this IPSecConnection.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -396,9 +394,14 @@ class IPSecConnection(object):
         If you don't provide a value when creating the IPSec connection, the `ipAddress` attribute
         for the :class:`Cpe` object specified by `cpeId` is used as the `cpeLocalIdentifier`.
 
+        For information about why you'd provide this value, see
+        `If Your CPE Is Behind a NAT Device`__.
+
         Example IP address: `10.0.3.3`
 
         Example hostname: `cpe.example.com`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Tasks/overviewIPsec.htm#nat
 
 
         :return: The cpe_local_identifier of this IPSecConnection.
@@ -417,9 +420,14 @@ class IPSecConnection(object):
         If you don't provide a value when creating the IPSec connection, the `ipAddress` attribute
         for the :class:`Cpe` object specified by `cpeId` is used as the `cpeLocalIdentifier`.
 
+        For information about why you'd provide this value, see
+        `If Your CPE Is Behind a NAT Device`__.
+
         Example IP address: `10.0.3.3`
 
         Example hostname: `cpe.example.com`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Tasks/overviewIPsec.htm#nat
 
 
         :param cpe_local_identifier: The cpe_local_identifier of this IPSecConnection.

--- a/src/oci/core/models/ip_sec_connection_tunnel_shared_secret.py
+++ b/src/oci/core/models/ip_sec_connection_tunnel_shared_secret.py
@@ -38,7 +38,7 @@ class IPSecConnectionTunnelSharedSecret(object):
         **[Required]** Gets the shared_secret of this IPSecConnectionTunnelSharedSecret.
         The tunnel's shared secret (pre-shared key).
 
-        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 
 
         :return: The shared_secret of this IPSecConnectionTunnelSharedSecret.
@@ -52,7 +52,7 @@ class IPSecConnectionTunnelSharedSecret(object):
         Sets the shared_secret of this IPSecConnectionTunnelSharedSecret.
         The tunnel's shared secret (pre-shared key).
 
-        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 
 
         :param shared_secret: The shared_secret of this IPSecConnectionTunnelSharedSecret.

--- a/src/oci/core/models/launch_instance_details.py
+++ b/src/oci/core/models/launch_instance_details.py
@@ -227,8 +227,8 @@ class LaunchInstanceDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this LaunchInstanceDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -244,8 +244,8 @@ class LaunchInstanceDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this LaunchInstanceDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -370,8 +370,7 @@ class LaunchInstanceDetails(object):
         """
         Gets the freeform_tags of this LaunchInstanceDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -388,8 +387,7 @@ class LaunchInstanceDetails(object):
         """
         Sets the freeform_tags of this LaunchInstanceDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/local_peering_gateway.py
+++ b/src/oci/core/models/local_peering_gateway.py
@@ -205,8 +205,8 @@ class LocalPeeringGateway(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this LocalPeeringGateway.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -222,8 +222,8 @@ class LocalPeeringGateway(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this LocalPeeringGateway.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -266,8 +266,7 @@ class LocalPeeringGateway(object):
         """
         Gets the freeform_tags of this LocalPeeringGateway.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -284,8 +283,7 @@ class LocalPeeringGateway(object):
         """
         Sets the freeform_tags of this LocalPeeringGateway.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/nat_gateway.py
+++ b/src/oci/core/models/nat_gateway.py
@@ -162,8 +162,8 @@ class NatGateway(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this NatGateway.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -179,8 +179,8 @@ class NatGateway(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this NatGateway.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -223,8 +223,7 @@ class NatGateway(object):
         """
         Gets the freeform_tags of this NatGateway.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -241,8 +240,7 @@ class NatGateway(object):
         """
         Sets the freeform_tags of this NatGateway.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/private_ip.py
+++ b/src/oci/core/models/private_ip.py
@@ -200,8 +200,8 @@ class PrivateIp(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this PrivateIp.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -217,8 +217,8 @@ class PrivateIp(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this PrivateIp.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -261,8 +261,7 @@ class PrivateIp(object):
         """
         Gets the freeform_tags of this PrivateIp.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -279,8 +278,7 @@ class PrivateIp(object):
         """
         Sets the freeform_tags of this PrivateIp.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/public_ip.py
+++ b/src/oci/core/models/public_ip.py
@@ -324,8 +324,8 @@ class PublicIp(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this PublicIp.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -341,8 +341,8 @@ class PublicIp(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this PublicIp.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -385,8 +385,7 @@ class PublicIp(object):
         """
         Gets the freeform_tags of this PublicIp.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -403,8 +402,7 @@ class PublicIp(object):
         """
         Sets the freeform_tags of this PublicIp.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/route_table.py
+++ b/src/oci/core/models/route_table.py
@@ -146,8 +146,8 @@ class RouteTable(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this RouteTable.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -163,8 +163,8 @@ class RouteTable(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this RouteTable.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -207,8 +207,7 @@ class RouteTable(object):
         """
         Gets the freeform_tags of this RouteTable.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -225,8 +224,7 @@ class RouteTable(object):
         """
         Sets the freeform_tags of this RouteTable.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/security_list.py
+++ b/src/oci/core/models/security_list.py
@@ -159,8 +159,8 @@ class SecurityList(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this SecurityList.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -176,8 +176,8 @@ class SecurityList(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this SecurityList.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -244,8 +244,7 @@ class SecurityList(object):
         """
         Gets the freeform_tags of this SecurityList.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -262,8 +261,7 @@ class SecurityList(object):
         """
         Sets the freeform_tags of this SecurityList.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/service_gateway.py
+++ b/src/oci/core/models/service_gateway.py
@@ -193,8 +193,8 @@ class ServiceGateway(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this ServiceGateway.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -210,8 +210,8 @@ class ServiceGateway(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this ServiceGateway.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -254,8 +254,7 @@ class ServiceGateway(object):
         """
         Gets the freeform_tags of this ServiceGateway.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -272,8 +271,7 @@ class ServiceGateway(object):
         """
         Sets the freeform_tags of this ServiceGateway.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/subnet.py
+++ b/src/oci/core/models/subnet.py
@@ -270,8 +270,8 @@ class Subnet(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this Subnet.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -287,8 +287,8 @@ class Subnet(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this Subnet.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -407,8 +407,7 @@ class Subnet(object):
         """
         Gets the freeform_tags of this Subnet.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -425,8 +424,7 @@ class Subnet(object):
         """
         Sets the freeform_tags of this Subnet.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/tunnel_config.py
+++ b/src/oci/core/models/tunnel_config.py
@@ -83,7 +83,7 @@ class TunnelConfig(object):
         **[Required]** Gets the shared_secret of this TunnelConfig.
         The shared secret of the IPSec tunnel.
 
-        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 
 
         :return: The shared_secret of this TunnelConfig.
@@ -97,7 +97,7 @@ class TunnelConfig(object):
         Sets the shared_secret of this TunnelConfig.
         The shared secret of the IPSec tunnel.
 
-        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 
 
         :param shared_secret: The shared_secret of this TunnelConfig.

--- a/src/oci/core/models/update_boot_volume_backup_details.py
+++ b/src/oci/core/models/update_boot_volume_backup_details.py
@@ -50,8 +50,8 @@ class UpdateBootVolumeBackupDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateBootVolumeBackupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -67,8 +67,8 @@ class UpdateBootVolumeBackupDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateBootVolumeBackupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -111,8 +111,7 @@ class UpdateBootVolumeBackupDetails(object):
         """
         Gets the freeform_tags of this UpdateBootVolumeBackupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -129,8 +128,7 @@ class UpdateBootVolumeBackupDetails(object):
         """
         Sets the freeform_tags of this UpdateBootVolumeBackupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_boot_volume_details.py
+++ b/src/oci/core/models/update_boot_volume_details.py
@@ -57,8 +57,8 @@ class UpdateBootVolumeDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateBootVolumeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -74,8 +74,8 @@ class UpdateBootVolumeDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateBootVolumeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -118,8 +118,7 @@ class UpdateBootVolumeDetails(object):
         """
         Gets the freeform_tags of this UpdateBootVolumeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -136,8 +135,7 @@ class UpdateBootVolumeDetails(object):
         """
         Sets the freeform_tags of this UpdateBootVolumeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_console_history_details.py
+++ b/src/oci/core/models/update_console_history_details.py
@@ -50,8 +50,8 @@ class UpdateConsoleHistoryDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateConsoleHistoryDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -67,8 +67,8 @@ class UpdateConsoleHistoryDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateConsoleHistoryDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -109,8 +109,7 @@ class UpdateConsoleHistoryDetails(object):
         """
         Gets the freeform_tags of this UpdateConsoleHistoryDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -127,8 +126,7 @@ class UpdateConsoleHistoryDetails(object):
         """
         Sets the freeform_tags of this UpdateConsoleHistoryDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_cpe_details.py
+++ b/src/oci/core/models/update_cpe_details.py
@@ -50,8 +50,8 @@ class UpdateCpeDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateCpeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -67,8 +67,8 @@ class UpdateCpeDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateCpeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -111,8 +111,7 @@ class UpdateCpeDetails(object):
         """
         Gets the freeform_tags of this UpdateCpeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -129,8 +128,7 @@ class UpdateCpeDetails(object):
         """
         Sets the freeform_tags of this UpdateCpeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_dhcp_details.py
+++ b/src/oci/core/models/update_dhcp_details.py
@@ -57,8 +57,8 @@ class UpdateDhcpDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateDhcpDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -74,8 +74,8 @@ class UpdateDhcpDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateDhcpDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -118,8 +118,7 @@ class UpdateDhcpDetails(object):
         """
         Gets the freeform_tags of this UpdateDhcpDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -136,8 +135,7 @@ class UpdateDhcpDetails(object):
         """
         Sets the freeform_tags of this UpdateDhcpDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_drg_details.py
+++ b/src/oci/core/models/update_drg_details.py
@@ -50,8 +50,8 @@ class UpdateDrgDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateDrgDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -67,8 +67,8 @@ class UpdateDrgDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateDrgDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -111,8 +111,7 @@ class UpdateDrgDetails(object):
         """
         Gets the freeform_tags of this UpdateDrgDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -129,8 +128,7 @@ class UpdateDrgDetails(object):
         """
         Sets the freeform_tags of this UpdateDrgDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_image_details.py
+++ b/src/oci/core/models/update_image_details.py
@@ -29,29 +29,43 @@ class UpdateImageDetails(object):
             The value to assign to the freeform_tags property of this UpdateImageDetails.
         :type freeform_tags: dict(str, str)
 
+        :param operating_system:
+            The value to assign to the operating_system property of this UpdateImageDetails.
+        :type operating_system: str
+
+        :param operating_system_version:
+            The value to assign to the operating_system_version property of this UpdateImageDetails.
+        :type operating_system_version: str
+
         """
         self.swagger_types = {
             'defined_tags': 'dict(str, dict(str, object))',
             'display_name': 'str',
-            'freeform_tags': 'dict(str, str)'
+            'freeform_tags': 'dict(str, str)',
+            'operating_system': 'str',
+            'operating_system_version': 'str'
         }
 
         self.attribute_map = {
             'defined_tags': 'definedTags',
             'display_name': 'displayName',
-            'freeform_tags': 'freeformTags'
+            'freeform_tags': 'freeformTags',
+            'operating_system': 'operatingSystem',
+            'operating_system_version': 'operatingSystemVersion'
         }
 
         self._defined_tags = None
         self._display_name = None
         self._freeform_tags = None
+        self._operating_system = None
+        self._operating_system_version = None
 
     @property
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateImageDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -67,8 +81,8 @@ class UpdateImageDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateImageDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -115,8 +129,7 @@ class UpdateImageDetails(object):
         """
         Gets the freeform_tags of this UpdateImageDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -133,8 +146,7 @@ class UpdateImageDetails(object):
         """
         Sets the freeform_tags of this UpdateImageDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -145,6 +157,62 @@ class UpdateImageDetails(object):
         :type: dict(str, str)
         """
         self._freeform_tags = freeform_tags
+
+    @property
+    def operating_system(self):
+        """
+        Gets the operating_system of this UpdateImageDetails.
+        Operating system
+
+        Example: `Oracle Linux`
+
+
+        :return: The operating_system of this UpdateImageDetails.
+        :rtype: str
+        """
+        return self._operating_system
+
+    @operating_system.setter
+    def operating_system(self, operating_system):
+        """
+        Sets the operating_system of this UpdateImageDetails.
+        Operating system
+
+        Example: `Oracle Linux`
+
+
+        :param operating_system: The operating_system of this UpdateImageDetails.
+        :type: str
+        """
+        self._operating_system = operating_system
+
+    @property
+    def operating_system_version(self):
+        """
+        Gets the operating_system_version of this UpdateImageDetails.
+        Operating system version
+
+        Example: `7.4`
+
+
+        :return: The operating_system_version of this UpdateImageDetails.
+        :rtype: str
+        """
+        return self._operating_system_version
+
+    @operating_system_version.setter
+    def operating_system_version(self, operating_system_version):
+        """
+        Sets the operating_system_version of this UpdateImageDetails.
+        Operating system version
+
+        Example: `7.4`
+
+
+        :param operating_system_version: The operating_system_version of this UpdateImageDetails.
+        :type: str
+        """
+        self._operating_system_version = operating_system_version
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/update_instance_configuration_details.py
+++ b/src/oci/core/models/update_instance_configuration_details.py
@@ -50,8 +50,8 @@ class UpdateInstanceConfigurationDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateInstanceConfigurationDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -67,8 +67,8 @@ class UpdateInstanceConfigurationDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateInstanceConfigurationDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -115,8 +115,7 @@ class UpdateInstanceConfigurationDetails(object):
         """
         Gets the freeform_tags of this UpdateInstanceConfigurationDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -133,8 +132,7 @@ class UpdateInstanceConfigurationDetails(object):
         """
         Sets the freeform_tags of this UpdateInstanceConfigurationDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_instance_details.py
+++ b/src/oci/core/models/update_instance_details.py
@@ -71,8 +71,8 @@ class UpdateInstanceDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateInstanceDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -88,8 +88,8 @@ class UpdateInstanceDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateInstanceDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -136,8 +136,7 @@ class UpdateInstanceDetails(object):
         """
         Gets the freeform_tags of this UpdateInstanceDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -154,8 +153,7 @@ class UpdateInstanceDetails(object):
         """
         Sets the freeform_tags of this UpdateInstanceDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_instance_pool_details.py
+++ b/src/oci/core/models/update_instance_pool_details.py
@@ -71,8 +71,8 @@ class UpdateInstancePoolDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateInstancePoolDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -88,8 +88,8 @@ class UpdateInstancePoolDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateInstancePoolDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -130,8 +130,7 @@ class UpdateInstancePoolDetails(object):
         """
         Gets the freeform_tags of this UpdateInstancePoolDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -148,8 +147,7 @@ class UpdateInstancePoolDetails(object):
         """
         Sets the freeform_tags of this UpdateInstancePoolDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_internet_gateway_details.py
+++ b/src/oci/core/models/update_internet_gateway_details.py
@@ -57,8 +57,8 @@ class UpdateInternetGatewayDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateInternetGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -74,8 +74,8 @@ class UpdateInternetGatewayDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateInternetGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -118,8 +118,7 @@ class UpdateInternetGatewayDetails(object):
         """
         Gets the freeform_tags of this UpdateInternetGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -136,8 +135,7 @@ class UpdateInternetGatewayDetails(object):
         """
         Sets the freeform_tags of this UpdateInternetGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_ip_sec_connection_details.py
+++ b/src/oci/core/models/update_ip_sec_connection_details.py
@@ -80,8 +80,8 @@ class UpdateIPSecConnectionDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateIPSecConnectionDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -97,8 +97,8 @@ class UpdateIPSecConnectionDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateIPSecConnectionDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -141,8 +141,7 @@ class UpdateIPSecConnectionDetails(object):
         """
         Gets the freeform_tags of this UpdateIPSecConnectionDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -159,8 +158,7 @@ class UpdateIPSecConnectionDetails(object):
         """
         Sets the freeform_tags of this UpdateIPSecConnectionDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -180,9 +178,14 @@ class UpdateIPSecConnectionDetails(object):
         fully qualified domain name (FQDN)). The type of identifier you provide here must correspond
         to the value for `cpeLocalIdentifierType`.
 
+        For information about why you'd provide this value, see
+        `If Your CPE Is Behind a NAT Device`__.
+
         Example IP address: `10.0.3.3`
 
         Example hostname: `cpe.example.com`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Tasks/overviewIPsec.htm#nat
 
 
         :return: The cpe_local_identifier of this UpdateIPSecConnectionDetails.
@@ -198,9 +201,14 @@ class UpdateIPSecConnectionDetails(object):
         fully qualified domain name (FQDN)). The type of identifier you provide here must correspond
         to the value for `cpeLocalIdentifierType`.
 
+        For information about why you'd provide this value, see
+        `If Your CPE Is Behind a NAT Device`__.
+
         Example IP address: `10.0.3.3`
 
         Example hostname: `cpe.example.com`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Tasks/overviewIPsec.htm#nat
 
 
         :param cpe_local_identifier: The cpe_local_identifier of this UpdateIPSecConnectionDetails.

--- a/src/oci/core/models/update_ip_sec_connection_tunnel_shared_secret_details.py
+++ b/src/oci/core/models/update_ip_sec_connection_tunnel_shared_secret_details.py
@@ -36,9 +36,10 @@ class UpdateIPSecConnectionTunnelSharedSecretDetails(object):
     def shared_secret(self):
         """
         Gets the shared_secret of this UpdateIPSecConnectionTunnelSharedSecretDetails.
-        The shared secret (pre-shared key) to use for the tunnel.
+        The shared secret (pre-shared key) to use for the tunnel. Only numbers, letters, and spaces
+        are allowed.
 
-        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 
 
         :return: The shared_secret of this UpdateIPSecConnectionTunnelSharedSecretDetails.
@@ -50,9 +51,10 @@ class UpdateIPSecConnectionTunnelSharedSecretDetails(object):
     def shared_secret(self, shared_secret):
         """
         Sets the shared_secret of this UpdateIPSecConnectionTunnelSharedSecretDetails.
-        The shared secret (pre-shared key) to use for the tunnel.
+        The shared secret (pre-shared key) to use for the tunnel. Only numbers, letters, and spaces
+        are allowed.
 
-        Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 
 
         :param shared_secret: The shared_secret of this UpdateIPSecConnectionTunnelSharedSecretDetails.

--- a/src/oci/core/models/update_local_peering_gateway_details.py
+++ b/src/oci/core/models/update_local_peering_gateway_details.py
@@ -57,8 +57,8 @@ class UpdateLocalPeeringGatewayDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateLocalPeeringGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -74,8 +74,8 @@ class UpdateLocalPeeringGatewayDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateLocalPeeringGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -118,8 +118,7 @@ class UpdateLocalPeeringGatewayDetails(object):
         """
         Gets the freeform_tags of this UpdateLocalPeeringGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -136,8 +135,7 @@ class UpdateLocalPeeringGatewayDetails(object):
         """
         Sets the freeform_tags of this UpdateLocalPeeringGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_nat_gateway_details.py
+++ b/src/oci/core/models/update_nat_gateway_details.py
@@ -57,8 +57,8 @@ class UpdateNatGatewayDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateNatGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -74,8 +74,8 @@ class UpdateNatGatewayDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateNatGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -118,8 +118,7 @@ class UpdateNatGatewayDetails(object):
         """
         Gets the freeform_tags of this UpdateNatGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -136,8 +135,7 @@ class UpdateNatGatewayDetails(object):
         """
         Sets the freeform_tags of this UpdateNatGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_private_ip_details.py
+++ b/src/oci/core/models/update_private_ip_details.py
@@ -64,8 +64,8 @@ class UpdatePrivateIpDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdatePrivateIpDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -81,8 +81,8 @@ class UpdatePrivateIpDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdatePrivateIpDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -125,8 +125,7 @@ class UpdatePrivateIpDetails(object):
         """
         Gets the freeform_tags of this UpdatePrivateIpDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -143,8 +142,7 @@ class UpdatePrivateIpDetails(object):
         """
         Sets the freeform_tags of this UpdatePrivateIpDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_public_ip_details.py
+++ b/src/oci/core/models/update_public_ip_details.py
@@ -57,8 +57,8 @@ class UpdatePublicIpDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdatePublicIpDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -74,8 +74,8 @@ class UpdatePublicIpDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdatePublicIpDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -118,8 +118,7 @@ class UpdatePublicIpDetails(object):
         """
         Gets the freeform_tags of this UpdatePublicIpDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -136,8 +135,7 @@ class UpdatePublicIpDetails(object):
         """
         Sets the freeform_tags of this UpdatePublicIpDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_route_table_details.py
+++ b/src/oci/core/models/update_route_table_details.py
@@ -57,8 +57,8 @@ class UpdateRouteTableDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateRouteTableDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -74,8 +74,8 @@ class UpdateRouteTableDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateRouteTableDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -118,8 +118,7 @@ class UpdateRouteTableDetails(object):
         """
         Gets the freeform_tags of this UpdateRouteTableDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -136,8 +135,7 @@ class UpdateRouteTableDetails(object):
         """
         Sets the freeform_tags of this UpdateRouteTableDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_security_list_details.py
+++ b/src/oci/core/models/update_security_list_details.py
@@ -64,8 +64,8 @@ class UpdateSecurityListDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateSecurityListDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -81,8 +81,8 @@ class UpdateSecurityListDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateSecurityListDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -149,8 +149,7 @@ class UpdateSecurityListDetails(object):
         """
         Gets the freeform_tags of this UpdateSecurityListDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -167,8 +166,7 @@ class UpdateSecurityListDetails(object):
         """
         Sets the freeform_tags of this UpdateSecurityListDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_service_gateway_details.py
+++ b/src/oci/core/models/update_service_gateway_details.py
@@ -94,8 +94,8 @@ class UpdateServiceGatewayDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateServiceGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -111,8 +111,8 @@ class UpdateServiceGatewayDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateServiceGatewayDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -155,8 +155,7 @@ class UpdateServiceGatewayDetails(object):
         """
         Gets the freeform_tags of this UpdateServiceGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -173,8 +172,7 @@ class UpdateServiceGatewayDetails(object):
         """
         Sets the freeform_tags of this UpdateServiceGatewayDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_subnet_details.py
+++ b/src/oci/core/models/update_subnet_details.py
@@ -71,8 +71,8 @@ class UpdateSubnetDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateSubnetDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -88,8 +88,8 @@ class UpdateSubnetDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateSubnetDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -156,8 +156,7 @@ class UpdateSubnetDetails(object):
         """
         Gets the freeform_tags of this UpdateSubnetDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -174,8 +173,7 @@ class UpdateSubnetDetails(object):
         """
         Sets the freeform_tags of this UpdateSubnetDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_vcn_details.py
+++ b/src/oci/core/models/update_vcn_details.py
@@ -50,8 +50,8 @@ class UpdateVcnDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateVcnDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -67,8 +67,8 @@ class UpdateVcnDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateVcnDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -111,8 +111,7 @@ class UpdateVcnDetails(object):
         """
         Gets the freeform_tags of this UpdateVcnDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -129,8 +128,7 @@ class UpdateVcnDetails(object):
         """
         Sets the freeform_tags of this UpdateVcnDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_vnic_details.py
+++ b/src/oci/core/models/update_vnic_details.py
@@ -64,8 +64,8 @@ class UpdateVnicDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateVnicDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -81,8 +81,8 @@ class UpdateVnicDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateVnicDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -123,8 +123,7 @@ class UpdateVnicDetails(object):
         """
         Gets the freeform_tags of this UpdateVnicDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -141,8 +140,7 @@ class UpdateVnicDetails(object):
         """
         Sets the freeform_tags of this UpdateVnicDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_volume_backup_details.py
+++ b/src/oci/core/models/update_volume_backup_details.py
@@ -50,8 +50,8 @@ class UpdateVolumeBackupDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateVolumeBackupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -67,8 +67,8 @@ class UpdateVolumeBackupDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateVolumeBackupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -111,8 +111,7 @@ class UpdateVolumeBackupDetails(object):
         """
         Gets the freeform_tags of this UpdateVolumeBackupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -129,8 +128,7 @@ class UpdateVolumeBackupDetails(object):
         """
         Sets the freeform_tags of this UpdateVolumeBackupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_volume_details.py
+++ b/src/oci/core/models/update_volume_details.py
@@ -57,8 +57,8 @@ class UpdateVolumeDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateVolumeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -74,8 +74,8 @@ class UpdateVolumeDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateVolumeDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -118,8 +118,7 @@ class UpdateVolumeDetails(object):
         """
         Gets the freeform_tags of this UpdateVolumeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -136,8 +135,7 @@ class UpdateVolumeDetails(object):
         """
         Sets the freeform_tags of this UpdateVolumeDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_volume_group_backup_details.py
+++ b/src/oci/core/models/update_volume_group_backup_details.py
@@ -50,8 +50,8 @@ class UpdateVolumeGroupBackupDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateVolumeGroupBackupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -67,8 +67,8 @@ class UpdateVolumeGroupBackupDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateVolumeGroupBackupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -109,8 +109,7 @@ class UpdateVolumeGroupBackupDetails(object):
         """
         Gets the freeform_tags of this UpdateVolumeGroupBackupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -127,8 +126,7 @@ class UpdateVolumeGroupBackupDetails(object):
         """
         Sets the freeform_tags of this UpdateVolumeGroupBackupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/update_volume_group_details.py
+++ b/src/oci/core/models/update_volume_group_details.py
@@ -57,8 +57,8 @@ class UpdateVolumeGroupDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateVolumeGroupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -74,8 +74,8 @@ class UpdateVolumeGroupDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateVolumeGroupDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -116,8 +116,7 @@ class UpdateVolumeGroupDetails(object):
         """
         Gets the freeform_tags of this UpdateVolumeGroupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -134,8 +133,7 @@ class UpdateVolumeGroupDetails(object):
         """
         Sets the freeform_tags of this UpdateVolumeGroupDetails.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/vcn.py
+++ b/src/oci/core/models/vcn.py
@@ -273,8 +273,8 @@ class Vcn(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this Vcn.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -290,8 +290,8 @@ class Vcn(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this Vcn.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -386,8 +386,7 @@ class Vcn(object):
         """
         Gets the freeform_tags of this Vcn.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -404,8 +403,7 @@ class Vcn(object):
         """
         Sets the freeform_tags of this Vcn.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/vnic.py
+++ b/src/oci/core/models/vnic.py
@@ -225,8 +225,8 @@ class Vnic(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this Vnic.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -242,8 +242,8 @@ class Vnic(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this Vnic.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -286,8 +286,7 @@ class Vnic(object):
         """
         Gets the freeform_tags of this Vnic.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -304,8 +303,7 @@ class Vnic(object):
         """
         Sets the freeform_tags of this Vnic.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/volume.py
+++ b/src/oci/core/models/volume.py
@@ -217,8 +217,8 @@ class Volume(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this Volume.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -234,8 +234,8 @@ class Volume(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this Volume.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -278,8 +278,7 @@ class Volume(object):
         """
         Gets the freeform_tags of this Volume.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -296,8 +295,7 @@ class Volume(object):
         """
         Sets the freeform_tags of this Volume.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/volume_backup.py
+++ b/src/oci/core/models/volume_backup.py
@@ -230,8 +230,8 @@ class VolumeBackup(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this VolumeBackup.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -247,8 +247,8 @@ class VolumeBackup(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this VolumeBackup.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -323,8 +323,7 @@ class VolumeBackup(object):
         """
         Gets the freeform_tags of this VolumeBackup.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -341,8 +340,7 @@ class VolumeBackup(object):
         """
         Sets the freeform_tags of this VolumeBackup.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/volume_group.py
+++ b/src/oci/core/models/volume_group.py
@@ -196,8 +196,8 @@ class VolumeGroup(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this VolumeGroup.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -213,8 +213,8 @@ class VolumeGroup(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this VolumeGroup.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -255,8 +255,7 @@ class VolumeGroup(object):
         """
         Gets the freeform_tags of this VolumeGroup.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -273,8 +272,7 @@ class VolumeGroup(object):
         """
         Sets the freeform_tags of this VolumeGroup.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/models/volume_group_backup.py
+++ b/src/oci/core/models/volume_group_backup.py
@@ -209,8 +209,8 @@ class VolumeGroupBackup(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this VolumeGroupBackup.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -226,8 +226,8 @@ class VolumeGroupBackup(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this VolumeGroupBackup.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace.
-        For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
@@ -268,8 +268,7 @@ class VolumeGroupBackup(object):
         """
         Gets the freeform_tags of this VolumeGroupBackup.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 
@@ -286,8 +285,7 @@ class VolumeGroupBackup(object):
         """
         Sets the freeform_tags of this VolumeGroupBackup.
         Free-form tags for this resource. Each tag is a simple key-value pair with no
-        predefined name, type, or namespace. For more information, see
-        `Resource Tags`__.
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
 
         Example: `{\"Department\": \"Finance\"}`
 

--- a/src/oci/core/virtual_network_client.py
+++ b/src/oci/core/virtual_network_client.py
@@ -3436,7 +3436,9 @@ class VirtualNetworkClient(object):
 
 
         :param str vcn_id: (required)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
@@ -5516,7 +5518,9 @@ class VirtualNetworkClient(object):
 
 
         :param str vcn_id: (required)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -5763,7 +5767,9 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -5845,7 +5851,9 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -5983,7 +5991,9 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -6066,7 +6076,9 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str cross_connect_group_id: (optional)
             The OCID of the cross-connect group.
@@ -6210,7 +6222,9 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -6294,10 +6308,14 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str vcn_id: (required)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -6436,10 +6454,14 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str vcn_id: (optional)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str drg_id: (optional)
             The OCID of the DRG.
@@ -6528,7 +6550,9 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -6618,7 +6642,9 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -6798,10 +6824,14 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str vcn_id: (required)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -7033,7 +7063,9 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str drg_id: (optional)
             The OCID of the DRG.
@@ -7126,10 +7158,14 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str vcn_id: (required)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -7213,10 +7249,14 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str vcn_id: (optional)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -7494,7 +7534,9 @@ class VirtualNetworkClient(object):
             Allowed values are: "REGION", "AVAILABILITY_DOMAIN"
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -7605,7 +7647,9 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str drg_id: (optional)
             The OCID of the DRG.
@@ -7694,10 +7738,14 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str vcn_id: (required)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -7835,10 +7883,14 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str vcn_id: (required)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -7977,10 +8029,14 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str vcn_id: (optional)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -8193,10 +8249,14 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str vcn_id: (required)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -8334,7 +8394,9 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -8471,7 +8533,9 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -8642,7 +8706,9 @@ class VirtualNetworkClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -10404,7 +10470,9 @@ class VirtualNetworkClient(object):
 
 
         :param str vcn_id: (required)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param UpdateVcnDetails update_vcn_details: (required)
             Details object for updating a VCN.

--- a/src/oci/core/virtual_network_client_composite_operations.py
+++ b/src/oci/core/virtual_network_client_composite_operations.py
@@ -1426,7 +1426,9 @@ class VirtualNetworkClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str vcn_id: (required)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.core.models.Vcn.lifecycle_state`
@@ -2228,7 +2230,9 @@ class VirtualNetworkClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str vcn_id: (required)
-            The OCID of the VCN.
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param UpdateVcnDetails update_vcn_details: (required)
             Details object for updating a VCN.

--- a/src/oci/database/models/autonomous_database.py
+++ b/src/oci/database/models/autonomous_database.py
@@ -167,6 +167,10 @@ class AutonomousDatabase(object):
             The value to assign to the whitelisted_ips property of this AutonomousDatabase.
         :type whitelisted_ips: list[str]
 
+        :param is_auto_scaling_enabled:
+            The value to assign to the is_auto_scaling_enabled property of this AutonomousDatabase.
+        :type is_auto_scaling_enabled: bool
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -186,7 +190,8 @@ class AutonomousDatabase(object):
             'defined_tags': 'dict(str, dict(str, object))',
             'db_version': 'str',
             'db_workload': 'str',
-            'whitelisted_ips': 'list[str]'
+            'whitelisted_ips': 'list[str]',
+            'is_auto_scaling_enabled': 'bool'
         }
 
         self.attribute_map = {
@@ -207,7 +212,8 @@ class AutonomousDatabase(object):
             'defined_tags': 'definedTags',
             'db_version': 'dbVersion',
             'db_workload': 'dbWorkload',
-            'whitelisted_ips': 'whitelistedIps'
+            'whitelisted_ips': 'whitelistedIps',
+            'is_auto_scaling_enabled': 'isAutoScalingEnabled'
         }
 
         self._id = None
@@ -228,6 +234,7 @@ class AutonomousDatabase(object):
         self._db_version = None
         self._db_workload = None
         self._whitelisted_ips = None
+        self._is_auto_scaling_enabled = None
 
     @property
     def id(self):
@@ -706,6 +713,30 @@ class AutonomousDatabase(object):
         :type: list[str]
         """
         self._whitelisted_ips = whitelisted_ips
+
+    @property
+    def is_auto_scaling_enabled(self):
+        """
+        Gets the is_auto_scaling_enabled of this AutonomousDatabase.
+        Indicates if auto scaling is enabled for the Autonomous Database CPU core count.
+
+
+        :return: The is_auto_scaling_enabled of this AutonomousDatabase.
+        :rtype: bool
+        """
+        return self._is_auto_scaling_enabled
+
+    @is_auto_scaling_enabled.setter
+    def is_auto_scaling_enabled(self, is_auto_scaling_enabled):
+        """
+        Sets the is_auto_scaling_enabled of this AutonomousDatabase.
+        Indicates if auto scaling is enabled for the Autonomous Database CPU core count.
+
+
+        :param is_auto_scaling_enabled: The is_auto_scaling_enabled of this AutonomousDatabase.
+        :type: bool
+        """
+        self._is_auto_scaling_enabled = is_auto_scaling_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/autonomous_database_summary.py
+++ b/src/oci/database/models/autonomous_database_summary.py
@@ -169,6 +169,10 @@ class AutonomousDatabaseSummary(object):
             The value to assign to the whitelisted_ips property of this AutonomousDatabaseSummary.
         :type whitelisted_ips: list[str]
 
+        :param is_auto_scaling_enabled:
+            The value to assign to the is_auto_scaling_enabled property of this AutonomousDatabaseSummary.
+        :type is_auto_scaling_enabled: bool
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -188,7 +192,8 @@ class AutonomousDatabaseSummary(object):
             'defined_tags': 'dict(str, dict(str, object))',
             'db_version': 'str',
             'db_workload': 'str',
-            'whitelisted_ips': 'list[str]'
+            'whitelisted_ips': 'list[str]',
+            'is_auto_scaling_enabled': 'bool'
         }
 
         self.attribute_map = {
@@ -209,7 +214,8 @@ class AutonomousDatabaseSummary(object):
             'defined_tags': 'definedTags',
             'db_version': 'dbVersion',
             'db_workload': 'dbWorkload',
-            'whitelisted_ips': 'whitelistedIps'
+            'whitelisted_ips': 'whitelistedIps',
+            'is_auto_scaling_enabled': 'isAutoScalingEnabled'
         }
 
         self._id = None
@@ -230,6 +236,7 @@ class AutonomousDatabaseSummary(object):
         self._db_version = None
         self._db_workload = None
         self._whitelisted_ips = None
+        self._is_auto_scaling_enabled = None
 
     @property
     def id(self):
@@ -708,6 +715,30 @@ class AutonomousDatabaseSummary(object):
         :type: list[str]
         """
         self._whitelisted_ips = whitelisted_ips
+
+    @property
+    def is_auto_scaling_enabled(self):
+        """
+        Gets the is_auto_scaling_enabled of this AutonomousDatabaseSummary.
+        Indicates if auto scaling is enabled for the Autonomous Database CPU core count.
+
+
+        :return: The is_auto_scaling_enabled of this AutonomousDatabaseSummary.
+        :rtype: bool
+        """
+        return self._is_auto_scaling_enabled
+
+    @is_auto_scaling_enabled.setter
+    def is_auto_scaling_enabled(self, is_auto_scaling_enabled):
+        """
+        Sets the is_auto_scaling_enabled of this AutonomousDatabaseSummary.
+        Indicates if auto scaling is enabled for the Autonomous Database CPU core count.
+
+
+        :param is_auto_scaling_enabled: The is_auto_scaling_enabled of this AutonomousDatabaseSummary.
+        :type: bool
+        """
+        self._is_auto_scaling_enabled = is_auto_scaling_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/create_autonomous_database_base.py
+++ b/src/oci/database/models/create_autonomous_database_base.py
@@ -82,6 +82,10 @@ class CreateAutonomousDatabaseBase(object):
             Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
         :type license_model: str
 
+        :param is_auto_scaling_enabled:
+            The value to assign to the is_auto_scaling_enabled property of this CreateAutonomousDatabaseBase.
+        :type is_auto_scaling_enabled: bool
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this CreateAutonomousDatabaseBase.
         :type freeform_tags: dict(str, str)
@@ -105,6 +109,7 @@ class CreateAutonomousDatabaseBase(object):
             'admin_password': 'str',
             'display_name': 'str',
             'license_model': 'str',
+            'is_auto_scaling_enabled': 'bool',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str'
@@ -119,6 +124,7 @@ class CreateAutonomousDatabaseBase(object):
             'admin_password': 'adminPassword',
             'display_name': 'displayName',
             'license_model': 'licenseModel',
+            'is_auto_scaling_enabled': 'isAutoScalingEnabled',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source'
@@ -132,6 +138,7 @@ class CreateAutonomousDatabaseBase(object):
         self._admin_password = None
         self._display_name = None
         self._license_model = None
+        self._is_auto_scaling_enabled = None
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None
@@ -363,6 +370,30 @@ class CreateAutonomousDatabaseBase(object):
                 .format(allowed_values)
             )
         self._license_model = license_model
+
+    @property
+    def is_auto_scaling_enabled(self):
+        """
+        Gets the is_auto_scaling_enabled of this CreateAutonomousDatabaseBase.
+        Indicates if auto scaling is enabled for the Autonomous Database CPU core count. The default value is false.
+
+
+        :return: The is_auto_scaling_enabled of this CreateAutonomousDatabaseBase.
+        :rtype: bool
+        """
+        return self._is_auto_scaling_enabled
+
+    @is_auto_scaling_enabled.setter
+    def is_auto_scaling_enabled(self, is_auto_scaling_enabled):
+        """
+        Sets the is_auto_scaling_enabled of this CreateAutonomousDatabaseBase.
+        Indicates if auto scaling is enabled for the Autonomous Database CPU core count. The default value is false.
+
+
+        :param is_auto_scaling_enabled: The is_auto_scaling_enabled of this CreateAutonomousDatabaseBase.
+        :type: bool
+        """
+        self._is_auto_scaling_enabled = is_auto_scaling_enabled
 
     @property
     def freeform_tags(self):

--- a/src/oci/database/models/create_autonomous_database_clone_details.py
+++ b/src/oci/database/models/create_autonomous_database_clone_details.py
@@ -60,6 +60,10 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
         :type license_model: str
 
+        :param is_auto_scaling_enabled:
+            The value to assign to the is_auto_scaling_enabled property of this CreateAutonomousDatabaseCloneDetails.
+        :type is_auto_scaling_enabled: bool
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this CreateAutonomousDatabaseCloneDetails.
         :type freeform_tags: dict(str, str)
@@ -92,6 +96,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'admin_password': 'str',
             'display_name': 'str',
             'license_model': 'str',
+            'is_auto_scaling_enabled': 'bool',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str',
@@ -108,6 +113,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'admin_password': 'adminPassword',
             'display_name': 'displayName',
             'license_model': 'licenseModel',
+            'is_auto_scaling_enabled': 'isAutoScalingEnabled',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source',
@@ -123,6 +129,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
         self._admin_password = None
         self._display_name = None
         self._license_model = None
+        self._is_auto_scaling_enabled = None
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None

--- a/src/oci/database/models/create_autonomous_database_details.py
+++ b/src/oci/database/models/create_autonomous_database_details.py
@@ -52,6 +52,10 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
         :type license_model: str
 
+        :param is_auto_scaling_enabled:
+            The value to assign to the is_auto_scaling_enabled property of this CreateAutonomousDatabaseDetails.
+        :type is_auto_scaling_enabled: bool
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this CreateAutonomousDatabaseDetails.
         :type freeform_tags: dict(str, str)
@@ -75,6 +79,7 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'admin_password': 'str',
             'display_name': 'str',
             'license_model': 'str',
+            'is_auto_scaling_enabled': 'bool',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str'
@@ -89,6 +94,7 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'admin_password': 'adminPassword',
             'display_name': 'displayName',
             'license_model': 'licenseModel',
+            'is_auto_scaling_enabled': 'isAutoScalingEnabled',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source'
@@ -102,6 +108,7 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
         self._admin_password = None
         self._display_name = None
         self._license_model = None
+        self._is_auto_scaling_enabled = None
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None

--- a/src/oci/database/models/update_autonomous_database_details.py
+++ b/src/oci/database/models/update_autonomous_database_details.py
@@ -60,6 +60,10 @@ class UpdateAutonomousDatabaseDetails(object):
             The value to assign to the whitelisted_ips property of this UpdateAutonomousDatabaseDetails.
         :type whitelisted_ips: list[str]
 
+        :param is_auto_scaling_enabled:
+            The value to assign to the is_auto_scaling_enabled property of this UpdateAutonomousDatabaseDetails.
+        :type is_auto_scaling_enabled: bool
+
         """
         self.swagger_types = {
             'cpu_core_count': 'int',
@@ -69,7 +73,8 @@ class UpdateAutonomousDatabaseDetails(object):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'license_model': 'str',
-            'whitelisted_ips': 'list[str]'
+            'whitelisted_ips': 'list[str]',
+            'is_auto_scaling_enabled': 'bool'
         }
 
         self.attribute_map = {
@@ -80,7 +85,8 @@ class UpdateAutonomousDatabaseDetails(object):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'license_model': 'licenseModel',
-            'whitelisted_ips': 'whitelistedIps'
+            'whitelisted_ips': 'whitelistedIps',
+            'is_auto_scaling_enabled': 'isAutoScalingEnabled'
         }
 
         self._cpu_core_count = None
@@ -91,6 +97,7 @@ class UpdateAutonomousDatabaseDetails(object):
         self._defined_tags = None
         self._license_model = None
         self._whitelisted_ips = None
+        self._is_auto_scaling_enabled = None
 
     @property
     def cpu_core_count(self):
@@ -311,6 +318,30 @@ class UpdateAutonomousDatabaseDetails(object):
         :type: list[str]
         """
         self._whitelisted_ips = whitelisted_ips
+
+    @property
+    def is_auto_scaling_enabled(self):
+        """
+        Gets the is_auto_scaling_enabled of this UpdateAutonomousDatabaseDetails.
+        Indicates if auto scaling is enabled for the Autonomous Database CPU core count. The default value is false.
+
+
+        :return: The is_auto_scaling_enabled of this UpdateAutonomousDatabaseDetails.
+        :rtype: bool
+        """
+        return self._is_auto_scaling_enabled
+
+    @is_auto_scaling_enabled.setter
+    def is_auto_scaling_enabled(self, is_auto_scaling_enabled):
+        """
+        Sets the is_auto_scaling_enabled of this UpdateAutonomousDatabaseDetails.
+        Indicates if auto scaling is enabled for the Autonomous Database CPU core count. The default value is false.
+
+
+        :param is_auto_scaling_enabled: The is_auto_scaling_enabled of this UpdateAutonomousDatabaseDetails.
+        :type: bool
+        """
+        self._is_auto_scaling_enabled = is_auto_scaling_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/identity/identity_client.py
+++ b/src/oci/identity/identity_client.py
@@ -2774,6 +2774,83 @@ class IdentityClient(object):
                 path_params=path_params,
                 header_params=header_params)
 
+    def delete_tag(self, tag_namespace_id, tag_name, **kwargs):
+        """
+        DeleteTag
+        Deletes the the specified tag definition.
+
+
+        :param str tag_namespace_id: (required)
+            The OCID of the tag namespace.
+
+        :param str tag_name: (required)
+            The name of the tag.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/tagNamespaces/{tagNamespaceId}/tags/{tagName}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_tag got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "tagNamespaceId": tag_namespace_id,
+            "tagName": tag_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
     def delete_tag_default(self, tag_default_id, **kwargs):
         """
         DeleteTagDefault
@@ -2832,6 +2909,86 @@ class IdentityClient(object):
             "content-type": "application/json",
             "opc-request-id": kwargs.get("opc_request_id", missing),
             "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_tag_namespace(self, tag_namespace_id, **kwargs):
+        """
+        DeleteTagNamespace
+        Delete the specified tag namespace. Only an empty tagnamespace can be deleted.
+        If the tag namespace you are trying to delete is not empty, please remove tag definitions from it first.
+
+
+        :param str tag_namespace_id: (required)
+            The OCID of the tag namespace.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/tagNamespaces/{tagNamespaceId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_tag_namespace got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "tagNamespaceId": tag_namespace_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
@@ -5539,6 +5696,11 @@ class IdentityClient(object):
             An optional boolean parameter indicating whether to retrieve all tag namespaces in subcompartments. If this
             parameter is not specified, only the tag namespaces defined in the specified compartment are retrieved.
 
+        :param str lifecycle_state: (optional)
+            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+
+            Allowed values are: "ACTIVE", "INACTIVE", "DELETING", "DELETED"
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -5558,18 +5720,27 @@ class IdentityClient(object):
             "retry_strategy",
             "page",
             "limit",
-            "include_subcompartments"
+            "include_subcompartments",
+            "lifecycle_state"
         ]
         extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
         if extra_kwargs:
             raise ValueError(
                 "list_tag_namespaces got unknown kwargs: {!r}".format(extra_kwargs))
 
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["ACTIVE", "INACTIVE", "DELETING", "DELETED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
         query_params = {
             "compartmentId": compartment_id,
             "page": kwargs.get("page", missing),
             "limit": kwargs.get("limit", missing),
-            "includeSubcompartments": kwargs.get("include_subcompartments", missing)
+            "includeSubcompartments": kwargs.get("include_subcompartments", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -5613,6 +5784,11 @@ class IdentityClient(object):
         :param int limit: (optional)
             The maximum number of items to return in a paginated \"List\" call.
 
+        :param str lifecycle_state: (optional)
+            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+
+            Allowed values are: "ACTIVE", "INACTIVE", "DELETING", "DELETED"
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -5631,7 +5807,8 @@ class IdentityClient(object):
         expected_kwargs = [
             "retry_strategy",
             "page",
-            "limit"
+            "limit",
+            "lifecycle_state"
         ]
         extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
         if extra_kwargs:
@@ -5648,9 +5825,17 @@ class IdentityClient(object):
             if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
 
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["ACTIVE", "INACTIVE", "DELETING", "DELETED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
         query_params = {
             "page": kwargs.get("page", missing),
-            "limit": kwargs.get("limit", missing)
+            "limit": kwargs.get("limit", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -6993,6 +7178,11 @@ class IdentityClient(object):
         :param UpdateTagDetails update_tag_details: (required)
             Request object for updating a tag.
 
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -7007,7 +7197,11 @@ class IdentityClient(object):
         resource_path = "/tagNamespaces/{tagNamespaceId}/tags/{tagName}"
         method = "PUT"
 
-        expected_kwargs = ["retry_strategy"]
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
         extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
         if extra_kwargs:
             raise ValueError(
@@ -7026,8 +7220,10 @@ class IdentityClient(object):
 
         header_params = {
             "accept": "application/json",
-            "content-type": "application/json"
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
         }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
         retry_strategy = self.retry_strategy
         if kwargs.get('retry_strategy'):
@@ -7054,7 +7250,7 @@ class IdentityClient(object):
     def update_tag_default(self, tag_default_id, update_tag_default_details, **kwargs):
         """
         UpdateTagDefault
-        Updates the the specified tag default. You can update the following field: `value`.
+        Updates the specified tag default. You can update the following field: `value`.
 
 
         :param str tag_default_id: (required)

--- a/src/oci/identity/identity_client_composite_operations.py
+++ b/src/oci/identity/identity_client_composite_operations.py
@@ -329,6 +329,47 @@ class IdentityClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def create_tag_and_wait_for_state(self, tag_namespace_id, create_tag_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.identity.IdentityClient.create_tag` and waits for the :py:class:`~oci.identity.models.Tag` acted upon
+        to enter the given state(s).
+
+        :param str tag_namespace_id: (required)
+            The OCID of the tag namespace.
+
+        :param CreateTagDetails create_tag_details: (required)
+            Request object for creating a new tag in the specified tag namespace.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.identity.models.Tag.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.identity.IdentityClient.create_tag`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_tag(tag_namespace_id, create_tag_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_tag(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_tag_default_and_wait_for_state(self, create_tag_default_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.identity.IdentityClient.create_tag_default` and waits for the :py:class:`~oci.identity.models.TagDefault` acted upon
@@ -358,6 +399,44 @@ class IdentityClientCompositeOperations(object):
             waiter_result = oci.wait_until(
                 self.client,
                 self.client.get_tag_default(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_tag_namespace_and_wait_for_state(self, create_tag_namespace_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.identity.IdentityClient.create_tag_namespace` and waits for the :py:class:`~oci.identity.models.TagNamespace` acted upon
+        to enter the given state(s).
+
+        :param CreateTagNamespaceDetails create_tag_namespace_details: (required)
+            Request object for creating a new tag namespace.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.identity.models.TagNamespace.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.identity.IdentityClient.create_tag_namespace`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_tag_namespace(create_tag_namespace_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_tag_namespace(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )
@@ -639,6 +718,55 @@ class IdentityClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def delete_tag_and_wait_for_state(self, tag_namespace_id, tag_name, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.identity.IdentityClient.delete_tag` and waits for the :py:class:`~oci.identity.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str tag_namespace_id: (required)
+            The OCID of the tag namespace.
+
+        :param str tag_name: (required)
+            The name of the tag.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.identity.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.identity.IdentityClient.delete_tag`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = None
+        try:
+            operation_result = self.client.delete_tag(tag_namespace_id, tag_name, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def delete_tag_default_and_wait_for_state(self, tag_default_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.identity.IdentityClient.delete_tag_default` and waits for the :py:class:`~oci.identity.models.TagDefault` acted upon
@@ -661,6 +789,53 @@ class IdentityClientCompositeOperations(object):
         operation_result = None
         try:
             operation_result = self.client.delete_tag_default(tag_default_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                initial_get_result,
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                succeed_on_not_found=True,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_tag_namespace_and_wait_for_state(self, tag_namespace_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.identity.IdentityClient.delete_tag_namespace` and waits for the :py:class:`~oci.identity.models.TagNamespace` acted upon
+        to enter the given state(s).
+
+        :param str tag_namespace_id: (required)
+            The OCID of the tag namespace.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.identity.models.TagNamespace.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.identity.IdentityClient.delete_tag_namespace`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        initial_get_result = self.client.get_tag_namespace(tag_namespace_id)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_tag_namespace(tag_namespace_id, **operation_kwargs)
         except oci.exceptions.ServiceError as e:
             if e.status == 404:
                 return WAIT_RESOURCE_NOT_FOUND
@@ -1023,6 +1198,50 @@ class IdentityClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def update_tag_and_wait_for_state(self, tag_namespace_id, tag_name, update_tag_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.identity.IdentityClient.update_tag` and waits for the :py:class:`~oci.identity.models.Tag` acted upon
+        to enter the given state(s).
+
+        :param str tag_namespace_id: (required)
+            The OCID of the tag namespace.
+
+        :param str tag_name: (required)
+            The name of the tag.
+
+        :param UpdateTagDetails update_tag_details: (required)
+            Request object for updating a tag.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.identity.models.Tag.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.identity.IdentityClient.update_tag`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_tag(tag_namespace_id, tag_name, update_tag_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_tag(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def update_tag_default_and_wait_for_state(self, tag_default_id, update_tag_default_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.identity.IdentityClient.update_tag_default` and waits for the :py:class:`~oci.identity.models.TagDefault` acted upon
@@ -1055,6 +1274,47 @@ class IdentityClientCompositeOperations(object):
             waiter_result = oci.wait_until(
                 self.client,
                 self.client.get_tag_default(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_tag_namespace_and_wait_for_state(self, tag_namespace_id, update_tag_namespace_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.identity.IdentityClient.update_tag_namespace` and waits for the :py:class:`~oci.identity.models.TagNamespace` acted upon
+        to enter the given state(s).
+
+        :param str tag_namespace_id: (required)
+            The OCID of the tag namespace.
+
+        :param UpdateTagNamespaceDetails update_tag_namespace_details: (required)
+            Request object for updating a namespace.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.identity.models.TagNamespace.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.identity.IdentityClient.update_tag_namespace`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_tag_namespace(tag_namespace_id, update_tag_namespace_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_tag_namespace(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )

--- a/src/oci/identity/models/tag.py
+++ b/src/oci/identity/models/tag.py
@@ -16,6 +16,22 @@ class Tag(object):
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm
     """
 
+    #: A constant which can be used with the lifecycle_state property of a Tag.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a Tag.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a Tag.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a Tag.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
     def __init__(self, **kwargs):
         """
         Initializes a new Tag object with values from keyword arguments.
@@ -57,6 +73,12 @@ class Tag(object):
             The value to assign to the is_retired property of this Tag.
         :type is_retired: bool
 
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this Tag.
+            Allowed values for this property are: "ACTIVE", "INACTIVE", "DELETING", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
         :param time_created:
             The value to assign to the time_created property of this Tag.
         :type time_created: datetime
@@ -76,6 +98,7 @@ class Tag(object):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'is_retired': 'bool',
+            'lifecycle_state': 'str',
             'time_created': 'datetime',
             'is_cost_tracking': 'bool'
         }
@@ -90,6 +113,7 @@ class Tag(object):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'is_retired': 'isRetired',
+            'lifecycle_state': 'lifecycleState',
             'time_created': 'timeCreated',
             'is_cost_tracking': 'isCostTracking'
         }
@@ -103,6 +127,7 @@ class Tag(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._is_retired = None
+        self._lifecycle_state = None
         self._time_created = None
         self._is_cost_tracking = None
 
@@ -343,6 +368,36 @@ class Tag(object):
         :type: bool
         """
         self._is_retired = is_retired
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this Tag.
+        The tag's current state. After creating a tag, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tag, make sure its `lifecycleState` is INACTIVE before using it.
+
+        Allowed values for this property are: "ACTIVE", "INACTIVE", "DELETING", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this Tag.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this Tag.
+        The tag's current state. After creating a tag, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tag, make sure its `lifecycleState` is INACTIVE before using it.
+
+
+        :param lifecycle_state: The lifecycle_state of this Tag.
+        :type: str
+        """
+        allowed_values = ["ACTIVE", "INACTIVE", "DELETING", "DELETED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
 
     @property
     def time_created(self):

--- a/src/oci/identity/models/tag_namespace.py
+++ b/src/oci/identity/models/tag_namespace.py
@@ -15,6 +15,22 @@ class TagNamespace(object):
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm
     """
 
+    #: A constant which can be used with the lifecycle_state property of a TagNamespace.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a TagNamespace.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a TagNamespace.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a TagNamespace.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
     def __init__(self, **kwargs):
         """
         Initializes a new TagNamespace object with values from keyword arguments.
@@ -48,6 +64,12 @@ class TagNamespace(object):
             The value to assign to the is_retired property of this TagNamespace.
         :type is_retired: bool
 
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TagNamespace.
+            Allowed values for this property are: "ACTIVE", "INACTIVE", "DELETING", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
         :param time_created:
             The value to assign to the time_created property of this TagNamespace.
         :type time_created: datetime
@@ -61,6 +83,7 @@ class TagNamespace(object):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'is_retired': 'bool',
+            'lifecycle_state': 'str',
             'time_created': 'datetime'
         }
 
@@ -72,6 +95,7 @@ class TagNamespace(object):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'is_retired': 'isRetired',
+            'lifecycle_state': 'lifecycleState',
             'time_created': 'timeCreated'
         }
 
@@ -82,6 +106,7 @@ class TagNamespace(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._is_retired = None
+        self._lifecycle_state = None
         self._time_created = None
 
     @property
@@ -273,6 +298,36 @@ class TagNamespace(object):
         :type: bool
         """
         self._is_retired = is_retired
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this TagNamespace.
+        The tagnamespace's current state. After creating a tagnamespace, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tagnamespace, make sure its `lifecycleState` is INACTIVE before using it.
+
+        Allowed values for this property are: "ACTIVE", "INACTIVE", "DELETING", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this TagNamespace.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this TagNamespace.
+        The tagnamespace's current state. After creating a tagnamespace, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tagnamespace, make sure its `lifecycleState` is INACTIVE before using it.
+
+
+        :param lifecycle_state: The lifecycle_state of this TagNamespace.
+        :type: str
+        """
+        allowed_values = ["ACTIVE", "INACTIVE", "DELETING", "DELETED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
 
     @property
     def time_created(self):

--- a/src/oci/identity/models/tag_namespace_summary.py
+++ b/src/oci/identity/models/tag_namespace_summary.py
@@ -45,6 +45,10 @@ class TagNamespaceSummary(object):
             The value to assign to the is_retired property of this TagNamespaceSummary.
         :type is_retired: bool
 
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TagNamespaceSummary.
+        :type lifecycle_state: str
+
         :param time_created:
             The value to assign to the time_created property of this TagNamespaceSummary.
         :type time_created: datetime
@@ -58,6 +62,7 @@ class TagNamespaceSummary(object):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'is_retired': 'bool',
+            'lifecycle_state': 'str',
             'time_created': 'datetime'
         }
 
@@ -69,6 +74,7 @@ class TagNamespaceSummary(object):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'is_retired': 'isRetired',
+            'lifecycle_state': 'lifecycleState',
             'time_created': 'timeCreated'
         }
 
@@ -79,6 +85,7 @@ class TagNamespaceSummary(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._is_retired = None
+        self._lifecycle_state = None
         self._time_created = None
 
     @property
@@ -270,6 +277,30 @@ class TagNamespaceSummary(object):
         :type: bool
         """
         self._is_retired = is_retired
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this TagNamespaceSummary.
+        The tagnamespace's current state. After creating a tagnamespace, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tagnamespace, make sure its `lifecycleState` is INACTIVE before using it.
+
+
+        :return: The lifecycle_state of this TagNamespaceSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this TagNamespaceSummary.
+        The tagnamespace's current state. After creating a tagnamespace, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tagnamespace, make sure its `lifecycleState` is INACTIVE before using it.
+
+
+        :param lifecycle_state: The lifecycle_state of this TagNamespaceSummary.
+        :type: str
+        """
+        self._lifecycle_state = lifecycle_state
 
     @property
     def time_created(self):

--- a/src/oci/identity/models/tag_summary.py
+++ b/src/oci/identity/models/tag_summary.py
@@ -45,6 +45,10 @@ class TagSummary(object):
             The value to assign to the is_retired property of this TagSummary.
         :type is_retired: bool
 
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TagSummary.
+        :type lifecycle_state: str
+
         :param time_created:
             The value to assign to the time_created property of this TagSummary.
         :type time_created: datetime
@@ -62,6 +66,7 @@ class TagSummary(object):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'is_retired': 'bool',
+            'lifecycle_state': 'str',
             'time_created': 'datetime',
             'is_cost_tracking': 'bool'
         }
@@ -74,6 +79,7 @@ class TagSummary(object):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'is_retired': 'isRetired',
+            'lifecycle_state': 'lifecycleState',
             'time_created': 'timeCreated',
             'is_cost_tracking': 'isCostTracking'
         }
@@ -85,6 +91,7 @@ class TagSummary(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._is_retired = None
+        self._lifecycle_state = None
         self._time_created = None
         self._is_cost_tracking = None
 
@@ -277,6 +284,30 @@ class TagSummary(object):
         :type: bool
         """
         self._is_retired = is_retired
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this TagSummary.
+        The tag's current state. After creating a tag, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tag, make sure its `lifecycleState` is INACTIVE before using it.
+
+
+        :return: The lifecycle_state of this TagSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this TagSummary.
+        The tag's current state. After creating a tag, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tag, make sure its `lifecycleState` is INACTIVE before using it.
+
+
+        :param lifecycle_state: The lifecycle_state of this TagSummary.
+        :type: str
+        """
+        self._lifecycle_state = lifecycle_state
 
     @property
     def time_created(self):

--- a/src/oci/identity/models/work_request.py
+++ b/src/oci/identity/models/work_request.py
@@ -17,6 +17,10 @@ class WorkRequest(object):
     #: This constant has a value of "DELETE_COMPARTMENT"
     OPERATION_TYPE_DELETE_COMPARTMENT = "DELETE_COMPARTMENT"
 
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "DELETE_TAG_DEFINITION"
+    OPERATION_TYPE_DELETE_TAG_DEFINITION = "DELETE_TAG_DEFINITION"
+
     #: A constant which can be used with the status property of a WorkRequest.
     #: This constant has a value of "ACCEPTED"
     STATUS_ACCEPTED = "ACCEPTED"
@@ -52,7 +56,7 @@ class WorkRequest(object):
 
         :param operation_type:
             The value to assign to the operation_type property of this WorkRequest.
-            Allowed values for this property are: "DELETE_COMPARTMENT", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "DELETE_COMPARTMENT", "DELETE_TAG_DEFINITION", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type operation_type: str
 
@@ -165,7 +169,7 @@ class WorkRequest(object):
         **[Required]** Gets the operation_type of this WorkRequest.
         An enum-like description of the type of work the work request is doing.
 
-        Allowed values for this property are: "DELETE_COMPARTMENT", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "DELETE_COMPARTMENT", "DELETE_TAG_DEFINITION", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -184,7 +188,7 @@ class WorkRequest(object):
         :param operation_type: The operation_type of this WorkRequest.
         :type: str
         """
-        allowed_values = ["DELETE_COMPARTMENT"]
+        allowed_values = ["DELETE_COMPARTMENT", "DELETE_TAG_DEFINITION"]
         if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
             operation_type = 'UNKNOWN_ENUM_VALUE'
         self._operation_type = operation_type

--- a/src/oci/identity/models/work_request_summary.py
+++ b/src/oci/identity/models/work_request_summary.py
@@ -16,6 +16,10 @@ class WorkRequestSummary(object):
     #: This constant has a value of "DELETE_COMPARTMENT"
     OPERATION_TYPE_DELETE_COMPARTMENT = "DELETE_COMPARTMENT"
 
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "DELETE_TAG_DEFINITION"
+    OPERATION_TYPE_DELETE_TAG_DEFINITION = "DELETE_TAG_DEFINITION"
+
     #: A constant which can be used with the status property of a WorkRequestSummary.
     #: This constant has a value of "ACCEPTED"
     STATUS_ACCEPTED = "ACCEPTED"
@@ -51,7 +55,7 @@ class WorkRequestSummary(object):
 
         :param operation_type:
             The value to assign to the operation_type property of this WorkRequestSummary.
-            Allowed values for this property are: "DELETE_COMPARTMENT", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "DELETE_COMPARTMENT", "DELETE_TAG_DEFINITION", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type operation_type: str
 
@@ -157,7 +161,7 @@ class WorkRequestSummary(object):
         **[Required]** Gets the operation_type of this WorkRequestSummary.
         An enum-like description of the type of work the work request is doing.
 
-        Allowed values for this property are: "DELETE_COMPARTMENT", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "DELETE_COMPARTMENT", "DELETE_TAG_DEFINITION", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -176,7 +180,7 @@ class WorkRequestSummary(object):
         :param operation_type: The operation_type of this WorkRequestSummary.
         :type: str
         """
-        allowed_values = ["DELETE_COMPARTMENT"]
+        allowed_values = ["DELETE_COMPARTMENT", "DELETE_TAG_DEFINITION"]
         if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
             operation_type = 'UNKNOWN_ENUM_VALUE'
         self._operation_type = operation_type

--- a/src/oci/load_balancer/load_balancer_client.py
+++ b/src/oci/load_balancer/load_balancer_client.py
@@ -75,7 +75,7 @@ class LoadBalancerClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20170115',
-            'service_endpoint_template': 'https://iaas.{region}.oraclecloud.com',
+            'service_endpoint_template': 'https://iaas.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("load_balancer", config, signer, load_balancer_type_mapping, **base_client_init_kwargs)

--- a/src/oci/load_balancer/models/session_persistence_configuration_details.py
+++ b/src/oci/load_balancer/models/session_persistence_configuration_details.py
@@ -13,6 +13,7 @@ class SessionPersistenceConfigurationDetails(object):
     Service to direct any number of requests that originate from a single logical client to a single backend web server.
     For more information, see `Session Persistence`__.
 
+
     To disable session persistence on a running load balancer, use the
     :func:`update_backend_set` operation and specify \"null\" for the
     `SessionPersistenceConfigurationDetails` object.

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "2.2.11"
+__version__ = "2.2.12"


### PR DESCRIPTION
## Added

- Support for autoscaling autonomous databases and autonomous data warehouses in the Database service

- Support for specifying fault domains as part of instance configurations in the Compute Autoscaling service

- Support for deleting tag definitions and tag namespaces in the Identity service



##Fixed

- Support for regions in realms other than oraclecloud.com in the Load Balancing service
