### PR TITLE
Releasing version 2.2.13

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+2.2.13 - 2019-06-11
+====================
+
+Added
+-----
+* Support for specifying custom boot volume sizes on instance configurations in the Compute Autoscaling service
+* Support for 'Autonomous Transaction Processing - Dedicated' features, as well as maintenance run and backup operations on autonomous databases, autonomous container databases, and autonomous Exadata infrastructure in the Database service
+
+====================
 2.2.12 - 2019-06-04
 ====================
 

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -18,6 +18,9 @@ Database
     :nosignatures:
     :template: autosummary/model_class.rst
 
+    oci.database.models.AutonomousContainerDatabase
+    oci.database.models.AutonomousContainerDatabaseBackupConfig
+    oci.database.models.AutonomousContainerDatabaseSummary
     oci.database.models.AutonomousDataWarehouse
     oci.database.models.AutonomousDataWarehouseBackup
     oci.database.models.AutonomousDataWarehouseBackupSummary
@@ -27,10 +30,16 @@ Database
     oci.database.models.AutonomousDatabaseBackup
     oci.database.models.AutonomousDatabaseBackupSummary
     oci.database.models.AutonomousDatabaseConnectionStrings
+    oci.database.models.AutonomousDatabaseConnectionUrls
     oci.database.models.AutonomousDatabaseSummary
+    oci.database.models.AutonomousExadataInfrastructure
+    oci.database.models.AutonomousExadataInfrastructureMaintenanceWindow
+    oci.database.models.AutonomousExadataInfrastructureShapeSummary
+    oci.database.models.AutonomousExadataInfrastructureSummary
     oci.database.models.Backup
     oci.database.models.BackupSummary
     oci.database.models.CompleteExternalBackupJobDetails
+    oci.database.models.CreateAutonomousContainerDatabaseDetails
     oci.database.models.CreateAutonomousDataWarehouseBackupDetails
     oci.database.models.CreateAutonomousDataWarehouseDetails
     oci.database.models.CreateAutonomousDatabaseBackupDetails
@@ -54,6 +63,7 @@ Database
     oci.database.models.Database
     oci.database.models.DatabaseConnectionStrings
     oci.database.models.DatabaseSummary
+    oci.database.models.DayOfWeek
     oci.database.models.DbBackupConfig
     oci.database.models.DbHome
     oci.database.models.DbHomeSummary
@@ -71,9 +81,14 @@ Database
     oci.database.models.FailoverDataGuardAssociationDetails
     oci.database.models.GenerateAutonomousDataWarehouseWalletDetails
     oci.database.models.GenerateAutonomousDatabaseWalletDetails
+    oci.database.models.LaunchAutonomousExadataInfrastructureDetails
     oci.database.models.LaunchDbSystemBase
     oci.database.models.LaunchDbSystemDetails
     oci.database.models.LaunchDbSystemFromBackupDetails
+    oci.database.models.MaintenanceRun
+    oci.database.models.MaintenanceRunSummary
+    oci.database.models.MaintenanceWindow
+    oci.database.models.Month
     oci.database.models.Patch
     oci.database.models.PatchDetails
     oci.database.models.PatchHistoryEntry
@@ -84,8 +99,11 @@ Database
     oci.database.models.RestoreAutonomousDatabaseDetails
     oci.database.models.RestoreDatabaseDetails
     oci.database.models.SwitchoverDataGuardAssociationDetails
+    oci.database.models.UpdateAutonomousContainerDatabaseDetails
     oci.database.models.UpdateAutonomousDataWarehouseDetails
     oci.database.models.UpdateAutonomousDatabaseDetails
+    oci.database.models.UpdateAutonomousExadataInfrastructureDetails
     oci.database.models.UpdateDatabaseDetails
     oci.database.models.UpdateDbHomeDetails
     oci.database.models.UpdateDbSystemDetails
+    oci.database.models.UpdateMaintenanceRunDetails

--- a/docs/api/database/models/oci.database.models.AutonomousContainerDatabase.rst
+++ b/docs/api/database/models/oci.database.models.AutonomousContainerDatabase.rst
@@ -1,0 +1,11 @@
+AutonomousContainerDatabase
+===========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: AutonomousContainerDatabase
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.AutonomousContainerDatabaseBackupConfig.rst
+++ b/docs/api/database/models/oci.database.models.AutonomousContainerDatabaseBackupConfig.rst
@@ -1,0 +1,11 @@
+AutonomousContainerDatabaseBackupConfig
+=======================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: AutonomousContainerDatabaseBackupConfig
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.AutonomousContainerDatabaseSummary.rst
+++ b/docs/api/database/models/oci.database.models.AutonomousContainerDatabaseSummary.rst
@@ -1,0 +1,11 @@
+AutonomousContainerDatabaseSummary
+==================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: AutonomousContainerDatabaseSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.AutonomousDatabaseConnectionUrls.rst
+++ b/docs/api/database/models/oci.database.models.AutonomousDatabaseConnectionUrls.rst
@@ -1,0 +1,11 @@
+AutonomousDatabaseConnectionUrls
+================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: AutonomousDatabaseConnectionUrls
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.AutonomousExadataInfrastructure.rst
+++ b/docs/api/database/models/oci.database.models.AutonomousExadataInfrastructure.rst
@@ -1,0 +1,11 @@
+AutonomousExadataInfrastructure
+===============================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: AutonomousExadataInfrastructure
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.AutonomousExadataInfrastructureMaintenanceWindow.rst
+++ b/docs/api/database/models/oci.database.models.AutonomousExadataInfrastructureMaintenanceWindow.rst
@@ -1,0 +1,11 @@
+AutonomousExadataInfrastructureMaintenanceWindow
+================================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: AutonomousExadataInfrastructureMaintenanceWindow
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.AutonomousExadataInfrastructureShapeSummary.rst
+++ b/docs/api/database/models/oci.database.models.AutonomousExadataInfrastructureShapeSummary.rst
@@ -1,0 +1,11 @@
+AutonomousExadataInfrastructureShapeSummary
+===========================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: AutonomousExadataInfrastructureShapeSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.AutonomousExadataInfrastructureSummary.rst
+++ b/docs/api/database/models/oci.database.models.AutonomousExadataInfrastructureSummary.rst
@@ -1,0 +1,11 @@
+AutonomousExadataInfrastructureSummary
+======================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: AutonomousExadataInfrastructureSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateAutonomousContainerDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateAutonomousContainerDatabaseDetails.rst
@@ -1,0 +1,11 @@
+CreateAutonomousContainerDatabaseDetails
+========================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateAutonomousContainerDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.DayOfWeek.rst
+++ b/docs/api/database/models/oci.database.models.DayOfWeek.rst
@@ -1,0 +1,11 @@
+DayOfWeek
+=========
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: DayOfWeek
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.LaunchAutonomousExadataInfrastructureDetails.rst
+++ b/docs/api/database/models/oci.database.models.LaunchAutonomousExadataInfrastructureDetails.rst
@@ -1,0 +1,11 @@
+LaunchAutonomousExadataInfrastructureDetails
+============================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: LaunchAutonomousExadataInfrastructureDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.MaintenanceRun.rst
+++ b/docs/api/database/models/oci.database.models.MaintenanceRun.rst
@@ -1,0 +1,11 @@
+MaintenanceRun
+==============
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: MaintenanceRun
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.MaintenanceRunSummary.rst
+++ b/docs/api/database/models/oci.database.models.MaintenanceRunSummary.rst
@@ -1,0 +1,11 @@
+MaintenanceRunSummary
+=====================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: MaintenanceRunSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.MaintenanceWindow.rst
+++ b/docs/api/database/models/oci.database.models.MaintenanceWindow.rst
@@ -1,0 +1,11 @@
+MaintenanceWindow
+=================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: MaintenanceWindow
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.Month.rst
+++ b/docs/api/database/models/oci.database.models.Month.rst
@@ -1,0 +1,11 @@
+Month
+=====
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: Month
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateAutonomousContainerDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateAutonomousContainerDatabaseDetails.rst
@@ -1,0 +1,11 @@
+UpdateAutonomousContainerDatabaseDetails
+========================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateAutonomousContainerDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateAutonomousExadataInfrastructureDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateAutonomousExadataInfrastructureDetails.rst
@@ -1,0 +1,11 @@
+UpdateAutonomousExadataInfrastructureDetails
+============================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateAutonomousExadataInfrastructureDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateMaintenanceRunDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateMaintenanceRunDetails.rst
@@ -1,0 +1,11 @@
+UpdateMaintenanceRunDetails
+===========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateMaintenanceRunDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/composite_operations_work_request_example.py
+++ b/examples/composite_operations_work_request_example.py
@@ -1,0 +1,54 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+# This script provides a basic example of how to use composite operations via work request service in the Python SDK.
+# There's another similar example ./composite_operations_example.py shows how to use composite operations based on
+# a resources's states (such as: compute instance's lifecycle states), which internally keep pulling that resource via
+# a GET call until the resource's states change to expected one. However, in some other cases, a resource can be impacted
+# by many different things or multiple resources are impacted by an operation. A work request service is for that use
+# case. For details, please see work request service document here:
+# https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/viewingworkrequestcompute.htm
+#
+# This script demonstrates how to use work request service via composite operations. In particular, how to create an image
+#
+# The script accepts two arguments:
+#   - The first argument is the instance id which you want to use as the basis for the image
+#   - The second argument is the target compartment id containing the instance you want to use as the basis for the image
+
+import oci
+import sys
+
+
+def create_image(compute_composite_ops, instance_id, compartment_id):
+    # Here we use a composite operation to create a VCN and wait for it to enter the given state. Note that the
+    # states are passed as an array so it is possible to wait on multiple states. The waiter will complete
+    # (and the method will return) once the resource enters ANY of the provided states.
+    create_image_details = oci.core.models.CreateImageDetails()
+    create_image_details.instance_id = instance_id
+    create_image_details.compartment_id = compartment_id
+    work_request_response = compute_composite_ops.create_image_and_wait_for_work_request(
+        create_image_details,
+    )
+
+    print('{}\n\n'.format(work_request_response.data))
+
+
+# Default config file and profile
+config = oci.config.from_file()
+compute_client = oci.core.ComputeClient(config)
+
+# To use different config for work request client, you can init composite operation like:
+# work_request_client = oci.work_requests.WorkRequestClient(new_config)
+# compute_composite_ops = oci.core.ComputeClientCompositeOperations(client=compute_client, work_request_client=work_request_client)
+
+# if work request client not provided, it will be initialize internally and use config for compute_client
+compute_composite_ops = oci.core.ComputeClientCompositeOperations(compute_client)
+
+if len(sys.argv) != 3:
+    raise RuntimeError('This script needs to be provided a instance ID and compartment ID')
+
+instance_id = sys.argv[1]
+compartment_id = sys.argv[2]
+
+create_image(compute_composite_ops, instance_id, compartment_id)
+print('create image operation complete')

--- a/examples/showoci/CHANGELOG.rst
+++ b/examples/showoci/CHANGELOG.rst
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+19.6.10 - 2019-06-10
+====================
+
+Added
+-----
+* Added support for autoscale Autonomous Database
+* Added Workload Type for the Autonomous Database Summary
+
+====================
 19.6.3 - 2019-06-03
 ====================
 

--- a/examples/showoci/showoci.py
+++ b/examples/showoci/showoci.py
@@ -62,7 +62,7 @@ import sys
 import argparse
 import datetime
 
-version = "19.6.3"
+version = "19.6.10"
 
 ##########################################################################
 # execute_extract

--- a/examples/showoci/showoci_data.py
+++ b/examples/showoci/showoci_data.py
@@ -1642,13 +1642,15 @@ class ShowOCIData(object):
             list_autos = self.service.search_multi_items(self.service.C_DATABASE, self.service.C_DATABASE_AUTONOMOUS, 'region_name', region_name, 'compartment_id', compartment['id'])
 
             for dbs in list_autos:
-                value = {'id': str(dbs['id']), 'name': (str(dbs['display_name']) + " - " + str(dbs['license_model']) + " - " + str(dbs['lifecycle_state']) + " (" + str(dbs['sum_count']) + " OCPUs)"),
+                value = {'id': str(dbs['id']), 'name': (str(dbs['display_name']) + " - " + str(dbs['license_model']) + " - " + str(dbs['lifecycle_state']) + " (" + str(dbs['sum_count']) + " OCPUs" + (" AutoScale" if dbs['is_auto_scaling_enabled'] else "") + ") - " + dbs['db_workload']),
                          'cpu_core_count': str(dbs['cpu_core_count']), 'data_storage_size_in_tbs': str(dbs['data_storage_size_in_tbs']),
                          'db_name': str(dbs['db_name']), 'service_console_url': str(dbs['service_console_url']), 'time_created': str(dbs['time_created'])[0:16],
-                         'connection_strings': str(dbs['connection_strings']), 'sum_info': "Autonomous Database (OCPUs) - " + dbs['license_model'],
+                         'connection_strings': str(dbs['connection_strings']), 'sum_info': "Autonomous Database " + str(dbs['db_workload']) + " (OCPUs) - " + dbs['license_model'],
                          'sum_count': str(dbs['sum_count']), 'sum_info_storage': "Autonomous Database (tb)",
                          'sum_size_tb': str(dbs['data_storage_size_in_tbs']), 'backups': self.__get_database_autonomous_backups(dbs['backups']),
                          'whitelisted_ips': dbs['whitelisted_ips'],
+                         'is_auto_scaling_enabled': dbs['is_auto_scaling_enabled'],
+                         'db_workload': dbs['db_workload'],
                          'defined_tags': dbs['defined_tags'], 'freeform_tags': dbs['freeform_tags']}
 
                 data.append(value)

--- a/examples/showoci/showoci_service.py
+++ b/examples/showoci/showoci_service.py
@@ -98,7 +98,7 @@ class ShowOCIFlags(object):
 # class ShowOCIService
 ##########################################################################
 class ShowOCIService(object):
-    oci_compatible_version = "2.2.10"
+    oci_compatible_version = "2.2.12"
 
     ##########################################################################
     # Global Constants
@@ -4893,6 +4893,8 @@ class ShowOCIService(object):
                              'freeform_tags': [] if dbs.freeform_tags is None else dbs.freeform_tags,
                              'region_name': str(self.config['region']),
                              'whitelisted_ips': "" if dbs.whitelisted_ips is None else str(', '.join(x for x in dbs.whitelisted_ips)),
+                             'db_workload': str(dbs.db_workload),
+                             'is_auto_scaling_enabled': dbs.is_auto_scaling_enabled,
                              'backups': self.__load_database_autonomouns_backups(database_client, dbs.id)}
 
                     # license model

--- a/src/oci/core/blockstorage_client.py
+++ b/src/oci/core/blockstorage_client.py
@@ -83,6 +83,8 @@ class BlockstorageClient(object):
         }
         self.base_client = BaseClient("blockstorage", config, signer, core_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
+        self._config = config
+        self._kwargs = kwargs
 
     def copy_volume_backup(self, volume_backup_id, copy_volume_backup_details, **kwargs):
         """

--- a/src/oci/core/blockstorage_client_composite_operations.py
+++ b/src/oci/core/blockstorage_client_composite_operations.py
@@ -13,14 +13,18 @@ class BlockstorageClientCompositeOperations(object):
     to enter a given state, you can call a single method in this class to accomplish the same functionality
     """
 
-    def __init__(self, client, **kwargs):
+    def __init__(self, client, work_request_client=None, **kwargs):
         """
         Creates a new BlockstorageClientCompositeOperations object
 
         :param BlockstorageClient client:
             The service client which will be wrapped by this object
+
+        :param oci.work_requests.WorkRequestClient work_request_client: (optional)
+            The work request service client which will be used to wait for work request states. Default is None.
         """
         self.client = client
+        self._work_request_client = work_request_client if work_request_client else oci.work_requests.WorkRequestClient(self.client._config, **self.client._kwargs)
 
     def copy_volume_backup_and_wait_for_state(self, volume_backup_id, copy_volume_backup_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """

--- a/src/oci/core/compute_client.py
+++ b/src/oci/core/compute_client.py
@@ -83,6 +83,8 @@ class ComputeClient(object):
         }
         self.base_client = BaseClient("compute", config, signer, core_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
+        self._config = config
+        self._kwargs = kwargs
 
     def attach_boot_volume(self, attach_boot_volume_details, **kwargs):
         """

--- a/src/oci/core/compute_client_composite_operations.py
+++ b/src/oci/core/compute_client_composite_operations.py
@@ -13,14 +13,18 @@ class ComputeClientCompositeOperations(object):
     to enter a given state, you can call a single method in this class to accomplish the same functionality
     """
 
-    def __init__(self, client, **kwargs):
+    def __init__(self, client, work_request_client=None, **kwargs):
         """
         Creates a new ComputeClientCompositeOperations object
 
         :param ComputeClient client:
             The service client which will be wrapped by this object
+
+        :param oci.work_requests.WorkRequestClient work_request_client: (optional)
+            The work request service client which will be used to wait for work request states. Default is None.
         """
         self.client = client
+        self._work_request_client = work_request_client if work_request_client else oci.work_requests.WorkRequestClient(self.client._config, **self.client._kwargs)
 
     def attach_boot_volume_and_wait_for_state(self, attach_boot_volume_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
@@ -171,6 +175,41 @@ class ComputeClientCompositeOperations(object):
             result_to_return = waiter_result
 
             return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_image_and_wait_for_work_request(self, create_image_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.core.ComputeClient.create_image` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param CreateImageDetails create_image_details: (required)
+            Image creation details
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.core.ComputeClient.create_image`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_image(create_image_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -532,6 +571,44 @@ class ComputeClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def export_image_and_wait_for_work_request(self, image_id, export_image_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.core.ComputeClient.export_image` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str image_id: (required)
+            The OCID of the image.
+
+        :param ExportImageDetails export_image_details: (required)
+            Details for the image export.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.core.ComputeClient.export_image`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.export_image(image_id, export_image_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def export_image_and_wait_for_state(self, image_id, export_image_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.core.ComputeClient.export_image` and waits for the :py:class:`~oci.core.models.Image` acted upon
@@ -613,6 +690,41 @@ class ComputeClientCompositeOperations(object):
             result_to_return = waiter_result
 
             return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def launch_instance_and_wait_for_work_request(self, launch_instance_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.core.ComputeClient.launch_instance` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param LaunchInstanceDetails launch_instance_details: (required)
+            Instance details
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.core.ComputeClient.launch_instance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.launch_instance(launch_instance_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 

--- a/src/oci/core/compute_management_client.py
+++ b/src/oci/core/compute_management_client.py
@@ -83,6 +83,8 @@ class ComputeManagementClient(object):
         }
         self.base_client = BaseClient("compute_management", config, signer, core_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
+        self._config = config
+        self._kwargs = kwargs
 
     def attach_load_balancer(self, instance_pool_id, attach_load_balancer_details, **kwargs):
         """

--- a/src/oci/core/compute_management_client_composite_operations.py
+++ b/src/oci/core/compute_management_client_composite_operations.py
@@ -13,14 +13,18 @@ class ComputeManagementClientCompositeOperations(object):
     to enter a given state, you can call a single method in this class to accomplish the same functionality
     """
 
-    def __init__(self, client, **kwargs):
+    def __init__(self, client, work_request_client=None, **kwargs):
         """
         Creates a new ComputeManagementClientCompositeOperations object
 
         :param ComputeManagementClient client:
             The service client which will be wrapped by this object
+
+        :param oci.work_requests.WorkRequestClient work_request_client: (optional)
+            The work request service client which will be used to wait for work request states. Default is None.
         """
         self.client = client
+        self._work_request_client = work_request_client if work_request_client else oci.work_requests.WorkRequestClient(self.client._config, **self.client._kwargs)
 
     def attach_load_balancer_and_wait_for_state(self, instance_pool_id, attach_load_balancer_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """

--- a/src/oci/core/models/instance_configuration_instance_source_via_image_details.py
+++ b/src/oci/core/models/instance_configuration_instance_source_via_image_details.py
@@ -22,6 +22,10 @@ class InstanceConfigurationInstanceSourceViaImageDetails(InstanceConfigurationIn
             The value to assign to the source_type property of this InstanceConfigurationInstanceSourceViaImageDetails.
         :type source_type: str
 
+        :param boot_volume_size_in_gbs:
+            The value to assign to the boot_volume_size_in_gbs property of this InstanceConfigurationInstanceSourceViaImageDetails.
+        :type boot_volume_size_in_gbs: int
+
         :param image_id:
             The value to assign to the image_id property of this InstanceConfigurationInstanceSourceViaImageDetails.
         :type image_id: str
@@ -29,17 +33,44 @@ class InstanceConfigurationInstanceSourceViaImageDetails(InstanceConfigurationIn
         """
         self.swagger_types = {
             'source_type': 'str',
+            'boot_volume_size_in_gbs': 'int',
             'image_id': 'str'
         }
 
         self.attribute_map = {
             'source_type': 'sourceType',
+            'boot_volume_size_in_gbs': 'bootVolumeSizeInGBs',
             'image_id': 'imageId'
         }
 
         self._source_type = None
+        self._boot_volume_size_in_gbs = None
         self._image_id = None
         self._source_type = 'image'
+
+    @property
+    def boot_volume_size_in_gbs(self):
+        """
+        Gets the boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.
+        The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 16384 GB (16TB).
+
+
+        :return: The boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.
+        :rtype: int
+        """
+        return self._boot_volume_size_in_gbs
+
+    @boot_volume_size_in_gbs.setter
+    def boot_volume_size_in_gbs(self, boot_volume_size_in_gbs):
+        """
+        Sets the boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.
+        The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 16384 GB (16TB).
+
+
+        :param boot_volume_size_in_gbs: The boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.
+        :type: int
+        """
+        self._boot_volume_size_in_gbs = boot_volume_size_in_gbs
 
     @property
     def image_id(self):

--- a/src/oci/core/virtual_network_client.py
+++ b/src/oci/core/virtual_network_client.py
@@ -83,6 +83,8 @@ class VirtualNetworkClient(object):
         }
         self.base_client = BaseClient("virtual_network", config, signer, core_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
+        self._config = config
+        self._kwargs = kwargs
 
     def attach_service_id(self, service_gateway_id, attach_service_details, **kwargs):
         """

--- a/src/oci/core/virtual_network_client_composite_operations.py
+++ b/src/oci/core/virtual_network_client_composite_operations.py
@@ -13,14 +13,18 @@ class VirtualNetworkClientCompositeOperations(object):
     to enter a given state, you can call a single method in this class to accomplish the same functionality
     """
 
-    def __init__(self, client, **kwargs):
+    def __init__(self, client, work_request_client=None, **kwargs):
         """
         Creates a new VirtualNetworkClientCompositeOperations object
 
         :param VirtualNetworkClient client:
             The service client which will be wrapped by this object
+
+        :param oci.work_requests.WorkRequestClient work_request_client: (optional)
+            The work request service client which will be used to wait for work request states. Default is None.
         """
         self.client = client
+        self._work_request_client = work_request_client if work_request_client else oci.work_requests.WorkRequestClient(self.client._config, **self.client._kwargs)
 
     def attach_service_id_and_wait_for_state(self, service_gateway_id, attach_service_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """

--- a/src/oci/database/database_client.py
+++ b/src/oci/database/database_client.py
@@ -177,6 +177,75 @@ class DatabaseClient(object):
                 body=complete_external_backup_job_details,
                 response_type="ExternalBackupJob")
 
+    def create_autonomous_container_database(self, create_autonomous_container_database_details, **kwargs):
+        """
+        CreateAutonomousContainerDatabase
+        Create a new Autonomous Container Database in the specified Autonomous Exadata Infrastructure.
+
+
+        :param CreateAutonomousContainerDatabaseDetails create_autonomous_container_database_details: (required)
+            Request to create an Autonomous Container Database in a specified Autonomous Exadata Infrastructure.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.AutonomousContainerDatabase`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousContainerDatabases"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_autonomous_container_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_autonomous_container_database_details,
+                response_type="AutonomousContainerDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_autonomous_container_database_details,
+                response_type="AutonomousContainerDatabase")
+
     def create_autonomous_data_warehouse(self, create_autonomous_data_warehouse_details, **kwargs):
         """
         Creates a new Autonomous Data Warehouse.
@@ -1472,6 +1541,72 @@ class DatabaseClient(object):
                 body=generate_autonomous_database_wallet_details,
                 response_type="stream")
 
+    def get_autonomous_container_database(self, autonomous_container_database_id, **kwargs):
+        """
+        GetAutonomousContainerDatabase
+        Gets information about the specified Autonomous Container Database.
+
+
+        :param str autonomous_container_database_id: (required)
+            The Autonomous Container Database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.AutonomousContainerDatabase`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousContainerDatabases/{autonomousContainerDatabaseId}"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_autonomous_container_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "autonomousContainerDatabaseId": autonomous_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="AutonomousContainerDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="AutonomousContainerDatabase")
+
     def get_autonomous_data_warehouse(self, autonomous_data_warehouse_id, **kwargs):
         """
         Gets the details of the specified Autonomous Data Warehouse.
@@ -1753,6 +1888,72 @@ class DatabaseClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 response_type="AutonomousDatabaseBackup")
+
+    def get_autonomous_exadata_infrastructure(self, autonomous_exadata_infrastructure_id, **kwargs):
+        """
+        GetAutonomousExadataInfrastructure
+        Gets information about the specified Autonomous Exadata Infrastructure.
+
+
+        :param str autonomous_exadata_infrastructure_id: (required)
+            The Autonomous Exadata Infrastructure  `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.AutonomousExadataInfrastructure`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousExadataInfrastructures/{autonomousExadataInfrastructureId}"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_autonomous_exadata_infrastructure got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "autonomousExadataInfrastructureId": autonomous_exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="AutonomousExadataInfrastructure")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="AutonomousExadataInfrastructure")
 
     def get_backup(self, backup_id, **kwargs):
         """
@@ -2589,6 +2790,139 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="ExternalBackupJob")
 
+    def get_maintenance_run(self, maintenance_run_id, **kwargs):
+        """
+        GetMaintenanceRun
+        Gets information about the specified Maintenance Run.
+
+
+        :param str maintenance_run_id: (required)
+            The Maintenance Run OCID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.MaintenanceRun`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/maintenanceRuns/{maintenanceRunId}"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_maintenance_run got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "maintenanceRunId": maintenance_run_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="MaintenanceRun")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="MaintenanceRun")
+
+    def launch_autonomous_exadata_infrastructure(self, launch_autonomous_exadata_infrastructure_details, **kwargs):
+        """
+        LaunchAutonomousExadataInfrastructure
+        Launches a new Autonomous Exadata Infrastructure in the specified compartment and availability domain.
+
+
+        :param LaunchAutonomousExadataInfrastructureDetails launch_autonomous_exadata_infrastructure_details: (required)
+            Request to launch a Autonomous Exadata Infrastructure.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.AutonomousExadataInfrastructure`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousExadataInfrastructures"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "launch_autonomous_exadata_infrastructure got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=launch_autonomous_exadata_infrastructure_details,
+                response_type="AutonomousExadataInfrastructure")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=launch_autonomous_exadata_infrastructure_details,
+                response_type="AutonomousExadataInfrastructure")
+
     def launch_db_system(self, launch_db_system_details, **kwargs):
         """
         LaunchDbSystem
@@ -2664,6 +2998,141 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=launch_db_system_details,
                 response_type="DbSystem")
+
+    def list_autonomous_container_databases(self, compartment_id, **kwargs):
+        """
+        ListAutonomousContainerDatabases
+        Gets a list of the Autonomous Container Databases in the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str autonomous_exadata_infrastructure_id: (optional)
+            The Autonomous Exadata Infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str sort_by: (optional)
+            The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+
+            **Note:** If you do not include the availability domain filter, the resources are grouped by availability domain, then sorted.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the given lifecycle state exactly.
+
+            Allowed values are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "BACKUP_IN_PROGRESS", "RESTORING", "RESTORE_FAILED", "RESTARTING", "MAINTENANCE_IN_PROGRESS"
+
+        :param str availability_domain: (optional)
+            A filter to return only resources that match the given availability domain exactly.
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.AutonomousContainerDatabaseSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousContainerDatabases"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "autonomous_exadata_infrastructure_id",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state",
+            "availability_domain",
+            "display_name"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_autonomous_container_databases got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "BACKUP_IN_PROGRESS", "RESTORING", "RESTORE_FAILED", "RESTARTING", "MAINTENANCE_IN_PROGRESS"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "autonomousExadataInfrastructureId": kwargs.get("autonomous_exadata_infrastructure_id", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "availabilityDomain": kwargs.get("availability_domain", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AutonomousContainerDatabaseSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AutonomousContainerDatabaseSummary]")
 
     def list_autonomous_data_warehouse_backups(self, **kwargs):
         """
@@ -3067,6 +3536,11 @@ class DatabaseClient(object):
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
+        :param str autonomous_container_database_id: (optional)
+            The Autonomous Container Database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
         :param int limit: (optional)
             The maximum number of items to return per page.
 
@@ -3088,7 +3562,7 @@ class DatabaseClient(object):
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the given lifecycle state exactly.
 
-            Allowed values are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING"
+            Allowed values are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS"
 
         :param str db_workload: (optional)
             A filter to return only autonomous database resources that match the specified workload type.
@@ -3118,6 +3592,7 @@ class DatabaseClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
+            "autonomous_container_database_id",
             "limit",
             "page",
             "sort_by",
@@ -3147,7 +3622,7 @@ class DatabaseClient(object):
                 )
 
         if 'lifecycle_state' in kwargs:
-            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING"]
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS"]
             if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
                 raise ValueError(
                     "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
@@ -3162,6 +3637,7 @@ class DatabaseClient(object):
 
         query_params = {
             "compartmentId": compartment_id,
+            "autonomousContainerDatabaseId": kwargs.get("autonomous_container_database_id", missing),
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing),
             "sortBy": kwargs.get("sort_by", missing),
@@ -3198,6 +3674,218 @@ class DatabaseClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="list[AutonomousDatabaseSummary]")
+
+    def list_autonomous_exadata_infrastructure_shapes(self, availability_domain, compartment_id, **kwargs):
+        """
+        ListAutonomousExadataInfrastructureShapes
+        Gets a list of the shapes that can be used to launch a new Autonomous Exadata Infrastructure DB system. The shape determines resources to allocate to the DB system (CPU cores, memory and storage).
+
+
+        :param str availability_domain: (required)
+            The name of the Availability Domain.
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.AutonomousExadataInfrastructureShapeSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousExadataInfrastructureShapes"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "opc_request_id"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_autonomous_exadata_infrastructure_shapes got unknown kwargs: {!r}".format(extra_kwargs))
+
+        query_params = {
+            "availabilityDomain": availability_domain,
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AutonomousExadataInfrastructureShapeSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AutonomousExadataInfrastructureShapeSummary]")
+
+    def list_autonomous_exadata_infrastructures(self, compartment_id, **kwargs):
+        """
+        ListAutonomousExadataInfrastructures
+        Gets a list of the Autonomous Exadata Infrastructures in the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str sort_by: (optional)
+            The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+
+              **Note:** If you do not include the availability domain filter, the resources are grouped by availability domain, then sorted.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the given lifecycle state exactly.
+
+            Allowed values are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"
+
+        :param str availability_domain: (optional)
+            A filter to return only resources that match the given availability domain exactly.
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.AutonomousExadataInfrastructureSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousExadataInfrastructures"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state",
+            "availability_domain",
+            "display_name"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_autonomous_exadata_infrastructures got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "availabilityDomain": kwargs.get("availability_domain", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AutonomousExadataInfrastructureSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AutonomousExadataInfrastructureSummary]")
 
     def list_backups(self, **kwargs):
         """
@@ -3663,7 +4351,7 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="list[PatchSummary]")
 
-    def list_db_homes(self, compartment_id, db_system_id, **kwargs):
+    def list_db_homes(self, compartment_id, **kwargs):
         """
         ListDbHomes
         Gets a list of database homes in the specified DB system and compartment. A database home is a directory where Oracle Database software is installed.
@@ -3674,7 +4362,7 @@ class DatabaseClient(object):
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
-        :param str db_system_id: (required)
+        :param str db_system_id: (optional)
             The `OCID`__ of the DB system.
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
@@ -3720,6 +4408,7 @@ class DatabaseClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
+            "db_system_id",
             "limit",
             "page",
             "sort_by",
@@ -3755,7 +4444,7 @@ class DatabaseClient(object):
 
         query_params = {
             "compartmentId": compartment_id,
-            "dbSystemId": db_system_id,
+            "dbSystemId": kwargs.get("db_system_id", missing),
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing),
             "sortBy": kwargs.get("sort_by", missing),
@@ -3790,7 +4479,7 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="list[DbHomeSummary]")
 
-    def list_db_nodes(self, compartment_id, db_system_id, **kwargs):
+    def list_db_nodes(self, compartment_id, **kwargs):
         """
         ListDbNodes
         Gets a list of database nodes in the specified DB system and compartment. A database node is a server running database software.
@@ -3801,7 +4490,7 @@ class DatabaseClient(object):
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
-        :param str db_system_id: (required)
+        :param str db_system_id: (optional)
             The `OCID`__ of the DB system.
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
@@ -3844,6 +4533,7 @@ class DatabaseClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
+            "db_system_id",
             "limit",
             "page",
             "sort_by",
@@ -3878,7 +4568,7 @@ class DatabaseClient(object):
 
         query_params = {
             "compartmentId": compartment_id,
-            "dbSystemId": db_system_id,
+            "dbSystemId": kwargs.get("db_system_id", missing),
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing),
             "sortBy": kwargs.get("sort_by", missing),
@@ -4381,6 +5071,162 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="list[DbVersionSummary]")
 
+    def list_maintenance_runs(self, compartment_id, **kwargs):
+        """
+        ListMaintenanceRuns
+        Gets a list of the Maintenance Runs in the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str target_resource_id: (optional)
+            The target resource ID.
+
+        :param str target_resource_type: (optional)
+            The type of the target resource.
+
+            Allowed values are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE"
+
+        :param str maintenance_type: (optional)
+            The maintenance type.
+
+            Allowed values are: "PLANNED", "UNPLANNED"
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str sort_by: (optional)
+            The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIME_SCHEDULED and TIME_ENDED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+
+            **Note:** If you do not include the availability domain filter, the resources are grouped by availability domain, then sorted.
+
+            Allowed values are: "TIME_SCHEDULED", "TIME_ENDED", "DISPLAYNAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the given lifecycle state exactly.
+
+            Allowed values are: "SCHEDULED", "IN_PROGRESS", "SUCCEEDED", "SKIPPED", "FAILED"
+
+        :param str availability_domain: (optional)
+            A filter to return only resources that match the given availability domain exactly.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.MaintenanceRunSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/maintenanceRuns"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "target_resource_id",
+            "target_resource_type",
+            "maintenance_type",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state",
+            "availability_domain"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_maintenance_runs got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'target_resource_type' in kwargs:
+            target_resource_type_allowed_values = ["AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE"]
+            if kwargs['target_resource_type'] not in target_resource_type_allowed_values:
+                raise ValueError(
+                    "Invalid value for `target_resource_type`, must be one of {0}".format(target_resource_type_allowed_values)
+                )
+
+        if 'maintenance_type' in kwargs:
+            maintenance_type_allowed_values = ["PLANNED", "UNPLANNED"]
+            if kwargs['maintenance_type'] not in maintenance_type_allowed_values:
+                raise ValueError(
+                    "Invalid value for `maintenance_type`, must be one of {0}".format(maintenance_type_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIME_SCHEDULED", "TIME_ENDED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["SCHEDULED", "IN_PROGRESS", "SUCCEEDED", "SKIPPED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "targetResourceId": kwargs.get("target_resource_id", missing),
+            "targetResourceType": kwargs.get("target_resource_type", missing),
+            "maintenanceType": kwargs.get("maintenance_type", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "availabilityDomain": kwargs.get("availability_domain", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[MaintenanceRunSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[MaintenanceRunSummary]")
+
     def reinstate_data_guard_association(self, database_id, data_guard_association_id, reinstate_data_guard_association_details, **kwargs):
         """
         Reinstates a database to a Data Guard association standby role.
@@ -4468,6 +5314,88 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=reinstate_data_guard_association_details,
                 response_type="DataGuardAssociation")
+
+    def restart_autonomous_container_database(self, autonomous_container_database_id, **kwargs):
+        """
+        Rolling restarts the specified Autonomous Container Database.
+        Rolling restarts the specified Autonomous Container Database.
+
+
+        :param str autonomous_container_database_id: (required)
+            The Autonomous Container Database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.AutonomousContainerDatabase`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousContainerDatabases/{autonomousContainerDatabaseId}/actions/restart"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "restart_autonomous_container_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "autonomousContainerDatabaseId": autonomous_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="AutonomousContainerDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="AutonomousContainerDatabase")
 
     def restore_autonomous_data_warehouse(self, autonomous_data_warehouse_id, restore_autonomous_data_warehouse_details, **kwargs):
         """
@@ -5119,6 +6047,156 @@ class DatabaseClient(object):
                 body=switchover_data_guard_association_details,
                 response_type="DataGuardAssociation")
 
+    def terminate_autonomous_container_database(self, autonomous_container_database_id, **kwargs):
+        """
+        TerminiateAutonomousContainerDatabase
+        Terminates an Autonomous Container Database, which permanently deletes the container database and any databases within the container database. The database data is local to the Autonomous Exadata Infrastructure and will be lost when the container database is terminated. Oracle recommends that you back up any data in the Autonomous Container Database prior to terminating it.
+
+
+        :param str autonomous_container_database_id: (required)
+            The Autonomous Container Database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousContainerDatabases/{autonomousContainerDatabaseId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "terminate_autonomous_container_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "autonomousContainerDatabaseId": autonomous_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def terminate_autonomous_exadata_infrastructure(self, autonomous_exadata_infrastructure_id, **kwargs):
+        """
+        TerminateAutonomousExadataInfrastructure
+        Terminates an Autonomous Exadata Infrastructure, which permanently deletes the Exadata Infrastructure and any container databases and databases contained in the Exadata Infrastructure. The database data is local to the Autonomous Exadata Infrastructure and will be lost when the system is terminated. Oracle recommends that you back up any data in the Autonomous Exadata Infrastructure prior to terminating it.
+
+
+        :param str autonomous_exadata_infrastructure_id: (required)
+            The Autonomous Exadata Infrastructure  `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousExadataInfrastructures/{autonomousExadataInfrastructureId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "terminate_autonomous_exadata_infrastructure got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "autonomousExadataInfrastructureId": autonomous_exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
     def terminate_db_system(self, db_system_id, **kwargs):
         """
         TerminateDbSystem
@@ -5193,6 +6271,88 @@ class DatabaseClient(object):
                 method=method,
                 path_params=path_params,
                 header_params=header_params)
+
+    def update_autonomous_container_database(self, autonomous_container_database_id, update_autonomous_container_database_details, **kwargs):
+        """
+        UpdateAutonomousContainerDatabase
+        Updates the properties of an Autonomous Container Database, such as the CPU core count and storage size.
+
+
+        :param str autonomous_container_database_id: (required)
+            The Autonomous Container Database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateAutonomousContainerDatabaseDetails update_autonomous_container_database_details: (required)
+            Request to update the properties of an Autonomous Container Database.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.AutonomousContainerDatabase`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousContainerDatabases/{autonomousContainerDatabaseId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_autonomous_container_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "autonomousContainerDatabaseId": autonomous_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_autonomous_container_database_details,
+                response_type="AutonomousContainerDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_autonomous_container_database_details,
+                response_type="AutonomousContainerDatabase")
 
     def update_autonomous_data_warehouse(self, autonomous_data_warehouse_id, update_autonomous_data_warehouse_details, **kwargs):
         """
@@ -5362,6 +6522,88 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=update_autonomous_database_details,
                 response_type="AutonomousDatabase")
+
+    def update_autonomous_exadata_infrastructure(self, autonomous_exadata_infrastructure_id, update_autonomous_exadata_infrastructures_details, **kwargs):
+        """
+        UpdateAutonomousExadataInfrastructure
+        Updates the properties of an Autonomous Exadata Infrastructure, such as the CPU core count.
+
+
+        :param str autonomous_exadata_infrastructure_id: (required)
+            The Autonomous Exadata Infrastructure  `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateAutonomousExadataInfrastructureDetails update_autonomous_exadata_infrastructures_details: (required)
+            Request to update the properties of a Autonomous Exadata Infrastructure.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.AutonomousExadataInfrastructure`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousExadataInfrastructures/{autonomousExadataInfrastructureId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_autonomous_exadata_infrastructure got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "autonomousExadataInfrastructureId": autonomous_exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_autonomous_exadata_infrastructures_details,
+                response_type="AutonomousExadataInfrastructure")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_autonomous_exadata_infrastructures_details,
+                response_type="AutonomousExadataInfrastructure")
 
     def update_database(self, database_id, update_database_details, **kwargs):
         """
@@ -5694,3 +6936,83 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=exadata_iorm_config_update_details,
                 response_type="ExadataIormConfig")
+
+    def update_maintenance_run(self, maintenance_run_id, update_maintenance_run_details, **kwargs):
+        """
+        UpdateMaintenanceRun
+        Updates the properties of a Maintenance Run, such as the state of a Maintenance Run.
+
+
+        :param str maintenance_run_id: (required)
+            The Maintenance Run OCID.
+
+        :param UpdateMaintenanceRunDetails update_maintenance_run_details: (required)
+            Request to update the properties of a Maintenance Run.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.MaintenanceRun`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/maintenanceRuns/{maintenanceRunId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_maintenance_run got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "maintenanceRunId": maintenance_run_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_maintenance_run_details,
+                response_type="MaintenanceRun")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_maintenance_run_details,
+                response_type="MaintenanceRun")

--- a/src/oci/database/database_client_composite_operations.py
+++ b/src/oci/database/database_client_composite_operations.py
@@ -22,6 +22,44 @@ class DatabaseClientCompositeOperations(object):
         """
         self.client = client
 
+    def create_autonomous_container_database_and_wait_for_state(self, create_autonomous_container_database_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_autonomous_container_database` and waits for the :py:class:`~oci.database.models.AutonomousContainerDatabase` acted upon
+        to enter the given state(s).
+
+        :param CreateAutonomousContainerDatabaseDetails create_autonomous_container_database_details: (required)
+            Request to create an Autonomous Container Database in a specified Autonomous Exadata Infrastructure.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.AutonomousContainerDatabase.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_autonomous_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_autonomous_container_database(create_autonomous_container_database_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_autonomous_container_database(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_autonomous_data_warehouse_and_wait_for_state(self, create_autonomous_data_warehouse_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.create_autonomous_data_warehouse` and waits for the :py:class:`~oci.database.models.AutonomousDataWarehouse` acted upon
@@ -582,6 +620,44 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def launch_autonomous_exadata_infrastructure_and_wait_for_state(self, launch_autonomous_exadata_infrastructure_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.launch_autonomous_exadata_infrastructure` and waits for the :py:class:`~oci.database.models.AutonomousExadataInfrastructure` acted upon
+        to enter the given state(s).
+
+        :param LaunchAutonomousExadataInfrastructureDetails launch_autonomous_exadata_infrastructure_details: (required)
+            Request to launch a Autonomous Exadata Infrastructure.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.AutonomousExadataInfrastructure.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.launch_autonomous_exadata_infrastructure`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.launch_autonomous_exadata_infrastructure(launch_autonomous_exadata_infrastructure_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_autonomous_exadata_infrastructure(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def launch_db_system_and_wait_for_state(self, launch_db_system_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.launch_db_system` and waits for the :py:class:`~oci.database.models.DbSystem` acted upon
@@ -659,6 +735,46 @@ class DatabaseClientCompositeOperations(object):
             waiter_result = oci.wait_until(
                 self.client,
                 self.client.get_data_guard_association(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def restart_autonomous_container_database_and_wait_for_state(self, autonomous_container_database_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.restart_autonomous_container_database` and waits for the :py:class:`~oci.database.models.AutonomousContainerDatabase` acted upon
+        to enter the given state(s).
+
+        :param str autonomous_container_database_id: (required)
+            The Autonomous Container Database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.AutonomousContainerDatabase.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.restart_autonomous_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.restart_autonomous_container_database(autonomous_container_database_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_autonomous_container_database(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )
@@ -1005,6 +1121,104 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def terminate_autonomous_container_database_and_wait_for_state(self, autonomous_container_database_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.terminate_autonomous_container_database` and waits for the :py:class:`~oci.database.models.AutonomousContainerDatabase` acted upon
+        to enter the given state(s).
+
+        :param str autonomous_container_database_id: (required)
+            The Autonomous Container Database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.AutonomousContainerDatabase.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.terminate_autonomous_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        initial_get_result = self.client.get_autonomous_container_database(autonomous_container_database_id)
+        operation_result = None
+        try:
+            operation_result = self.client.terminate_autonomous_container_database(autonomous_container_database_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                initial_get_result,
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                succeed_on_not_found=True,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def terminate_autonomous_exadata_infrastructure_and_wait_for_state(self, autonomous_exadata_infrastructure_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.terminate_autonomous_exadata_infrastructure` and waits for the :py:class:`~oci.database.models.AutonomousExadataInfrastructure` acted upon
+        to enter the given state(s).
+
+        :param str autonomous_exadata_infrastructure_id: (required)
+            The Autonomous Exadata Infrastructure  `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.AutonomousExadataInfrastructure.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.terminate_autonomous_exadata_infrastructure`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        initial_get_result = self.client.get_autonomous_exadata_infrastructure(autonomous_exadata_infrastructure_id)
+        operation_result = None
+        try:
+            operation_result = self.client.terminate_autonomous_exadata_infrastructure(autonomous_exadata_infrastructure_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                initial_get_result,
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                succeed_on_not_found=True,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def terminate_db_system_and_wait_for_state(self, db_system_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.terminate_db_system` and waits for the :py:class:`~oci.database.models.DbSystem` acted upon
@@ -1046,6 +1260,49 @@ class DatabaseClientCompositeOperations(object):
                 initial_get_result,
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 succeed_on_not_found=True,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_autonomous_container_database_and_wait_for_state(self, autonomous_container_database_id, update_autonomous_container_database_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_autonomous_container_database` and waits for the :py:class:`~oci.database.models.AutonomousContainerDatabase` acted upon
+        to enter the given state(s).
+
+        :param str autonomous_container_database_id: (required)
+            The Autonomous Container Database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateAutonomousContainerDatabaseDetails update_autonomous_container_database_details: (required)
+            Request to update the properties of an Autonomous Container Database.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.AutonomousContainerDatabase.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_autonomous_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_autonomous_container_database(autonomous_container_database_id, update_autonomous_container_database_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_autonomous_container_database(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )
             result_to_return = waiter_result
@@ -1131,6 +1388,49 @@ class DatabaseClientCompositeOperations(object):
             waiter_result = oci.wait_until(
                 self.client,
                 self.client.get_autonomous_database(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_autonomous_exadata_infrastructure_and_wait_for_state(self, autonomous_exadata_infrastructure_id, update_autonomous_exadata_infrastructures_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_autonomous_exadata_infrastructure` and waits for the :py:class:`~oci.database.models.AutonomousExadataInfrastructure` acted upon
+        to enter the given state(s).
+
+        :param str autonomous_exadata_infrastructure_id: (required)
+            The Autonomous Exadata Infrastructure  `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateAutonomousExadataInfrastructureDetails update_autonomous_exadata_infrastructures_details: (required)
+            Request to update the properties of a Autonomous Exadata Infrastructure.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.AutonomousExadataInfrastructure.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_autonomous_exadata_infrastructure`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_autonomous_exadata_infrastructure(autonomous_exadata_infrastructure_id, update_autonomous_exadata_infrastructures_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_autonomous_exadata_infrastructure(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )
@@ -1303,6 +1603,47 @@ class DatabaseClientCompositeOperations(object):
             waiter_result = oci.wait_until(
                 self.client,
                 self.client.get_exadata_iorm_config(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_maintenance_run_and_wait_for_state(self, maintenance_run_id, update_maintenance_run_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_maintenance_run` and waits for the :py:class:`~oci.database.models.MaintenanceRun` acted upon
+        to enter the given state(s).
+
+        :param str maintenance_run_id: (required)
+            The Maintenance Run OCID.
+
+        :param UpdateMaintenanceRunDetails update_maintenance_run_details: (required)
+            Request to update the properties of a Maintenance Run.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.MaintenanceRun.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_maintenance_run`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_maintenance_run(maintenance_run_id, update_maintenance_run_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_maintenance_run(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )

--- a/src/oci/database/models/__init__.py
+++ b/src/oci/database/models/__init__.py
@@ -3,6 +3,9 @@
 
 from __future__ import absolute_import
 
+from .autonomous_container_database import AutonomousContainerDatabase
+from .autonomous_container_database_backup_config import AutonomousContainerDatabaseBackupConfig
+from .autonomous_container_database_summary import AutonomousContainerDatabaseSummary
 from .autonomous_data_warehouse import AutonomousDataWarehouse
 from .autonomous_data_warehouse_backup import AutonomousDataWarehouseBackup
 from .autonomous_data_warehouse_backup_summary import AutonomousDataWarehouseBackupSummary
@@ -12,10 +15,16 @@ from .autonomous_database import AutonomousDatabase
 from .autonomous_database_backup import AutonomousDatabaseBackup
 from .autonomous_database_backup_summary import AutonomousDatabaseBackupSummary
 from .autonomous_database_connection_strings import AutonomousDatabaseConnectionStrings
+from .autonomous_database_connection_urls import AutonomousDatabaseConnectionUrls
 from .autonomous_database_summary import AutonomousDatabaseSummary
+from .autonomous_exadata_infrastructure import AutonomousExadataInfrastructure
+from .autonomous_exadata_infrastructure_maintenance_window import AutonomousExadataInfrastructureMaintenanceWindow
+from .autonomous_exadata_infrastructure_shape_summary import AutonomousExadataInfrastructureShapeSummary
+from .autonomous_exadata_infrastructure_summary import AutonomousExadataInfrastructureSummary
 from .backup import Backup
 from .backup_summary import BackupSummary
 from .complete_external_backup_job_details import CompleteExternalBackupJobDetails
+from .create_autonomous_container_database_details import CreateAutonomousContainerDatabaseDetails
 from .create_autonomous_data_warehouse_backup_details import CreateAutonomousDataWarehouseBackupDetails
 from .create_autonomous_data_warehouse_details import CreateAutonomousDataWarehouseDetails
 from .create_autonomous_database_backup_details import CreateAutonomousDatabaseBackupDetails
@@ -39,6 +48,7 @@ from .data_guard_association_summary import DataGuardAssociationSummary
 from .database import Database
 from .database_connection_strings import DatabaseConnectionStrings
 from .database_summary import DatabaseSummary
+from .day_of_week import DayOfWeek
 from .db_backup_config import DbBackupConfig
 from .db_home import DbHome
 from .db_home_summary import DbHomeSummary
@@ -56,9 +66,14 @@ from .external_backup_job import ExternalBackupJob
 from .failover_data_guard_association_details import FailoverDataGuardAssociationDetails
 from .generate_autonomous_data_warehouse_wallet_details import GenerateAutonomousDataWarehouseWalletDetails
 from .generate_autonomous_database_wallet_details import GenerateAutonomousDatabaseWalletDetails
+from .launch_autonomous_exadata_infrastructure_details import LaunchAutonomousExadataInfrastructureDetails
 from .launch_db_system_base import LaunchDbSystemBase
 from .launch_db_system_details import LaunchDbSystemDetails
 from .launch_db_system_from_backup_details import LaunchDbSystemFromBackupDetails
+from .maintenance_run import MaintenanceRun
+from .maintenance_run_summary import MaintenanceRunSummary
+from .maintenance_window import MaintenanceWindow
+from .month import Month
 from .patch import Patch
 from .patch_details import PatchDetails
 from .patch_history_entry import PatchHistoryEntry
@@ -69,14 +84,20 @@ from .restore_autonomous_data_warehouse_details import RestoreAutonomousDataWare
 from .restore_autonomous_database_details import RestoreAutonomousDatabaseDetails
 from .restore_database_details import RestoreDatabaseDetails
 from .switchover_data_guard_association_details import SwitchoverDataGuardAssociationDetails
+from .update_autonomous_container_database_details import UpdateAutonomousContainerDatabaseDetails
 from .update_autonomous_data_warehouse_details import UpdateAutonomousDataWarehouseDetails
 from .update_autonomous_database_details import UpdateAutonomousDatabaseDetails
+from .update_autonomous_exadata_infrastructure_details import UpdateAutonomousExadataInfrastructureDetails
 from .update_database_details import UpdateDatabaseDetails
 from .update_db_home_details import UpdateDbHomeDetails
 from .update_db_system_details import UpdateDbSystemDetails
+from .update_maintenance_run_details import UpdateMaintenanceRunDetails
 
 # Maps type names to classes for database services.
 database_type_mapping = {
+    "AutonomousContainerDatabase": AutonomousContainerDatabase,
+    "AutonomousContainerDatabaseBackupConfig": AutonomousContainerDatabaseBackupConfig,
+    "AutonomousContainerDatabaseSummary": AutonomousContainerDatabaseSummary,
     "AutonomousDataWarehouse": AutonomousDataWarehouse,
     "AutonomousDataWarehouseBackup": AutonomousDataWarehouseBackup,
     "AutonomousDataWarehouseBackupSummary": AutonomousDataWarehouseBackupSummary,
@@ -86,10 +107,16 @@ database_type_mapping = {
     "AutonomousDatabaseBackup": AutonomousDatabaseBackup,
     "AutonomousDatabaseBackupSummary": AutonomousDatabaseBackupSummary,
     "AutonomousDatabaseConnectionStrings": AutonomousDatabaseConnectionStrings,
+    "AutonomousDatabaseConnectionUrls": AutonomousDatabaseConnectionUrls,
     "AutonomousDatabaseSummary": AutonomousDatabaseSummary,
+    "AutonomousExadataInfrastructure": AutonomousExadataInfrastructure,
+    "AutonomousExadataInfrastructureMaintenanceWindow": AutonomousExadataInfrastructureMaintenanceWindow,
+    "AutonomousExadataInfrastructureShapeSummary": AutonomousExadataInfrastructureShapeSummary,
+    "AutonomousExadataInfrastructureSummary": AutonomousExadataInfrastructureSummary,
     "Backup": Backup,
     "BackupSummary": BackupSummary,
     "CompleteExternalBackupJobDetails": CompleteExternalBackupJobDetails,
+    "CreateAutonomousContainerDatabaseDetails": CreateAutonomousContainerDatabaseDetails,
     "CreateAutonomousDataWarehouseBackupDetails": CreateAutonomousDataWarehouseBackupDetails,
     "CreateAutonomousDataWarehouseDetails": CreateAutonomousDataWarehouseDetails,
     "CreateAutonomousDatabaseBackupDetails": CreateAutonomousDatabaseBackupDetails,
@@ -113,6 +140,7 @@ database_type_mapping = {
     "Database": Database,
     "DatabaseConnectionStrings": DatabaseConnectionStrings,
     "DatabaseSummary": DatabaseSummary,
+    "DayOfWeek": DayOfWeek,
     "DbBackupConfig": DbBackupConfig,
     "DbHome": DbHome,
     "DbHomeSummary": DbHomeSummary,
@@ -130,9 +158,14 @@ database_type_mapping = {
     "FailoverDataGuardAssociationDetails": FailoverDataGuardAssociationDetails,
     "GenerateAutonomousDataWarehouseWalletDetails": GenerateAutonomousDataWarehouseWalletDetails,
     "GenerateAutonomousDatabaseWalletDetails": GenerateAutonomousDatabaseWalletDetails,
+    "LaunchAutonomousExadataInfrastructureDetails": LaunchAutonomousExadataInfrastructureDetails,
     "LaunchDbSystemBase": LaunchDbSystemBase,
     "LaunchDbSystemDetails": LaunchDbSystemDetails,
     "LaunchDbSystemFromBackupDetails": LaunchDbSystemFromBackupDetails,
+    "MaintenanceRun": MaintenanceRun,
+    "MaintenanceRunSummary": MaintenanceRunSummary,
+    "MaintenanceWindow": MaintenanceWindow,
+    "Month": Month,
     "Patch": Patch,
     "PatchDetails": PatchDetails,
     "PatchHistoryEntry": PatchHistoryEntry,
@@ -143,9 +176,12 @@ database_type_mapping = {
     "RestoreAutonomousDatabaseDetails": RestoreAutonomousDatabaseDetails,
     "RestoreDatabaseDetails": RestoreDatabaseDetails,
     "SwitchoverDataGuardAssociationDetails": SwitchoverDataGuardAssociationDetails,
+    "UpdateAutonomousContainerDatabaseDetails": UpdateAutonomousContainerDatabaseDetails,
     "UpdateAutonomousDataWarehouseDetails": UpdateAutonomousDataWarehouseDetails,
     "UpdateAutonomousDatabaseDetails": UpdateAutonomousDatabaseDetails,
+    "UpdateAutonomousExadataInfrastructureDetails": UpdateAutonomousExadataInfrastructureDetails,
     "UpdateDatabaseDetails": UpdateDatabaseDetails,
     "UpdateDbHomeDetails": UpdateDbHomeDetails,
-    "UpdateDbSystemDetails": UpdateDbSystemDetails
+    "UpdateDbSystemDetails": UpdateDbSystemDetails,
+    "UpdateMaintenanceRunDetails": UpdateMaintenanceRunDetails
 }

--- a/src/oci/database/models/autonomous_container_database.py
+++ b/src/oci/database/models/autonomous_container_database.py
@@ -1,0 +1,611 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AutonomousContainerDatabase(object):
+    """
+    AutonomousContainerDatabase model.
+    """
+
+    #: A constant which can be used with the service_level_agreement_type property of a AutonomousContainerDatabase.
+    #: This constant has a value of "STANDARD"
+    SERVICE_LEVEL_AGREEMENT_TYPE_STANDARD = "STANDARD"
+
+    #: A constant which can be used with the service_level_agreement_type property of a AutonomousContainerDatabase.
+    #: This constant has a value of "MISSION_CRITICAL"
+    SERVICE_LEVEL_AGREEMENT_TYPE_MISSION_CRITICAL = "MISSION_CRITICAL"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabase.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabase.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabase.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabase.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabase.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabase.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabase.
+    #: This constant has a value of "BACKUP_IN_PROGRESS"
+    LIFECYCLE_STATE_BACKUP_IN_PROGRESS = "BACKUP_IN_PROGRESS"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabase.
+    #: This constant has a value of "RESTORING"
+    LIFECYCLE_STATE_RESTORING = "RESTORING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabase.
+    #: This constant has a value of "RESTORE_FAILED"
+    LIFECYCLE_STATE_RESTORE_FAILED = "RESTORE_FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabase.
+    #: This constant has a value of "RESTARTING"
+    LIFECYCLE_STATE_RESTARTING = "RESTARTING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabase.
+    #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
+    LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
+
+    #: A constant which can be used with the patch_model property of a AutonomousContainerDatabase.
+    #: This constant has a value of "RELEASE_UPDATES"
+    PATCH_MODEL_RELEASE_UPDATES = "RELEASE_UPDATES"
+
+    #: A constant which can be used with the patch_model property of a AutonomousContainerDatabase.
+    #: This constant has a value of "RELEASE_UPDATE_REVISIONS"
+    PATCH_MODEL_RELEASE_UPDATE_REVISIONS = "RELEASE_UPDATE_REVISIONS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AutonomousContainerDatabase object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this AutonomousContainerDatabase.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this AutonomousContainerDatabase.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this AutonomousContainerDatabase.
+        :type display_name: str
+
+        :param service_level_agreement_type:
+            The value to assign to the service_level_agreement_type property of this AutonomousContainerDatabase.
+            Allowed values for this property are: "STANDARD", "MISSION_CRITICAL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type service_level_agreement_type: str
+
+        :param autonomous_exadata_infrastructure_id:
+            The value to assign to the autonomous_exadata_infrastructure_id property of this AutonomousContainerDatabase.
+        :type autonomous_exadata_infrastructure_id: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this AutonomousContainerDatabase.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "BACKUP_IN_PROGRESS", "RESTORING", "RESTORE_FAILED", "RESTARTING", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this AutonomousContainerDatabase.
+        :type lifecycle_details: str
+
+        :param time_created:
+            The value to assign to the time_created property of this AutonomousContainerDatabase.
+        :type time_created: datetime
+
+        :param patch_model:
+            The value to assign to the patch_model property of this AutonomousContainerDatabase.
+            Allowed values for this property are: "RELEASE_UPDATES", "RELEASE_UPDATE_REVISIONS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type patch_model: str
+
+        :param last_maintenance_run_id:
+            The value to assign to the last_maintenance_run_id property of this AutonomousContainerDatabase.
+        :type last_maintenance_run_id: str
+
+        :param next_maintenance_run_id:
+            The value to assign to the next_maintenance_run_id property of this AutonomousContainerDatabase.
+        :type next_maintenance_run_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this AutonomousContainerDatabase.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this AutonomousContainerDatabase.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this AutonomousContainerDatabase.
+        :type availability_domain: str
+
+        :param backup_config:
+            The value to assign to the backup_config property of this AutonomousContainerDatabase.
+        :type backup_config: AutonomousContainerDatabaseBackupConfig
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'service_level_agreement_type': 'str',
+            'autonomous_exadata_infrastructure_id': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'time_created': 'datetime',
+            'patch_model': 'str',
+            'last_maintenance_run_id': 'str',
+            'next_maintenance_run_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'availability_domain': 'str',
+            'backup_config': 'AutonomousContainerDatabaseBackupConfig'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'service_level_agreement_type': 'serviceLevelAgreementType',
+            'autonomous_exadata_infrastructure_id': 'autonomousExadataInfrastructureId',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_created': 'timeCreated',
+            'patch_model': 'patchModel',
+            'last_maintenance_run_id': 'lastMaintenanceRunId',
+            'next_maintenance_run_id': 'nextMaintenanceRunId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'availability_domain': 'availabilityDomain',
+            'backup_config': 'backupConfig'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._display_name = None
+        self._service_level_agreement_type = None
+        self._autonomous_exadata_infrastructure_id = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._time_created = None
+        self._patch_model = None
+        self._last_maintenance_run_id = None
+        self._next_maintenance_run_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._availability_domain = None
+        self._backup_config = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this AutonomousContainerDatabase.
+        The OCID of the Autonomous Container Database.
+
+
+        :return: The id of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this AutonomousContainerDatabase.
+        The OCID of the Autonomous Container Database.
+
+
+        :param id: The id of this AutonomousContainerDatabase.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this AutonomousContainerDatabase.
+        The OCID of the compartment.
+
+
+        :return: The compartment_id of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this AutonomousContainerDatabase.
+        The OCID of the compartment.
+
+
+        :param compartment_id: The compartment_id of this AutonomousContainerDatabase.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this AutonomousContainerDatabase.
+        The user-provided name for the Autonomous Container Database.
+
+
+        :return: The display_name of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this AutonomousContainerDatabase.
+        The user-provided name for the Autonomous Container Database.
+
+
+        :param display_name: The display_name of this AutonomousContainerDatabase.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def service_level_agreement_type(self):
+        """
+        **[Required]** Gets the service_level_agreement_type of this AutonomousContainerDatabase.
+        The service level agreement type of the container database. The default is STANDARD.
+
+        Allowed values for this property are: "STANDARD", "MISSION_CRITICAL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The service_level_agreement_type of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._service_level_agreement_type
+
+    @service_level_agreement_type.setter
+    def service_level_agreement_type(self, service_level_agreement_type):
+        """
+        Sets the service_level_agreement_type of this AutonomousContainerDatabase.
+        The service level agreement type of the container database. The default is STANDARD.
+
+
+        :param service_level_agreement_type: The service_level_agreement_type of this AutonomousContainerDatabase.
+        :type: str
+        """
+        allowed_values = ["STANDARD", "MISSION_CRITICAL"]
+        if not value_allowed_none_or_none_sentinel(service_level_agreement_type, allowed_values):
+            service_level_agreement_type = 'UNKNOWN_ENUM_VALUE'
+        self._service_level_agreement_type = service_level_agreement_type
+
+    @property
+    def autonomous_exadata_infrastructure_id(self):
+        """
+        **[Required]** Gets the autonomous_exadata_infrastructure_id of this AutonomousContainerDatabase.
+        The OCID of the Autonomous Exadata Infrastructure.
+
+
+        :return: The autonomous_exadata_infrastructure_id of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._autonomous_exadata_infrastructure_id
+
+    @autonomous_exadata_infrastructure_id.setter
+    def autonomous_exadata_infrastructure_id(self, autonomous_exadata_infrastructure_id):
+        """
+        Sets the autonomous_exadata_infrastructure_id of this AutonomousContainerDatabase.
+        The OCID of the Autonomous Exadata Infrastructure.
+
+
+        :param autonomous_exadata_infrastructure_id: The autonomous_exadata_infrastructure_id of this AutonomousContainerDatabase.
+        :type: str
+        """
+        self._autonomous_exadata_infrastructure_id = autonomous_exadata_infrastructure_id
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this AutonomousContainerDatabase.
+        The current state of the Autonomous Container Database.
+
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "BACKUP_IN_PROGRESS", "RESTORING", "RESTORE_FAILED", "RESTARTING", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this AutonomousContainerDatabase.
+        The current state of the Autonomous Container Database.
+
+
+        :param lifecycle_state: The lifecycle_state of this AutonomousContainerDatabase.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "BACKUP_IN_PROGRESS", "RESTORING", "RESTORE_FAILED", "RESTARTING", "MAINTENANCE_IN_PROGRESS"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this AutonomousContainerDatabase.
+        Additional information about the current lifecycleState.
+
+
+        :return: The lifecycle_details of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this AutonomousContainerDatabase.
+        Additional information about the current lifecycleState.
+
+
+        :param lifecycle_details: The lifecycle_details of this AutonomousContainerDatabase.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this AutonomousContainerDatabase.
+        The date and time the Autonomous was created.
+
+
+        :return: The time_created of this AutonomousContainerDatabase.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this AutonomousContainerDatabase.
+        The date and time the Autonomous was created.
+
+
+        :param time_created: The time_created of this AutonomousContainerDatabase.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def patch_model(self):
+        """
+        **[Required]** Gets the patch_model of this AutonomousContainerDatabase.
+        Database Patch model preference.
+
+        Allowed values for this property are: "RELEASE_UPDATES", "RELEASE_UPDATE_REVISIONS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The patch_model of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._patch_model
+
+    @patch_model.setter
+    def patch_model(self, patch_model):
+        """
+        Sets the patch_model of this AutonomousContainerDatabase.
+        Database Patch model preference.
+
+
+        :param patch_model: The patch_model of this AutonomousContainerDatabase.
+        :type: str
+        """
+        allowed_values = ["RELEASE_UPDATES", "RELEASE_UPDATE_REVISIONS"]
+        if not value_allowed_none_or_none_sentinel(patch_model, allowed_values):
+            patch_model = 'UNKNOWN_ENUM_VALUE'
+        self._patch_model = patch_model
+
+    @property
+    def last_maintenance_run_id(self):
+        """
+        Gets the last_maintenance_run_id of this AutonomousContainerDatabase.
+        The `OCID`__ of the last maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The last_maintenance_run_id of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._last_maintenance_run_id
+
+    @last_maintenance_run_id.setter
+    def last_maintenance_run_id(self, last_maintenance_run_id):
+        """
+        Sets the last_maintenance_run_id of this AutonomousContainerDatabase.
+        The `OCID`__ of the last maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param last_maintenance_run_id: The last_maintenance_run_id of this AutonomousContainerDatabase.
+        :type: str
+        """
+        self._last_maintenance_run_id = last_maintenance_run_id
+
+    @property
+    def next_maintenance_run_id(self):
+        """
+        Gets the next_maintenance_run_id of this AutonomousContainerDatabase.
+        The `OCID`__ of the next maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The next_maintenance_run_id of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._next_maintenance_run_id
+
+    @next_maintenance_run_id.setter
+    def next_maintenance_run_id(self, next_maintenance_run_id):
+        """
+        Sets the next_maintenance_run_id of this AutonomousContainerDatabase.
+        The `OCID`__ of the next maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param next_maintenance_run_id: The next_maintenance_run_id of this AutonomousContainerDatabase.
+        :type: str
+        """
+        self._next_maintenance_run_id = next_maintenance_run_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this AutonomousContainerDatabase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this AutonomousContainerDatabase.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this AutonomousContainerDatabase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this AutonomousContainerDatabase.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this AutonomousContainerDatabase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this AutonomousContainerDatabase.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this AutonomousContainerDatabase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this AutonomousContainerDatabase.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def availability_domain(self):
+        """
+        Gets the availability_domain of this AutonomousContainerDatabase.
+        The availability domain of the Autonomous Container Database.
+
+
+        :return: The availability_domain of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this AutonomousContainerDatabase.
+        The availability domain of the Autonomous Container Database.
+
+
+        :param availability_domain: The availability_domain of this AutonomousContainerDatabase.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def backup_config(self):
+        """
+        Gets the backup_config of this AutonomousContainerDatabase.
+
+        :return: The backup_config of this AutonomousContainerDatabase.
+        :rtype: AutonomousContainerDatabaseBackupConfig
+        """
+        return self._backup_config
+
+    @backup_config.setter
+    def backup_config(self, backup_config):
+        """
+        Sets the backup_config of this AutonomousContainerDatabase.
+
+        :param backup_config: The backup_config of this AutonomousContainerDatabase.
+        :type: AutonomousContainerDatabaseBackupConfig
+        """
+        self._backup_config = backup_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/autonomous_container_database_backup_config.py
+++ b/src/oci/database/models/autonomous_container_database_backup_config.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AutonomousContainerDatabaseBackupConfig(object):
+    """
+    Backup options for the Autonomous Container Database.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AutonomousContainerDatabaseBackupConfig object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param recovery_window_in_days:
+            The value to assign to the recovery_window_in_days property of this AutonomousContainerDatabaseBackupConfig.
+        :type recovery_window_in_days: int
+
+        """
+        self.swagger_types = {
+            'recovery_window_in_days': 'int'
+        }
+
+        self.attribute_map = {
+            'recovery_window_in_days': 'recoveryWindowInDays'
+        }
+
+        self._recovery_window_in_days = None
+
+    @property
+    def recovery_window_in_days(self):
+        """
+        Gets the recovery_window_in_days of this AutonomousContainerDatabaseBackupConfig.
+        Number of days between the current and the earliest point of recoverability covered by automatic backups.
+        This value applies to automatic backups. After a new automatic backup has been created, Oracle removes old automatic backups that are created before the window.
+        When the value is updated, it is applied to all existing automatic backups.
+
+
+        :return: The recovery_window_in_days of this AutonomousContainerDatabaseBackupConfig.
+        :rtype: int
+        """
+        return self._recovery_window_in_days
+
+    @recovery_window_in_days.setter
+    def recovery_window_in_days(self, recovery_window_in_days):
+        """
+        Sets the recovery_window_in_days of this AutonomousContainerDatabaseBackupConfig.
+        Number of days between the current and the earliest point of recoverability covered by automatic backups.
+        This value applies to automatic backups. After a new automatic backup has been created, Oracle removes old automatic backups that are created before the window.
+        When the value is updated, it is applied to all existing automatic backups.
+
+
+        :param recovery_window_in_days: The recovery_window_in_days of this AutonomousContainerDatabaseBackupConfig.
+        :type: int
+        """
+        self._recovery_window_in_days = recovery_window_in_days
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/autonomous_container_database_summary.py
+++ b/src/oci/database/models/autonomous_container_database_summary.py
@@ -1,0 +1,611 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AutonomousContainerDatabaseSummary(object):
+    """
+    An Autonomous Container Database is a container database service that enables the customer to host one or more databases within the container database. A basic container database runs on a single Autonomous Exadata Infrastructure from an availability domain without the Extreme Availability features enabled.
+    """
+
+    #: A constant which can be used with the service_level_agreement_type property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "STANDARD"
+    SERVICE_LEVEL_AGREEMENT_TYPE_STANDARD = "STANDARD"
+
+    #: A constant which can be used with the service_level_agreement_type property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "MISSION_CRITICAL"
+    SERVICE_LEVEL_AGREEMENT_TYPE_MISSION_CRITICAL = "MISSION_CRITICAL"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "BACKUP_IN_PROGRESS"
+    LIFECYCLE_STATE_BACKUP_IN_PROGRESS = "BACKUP_IN_PROGRESS"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "RESTORING"
+    LIFECYCLE_STATE_RESTORING = "RESTORING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "RESTORE_FAILED"
+    LIFECYCLE_STATE_RESTORE_FAILED = "RESTORE_FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "RESTARTING"
+    LIFECYCLE_STATE_RESTARTING = "RESTARTING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
+    LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
+
+    #: A constant which can be used with the patch_model property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "RELEASE_UPDATES"
+    PATCH_MODEL_RELEASE_UPDATES = "RELEASE_UPDATES"
+
+    #: A constant which can be used with the patch_model property of a AutonomousContainerDatabaseSummary.
+    #: This constant has a value of "RELEASE_UPDATE_REVISIONS"
+    PATCH_MODEL_RELEASE_UPDATE_REVISIONS = "RELEASE_UPDATE_REVISIONS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AutonomousContainerDatabaseSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this AutonomousContainerDatabaseSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this AutonomousContainerDatabaseSummary.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this AutonomousContainerDatabaseSummary.
+        :type display_name: str
+
+        :param service_level_agreement_type:
+            The value to assign to the service_level_agreement_type property of this AutonomousContainerDatabaseSummary.
+            Allowed values for this property are: "STANDARD", "MISSION_CRITICAL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type service_level_agreement_type: str
+
+        :param autonomous_exadata_infrastructure_id:
+            The value to assign to the autonomous_exadata_infrastructure_id property of this AutonomousContainerDatabaseSummary.
+        :type autonomous_exadata_infrastructure_id: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this AutonomousContainerDatabaseSummary.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "BACKUP_IN_PROGRESS", "RESTORING", "RESTORE_FAILED", "RESTARTING", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this AutonomousContainerDatabaseSummary.
+        :type lifecycle_details: str
+
+        :param time_created:
+            The value to assign to the time_created property of this AutonomousContainerDatabaseSummary.
+        :type time_created: datetime
+
+        :param patch_model:
+            The value to assign to the patch_model property of this AutonomousContainerDatabaseSummary.
+            Allowed values for this property are: "RELEASE_UPDATES", "RELEASE_UPDATE_REVISIONS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type patch_model: str
+
+        :param last_maintenance_run_id:
+            The value to assign to the last_maintenance_run_id property of this AutonomousContainerDatabaseSummary.
+        :type last_maintenance_run_id: str
+
+        :param next_maintenance_run_id:
+            The value to assign to the next_maintenance_run_id property of this AutonomousContainerDatabaseSummary.
+        :type next_maintenance_run_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this AutonomousContainerDatabaseSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this AutonomousContainerDatabaseSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this AutonomousContainerDatabaseSummary.
+        :type availability_domain: str
+
+        :param backup_config:
+            The value to assign to the backup_config property of this AutonomousContainerDatabaseSummary.
+        :type backup_config: AutonomousContainerDatabaseBackupConfig
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'service_level_agreement_type': 'str',
+            'autonomous_exadata_infrastructure_id': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'time_created': 'datetime',
+            'patch_model': 'str',
+            'last_maintenance_run_id': 'str',
+            'next_maintenance_run_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'availability_domain': 'str',
+            'backup_config': 'AutonomousContainerDatabaseBackupConfig'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'service_level_agreement_type': 'serviceLevelAgreementType',
+            'autonomous_exadata_infrastructure_id': 'autonomousExadataInfrastructureId',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_created': 'timeCreated',
+            'patch_model': 'patchModel',
+            'last_maintenance_run_id': 'lastMaintenanceRunId',
+            'next_maintenance_run_id': 'nextMaintenanceRunId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'availability_domain': 'availabilityDomain',
+            'backup_config': 'backupConfig'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._display_name = None
+        self._service_level_agreement_type = None
+        self._autonomous_exadata_infrastructure_id = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._time_created = None
+        self._patch_model = None
+        self._last_maintenance_run_id = None
+        self._next_maintenance_run_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._availability_domain = None
+        self._backup_config = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this AutonomousContainerDatabaseSummary.
+        The OCID of the Autonomous Container Database.
+
+
+        :return: The id of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this AutonomousContainerDatabaseSummary.
+        The OCID of the Autonomous Container Database.
+
+
+        :param id: The id of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this AutonomousContainerDatabaseSummary.
+        The OCID of the compartment.
+
+
+        :return: The compartment_id of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this AutonomousContainerDatabaseSummary.
+        The OCID of the compartment.
+
+
+        :param compartment_id: The compartment_id of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this AutonomousContainerDatabaseSummary.
+        The user-provided name for the Autonomous Container Database.
+
+
+        :return: The display_name of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this AutonomousContainerDatabaseSummary.
+        The user-provided name for the Autonomous Container Database.
+
+
+        :param display_name: The display_name of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def service_level_agreement_type(self):
+        """
+        **[Required]** Gets the service_level_agreement_type of this AutonomousContainerDatabaseSummary.
+        The service level agreement type of the container database. The default is STANDARD.
+
+        Allowed values for this property are: "STANDARD", "MISSION_CRITICAL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The service_level_agreement_type of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._service_level_agreement_type
+
+    @service_level_agreement_type.setter
+    def service_level_agreement_type(self, service_level_agreement_type):
+        """
+        Sets the service_level_agreement_type of this AutonomousContainerDatabaseSummary.
+        The service level agreement type of the container database. The default is STANDARD.
+
+
+        :param service_level_agreement_type: The service_level_agreement_type of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["STANDARD", "MISSION_CRITICAL"]
+        if not value_allowed_none_or_none_sentinel(service_level_agreement_type, allowed_values):
+            service_level_agreement_type = 'UNKNOWN_ENUM_VALUE'
+        self._service_level_agreement_type = service_level_agreement_type
+
+    @property
+    def autonomous_exadata_infrastructure_id(self):
+        """
+        **[Required]** Gets the autonomous_exadata_infrastructure_id of this AutonomousContainerDatabaseSummary.
+        The OCID of the Autonomous Exadata Infrastructure.
+
+
+        :return: The autonomous_exadata_infrastructure_id of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._autonomous_exadata_infrastructure_id
+
+    @autonomous_exadata_infrastructure_id.setter
+    def autonomous_exadata_infrastructure_id(self, autonomous_exadata_infrastructure_id):
+        """
+        Sets the autonomous_exadata_infrastructure_id of this AutonomousContainerDatabaseSummary.
+        The OCID of the Autonomous Exadata Infrastructure.
+
+
+        :param autonomous_exadata_infrastructure_id: The autonomous_exadata_infrastructure_id of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        self._autonomous_exadata_infrastructure_id = autonomous_exadata_infrastructure_id
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this AutonomousContainerDatabaseSummary.
+        The current state of the Autonomous Container Database.
+
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "BACKUP_IN_PROGRESS", "RESTORING", "RESTORE_FAILED", "RESTARTING", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this AutonomousContainerDatabaseSummary.
+        The current state of the Autonomous Container Database.
+
+
+        :param lifecycle_state: The lifecycle_state of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "BACKUP_IN_PROGRESS", "RESTORING", "RESTORE_FAILED", "RESTARTING", "MAINTENANCE_IN_PROGRESS"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this AutonomousContainerDatabaseSummary.
+        Additional information about the current lifecycleState.
+
+
+        :return: The lifecycle_details of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this AutonomousContainerDatabaseSummary.
+        Additional information about the current lifecycleState.
+
+
+        :param lifecycle_details: The lifecycle_details of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this AutonomousContainerDatabaseSummary.
+        The date and time the Autonomous was created.
+
+
+        :return: The time_created of this AutonomousContainerDatabaseSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this AutonomousContainerDatabaseSummary.
+        The date and time the Autonomous was created.
+
+
+        :param time_created: The time_created of this AutonomousContainerDatabaseSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def patch_model(self):
+        """
+        **[Required]** Gets the patch_model of this AutonomousContainerDatabaseSummary.
+        Database Patch model preference.
+
+        Allowed values for this property are: "RELEASE_UPDATES", "RELEASE_UPDATE_REVISIONS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The patch_model of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._patch_model
+
+    @patch_model.setter
+    def patch_model(self, patch_model):
+        """
+        Sets the patch_model of this AutonomousContainerDatabaseSummary.
+        Database Patch model preference.
+
+
+        :param patch_model: The patch_model of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["RELEASE_UPDATES", "RELEASE_UPDATE_REVISIONS"]
+        if not value_allowed_none_or_none_sentinel(patch_model, allowed_values):
+            patch_model = 'UNKNOWN_ENUM_VALUE'
+        self._patch_model = patch_model
+
+    @property
+    def last_maintenance_run_id(self):
+        """
+        Gets the last_maintenance_run_id of this AutonomousContainerDatabaseSummary.
+        The `OCID`__ of the last maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The last_maintenance_run_id of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._last_maintenance_run_id
+
+    @last_maintenance_run_id.setter
+    def last_maintenance_run_id(self, last_maintenance_run_id):
+        """
+        Sets the last_maintenance_run_id of this AutonomousContainerDatabaseSummary.
+        The `OCID`__ of the last maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param last_maintenance_run_id: The last_maintenance_run_id of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        self._last_maintenance_run_id = last_maintenance_run_id
+
+    @property
+    def next_maintenance_run_id(self):
+        """
+        Gets the next_maintenance_run_id of this AutonomousContainerDatabaseSummary.
+        The `OCID`__ of the next maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The next_maintenance_run_id of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._next_maintenance_run_id
+
+    @next_maintenance_run_id.setter
+    def next_maintenance_run_id(self, next_maintenance_run_id):
+        """
+        Sets the next_maintenance_run_id of this AutonomousContainerDatabaseSummary.
+        The `OCID`__ of the next maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param next_maintenance_run_id: The next_maintenance_run_id of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        self._next_maintenance_run_id = next_maintenance_run_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this AutonomousContainerDatabaseSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this AutonomousContainerDatabaseSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this AutonomousContainerDatabaseSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this AutonomousContainerDatabaseSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this AutonomousContainerDatabaseSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this AutonomousContainerDatabaseSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this AutonomousContainerDatabaseSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this AutonomousContainerDatabaseSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def availability_domain(self):
+        """
+        Gets the availability_domain of this AutonomousContainerDatabaseSummary.
+        The availability domain of the Autonomous Container Database.
+
+
+        :return: The availability_domain of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this AutonomousContainerDatabaseSummary.
+        The availability domain of the Autonomous Container Database.
+
+
+        :param availability_domain: The availability_domain of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def backup_config(self):
+        """
+        Gets the backup_config of this AutonomousContainerDatabaseSummary.
+
+        :return: The backup_config of this AutonomousContainerDatabaseSummary.
+        :rtype: AutonomousContainerDatabaseBackupConfig
+        """
+        return self._backup_config
+
+    @backup_config.setter
+    def backup_config(self, backup_config):
+        """
+        Sets the backup_config of this AutonomousContainerDatabaseSummary.
+
+        :param backup_config: The backup_config of this AutonomousContainerDatabaseSummary.
+        :type: AutonomousContainerDatabaseBackupConfig
+        """
+        self._backup_config = backup_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/autonomous_database.py
+++ b/src/oci/database/models/autonomous_database.py
@@ -68,6 +68,10 @@ class AutonomousDatabase(object):
     #: This constant has a value of "UPDATING"
     LIFECYCLE_STATE_UPDATING = "UPDATING"
 
+    #: A constant which can be used with the lifecycle_state property of a AutonomousDatabase.
+    #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
+    LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
+
     #: A constant which can be used with the license_model property of a AutonomousDatabase.
     #: This constant has a value of "LICENSE_INCLUDED"
     LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
@@ -99,7 +103,7 @@ class AutonomousDatabase(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this AutonomousDatabase.
-            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -119,6 +123,14 @@ class AutonomousDatabase(object):
             The value to assign to the data_storage_size_in_tbs property of this AutonomousDatabase.
         :type data_storage_size_in_tbs: int
 
+        :param is_dedicated:
+            The value to assign to the is_dedicated property of this AutonomousDatabase.
+        :type is_dedicated: bool
+
+        :param autonomous_container_database_id:
+            The value to assign to the autonomous_container_database_id property of this AutonomousDatabase.
+        :type autonomous_container_database_id: str
+
         :param time_created:
             The value to assign to the time_created property of this AutonomousDatabase.
         :type time_created: datetime
@@ -134,6 +146,10 @@ class AutonomousDatabase(object):
         :param connection_strings:
             The value to assign to the connection_strings property of this AutonomousDatabase.
         :type connection_strings: AutonomousDatabaseConnectionStrings
+
+        :param connection_urls:
+            The value to assign to the connection_urls property of this AutonomousDatabase.
+        :type connection_urls: AutonomousDatabaseConnectionUrls
 
         :param license_model:
             The value to assign to the license_model property of this AutonomousDatabase.
@@ -180,10 +196,13 @@ class AutonomousDatabase(object):
             'db_name': 'str',
             'cpu_core_count': 'int',
             'data_storage_size_in_tbs': 'int',
+            'is_dedicated': 'bool',
+            'autonomous_container_database_id': 'str',
             'time_created': 'datetime',
             'display_name': 'str',
             'service_console_url': 'str',
             'connection_strings': 'AutonomousDatabaseConnectionStrings',
+            'connection_urls': 'AutonomousDatabaseConnectionUrls',
             'license_model': 'str',
             'used_data_storage_size_in_tbs': 'int',
             'freeform_tags': 'dict(str, str)',
@@ -202,10 +221,13 @@ class AutonomousDatabase(object):
             'db_name': 'dbName',
             'cpu_core_count': 'cpuCoreCount',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
+            'is_dedicated': 'isDedicated',
+            'autonomous_container_database_id': 'autonomousContainerDatabaseId',
             'time_created': 'timeCreated',
             'display_name': 'displayName',
             'service_console_url': 'serviceConsoleUrl',
             'connection_strings': 'connectionStrings',
+            'connection_urls': 'connectionUrls',
             'license_model': 'licenseModel',
             'used_data_storage_size_in_tbs': 'usedDataStorageSizeInTBs',
             'freeform_tags': 'freeformTags',
@@ -223,10 +245,13 @@ class AutonomousDatabase(object):
         self._db_name = None
         self._cpu_core_count = None
         self._data_storage_size_in_tbs = None
+        self._is_dedicated = None
+        self._autonomous_container_database_id = None
         self._time_created = None
         self._display_name = None
         self._service_console_url = None
         self._connection_strings = None
+        self._connection_urls = None
         self._license_model = None
         self._used_data_storage_size_in_tbs = None
         self._freeform_tags = None
@@ -298,7 +323,7 @@ class AutonomousDatabase(object):
         **[Required]** Gets the lifecycle_state of this AutonomousDatabase.
         The current state of the database.
 
-        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -317,7 +342,7 @@ class AutonomousDatabase(object):
         :param lifecycle_state: The lifecycle_state of this AutonomousDatabase.
         :type: str
         """
-        allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING"]
+        allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
@@ -419,6 +444,58 @@ class AutonomousDatabase(object):
         self._data_storage_size_in_tbs = data_storage_size_in_tbs
 
     @property
+    def is_dedicated(self):
+        """
+        Gets the is_dedicated of this AutonomousDatabase.
+        True if it is dedicated database.
+
+
+        :return: The is_dedicated of this AutonomousDatabase.
+        :rtype: bool
+        """
+        return self._is_dedicated
+
+    @is_dedicated.setter
+    def is_dedicated(self, is_dedicated):
+        """
+        Sets the is_dedicated of this AutonomousDatabase.
+        True if it is dedicated database.
+
+
+        :param is_dedicated: The is_dedicated of this AutonomousDatabase.
+        :type: bool
+        """
+        self._is_dedicated = is_dedicated
+
+    @property
+    def autonomous_container_database_id(self):
+        """
+        Gets the autonomous_container_database_id of this AutonomousDatabase.
+        The Autonomous Container Database `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The autonomous_container_database_id of this AutonomousDatabase.
+        :rtype: str
+        """
+        return self._autonomous_container_database_id
+
+    @autonomous_container_database_id.setter
+    def autonomous_container_database_id(self, autonomous_container_database_id):
+        """
+        Sets the autonomous_container_database_id of this AutonomousDatabase.
+        The Autonomous Container Database `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param autonomous_container_database_id: The autonomous_container_database_id of this AutonomousDatabase.
+        :type: str
+        """
+        self._autonomous_container_database_id = autonomous_container_database_id
+
+    @property
     def time_created(self):
         """
         Gets the time_created of this AutonomousDatabase.
@@ -513,6 +590,26 @@ class AutonomousDatabase(object):
         :type: AutonomousDatabaseConnectionStrings
         """
         self._connection_strings = connection_strings
+
+    @property
+    def connection_urls(self):
+        """
+        Gets the connection_urls of this AutonomousDatabase.
+
+        :return: The connection_urls of this AutonomousDatabase.
+        :rtype: AutonomousDatabaseConnectionUrls
+        """
+        return self._connection_urls
+
+    @connection_urls.setter
+    def connection_urls(self, connection_urls):
+        """
+        Sets the connection_urls of this AutonomousDatabase.
+
+        :param connection_urls: The connection_urls of this AutonomousDatabase.
+        :type: AutonomousDatabaseConnectionUrls
+        """
+        self._connection_urls = connection_urls
 
     @property
     def license_model(self):

--- a/src/oci/database/models/autonomous_database_backup.py
+++ b/src/oci/database/models/autonomous_database_backup.py
@@ -83,6 +83,10 @@ class AutonomousDatabaseBackup(object):
             The value to assign to the lifecycle_details property of this AutonomousDatabaseBackup.
         :type lifecycle_details: str
 
+        :param database_size_in_tbs:
+            The value to assign to the database_size_in_tbs property of this AutonomousDatabaseBackup.
+        :type database_size_in_tbs: float
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this AutonomousDatabaseBackup.
             Allowed values for this property are: "CREATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
@@ -100,6 +104,7 @@ class AutonomousDatabaseBackup(object):
             'time_started': 'datetime',
             'time_ended': 'datetime',
             'lifecycle_details': 'str',
+            'database_size_in_tbs': 'float',
             'lifecycle_state': 'str'
         }
 
@@ -113,6 +118,7 @@ class AutonomousDatabaseBackup(object):
             'time_started': 'timeStarted',
             'time_ended': 'timeEnded',
             'lifecycle_details': 'lifecycleDetails',
+            'database_size_in_tbs': 'databaseSizeInTBs',
             'lifecycle_state': 'lifecycleState'
         }
 
@@ -125,6 +131,7 @@ class AutonomousDatabaseBackup(object):
         self._time_started = None
         self._time_ended = None
         self._lifecycle_details = None
+        self._database_size_in_tbs = None
         self._lifecycle_state = None
 
     @property
@@ -360,6 +367,30 @@ class AutonomousDatabaseBackup(object):
         :type: str
         """
         self._lifecycle_details = lifecycle_details
+
+    @property
+    def database_size_in_tbs(self):
+        """
+        Gets the database_size_in_tbs of this AutonomousDatabaseBackup.
+        The size of the database in terabytes at the time the backup was taken.
+
+
+        :return: The database_size_in_tbs of this AutonomousDatabaseBackup.
+        :rtype: float
+        """
+        return self._database_size_in_tbs
+
+    @database_size_in_tbs.setter
+    def database_size_in_tbs(self, database_size_in_tbs):
+        """
+        Sets the database_size_in_tbs of this AutonomousDatabaseBackup.
+        The size of the database in terabytes at the time the backup was taken.
+
+
+        :param database_size_in_tbs: The database_size_in_tbs of this AutonomousDatabaseBackup.
+        :type: float
+        """
+        self._database_size_in_tbs = database_size_in_tbs
 
     @property
     def lifecycle_state(self):

--- a/src/oci/database/models/autonomous_database_backup_summary.py
+++ b/src/oci/database/models/autonomous_database_backup_summary.py
@@ -88,6 +88,10 @@ class AutonomousDatabaseBackupSummary(object):
             The value to assign to the lifecycle_details property of this AutonomousDatabaseBackupSummary.
         :type lifecycle_details: str
 
+        :param database_size_in_tbs:
+            The value to assign to the database_size_in_tbs property of this AutonomousDatabaseBackupSummary.
+        :type database_size_in_tbs: float
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this AutonomousDatabaseBackupSummary.
             Allowed values for this property are: "CREATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
@@ -105,6 +109,7 @@ class AutonomousDatabaseBackupSummary(object):
             'time_started': 'datetime',
             'time_ended': 'datetime',
             'lifecycle_details': 'str',
+            'database_size_in_tbs': 'float',
             'lifecycle_state': 'str'
         }
 
@@ -118,6 +123,7 @@ class AutonomousDatabaseBackupSummary(object):
             'time_started': 'timeStarted',
             'time_ended': 'timeEnded',
             'lifecycle_details': 'lifecycleDetails',
+            'database_size_in_tbs': 'databaseSizeInTBs',
             'lifecycle_state': 'lifecycleState'
         }
 
@@ -130,6 +136,7 @@ class AutonomousDatabaseBackupSummary(object):
         self._time_started = None
         self._time_ended = None
         self._lifecycle_details = None
+        self._database_size_in_tbs = None
         self._lifecycle_state = None
 
     @property
@@ -365,6 +372,30 @@ class AutonomousDatabaseBackupSummary(object):
         :type: str
         """
         self._lifecycle_details = lifecycle_details
+
+    @property
+    def database_size_in_tbs(self):
+        """
+        Gets the database_size_in_tbs of this AutonomousDatabaseBackupSummary.
+        The size of the database in terabytes at the time the backup was taken.
+
+
+        :return: The database_size_in_tbs of this AutonomousDatabaseBackupSummary.
+        :rtype: float
+        """
+        return self._database_size_in_tbs
+
+    @database_size_in_tbs.setter
+    def database_size_in_tbs(self, database_size_in_tbs):
+        """
+        Sets the database_size_in_tbs of this AutonomousDatabaseBackupSummary.
+        The size of the database in terabytes at the time the backup was taken.
+
+
+        :param database_size_in_tbs: The database_size_in_tbs of this AutonomousDatabaseBackupSummary.
+        :type: float
+        """
+        self._database_size_in_tbs = database_size_in_tbs
 
     @property
     def lifecycle_state(self):

--- a/src/oci/database/models/autonomous_database_connection_strings.py
+++ b/src/oci/database/models/autonomous_database_connection_strings.py
@@ -29,6 +29,10 @@ class AutonomousDatabaseConnectionStrings(object):
             The value to assign to the low property of this AutonomousDatabaseConnectionStrings.
         :type low: str
 
+        :param dedicated:
+            The value to assign to the dedicated property of this AutonomousDatabaseConnectionStrings.
+        :type dedicated: str
+
         :param all_connection_strings:
             The value to assign to the all_connection_strings property of this AutonomousDatabaseConnectionStrings.
         :type all_connection_strings: dict(str, str)
@@ -38,6 +42,7 @@ class AutonomousDatabaseConnectionStrings(object):
             'high': 'str',
             'medium': 'str',
             'low': 'str',
+            'dedicated': 'str',
             'all_connection_strings': 'dict(str, str)'
         }
 
@@ -45,12 +50,14 @@ class AutonomousDatabaseConnectionStrings(object):
             'high': 'high',
             'medium': 'medium',
             'low': 'low',
+            'dedicated': 'dedicated',
             'all_connection_strings': 'allConnectionStrings'
         }
 
         self._high = None
         self._medium = None
         self._low = None
+        self._dedicated = None
         self._all_connection_strings = None
 
     @property
@@ -124,6 +131,30 @@ class AutonomousDatabaseConnectionStrings(object):
         :type: str
         """
         self._low = low
+
+    @property
+    def dedicated(self):
+        """
+        Gets the dedicated of this AutonomousDatabaseConnectionStrings.
+        The database service provides the least level of resources to each SQL statement, but supports the most number of concurrent SQL statements.
+
+
+        :return: The dedicated of this AutonomousDatabaseConnectionStrings.
+        :rtype: str
+        """
+        return self._dedicated
+
+    @dedicated.setter
+    def dedicated(self, dedicated):
+        """
+        Sets the dedicated of this AutonomousDatabaseConnectionStrings.
+        The database service provides the least level of resources to each SQL statement, but supports the most number of concurrent SQL statements.
+
+
+        :param dedicated: The dedicated of this AutonomousDatabaseConnectionStrings.
+        :type: str
+        """
+        self._dedicated = dedicated
 
     @property
     def all_connection_strings(self):

--- a/src/oci/database/models/autonomous_database_connection_urls.py
+++ b/src/oci/database/models/autonomous_database_connection_urls.py
@@ -1,0 +1,102 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AutonomousDatabaseConnectionUrls(object):
+    """
+    The URLs for accessing Oracle Application Express (APEX) and SQL Developer Web with a browser from a Compute instance within your VCN or that has a direct connection to your VCN.
+
+    Example: `{\"sqlDevWebUrl\": \"https://<hostname>/ords...\", \"apexUrl\", \"https://<hostname>/ords...\"}`
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AutonomousDatabaseConnectionUrls object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param sql_dev_web_url:
+            The value to assign to the sql_dev_web_url property of this AutonomousDatabaseConnectionUrls.
+        :type sql_dev_web_url: str
+
+        :param apex_url:
+            The value to assign to the apex_url property of this AutonomousDatabaseConnectionUrls.
+        :type apex_url: str
+
+        """
+        self.swagger_types = {
+            'sql_dev_web_url': 'str',
+            'apex_url': 'str'
+        }
+
+        self.attribute_map = {
+            'sql_dev_web_url': 'sqlDevWebUrl',
+            'apex_url': 'apexUrl'
+        }
+
+        self._sql_dev_web_url = None
+        self._apex_url = None
+
+    @property
+    def sql_dev_web_url(self):
+        """
+        Gets the sql_dev_web_url of this AutonomousDatabaseConnectionUrls.
+        Oracle SQL Developer Web URL.
+
+
+        :return: The sql_dev_web_url of this AutonomousDatabaseConnectionUrls.
+        :rtype: str
+        """
+        return self._sql_dev_web_url
+
+    @sql_dev_web_url.setter
+    def sql_dev_web_url(self, sql_dev_web_url):
+        """
+        Sets the sql_dev_web_url of this AutonomousDatabaseConnectionUrls.
+        Oracle SQL Developer Web URL.
+
+
+        :param sql_dev_web_url: The sql_dev_web_url of this AutonomousDatabaseConnectionUrls.
+        :type: str
+        """
+        self._sql_dev_web_url = sql_dev_web_url
+
+    @property
+    def apex_url(self):
+        """
+        Gets the apex_url of this AutonomousDatabaseConnectionUrls.
+        Oracle Application Express (APEX) URL.
+
+
+        :return: The apex_url of this AutonomousDatabaseConnectionUrls.
+        :rtype: str
+        """
+        return self._apex_url
+
+    @apex_url.setter
+    def apex_url(self, apex_url):
+        """
+        Sets the apex_url of this AutonomousDatabaseConnectionUrls.
+        Oracle Application Express (APEX) URL.
+
+
+        :param apex_url: The apex_url of this AutonomousDatabaseConnectionUrls.
+        :type: str
+        """
+        self._apex_url = apex_url
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/autonomous_database_summary.py
+++ b/src/oci/database/models/autonomous_database_summary.py
@@ -70,6 +70,10 @@ class AutonomousDatabaseSummary(object):
     #: This constant has a value of "UPDATING"
     LIFECYCLE_STATE_UPDATING = "UPDATING"
 
+    #: A constant which can be used with the lifecycle_state property of a AutonomousDatabaseSummary.
+    #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
+    LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
+
     #: A constant which can be used with the license_model property of a AutonomousDatabaseSummary.
     #: This constant has a value of "LICENSE_INCLUDED"
     LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
@@ -101,7 +105,7 @@ class AutonomousDatabaseSummary(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this AutonomousDatabaseSummary.
-            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -121,6 +125,14 @@ class AutonomousDatabaseSummary(object):
             The value to assign to the data_storage_size_in_tbs property of this AutonomousDatabaseSummary.
         :type data_storage_size_in_tbs: int
 
+        :param is_dedicated:
+            The value to assign to the is_dedicated property of this AutonomousDatabaseSummary.
+        :type is_dedicated: bool
+
+        :param autonomous_container_database_id:
+            The value to assign to the autonomous_container_database_id property of this AutonomousDatabaseSummary.
+        :type autonomous_container_database_id: str
+
         :param time_created:
             The value to assign to the time_created property of this AutonomousDatabaseSummary.
         :type time_created: datetime
@@ -136,6 +148,10 @@ class AutonomousDatabaseSummary(object):
         :param connection_strings:
             The value to assign to the connection_strings property of this AutonomousDatabaseSummary.
         :type connection_strings: AutonomousDatabaseConnectionStrings
+
+        :param connection_urls:
+            The value to assign to the connection_urls property of this AutonomousDatabaseSummary.
+        :type connection_urls: AutonomousDatabaseConnectionUrls
 
         :param license_model:
             The value to assign to the license_model property of this AutonomousDatabaseSummary.
@@ -182,10 +198,13 @@ class AutonomousDatabaseSummary(object):
             'db_name': 'str',
             'cpu_core_count': 'int',
             'data_storage_size_in_tbs': 'int',
+            'is_dedicated': 'bool',
+            'autonomous_container_database_id': 'str',
             'time_created': 'datetime',
             'display_name': 'str',
             'service_console_url': 'str',
             'connection_strings': 'AutonomousDatabaseConnectionStrings',
+            'connection_urls': 'AutonomousDatabaseConnectionUrls',
             'license_model': 'str',
             'used_data_storage_size_in_tbs': 'int',
             'freeform_tags': 'dict(str, str)',
@@ -204,10 +223,13 @@ class AutonomousDatabaseSummary(object):
             'db_name': 'dbName',
             'cpu_core_count': 'cpuCoreCount',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
+            'is_dedicated': 'isDedicated',
+            'autonomous_container_database_id': 'autonomousContainerDatabaseId',
             'time_created': 'timeCreated',
             'display_name': 'displayName',
             'service_console_url': 'serviceConsoleUrl',
             'connection_strings': 'connectionStrings',
+            'connection_urls': 'connectionUrls',
             'license_model': 'licenseModel',
             'used_data_storage_size_in_tbs': 'usedDataStorageSizeInTBs',
             'freeform_tags': 'freeformTags',
@@ -225,10 +247,13 @@ class AutonomousDatabaseSummary(object):
         self._db_name = None
         self._cpu_core_count = None
         self._data_storage_size_in_tbs = None
+        self._is_dedicated = None
+        self._autonomous_container_database_id = None
         self._time_created = None
         self._display_name = None
         self._service_console_url = None
         self._connection_strings = None
+        self._connection_urls = None
         self._license_model = None
         self._used_data_storage_size_in_tbs = None
         self._freeform_tags = None
@@ -300,7 +325,7 @@ class AutonomousDatabaseSummary(object):
         **[Required]** Gets the lifecycle_state of this AutonomousDatabaseSummary.
         The current state of the database.
 
-        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -319,7 +344,7 @@ class AutonomousDatabaseSummary(object):
         :param lifecycle_state: The lifecycle_state of this AutonomousDatabaseSummary.
         :type: str
         """
-        allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING"]
+        allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
@@ -421,6 +446,58 @@ class AutonomousDatabaseSummary(object):
         self._data_storage_size_in_tbs = data_storage_size_in_tbs
 
     @property
+    def is_dedicated(self):
+        """
+        Gets the is_dedicated of this AutonomousDatabaseSummary.
+        True if it is dedicated database.
+
+
+        :return: The is_dedicated of this AutonomousDatabaseSummary.
+        :rtype: bool
+        """
+        return self._is_dedicated
+
+    @is_dedicated.setter
+    def is_dedicated(self, is_dedicated):
+        """
+        Sets the is_dedicated of this AutonomousDatabaseSummary.
+        True if it is dedicated database.
+
+
+        :param is_dedicated: The is_dedicated of this AutonomousDatabaseSummary.
+        :type: bool
+        """
+        self._is_dedicated = is_dedicated
+
+    @property
+    def autonomous_container_database_id(self):
+        """
+        Gets the autonomous_container_database_id of this AutonomousDatabaseSummary.
+        The Autonomous Container Database `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The autonomous_container_database_id of this AutonomousDatabaseSummary.
+        :rtype: str
+        """
+        return self._autonomous_container_database_id
+
+    @autonomous_container_database_id.setter
+    def autonomous_container_database_id(self, autonomous_container_database_id):
+        """
+        Sets the autonomous_container_database_id of this AutonomousDatabaseSummary.
+        The Autonomous Container Database `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param autonomous_container_database_id: The autonomous_container_database_id of this AutonomousDatabaseSummary.
+        :type: str
+        """
+        self._autonomous_container_database_id = autonomous_container_database_id
+
+    @property
     def time_created(self):
         """
         Gets the time_created of this AutonomousDatabaseSummary.
@@ -515,6 +592,26 @@ class AutonomousDatabaseSummary(object):
         :type: AutonomousDatabaseConnectionStrings
         """
         self._connection_strings = connection_strings
+
+    @property
+    def connection_urls(self):
+        """
+        Gets the connection_urls of this AutonomousDatabaseSummary.
+
+        :return: The connection_urls of this AutonomousDatabaseSummary.
+        :rtype: AutonomousDatabaseConnectionUrls
+        """
+        return self._connection_urls
+
+    @connection_urls.setter
+    def connection_urls(self, connection_urls):
+        """
+        Sets the connection_urls of this AutonomousDatabaseSummary.
+
+        :param connection_urls: The connection_urls of this AutonomousDatabaseSummary.
+        :type: AutonomousDatabaseConnectionUrls
+        """
+        self._connection_urls = connection_urls
 
     @property
     def license_model(self):

--- a/src/oci/database/models/autonomous_exadata_infrastructure.py
+++ b/src/oci/database/models/autonomous_exadata_infrastructure.py
@@ -1,0 +1,655 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AutonomousExadataInfrastructure(object):
+    """
+    AutonomousExadataInfrastructure model.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructure.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructure.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructure.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructure.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructure.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructure.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructure.
+    #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
+    LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
+
+    #: A constant which can be used with the license_model property of a AutonomousExadataInfrastructure.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a AutonomousExadataInfrastructure.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AutonomousExadataInfrastructure object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this AutonomousExadataInfrastructure.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this AutonomousExadataInfrastructure.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this AutonomousExadataInfrastructure.
+        :type display_name: str
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this AutonomousExadataInfrastructure.
+        :type availability_domain: str
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this AutonomousExadataInfrastructure.
+        :type subnet_id: str
+
+        :param shape:
+            The value to assign to the shape property of this AutonomousExadataInfrastructure.
+        :type shape: str
+
+        :param hostname:
+            The value to assign to the hostname property of this AutonomousExadataInfrastructure.
+        :type hostname: str
+
+        :param domain:
+            The value to assign to the domain property of this AutonomousExadataInfrastructure.
+        :type domain: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this AutonomousExadataInfrastructure.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this AutonomousExadataInfrastructure.
+        :type lifecycle_details: str
+
+        :param license_model:
+            The value to assign to the license_model property of this AutonomousExadataInfrastructure.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type license_model: str
+
+        :param time_created:
+            The value to assign to the time_created property of this AutonomousExadataInfrastructure.
+        :type time_created: datetime
+
+        :param maintenance_window:
+            The value to assign to the maintenance_window property of this AutonomousExadataInfrastructure.
+        :type maintenance_window: MaintenanceWindow
+
+        :param last_maintenance_run_id:
+            The value to assign to the last_maintenance_run_id property of this AutonomousExadataInfrastructure.
+        :type last_maintenance_run_id: str
+
+        :param next_maintenance_run_id:
+            The value to assign to the next_maintenance_run_id property of this AutonomousExadataInfrastructure.
+        :type next_maintenance_run_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this AutonomousExadataInfrastructure.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this AutonomousExadataInfrastructure.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'availability_domain': 'str',
+            'subnet_id': 'str',
+            'shape': 'str',
+            'hostname': 'str',
+            'domain': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'license_model': 'str',
+            'time_created': 'datetime',
+            'maintenance_window': 'MaintenanceWindow',
+            'last_maintenance_run_id': 'str',
+            'next_maintenance_run_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'availability_domain': 'availabilityDomain',
+            'subnet_id': 'subnetId',
+            'shape': 'shape',
+            'hostname': 'hostname',
+            'domain': 'domain',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'license_model': 'licenseModel',
+            'time_created': 'timeCreated',
+            'maintenance_window': 'maintenanceWindow',
+            'last_maintenance_run_id': 'lastMaintenanceRunId',
+            'next_maintenance_run_id': 'nextMaintenanceRunId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._display_name = None
+        self._availability_domain = None
+        self._subnet_id = None
+        self._shape = None
+        self._hostname = None
+        self._domain = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._license_model = None
+        self._time_created = None
+        self._maintenance_window = None
+        self._last_maintenance_run_id = None
+        self._next_maintenance_run_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this AutonomousExadataInfrastructure.
+        The OCID of the Autonomous Exadata Infrastructure.
+
+
+        :return: The id of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this AutonomousExadataInfrastructure.
+        The OCID of the Autonomous Exadata Infrastructure.
+
+
+        :param id: The id of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this AutonomousExadataInfrastructure.
+        The OCID of the compartment.
+
+
+        :return: The compartment_id of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this AutonomousExadataInfrastructure.
+        The OCID of the compartment.
+
+
+        :param compartment_id: The compartment_id of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this AutonomousExadataInfrastructure.
+        The user-friendly name for the Autonomous Exadata Infrastructure.
+
+
+        :return: The display_name of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this AutonomousExadataInfrastructure.
+        The user-friendly name for the Autonomous Exadata Infrastructure.
+
+
+        :param display_name: The display_name of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def availability_domain(self):
+        """
+        **[Required]** Gets the availability_domain of this AutonomousExadataInfrastructure.
+        The name of the availability domain that the Autonomous Exadata Infrastructure is located in.
+
+
+        :return: The availability_domain of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this AutonomousExadataInfrastructure.
+        The name of the availability domain that the Autonomous Exadata Infrastructure is located in.
+
+
+        :param availability_domain: The availability_domain of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def subnet_id(self):
+        """
+        **[Required]** Gets the subnet_id of this AutonomousExadataInfrastructure.
+        The OCID of the subnet the Autonomous Exadata Infrastructure is associated with.
+
+        **Subnet Restrictions:**
+        - For Autonomous Databases with Autonomous Exadata Infrastructure, do not use a subnet that overlaps with 192.168.128.0/20
+
+        These subnets are used by the Oracle Clusterware private interconnect on the database instance.
+        Specifying an overlapping subnet will cause the private interconnect to malfunction.
+        This restriction applies to both the client subnet and backup subnet.
+
+
+        :return: The subnet_id of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._subnet_id
+
+    @subnet_id.setter
+    def subnet_id(self, subnet_id):
+        """
+        Sets the subnet_id of this AutonomousExadataInfrastructure.
+        The OCID of the subnet the Autonomous Exadata Infrastructure is associated with.
+
+        **Subnet Restrictions:**
+        - For Autonomous Databases with Autonomous Exadata Infrastructure, do not use a subnet that overlaps with 192.168.128.0/20
+
+        These subnets are used by the Oracle Clusterware private interconnect on the database instance.
+        Specifying an overlapping subnet will cause the private interconnect to malfunction.
+        This restriction applies to both the client subnet and backup subnet.
+
+
+        :param subnet_id: The subnet_id of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        self._subnet_id = subnet_id
+
+    @property
+    def shape(self):
+        """
+        **[Required]** Gets the shape of this AutonomousExadataInfrastructure.
+        The shape of the Autonomous Exadata Infrastructure. The shape determines resources to allocate to the Autonomous Exadata Infrastructure (CPU cores, memory and storage).
+
+
+        :return: The shape of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this AutonomousExadataInfrastructure.
+        The shape of the Autonomous Exadata Infrastructure. The shape determines resources to allocate to the Autonomous Exadata Infrastructure (CPU cores, memory and storage).
+
+
+        :param shape: The shape of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def hostname(self):
+        """
+        **[Required]** Gets the hostname of this AutonomousExadataInfrastructure.
+        The host name for the Autonomous Exadata Infrastructure node.
+
+
+        :return: The hostname of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, hostname):
+        """
+        Sets the hostname of this AutonomousExadataInfrastructure.
+        The host name for the Autonomous Exadata Infrastructure node.
+
+
+        :param hostname: The hostname of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        self._hostname = hostname
+
+    @property
+    def domain(self):
+        """
+        **[Required]** Gets the domain of this AutonomousExadataInfrastructure.
+        The domain name for the Autonomous Exadata Infrastructure.
+
+
+        :return: The domain of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._domain
+
+    @domain.setter
+    def domain(self, domain):
+        """
+        Sets the domain of this AutonomousExadataInfrastructure.
+        The domain name for the Autonomous Exadata Infrastructure.
+
+
+        :param domain: The domain of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        self._domain = domain
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this AutonomousExadataInfrastructure.
+        The current lifecycle state of the Autonomous Exadata Infrastructure.
+
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this AutonomousExadataInfrastructure.
+        The current lifecycle state of the Autonomous Exadata Infrastructure.
+
+
+        :param lifecycle_state: The lifecycle_state of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this AutonomousExadataInfrastructure.
+        Additional information about the current lifecycle state of the Autonomous Exadata Infrastructure.
+
+
+        :return: The lifecycle_details of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this AutonomousExadataInfrastructure.
+        Additional information about the current lifecycle state of the Autonomous Exadata Infrastructure.
+
+
+        :param lifecycle_details: The lifecycle_details of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def license_model(self):
+        """
+        Gets the license_model of this AutonomousExadataInfrastructure.
+        The Oracle license model that applies to all databases in the Autonomous Exadata Infrastructure. The default is BRING_YOUR_OWN_LICENSE.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The license_model of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this AutonomousExadataInfrastructure.
+        The Oracle license model that applies to all databases in the Autonomous Exadata Infrastructure. The default is BRING_YOUR_OWN_LICENSE.
+
+
+        :param license_model: The license_model of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            license_model = 'UNKNOWN_ENUM_VALUE'
+        self._license_model = license_model
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this AutonomousExadataInfrastructure.
+        The date and time the Autonomous Exadata Infrastructure was created.
+
+
+        :return: The time_created of this AutonomousExadataInfrastructure.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this AutonomousExadataInfrastructure.
+        The date and time the Autonomous Exadata Infrastructure was created.
+
+
+        :param time_created: The time_created of this AutonomousExadataInfrastructure.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def maintenance_window(self):
+        """
+        **[Required]** Gets the maintenance_window of this AutonomousExadataInfrastructure.
+
+        :return: The maintenance_window of this AutonomousExadataInfrastructure.
+        :rtype: MaintenanceWindow
+        """
+        return self._maintenance_window
+
+    @maintenance_window.setter
+    def maintenance_window(self, maintenance_window):
+        """
+        Sets the maintenance_window of this AutonomousExadataInfrastructure.
+
+        :param maintenance_window: The maintenance_window of this AutonomousExadataInfrastructure.
+        :type: MaintenanceWindow
+        """
+        self._maintenance_window = maintenance_window
+
+    @property
+    def last_maintenance_run_id(self):
+        """
+        Gets the last_maintenance_run_id of this AutonomousExadataInfrastructure.
+        The `OCID`__ of the last maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The last_maintenance_run_id of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._last_maintenance_run_id
+
+    @last_maintenance_run_id.setter
+    def last_maintenance_run_id(self, last_maintenance_run_id):
+        """
+        Sets the last_maintenance_run_id of this AutonomousExadataInfrastructure.
+        The `OCID`__ of the last maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param last_maintenance_run_id: The last_maintenance_run_id of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        self._last_maintenance_run_id = last_maintenance_run_id
+
+    @property
+    def next_maintenance_run_id(self):
+        """
+        Gets the next_maintenance_run_id of this AutonomousExadataInfrastructure.
+        The `OCID`__ of the next maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The next_maintenance_run_id of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._next_maintenance_run_id
+
+    @next_maintenance_run_id.setter
+    def next_maintenance_run_id(self, next_maintenance_run_id):
+        """
+        Sets the next_maintenance_run_id of this AutonomousExadataInfrastructure.
+        The `OCID`__ of the next maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param next_maintenance_run_id: The next_maintenance_run_id of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        self._next_maintenance_run_id = next_maintenance_run_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this AutonomousExadataInfrastructure.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this AutonomousExadataInfrastructure.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this AutonomousExadataInfrastructure.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this AutonomousExadataInfrastructure.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this AutonomousExadataInfrastructure.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this AutonomousExadataInfrastructure.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this AutonomousExadataInfrastructure.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this AutonomousExadataInfrastructure.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/autonomous_exadata_infrastructure_maintenance_window.py
+++ b/src/oci/database/models/autonomous_exadata_infrastructure_maintenance_window.py
@@ -1,0 +1,141 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AutonomousExadataInfrastructureMaintenanceWindow(object):
+    """
+    Autonomous Exadata Infrastructure maintenance window details for quarterly patching.
+    """
+
+    #: A constant which can be used with the day_of_week property of a AutonomousExadataInfrastructureMaintenanceWindow.
+    #: This constant has a value of "ANY"
+    DAY_OF_WEEK_ANY = "ANY"
+
+    #: A constant which can be used with the day_of_week property of a AutonomousExadataInfrastructureMaintenanceWindow.
+    #: This constant has a value of "SUNDAY"
+    DAY_OF_WEEK_SUNDAY = "SUNDAY"
+
+    #: A constant which can be used with the day_of_week property of a AutonomousExadataInfrastructureMaintenanceWindow.
+    #: This constant has a value of "MONDAY"
+    DAY_OF_WEEK_MONDAY = "MONDAY"
+
+    #: A constant which can be used with the day_of_week property of a AutonomousExadataInfrastructureMaintenanceWindow.
+    #: This constant has a value of "TUESDAY"
+    DAY_OF_WEEK_TUESDAY = "TUESDAY"
+
+    #: A constant which can be used with the day_of_week property of a AutonomousExadataInfrastructureMaintenanceWindow.
+    #: This constant has a value of "WEDNESDAY"
+    DAY_OF_WEEK_WEDNESDAY = "WEDNESDAY"
+
+    #: A constant which can be used with the day_of_week property of a AutonomousExadataInfrastructureMaintenanceWindow.
+    #: This constant has a value of "THURSDAY"
+    DAY_OF_WEEK_THURSDAY = "THURSDAY"
+
+    #: A constant which can be used with the day_of_week property of a AutonomousExadataInfrastructureMaintenanceWindow.
+    #: This constant has a value of "FRIDAY"
+    DAY_OF_WEEK_FRIDAY = "FRIDAY"
+
+    #: A constant which can be used with the day_of_week property of a AutonomousExadataInfrastructureMaintenanceWindow.
+    #: This constant has a value of "SATURDAY"
+    DAY_OF_WEEK_SATURDAY = "SATURDAY"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AutonomousExadataInfrastructureMaintenanceWindow object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param day_of_week:
+            The value to assign to the day_of_week property of this AutonomousExadataInfrastructureMaintenanceWindow.
+            Allowed values for this property are: "ANY", "SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY"
+        :type day_of_week: str
+
+        :param hour_of_day:
+            The value to assign to the hour_of_day property of this AutonomousExadataInfrastructureMaintenanceWindow.
+        :type hour_of_day: int
+
+        """
+        self.swagger_types = {
+            'day_of_week': 'str',
+            'hour_of_day': 'int'
+        }
+
+        self.attribute_map = {
+            'day_of_week': 'dayOfWeek',
+            'hour_of_day': 'hourOfDay'
+        }
+
+        self._day_of_week = None
+        self._hour_of_day = None
+
+    @property
+    def day_of_week(self):
+        """
+        **[Required]** Gets the day_of_week of this AutonomousExadataInfrastructureMaintenanceWindow.
+        Day of the week that the patch should be applied to the Autonomous Exadata Infrastructure. Patches are applied during the first week of the quarter.
+
+        Allowed values for this property are: "ANY", "SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY"
+
+
+        :return: The day_of_week of this AutonomousExadataInfrastructureMaintenanceWindow.
+        :rtype: str
+        """
+        return self._day_of_week
+
+    @day_of_week.setter
+    def day_of_week(self, day_of_week):
+        """
+        Sets the day_of_week of this AutonomousExadataInfrastructureMaintenanceWindow.
+        Day of the week that the patch should be applied to the Autonomous Exadata Infrastructure. Patches are applied during the first week of the quarter.
+
+
+        :param day_of_week: The day_of_week of this AutonomousExadataInfrastructureMaintenanceWindow.
+        :type: str
+        """
+        allowed_values = ["ANY", "SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY"]
+        if not value_allowed_none_or_none_sentinel(day_of_week, allowed_values):
+            raise ValueError(
+                "Invalid value for `day_of_week`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._day_of_week = day_of_week
+
+    @property
+    def hour_of_day(self):
+        """
+        Gets the hour_of_day of this AutonomousExadataInfrastructureMaintenanceWindow.
+        Hour of the day that the patch should be applied.
+
+
+        :return: The hour_of_day of this AutonomousExadataInfrastructureMaintenanceWindow.
+        :rtype: int
+        """
+        return self._hour_of_day
+
+    @hour_of_day.setter
+    def hour_of_day(self, hour_of_day):
+        """
+        Sets the hour_of_day of this AutonomousExadataInfrastructureMaintenanceWindow.
+        Hour of the day that the patch should be applied.
+
+
+        :param hour_of_day: The hour_of_day of this AutonomousExadataInfrastructureMaintenanceWindow.
+        :type: int
+        """
+        self._hour_of_day = hour_of_day
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/autonomous_exadata_infrastructure_shape_summary.py
+++ b/src/oci/database/models/autonomous_exadata_infrastructure_shape_summary.py
@@ -1,0 +1,230 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AutonomousExadataInfrastructureShapeSummary(object):
+    """
+    The shape of the Autonomous Exadata Infrastructure. The shape determines resources to allocate to the Autonomous Exadata Infrastructure (CPU cores, memory and storage).
+
+    To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized, talk to an administrator.
+    If you're an administrator who needs to write policies to give users access,
+    see `Getting Started with Policies`__.
+
+    __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AutonomousExadataInfrastructureShapeSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this AutonomousExadataInfrastructureShapeSummary.
+        :type name: str
+
+        :param available_core_count:
+            The value to assign to the available_core_count property of this AutonomousExadataInfrastructureShapeSummary.
+        :type available_core_count: int
+
+        :param minimum_core_count:
+            The value to assign to the minimum_core_count property of this AutonomousExadataInfrastructureShapeSummary.
+        :type minimum_core_count: int
+
+        :param core_count_increment:
+            The value to assign to the core_count_increment property of this AutonomousExadataInfrastructureShapeSummary.
+        :type core_count_increment: int
+
+        :param minimum_node_count:
+            The value to assign to the minimum_node_count property of this AutonomousExadataInfrastructureShapeSummary.
+        :type minimum_node_count: int
+
+        :param maximum_node_count:
+            The value to assign to the maximum_node_count property of this AutonomousExadataInfrastructureShapeSummary.
+        :type maximum_node_count: int
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'available_core_count': 'int',
+            'minimum_core_count': 'int',
+            'core_count_increment': 'int',
+            'minimum_node_count': 'int',
+            'maximum_node_count': 'int'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'available_core_count': 'availableCoreCount',
+            'minimum_core_count': 'minimumCoreCount',
+            'core_count_increment': 'coreCountIncrement',
+            'minimum_node_count': 'minimumNodeCount',
+            'maximum_node_count': 'maximumNodeCount'
+        }
+
+        self._name = None
+        self._available_core_count = None
+        self._minimum_core_count = None
+        self._core_count_increment = None
+        self._minimum_node_count = None
+        self._maximum_node_count = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this AutonomousExadataInfrastructureShapeSummary.
+        The name of the shape used for the Autonomous Exadata Infrastructure.
+
+
+        :return: The name of this AutonomousExadataInfrastructureShapeSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this AutonomousExadataInfrastructureShapeSummary.
+        The name of the shape used for the Autonomous Exadata Infrastructure.
+
+
+        :param name: The name of this AutonomousExadataInfrastructureShapeSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def available_core_count(self):
+        """
+        **[Required]** Gets the available_core_count of this AutonomousExadataInfrastructureShapeSummary.
+        The maximum number of CPU cores that can be enabled on the Autonomous Exadata Infrastructure.
+
+
+        :return: The available_core_count of this AutonomousExadataInfrastructureShapeSummary.
+        :rtype: int
+        """
+        return self._available_core_count
+
+    @available_core_count.setter
+    def available_core_count(self, available_core_count):
+        """
+        Sets the available_core_count of this AutonomousExadataInfrastructureShapeSummary.
+        The maximum number of CPU cores that can be enabled on the Autonomous Exadata Infrastructure.
+
+
+        :param available_core_count: The available_core_count of this AutonomousExadataInfrastructureShapeSummary.
+        :type: int
+        """
+        self._available_core_count = available_core_count
+
+    @property
+    def minimum_core_count(self):
+        """
+        Gets the minimum_core_count of this AutonomousExadataInfrastructureShapeSummary.
+        The minimum number of CPU cores that can be enabled on the Autonomous Exadata Infrastructure.
+
+
+        :return: The minimum_core_count of this AutonomousExadataInfrastructureShapeSummary.
+        :rtype: int
+        """
+        return self._minimum_core_count
+
+    @minimum_core_count.setter
+    def minimum_core_count(self, minimum_core_count):
+        """
+        Sets the minimum_core_count of this AutonomousExadataInfrastructureShapeSummary.
+        The minimum number of CPU cores that can be enabled on the Autonomous Exadata Infrastructure.
+
+
+        :param minimum_core_count: The minimum_core_count of this AutonomousExadataInfrastructureShapeSummary.
+        :type: int
+        """
+        self._minimum_core_count = minimum_core_count
+
+    @property
+    def core_count_increment(self):
+        """
+        Gets the core_count_increment of this AutonomousExadataInfrastructureShapeSummary.
+        The increment in which core count can be increased or decreased.
+
+
+        :return: The core_count_increment of this AutonomousExadataInfrastructureShapeSummary.
+        :rtype: int
+        """
+        return self._core_count_increment
+
+    @core_count_increment.setter
+    def core_count_increment(self, core_count_increment):
+        """
+        Sets the core_count_increment of this AutonomousExadataInfrastructureShapeSummary.
+        The increment in which core count can be increased or decreased.
+
+
+        :param core_count_increment: The core_count_increment of this AutonomousExadataInfrastructureShapeSummary.
+        :type: int
+        """
+        self._core_count_increment = core_count_increment
+
+    @property
+    def minimum_node_count(self):
+        """
+        Gets the minimum_node_count of this AutonomousExadataInfrastructureShapeSummary.
+        The minimum number of nodes available for the shape.
+
+
+        :return: The minimum_node_count of this AutonomousExadataInfrastructureShapeSummary.
+        :rtype: int
+        """
+        return self._minimum_node_count
+
+    @minimum_node_count.setter
+    def minimum_node_count(self, minimum_node_count):
+        """
+        Sets the minimum_node_count of this AutonomousExadataInfrastructureShapeSummary.
+        The minimum number of nodes available for the shape.
+
+
+        :param minimum_node_count: The minimum_node_count of this AutonomousExadataInfrastructureShapeSummary.
+        :type: int
+        """
+        self._minimum_node_count = minimum_node_count
+
+    @property
+    def maximum_node_count(self):
+        """
+        Gets the maximum_node_count of this AutonomousExadataInfrastructureShapeSummary.
+        The maximum number of nodes available for the shape.
+
+
+        :return: The maximum_node_count of this AutonomousExadataInfrastructureShapeSummary.
+        :rtype: int
+        """
+        return self._maximum_node_count
+
+    @maximum_node_count.setter
+    def maximum_node_count(self, maximum_node_count):
+        """
+        Sets the maximum_node_count of this AutonomousExadataInfrastructureShapeSummary.
+        The maximum number of nodes available for the shape.
+
+
+        :param maximum_node_count: The maximum_node_count of this AutonomousExadataInfrastructureShapeSummary.
+        :type: int
+        """
+        self._maximum_node_count = maximum_node_count
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/autonomous_exadata_infrastructure_summary.py
+++ b/src/oci/database/models/autonomous_exadata_infrastructure_summary.py
@@ -1,0 +1,673 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AutonomousExadataInfrastructureSummary(object):
+    """
+    Infrastructure that enables the running of multiple Autonomous Databases within a dedicated DB system.
+    For more information about Autonomous Exadata Infrastructure, see
+    `Overview of Autonomous Database`__.
+
+    To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized, talk to an administrator. If you're an administrator who needs to write policies to give users access, see `Getting Started with Policies`__.
+
+    For information about access control and compartments, see
+    `Overview of the Identity Service`__.
+
+    For information about availability domains, see
+    `Regions and Availability Domains`__.
+
+    To get a list of availability domains, use the ListAvailabilityDomains operation
+    in the Identity service API.
+
+    __ https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/adboverview.htm
+    __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
+    __ https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm
+    __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructureSummary.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructureSummary.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructureSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructureSummary.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructureSummary.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructureSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a AutonomousExadataInfrastructureSummary.
+    #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
+    LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
+
+    #: A constant which can be used with the license_model property of a AutonomousExadataInfrastructureSummary.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a AutonomousExadataInfrastructureSummary.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AutonomousExadataInfrastructureSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this AutonomousExadataInfrastructureSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this AutonomousExadataInfrastructureSummary.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this AutonomousExadataInfrastructureSummary.
+        :type display_name: str
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this AutonomousExadataInfrastructureSummary.
+        :type availability_domain: str
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this AutonomousExadataInfrastructureSummary.
+        :type subnet_id: str
+
+        :param shape:
+            The value to assign to the shape property of this AutonomousExadataInfrastructureSummary.
+        :type shape: str
+
+        :param hostname:
+            The value to assign to the hostname property of this AutonomousExadataInfrastructureSummary.
+        :type hostname: str
+
+        :param domain:
+            The value to assign to the domain property of this AutonomousExadataInfrastructureSummary.
+        :type domain: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this AutonomousExadataInfrastructureSummary.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this AutonomousExadataInfrastructureSummary.
+        :type lifecycle_details: str
+
+        :param license_model:
+            The value to assign to the license_model property of this AutonomousExadataInfrastructureSummary.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type license_model: str
+
+        :param time_created:
+            The value to assign to the time_created property of this AutonomousExadataInfrastructureSummary.
+        :type time_created: datetime
+
+        :param maintenance_window:
+            The value to assign to the maintenance_window property of this AutonomousExadataInfrastructureSummary.
+        :type maintenance_window: MaintenanceWindow
+
+        :param last_maintenance_run_id:
+            The value to assign to the last_maintenance_run_id property of this AutonomousExadataInfrastructureSummary.
+        :type last_maintenance_run_id: str
+
+        :param next_maintenance_run_id:
+            The value to assign to the next_maintenance_run_id property of this AutonomousExadataInfrastructureSummary.
+        :type next_maintenance_run_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this AutonomousExadataInfrastructureSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this AutonomousExadataInfrastructureSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'availability_domain': 'str',
+            'subnet_id': 'str',
+            'shape': 'str',
+            'hostname': 'str',
+            'domain': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'license_model': 'str',
+            'time_created': 'datetime',
+            'maintenance_window': 'MaintenanceWindow',
+            'last_maintenance_run_id': 'str',
+            'next_maintenance_run_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'availability_domain': 'availabilityDomain',
+            'subnet_id': 'subnetId',
+            'shape': 'shape',
+            'hostname': 'hostname',
+            'domain': 'domain',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'license_model': 'licenseModel',
+            'time_created': 'timeCreated',
+            'maintenance_window': 'maintenanceWindow',
+            'last_maintenance_run_id': 'lastMaintenanceRunId',
+            'next_maintenance_run_id': 'nextMaintenanceRunId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._display_name = None
+        self._availability_domain = None
+        self._subnet_id = None
+        self._shape = None
+        self._hostname = None
+        self._domain = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._license_model = None
+        self._time_created = None
+        self._maintenance_window = None
+        self._last_maintenance_run_id = None
+        self._next_maintenance_run_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this AutonomousExadataInfrastructureSummary.
+        The OCID of the Autonomous Exadata Infrastructure.
+
+
+        :return: The id of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this AutonomousExadataInfrastructureSummary.
+        The OCID of the Autonomous Exadata Infrastructure.
+
+
+        :param id: The id of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this AutonomousExadataInfrastructureSummary.
+        The OCID of the compartment.
+
+
+        :return: The compartment_id of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this AutonomousExadataInfrastructureSummary.
+        The OCID of the compartment.
+
+
+        :param compartment_id: The compartment_id of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this AutonomousExadataInfrastructureSummary.
+        The user-friendly name for the Autonomous Exadata Infrastructure.
+
+
+        :return: The display_name of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this AutonomousExadataInfrastructureSummary.
+        The user-friendly name for the Autonomous Exadata Infrastructure.
+
+
+        :param display_name: The display_name of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def availability_domain(self):
+        """
+        **[Required]** Gets the availability_domain of this AutonomousExadataInfrastructureSummary.
+        The name of the availability domain that the Autonomous Exadata Infrastructure is located in.
+
+
+        :return: The availability_domain of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this AutonomousExadataInfrastructureSummary.
+        The name of the availability domain that the Autonomous Exadata Infrastructure is located in.
+
+
+        :param availability_domain: The availability_domain of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def subnet_id(self):
+        """
+        **[Required]** Gets the subnet_id of this AutonomousExadataInfrastructureSummary.
+        The OCID of the subnet the Autonomous Exadata Infrastructure is associated with.
+
+        **Subnet Restrictions:**
+        - For Autonomous Databases with Autonomous Exadata Infrastructure, do not use a subnet that overlaps with 192.168.128.0/20
+
+        These subnets are used by the Oracle Clusterware private interconnect on the database instance.
+        Specifying an overlapping subnet will cause the private interconnect to malfunction.
+        This restriction applies to both the client subnet and backup subnet.
+
+
+        :return: The subnet_id of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._subnet_id
+
+    @subnet_id.setter
+    def subnet_id(self, subnet_id):
+        """
+        Sets the subnet_id of this AutonomousExadataInfrastructureSummary.
+        The OCID of the subnet the Autonomous Exadata Infrastructure is associated with.
+
+        **Subnet Restrictions:**
+        - For Autonomous Databases with Autonomous Exadata Infrastructure, do not use a subnet that overlaps with 192.168.128.0/20
+
+        These subnets are used by the Oracle Clusterware private interconnect on the database instance.
+        Specifying an overlapping subnet will cause the private interconnect to malfunction.
+        This restriction applies to both the client subnet and backup subnet.
+
+
+        :param subnet_id: The subnet_id of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        self._subnet_id = subnet_id
+
+    @property
+    def shape(self):
+        """
+        **[Required]** Gets the shape of this AutonomousExadataInfrastructureSummary.
+        The shape of the Autonomous Exadata Infrastructure. The shape determines resources to allocate to the Autonomous Exadata Infrastructure (CPU cores, memory and storage).
+
+
+        :return: The shape of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this AutonomousExadataInfrastructureSummary.
+        The shape of the Autonomous Exadata Infrastructure. The shape determines resources to allocate to the Autonomous Exadata Infrastructure (CPU cores, memory and storage).
+
+
+        :param shape: The shape of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def hostname(self):
+        """
+        **[Required]** Gets the hostname of this AutonomousExadataInfrastructureSummary.
+        The host name for the Autonomous Exadata Infrastructure node.
+
+
+        :return: The hostname of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, hostname):
+        """
+        Sets the hostname of this AutonomousExadataInfrastructureSummary.
+        The host name for the Autonomous Exadata Infrastructure node.
+
+
+        :param hostname: The hostname of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        self._hostname = hostname
+
+    @property
+    def domain(self):
+        """
+        **[Required]** Gets the domain of this AutonomousExadataInfrastructureSummary.
+        The domain name for the Autonomous Exadata Infrastructure.
+
+
+        :return: The domain of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._domain
+
+    @domain.setter
+    def domain(self, domain):
+        """
+        Sets the domain of this AutonomousExadataInfrastructureSummary.
+        The domain name for the Autonomous Exadata Infrastructure.
+
+
+        :param domain: The domain of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        self._domain = domain
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this AutonomousExadataInfrastructureSummary.
+        The current lifecycle state of the Autonomous Exadata Infrastructure.
+
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this AutonomousExadataInfrastructureSummary.
+        The current lifecycle state of the Autonomous Exadata Infrastructure.
+
+
+        :param lifecycle_state: The lifecycle_state of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this AutonomousExadataInfrastructureSummary.
+        Additional information about the current lifecycle state of the Autonomous Exadata Infrastructure.
+
+
+        :return: The lifecycle_details of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this AutonomousExadataInfrastructureSummary.
+        Additional information about the current lifecycle state of the Autonomous Exadata Infrastructure.
+
+
+        :param lifecycle_details: The lifecycle_details of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def license_model(self):
+        """
+        Gets the license_model of this AutonomousExadataInfrastructureSummary.
+        The Oracle license model that applies to all databases in the Autonomous Exadata Infrastructure. The default is BRING_YOUR_OWN_LICENSE.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The license_model of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this AutonomousExadataInfrastructureSummary.
+        The Oracle license model that applies to all databases in the Autonomous Exadata Infrastructure. The default is BRING_YOUR_OWN_LICENSE.
+
+
+        :param license_model: The license_model of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            license_model = 'UNKNOWN_ENUM_VALUE'
+        self._license_model = license_model
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this AutonomousExadataInfrastructureSummary.
+        The date and time the Autonomous Exadata Infrastructure was created.
+
+
+        :return: The time_created of this AutonomousExadataInfrastructureSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this AutonomousExadataInfrastructureSummary.
+        The date and time the Autonomous Exadata Infrastructure was created.
+
+
+        :param time_created: The time_created of this AutonomousExadataInfrastructureSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def maintenance_window(self):
+        """
+        **[Required]** Gets the maintenance_window of this AutonomousExadataInfrastructureSummary.
+
+        :return: The maintenance_window of this AutonomousExadataInfrastructureSummary.
+        :rtype: MaintenanceWindow
+        """
+        return self._maintenance_window
+
+    @maintenance_window.setter
+    def maintenance_window(self, maintenance_window):
+        """
+        Sets the maintenance_window of this AutonomousExadataInfrastructureSummary.
+
+        :param maintenance_window: The maintenance_window of this AutonomousExadataInfrastructureSummary.
+        :type: MaintenanceWindow
+        """
+        self._maintenance_window = maintenance_window
+
+    @property
+    def last_maintenance_run_id(self):
+        """
+        Gets the last_maintenance_run_id of this AutonomousExadataInfrastructureSummary.
+        The `OCID`__ of the last maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The last_maintenance_run_id of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._last_maintenance_run_id
+
+    @last_maintenance_run_id.setter
+    def last_maintenance_run_id(self, last_maintenance_run_id):
+        """
+        Sets the last_maintenance_run_id of this AutonomousExadataInfrastructureSummary.
+        The `OCID`__ of the last maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param last_maintenance_run_id: The last_maintenance_run_id of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        self._last_maintenance_run_id = last_maintenance_run_id
+
+    @property
+    def next_maintenance_run_id(self):
+        """
+        Gets the next_maintenance_run_id of this AutonomousExadataInfrastructureSummary.
+        The `OCID`__ of the next maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The next_maintenance_run_id of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._next_maintenance_run_id
+
+    @next_maintenance_run_id.setter
+    def next_maintenance_run_id(self, next_maintenance_run_id):
+        """
+        Sets the next_maintenance_run_id of this AutonomousExadataInfrastructureSummary.
+        The `OCID`__ of the next maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param next_maintenance_run_id: The next_maintenance_run_id of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        self._next_maintenance_run_id = next_maintenance_run_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this AutonomousExadataInfrastructureSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this AutonomousExadataInfrastructureSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this AutonomousExadataInfrastructureSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this AutonomousExadataInfrastructureSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this AutonomousExadataInfrastructureSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this AutonomousExadataInfrastructureSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this AutonomousExadataInfrastructureSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this AutonomousExadataInfrastructureSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/backup.py
+++ b/src/oci/database/models/backup.py
@@ -20,6 +20,10 @@ class Backup(object):
     #: This constant has a value of "FULL"
     TYPE_FULL = "FULL"
 
+    #: A constant which can be used with the type property of a Backup.
+    #: This constant has a value of "VIRTUAL_FULL"
+    TYPE_VIRTUAL_FULL = "VIRTUAL_FULL"
+
     #: A constant which can be used with the lifecycle_state property of a Backup.
     #: This constant has a value of "CREATING"
     LIFECYCLE_STATE_CREATING = "CREATING"
@@ -83,7 +87,7 @@ class Backup(object):
 
         :param type:
             The value to assign to the type property of this Backup.
-            Allowed values for this property are: "INCREMENTAL", "FULL", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "INCREMENTAL", "FULL", "VIRTUAL_FULL", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type type: str
 
@@ -277,7 +281,7 @@ class Backup(object):
         Gets the type of this Backup.
         The type of backup.
 
-        Allowed values for this property are: "INCREMENTAL", "FULL", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "INCREMENTAL", "FULL", "VIRTUAL_FULL", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -296,7 +300,7 @@ class Backup(object):
         :param type: The type of this Backup.
         :type: str
         """
-        allowed_values = ["INCREMENTAL", "FULL"]
+        allowed_values = ["INCREMENTAL", "FULL", "VIRTUAL_FULL"]
         if not value_allowed_none_or_none_sentinel(type, allowed_values):
             type = 'UNKNOWN_ENUM_VALUE'
         self._type = type

--- a/src/oci/database/models/backup_summary.py
+++ b/src/oci/database/models/backup_summary.py
@@ -25,6 +25,10 @@ class BackupSummary(object):
     #: This constant has a value of "FULL"
     TYPE_FULL = "FULL"
 
+    #: A constant which can be used with the type property of a BackupSummary.
+    #: This constant has a value of "VIRTUAL_FULL"
+    TYPE_VIRTUAL_FULL = "VIRTUAL_FULL"
+
     #: A constant which can be used with the lifecycle_state property of a BackupSummary.
     #: This constant has a value of "CREATING"
     LIFECYCLE_STATE_CREATING = "CREATING"
@@ -88,7 +92,7 @@ class BackupSummary(object):
 
         :param type:
             The value to assign to the type property of this BackupSummary.
-            Allowed values for this property are: "INCREMENTAL", "FULL", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "INCREMENTAL", "FULL", "VIRTUAL_FULL", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type type: str
 
@@ -282,7 +286,7 @@ class BackupSummary(object):
         Gets the type of this BackupSummary.
         The type of backup.
 
-        Allowed values for this property are: "INCREMENTAL", "FULL", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "INCREMENTAL", "FULL", "VIRTUAL_FULL", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -301,7 +305,7 @@ class BackupSummary(object):
         :param type: The type of this BackupSummary.
         :type: str
         """
-        allowed_values = ["INCREMENTAL", "FULL"]
+        allowed_values = ["INCREMENTAL", "FULL", "VIRTUAL_FULL"]
         if not value_allowed_none_or_none_sentinel(type, allowed_values):
             type = 'UNKNOWN_ENUM_VALUE'
         self._type = type

--- a/src/oci/database/models/create_autonomous_container_database_details.py
+++ b/src/oci/database/models/create_autonomous_container_database_details.py
@@ -1,0 +1,336 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateAutonomousContainerDatabaseDetails(object):
+    """
+    Describes the required parameters for the creation of an Autonomous Container Database.
+    """
+
+    #: A constant which can be used with the service_level_agreement_type property of a CreateAutonomousContainerDatabaseDetails.
+    #: This constant has a value of "STANDARD"
+    SERVICE_LEVEL_AGREEMENT_TYPE_STANDARD = "STANDARD"
+
+    #: A constant which can be used with the patch_model property of a CreateAutonomousContainerDatabaseDetails.
+    #: This constant has a value of "RELEASE_UPDATES"
+    PATCH_MODEL_RELEASE_UPDATES = "RELEASE_UPDATES"
+
+    #: A constant which can be used with the patch_model property of a CreateAutonomousContainerDatabaseDetails.
+    #: This constant has a value of "RELEASE_UPDATE_REVISIONS"
+    PATCH_MODEL_RELEASE_UPDATE_REVISIONS = "RELEASE_UPDATE_REVISIONS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateAutonomousContainerDatabaseDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateAutonomousContainerDatabaseDetails.
+        :type display_name: str
+
+        :param service_level_agreement_type:
+            The value to assign to the service_level_agreement_type property of this CreateAutonomousContainerDatabaseDetails.
+            Allowed values for this property are: "STANDARD"
+        :type service_level_agreement_type: str
+
+        :param autonomous_exadata_infrastructure_id:
+            The value to assign to the autonomous_exadata_infrastructure_id property of this CreateAutonomousContainerDatabaseDetails.
+        :type autonomous_exadata_infrastructure_id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateAutonomousContainerDatabaseDetails.
+        :type compartment_id: str
+
+        :param patch_model:
+            The value to assign to the patch_model property of this CreateAutonomousContainerDatabaseDetails.
+            Allowed values for this property are: "RELEASE_UPDATES", "RELEASE_UPDATE_REVISIONS"
+        :type patch_model: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateAutonomousContainerDatabaseDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateAutonomousContainerDatabaseDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param backup_config:
+            The value to assign to the backup_config property of this CreateAutonomousContainerDatabaseDetails.
+        :type backup_config: AutonomousContainerDatabaseBackupConfig
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'service_level_agreement_type': 'str',
+            'autonomous_exadata_infrastructure_id': 'str',
+            'compartment_id': 'str',
+            'patch_model': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'backup_config': 'AutonomousContainerDatabaseBackupConfig'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'service_level_agreement_type': 'serviceLevelAgreementType',
+            'autonomous_exadata_infrastructure_id': 'autonomousExadataInfrastructureId',
+            'compartment_id': 'compartmentId',
+            'patch_model': 'patchModel',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'backup_config': 'backupConfig'
+        }
+
+        self._display_name = None
+        self._service_level_agreement_type = None
+        self._autonomous_exadata_infrastructure_id = None
+        self._compartment_id = None
+        self._patch_model = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._backup_config = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateAutonomousContainerDatabaseDetails.
+        The display name for the Autonomous Container Database.
+
+
+        :return: The display_name of this CreateAutonomousContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateAutonomousContainerDatabaseDetails.
+        The display name for the Autonomous Container Database.
+
+
+        :param display_name: The display_name of this CreateAutonomousContainerDatabaseDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def service_level_agreement_type(self):
+        """
+        Gets the service_level_agreement_type of this CreateAutonomousContainerDatabaseDetails.
+        The service level agreement type of the Autonomous Container Database. The default is STANDARD. For a Mission Critical Container Database, the specified Autonomous Exadata Infrastructure must be associated with a remote Autonomous Exadata Infrastructure.
+
+        Allowed values for this property are: "STANDARD"
+
+
+        :return: The service_level_agreement_type of this CreateAutonomousContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._service_level_agreement_type
+
+    @service_level_agreement_type.setter
+    def service_level_agreement_type(self, service_level_agreement_type):
+        """
+        Sets the service_level_agreement_type of this CreateAutonomousContainerDatabaseDetails.
+        The service level agreement type of the Autonomous Container Database. The default is STANDARD. For a Mission Critical Container Database, the specified Autonomous Exadata Infrastructure must be associated with a remote Autonomous Exadata Infrastructure.
+
+
+        :param service_level_agreement_type: The service_level_agreement_type of this CreateAutonomousContainerDatabaseDetails.
+        :type: str
+        """
+        allowed_values = ["STANDARD"]
+        if not value_allowed_none_or_none_sentinel(service_level_agreement_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `service_level_agreement_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._service_level_agreement_type = service_level_agreement_type
+
+    @property
+    def autonomous_exadata_infrastructure_id(self):
+        """
+        **[Required]** Gets the autonomous_exadata_infrastructure_id of this CreateAutonomousContainerDatabaseDetails.
+        The OCID of the Autonomous Exadata Infrastructure.
+
+
+        :return: The autonomous_exadata_infrastructure_id of this CreateAutonomousContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._autonomous_exadata_infrastructure_id
+
+    @autonomous_exadata_infrastructure_id.setter
+    def autonomous_exadata_infrastructure_id(self, autonomous_exadata_infrastructure_id):
+        """
+        Sets the autonomous_exadata_infrastructure_id of this CreateAutonomousContainerDatabaseDetails.
+        The OCID of the Autonomous Exadata Infrastructure.
+
+
+        :param autonomous_exadata_infrastructure_id: The autonomous_exadata_infrastructure_id of this CreateAutonomousContainerDatabaseDetails.
+        :type: str
+        """
+        self._autonomous_exadata_infrastructure_id = autonomous_exadata_infrastructure_id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this CreateAutonomousContainerDatabaseDetails.
+        The `OCID`__ of the compartment containing the Autonomous Container Database.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateAutonomousContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateAutonomousContainerDatabaseDetails.
+        The `OCID`__ of the compartment containing the Autonomous Container Database.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateAutonomousContainerDatabaseDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def patch_model(self):
+        """
+        **[Required]** Gets the patch_model of this CreateAutonomousContainerDatabaseDetails.
+        Database Patch model preference.
+
+        Allowed values for this property are: "RELEASE_UPDATES", "RELEASE_UPDATE_REVISIONS"
+
+
+        :return: The patch_model of this CreateAutonomousContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._patch_model
+
+    @patch_model.setter
+    def patch_model(self, patch_model):
+        """
+        Sets the patch_model of this CreateAutonomousContainerDatabaseDetails.
+        Database Patch model preference.
+
+
+        :param patch_model: The patch_model of this CreateAutonomousContainerDatabaseDetails.
+        :type: str
+        """
+        allowed_values = ["RELEASE_UPDATES", "RELEASE_UPDATE_REVISIONS"]
+        if not value_allowed_none_or_none_sentinel(patch_model, allowed_values):
+            raise ValueError(
+                "Invalid value for `patch_model`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._patch_model = patch_model
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateAutonomousContainerDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateAutonomousContainerDatabaseDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateAutonomousContainerDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateAutonomousContainerDatabaseDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateAutonomousContainerDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateAutonomousContainerDatabaseDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateAutonomousContainerDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateAutonomousContainerDatabaseDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def backup_config(self):
+        """
+        Gets the backup_config of this CreateAutonomousContainerDatabaseDetails.
+
+        :return: The backup_config of this CreateAutonomousContainerDatabaseDetails.
+        :rtype: AutonomousContainerDatabaseBackupConfig
+        """
+        return self._backup_config
+
+    @backup_config.setter
+    def backup_config(self, backup_config):
+        """
+        Sets the backup_config of this CreateAutonomousContainerDatabaseDetails.
+
+        :param backup_config: The backup_config of this CreateAutonomousContainerDatabaseDetails.
+        :type: AutonomousContainerDatabaseBackupConfig
+        """
+        self._backup_config = backup_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_autonomous_database_base.py
+++ b/src/oci/database/models/create_autonomous_database_base.py
@@ -86,6 +86,14 @@ class CreateAutonomousDatabaseBase(object):
             The value to assign to the is_auto_scaling_enabled property of this CreateAutonomousDatabaseBase.
         :type is_auto_scaling_enabled: bool
 
+        :param is_dedicated:
+            The value to assign to the is_dedicated property of this CreateAutonomousDatabaseBase.
+        :type is_dedicated: bool
+
+        :param autonomous_container_database_id:
+            The value to assign to the autonomous_container_database_id property of this CreateAutonomousDatabaseBase.
+        :type autonomous_container_database_id: str
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this CreateAutonomousDatabaseBase.
         :type freeform_tags: dict(str, str)
@@ -110,6 +118,8 @@ class CreateAutonomousDatabaseBase(object):
             'display_name': 'str',
             'license_model': 'str',
             'is_auto_scaling_enabled': 'bool',
+            'is_dedicated': 'bool',
+            'autonomous_container_database_id': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str'
@@ -125,6 +135,8 @@ class CreateAutonomousDatabaseBase(object):
             'display_name': 'displayName',
             'license_model': 'licenseModel',
             'is_auto_scaling_enabled': 'isAutoScalingEnabled',
+            'is_dedicated': 'isDedicated',
+            'autonomous_container_database_id': 'autonomousContainerDatabaseId',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source'
@@ -139,6 +151,8 @@ class CreateAutonomousDatabaseBase(object):
         self._display_name = None
         self._license_model = None
         self._is_auto_scaling_enabled = None
+        self._is_dedicated = None
+        self._autonomous_container_database_id = None
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None
@@ -394,6 +408,58 @@ class CreateAutonomousDatabaseBase(object):
         :type: bool
         """
         self._is_auto_scaling_enabled = is_auto_scaling_enabled
+
+    @property
+    def is_dedicated(self):
+        """
+        Gets the is_dedicated of this CreateAutonomousDatabaseBase.
+        True if it is dedicated database.
+
+
+        :return: The is_dedicated of this CreateAutonomousDatabaseBase.
+        :rtype: bool
+        """
+        return self._is_dedicated
+
+    @is_dedicated.setter
+    def is_dedicated(self, is_dedicated):
+        """
+        Sets the is_dedicated of this CreateAutonomousDatabaseBase.
+        True if it is dedicated database.
+
+
+        :param is_dedicated: The is_dedicated of this CreateAutonomousDatabaseBase.
+        :type: bool
+        """
+        self._is_dedicated = is_dedicated
+
+    @property
+    def autonomous_container_database_id(self):
+        """
+        Gets the autonomous_container_database_id of this CreateAutonomousDatabaseBase.
+        The Autonomous Container Database `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The autonomous_container_database_id of this CreateAutonomousDatabaseBase.
+        :rtype: str
+        """
+        return self._autonomous_container_database_id
+
+    @autonomous_container_database_id.setter
+    def autonomous_container_database_id(self, autonomous_container_database_id):
+        """
+        Sets the autonomous_container_database_id of this CreateAutonomousDatabaseBase.
+        The Autonomous Container Database `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param autonomous_container_database_id: The autonomous_container_database_id of this CreateAutonomousDatabaseBase.
+        :type: str
+        """
+        self._autonomous_container_database_id = autonomous_container_database_id
 
     @property
     def freeform_tags(self):

--- a/src/oci/database/models/create_autonomous_database_clone_details.py
+++ b/src/oci/database/models/create_autonomous_database_clone_details.py
@@ -64,6 +64,14 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             The value to assign to the is_auto_scaling_enabled property of this CreateAutonomousDatabaseCloneDetails.
         :type is_auto_scaling_enabled: bool
 
+        :param is_dedicated:
+            The value to assign to the is_dedicated property of this CreateAutonomousDatabaseCloneDetails.
+        :type is_dedicated: bool
+
+        :param autonomous_container_database_id:
+            The value to assign to the autonomous_container_database_id property of this CreateAutonomousDatabaseCloneDetails.
+        :type autonomous_container_database_id: str
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this CreateAutonomousDatabaseCloneDetails.
         :type freeform_tags: dict(str, str)
@@ -97,6 +105,8 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'display_name': 'str',
             'license_model': 'str',
             'is_auto_scaling_enabled': 'bool',
+            'is_dedicated': 'bool',
+            'autonomous_container_database_id': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str',
@@ -114,6 +124,8 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'display_name': 'displayName',
             'license_model': 'licenseModel',
             'is_auto_scaling_enabled': 'isAutoScalingEnabled',
+            'is_dedicated': 'isDedicated',
+            'autonomous_container_database_id': 'autonomousContainerDatabaseId',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source',
@@ -130,6 +142,8 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
         self._display_name = None
         self._license_model = None
         self._is_auto_scaling_enabled = None
+        self._is_dedicated = None
+        self._autonomous_container_database_id = None
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None

--- a/src/oci/database/models/create_autonomous_database_details.py
+++ b/src/oci/database/models/create_autonomous_database_details.py
@@ -56,6 +56,14 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             The value to assign to the is_auto_scaling_enabled property of this CreateAutonomousDatabaseDetails.
         :type is_auto_scaling_enabled: bool
 
+        :param is_dedicated:
+            The value to assign to the is_dedicated property of this CreateAutonomousDatabaseDetails.
+        :type is_dedicated: bool
+
+        :param autonomous_container_database_id:
+            The value to assign to the autonomous_container_database_id property of this CreateAutonomousDatabaseDetails.
+        :type autonomous_container_database_id: str
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this CreateAutonomousDatabaseDetails.
         :type freeform_tags: dict(str, str)
@@ -80,6 +88,8 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'display_name': 'str',
             'license_model': 'str',
             'is_auto_scaling_enabled': 'bool',
+            'is_dedicated': 'bool',
+            'autonomous_container_database_id': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str'
@@ -95,6 +105,8 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'display_name': 'displayName',
             'license_model': 'licenseModel',
             'is_auto_scaling_enabled': 'isAutoScalingEnabled',
+            'is_dedicated': 'isDedicated',
+            'autonomous_container_database_id': 'autonomousContainerDatabaseId',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source'
@@ -109,6 +121,8 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
         self._display_name = None
         self._license_model = None
         self._is_auto_scaling_enabled = None
+        self._is_dedicated = None
+        self._autonomous_container_database_id = None
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None

--- a/src/oci/database/models/create_db_home_with_db_system_id_base.py
+++ b/src/oci/database/models/create_db_home_with_db_system_id_base.py
@@ -81,7 +81,7 @@ class CreateDbHomeWithDbSystemIdBase(object):
     @property
     def db_system_id(self):
         """
-        **[Required]** Gets the db_system_id of this CreateDbHomeWithDbSystemIdBase.
+        Gets the db_system_id of this CreateDbHomeWithDbSystemIdBase.
         The `OCID`__ of the DB system.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm

--- a/src/oci/database/models/day_of_week.py
+++ b/src/oci/database/models/day_of_week.py
@@ -1,0 +1,105 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DayOfWeek(object):
+    """
+    Day of the week.
+    """
+
+    #: A constant which can be used with the name property of a DayOfWeek.
+    #: This constant has a value of "MONDAY"
+    NAME_MONDAY = "MONDAY"
+
+    #: A constant which can be used with the name property of a DayOfWeek.
+    #: This constant has a value of "TUESDAY"
+    NAME_TUESDAY = "TUESDAY"
+
+    #: A constant which can be used with the name property of a DayOfWeek.
+    #: This constant has a value of "WEDNESDAY"
+    NAME_WEDNESDAY = "WEDNESDAY"
+
+    #: A constant which can be used with the name property of a DayOfWeek.
+    #: This constant has a value of "THURSDAY"
+    NAME_THURSDAY = "THURSDAY"
+
+    #: A constant which can be used with the name property of a DayOfWeek.
+    #: This constant has a value of "FRIDAY"
+    NAME_FRIDAY = "FRIDAY"
+
+    #: A constant which can be used with the name property of a DayOfWeek.
+    #: This constant has a value of "SATURDAY"
+    NAME_SATURDAY = "SATURDAY"
+
+    #: A constant which can be used with the name property of a DayOfWeek.
+    #: This constant has a value of "SUNDAY"
+    NAME_SUNDAY = "SUNDAY"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DayOfWeek object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this DayOfWeek.
+            Allowed values for this property are: "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type name: str
+
+        """
+        self.swagger_types = {
+            'name': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name'
+        }
+
+        self._name = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this DayOfWeek.
+        Name of the day of the week.
+
+        Allowed values for this property are: "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The name of this DayOfWeek.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this DayOfWeek.
+        Name of the day of the week.
+
+
+        :param name: The name of this DayOfWeek.
+        :type: str
+        """
+        allowed_values = ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"]
+        if not value_allowed_none_or_none_sentinel(name, allowed_values):
+            name = 'UNKNOWN_ENUM_VALUE'
+        self._name = name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/launch_autonomous_exadata_infrastructure_details.py
+++ b/src/oci/database/models/launch_autonomous_exadata_infrastructure_details.py
@@ -1,0 +1,407 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class LaunchAutonomousExadataInfrastructureDetails(object):
+    """
+    Describes the input parameters to launch a new Autonomous Exadata Infrastructure.
+    """
+
+    #: A constant which can be used with the license_model property of a LaunchAutonomousExadataInfrastructureDetails.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a LaunchAutonomousExadataInfrastructureDetails.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new LaunchAutonomousExadataInfrastructureDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this LaunchAutonomousExadataInfrastructureDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this LaunchAutonomousExadataInfrastructureDetails.
+        :type display_name: str
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this LaunchAutonomousExadataInfrastructureDetails.
+        :type availability_domain: str
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this LaunchAutonomousExadataInfrastructureDetails.
+        :type subnet_id: str
+
+        :param shape:
+            The value to assign to the shape property of this LaunchAutonomousExadataInfrastructureDetails.
+        :type shape: str
+
+        :param domain:
+            The value to assign to the domain property of this LaunchAutonomousExadataInfrastructureDetails.
+        :type domain: str
+
+        :param license_model:
+            The value to assign to the license_model property of this LaunchAutonomousExadataInfrastructureDetails.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+        :type license_model: str
+
+        :param maintenance_window_details:
+            The value to assign to the maintenance_window_details property of this LaunchAutonomousExadataInfrastructureDetails.
+        :type maintenance_window_details: MaintenanceWindow
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this LaunchAutonomousExadataInfrastructureDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this LaunchAutonomousExadataInfrastructureDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'availability_domain': 'str',
+            'subnet_id': 'str',
+            'shape': 'str',
+            'domain': 'str',
+            'license_model': 'str',
+            'maintenance_window_details': 'MaintenanceWindow',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'availability_domain': 'availabilityDomain',
+            'subnet_id': 'subnetId',
+            'shape': 'shape',
+            'domain': 'domain',
+            'license_model': 'licenseModel',
+            'maintenance_window_details': 'maintenanceWindowDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._display_name = None
+        self._availability_domain = None
+        self._subnet_id = None
+        self._shape = None
+        self._domain = None
+        self._license_model = None
+        self._maintenance_window_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this LaunchAutonomousExadataInfrastructureDetails.
+        The `OCID`__ of the compartment the Autonomous Exadata Infrastructure belongs in.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this LaunchAutonomousExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this LaunchAutonomousExadataInfrastructureDetails.
+        The `OCID`__ of the compartment the Autonomous Exadata Infrastructure belongs in.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this LaunchAutonomousExadataInfrastructureDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this LaunchAutonomousExadataInfrastructureDetails.
+        The user-friendly name for the Autonomous Exadata Infrastructure. It does not have to be unique.
+
+
+        :return: The display_name of this LaunchAutonomousExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this LaunchAutonomousExadataInfrastructureDetails.
+        The user-friendly name for the Autonomous Exadata Infrastructure. It does not have to be unique.
+
+
+        :param display_name: The display_name of this LaunchAutonomousExadataInfrastructureDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def availability_domain(self):
+        """
+        **[Required]** Gets the availability_domain of this LaunchAutonomousExadataInfrastructureDetails.
+        The availability domain where the Autonomous Exadata Infrastructure is located.
+
+
+        :return: The availability_domain of this LaunchAutonomousExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this LaunchAutonomousExadataInfrastructureDetails.
+        The availability domain where the Autonomous Exadata Infrastructure is located.
+
+
+        :param availability_domain: The availability_domain of this LaunchAutonomousExadataInfrastructureDetails.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def subnet_id(self):
+        """
+        **[Required]** Gets the subnet_id of this LaunchAutonomousExadataInfrastructureDetails.
+        The `OCID`__ of the subnet the Autonomous Exadata Infrastructure is associated with.
+
+        **Subnet Restrictions:**
+        - For Autonomous Exadata Infrastructures, do not use a subnet that overlaps with 192.168.128.0/20
+
+        These subnets are used by the Oracle Clusterware private interconnect on the database instance.
+        Specifying an overlapping subnet will cause the private interconnect to malfunction.
+        This restriction applies to both the client subnet and backup subnet.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The subnet_id of this LaunchAutonomousExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._subnet_id
+
+    @subnet_id.setter
+    def subnet_id(self, subnet_id):
+        """
+        Sets the subnet_id of this LaunchAutonomousExadataInfrastructureDetails.
+        The `OCID`__ of the subnet the Autonomous Exadata Infrastructure is associated with.
+
+        **Subnet Restrictions:**
+        - For Autonomous Exadata Infrastructures, do not use a subnet that overlaps with 192.168.128.0/20
+
+        These subnets are used by the Oracle Clusterware private interconnect on the database instance.
+        Specifying an overlapping subnet will cause the private interconnect to malfunction.
+        This restriction applies to both the client subnet and backup subnet.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param subnet_id: The subnet_id of this LaunchAutonomousExadataInfrastructureDetails.
+        :type: str
+        """
+        self._subnet_id = subnet_id
+
+    @property
+    def shape(self):
+        """
+        **[Required]** Gets the shape of this LaunchAutonomousExadataInfrastructureDetails.
+        The shape of the Autonomous Exadata Infrastructure. The shape determines resources allocated to the Autonomous Exadata Infrastructure (CPU cores, memory and storage). To get a list of shapes, use the ListDbSystemShapes operation.
+
+
+        :return: The shape of this LaunchAutonomousExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this LaunchAutonomousExadataInfrastructureDetails.
+        The shape of the Autonomous Exadata Infrastructure. The shape determines resources allocated to the Autonomous Exadata Infrastructure (CPU cores, memory and storage). To get a list of shapes, use the ListDbSystemShapes operation.
+
+
+        :param shape: The shape of this LaunchAutonomousExadataInfrastructureDetails.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def domain(self):
+        """
+        Gets the domain of this LaunchAutonomousExadataInfrastructureDetails.
+        A domain name used for the Autonomous Exadata Infrastructure. If the Oracle-provided Internet and VCN
+        Resolver is enabled for the specified subnet, the domain name for the subnet is used
+        (don't provide one). Otherwise, provide a valid DNS domain name. Hyphens (-) are not permitted.
+
+
+        :return: The domain of this LaunchAutonomousExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._domain
+
+    @domain.setter
+    def domain(self, domain):
+        """
+        Sets the domain of this LaunchAutonomousExadataInfrastructureDetails.
+        A domain name used for the Autonomous Exadata Infrastructure. If the Oracle-provided Internet and VCN
+        Resolver is enabled for the specified subnet, the domain name for the subnet is used
+        (don't provide one). Otherwise, provide a valid DNS domain name. Hyphens (-) are not permitted.
+
+
+        :param domain: The domain of this LaunchAutonomousExadataInfrastructureDetails.
+        :type: str
+        """
+        self._domain = domain
+
+    @property
+    def license_model(self):
+        """
+        Gets the license_model of this LaunchAutonomousExadataInfrastructureDetails.
+        The Oracle license model that applies to all the databases in the Autonomous Exadata Infrastructure. The default is BRING_YOUR_OWN_LICENSE.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+
+
+        :return: The license_model of this LaunchAutonomousExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this LaunchAutonomousExadataInfrastructureDetails.
+        The Oracle license model that applies to all the databases in the Autonomous Exadata Infrastructure. The default is BRING_YOUR_OWN_LICENSE.
+
+
+        :param license_model: The license_model of this LaunchAutonomousExadataInfrastructureDetails.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            raise ValueError(
+                "Invalid value for `license_model`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._license_model = license_model
+
+    @property
+    def maintenance_window_details(self):
+        """
+        Gets the maintenance_window_details of this LaunchAutonomousExadataInfrastructureDetails.
+
+        :return: The maintenance_window_details of this LaunchAutonomousExadataInfrastructureDetails.
+        :rtype: MaintenanceWindow
+        """
+        return self._maintenance_window_details
+
+    @maintenance_window_details.setter
+    def maintenance_window_details(self, maintenance_window_details):
+        """
+        Sets the maintenance_window_details of this LaunchAutonomousExadataInfrastructureDetails.
+
+        :param maintenance_window_details: The maintenance_window_details of this LaunchAutonomousExadataInfrastructureDetails.
+        :type: MaintenanceWindow
+        """
+        self._maintenance_window_details = maintenance_window_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this LaunchAutonomousExadataInfrastructureDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this LaunchAutonomousExadataInfrastructureDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this LaunchAutonomousExadataInfrastructureDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this LaunchAutonomousExadataInfrastructureDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this LaunchAutonomousExadataInfrastructureDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this LaunchAutonomousExadataInfrastructureDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this LaunchAutonomousExadataInfrastructureDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this LaunchAutonomousExadataInfrastructureDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/launch_db_system_base.py
+++ b/src/oci/database/models/launch_db_system_base.py
@@ -802,7 +802,7 @@ class LaunchDbSystemBase(object):
         """
         Gets the source of this LaunchDbSystemBase.
         The source of the database:
-          NONE for creating a new database. DB_BACKUP for creating a new database by restoring from a backup. The default is NONE.
+        NONE for creating a new database. DB_BACKUP for creating a new database by restoring from a backup. The default is NONE.
 
         Allowed values for this property are: "NONE", "DB_BACKUP"
 
@@ -817,7 +817,7 @@ class LaunchDbSystemBase(object):
         """
         Sets the source of this LaunchDbSystemBase.
         The source of the database:
-          NONE for creating a new database. DB_BACKUP for creating a new database by restoring from a backup. The default is NONE.
+        NONE for creating a new database. DB_BACKUP for creating a new database by restoring from a backup. The default is NONE.
 
 
         :param source: The source of this LaunchDbSystemBase.

--- a/src/oci/database/models/launch_db_system_details.py
+++ b/src/oci/database/models/launch_db_system_details.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class LaunchDbSystemDetails(LaunchDbSystemBase):
     """
-    LaunchDbSystemDetails model.
+    Used for creating a new DB system. Does not use backups or an existing database for the creation of the initial database.
     """
 
     #: A constant which can be used with the database_edition property of a LaunchDbSystemDetails.

--- a/src/oci/database/models/launch_db_system_from_backup_details.py
+++ b/src/oci/database/models/launch_db_system_from_backup_details.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class LaunchDbSystemFromBackupDetails(LaunchDbSystemBase):
     """
-    LaunchDbSystemFromBackupDetails model.
+    Used for creating a new DB system from a database backup.
     """
 
     #: A constant which can be used with the database_edition property of a LaunchDbSystemFromBackupDetails.

--- a/src/oci/database/models/maintenance_run.py
+++ b/src/oci/database/models/maintenance_run.py
@@ -1,0 +1,521 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class MaintenanceRun(object):
+    """
+    Details of a Maintenance Run.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a MaintenanceRun.
+    #: This constant has a value of "SCHEDULED"
+    LIFECYCLE_STATE_SCHEDULED = "SCHEDULED"
+
+    #: A constant which can be used with the lifecycle_state property of a MaintenanceRun.
+    #: This constant has a value of "IN_PROGRESS"
+    LIFECYCLE_STATE_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the lifecycle_state property of a MaintenanceRun.
+    #: This constant has a value of "SUCCEEDED"
+    LIFECYCLE_STATE_SUCCEEDED = "SUCCEEDED"
+
+    #: A constant which can be used with the lifecycle_state property of a MaintenanceRun.
+    #: This constant has a value of "SKIPPED"
+    LIFECYCLE_STATE_SKIPPED = "SKIPPED"
+
+    #: A constant which can be used with the lifecycle_state property of a MaintenanceRun.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the target_resource_type property of a MaintenanceRun.
+    #: This constant has a value of "AUTONOMOUS_EXADATA_INFRASTRUCTURE"
+    TARGET_RESOURCE_TYPE_AUTONOMOUS_EXADATA_INFRASTRUCTURE = "AUTONOMOUS_EXADATA_INFRASTRUCTURE"
+
+    #: A constant which can be used with the target_resource_type property of a MaintenanceRun.
+    #: This constant has a value of "AUTONOMOUS_CONTAINER_DATABASE"
+    TARGET_RESOURCE_TYPE_AUTONOMOUS_CONTAINER_DATABASE = "AUTONOMOUS_CONTAINER_DATABASE"
+
+    #: A constant which can be used with the maintenance_type property of a MaintenanceRun.
+    #: This constant has a value of "PLANNED"
+    MAINTENANCE_TYPE_PLANNED = "PLANNED"
+
+    #: A constant which can be used with the maintenance_type property of a MaintenanceRun.
+    #: This constant has a value of "UNPLANNED"
+    MAINTENANCE_TYPE_UNPLANNED = "UNPLANNED"
+
+    #: A constant which can be used with the maintenance_subtype property of a MaintenanceRun.
+    #: This constant has a value of "QUARTERLY"
+    MAINTENANCE_SUBTYPE_QUARTERLY = "QUARTERLY"
+
+    #: A constant which can be used with the maintenance_subtype property of a MaintenanceRun.
+    #: This constant has a value of "HARDWARE"
+    MAINTENANCE_SUBTYPE_HARDWARE = "HARDWARE"
+
+    #: A constant which can be used with the maintenance_subtype property of a MaintenanceRun.
+    #: This constant has a value of "CRITICAL"
+    MAINTENANCE_SUBTYPE_CRITICAL = "CRITICAL"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new MaintenanceRun object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this MaintenanceRun.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this MaintenanceRun.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this MaintenanceRun.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this MaintenanceRun.
+        :type description: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this MaintenanceRun.
+            Allowed values for this property are: "SCHEDULED", "IN_PROGRESS", "SUCCEEDED", "SKIPPED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this MaintenanceRun.
+        :type lifecycle_details: str
+
+        :param time_scheduled:
+            The value to assign to the time_scheduled property of this MaintenanceRun.
+        :type time_scheduled: datetime
+
+        :param time_started:
+            The value to assign to the time_started property of this MaintenanceRun.
+        :type time_started: datetime
+
+        :param time_ended:
+            The value to assign to the time_ended property of this MaintenanceRun.
+        :type time_ended: datetime
+
+        :param target_resource_type:
+            The value to assign to the target_resource_type property of this MaintenanceRun.
+            Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type target_resource_type: str
+
+        :param target_resource_id:
+            The value to assign to the target_resource_id property of this MaintenanceRun.
+        :type target_resource_id: str
+
+        :param maintenance_type:
+            The value to assign to the maintenance_type property of this MaintenanceRun.
+            Allowed values for this property are: "PLANNED", "UNPLANNED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type maintenance_type: str
+
+        :param maintenance_subtype:
+            The value to assign to the maintenance_subtype property of this MaintenanceRun.
+            Allowed values for this property are: "QUARTERLY", "HARDWARE", "CRITICAL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type maintenance_subtype: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'description': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'time_scheduled': 'datetime',
+            'time_started': 'datetime',
+            'time_ended': 'datetime',
+            'target_resource_type': 'str',
+            'target_resource_id': 'str',
+            'maintenance_type': 'str',
+            'maintenance_subtype': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'description': 'description',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_scheduled': 'timeScheduled',
+            'time_started': 'timeStarted',
+            'time_ended': 'timeEnded',
+            'target_resource_type': 'targetResourceType',
+            'target_resource_id': 'targetResourceId',
+            'maintenance_type': 'maintenanceType',
+            'maintenance_subtype': 'maintenanceSubtype'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._display_name = None
+        self._description = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._time_scheduled = None
+        self._time_started = None
+        self._time_ended = None
+        self._target_resource_type = None
+        self._target_resource_id = None
+        self._maintenance_type = None
+        self._maintenance_subtype = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this MaintenanceRun.
+        The OCID of the Maintenance Run.
+
+
+        :return: The id of this MaintenanceRun.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this MaintenanceRun.
+        The OCID of the Maintenance Run.
+
+
+        :param id: The id of this MaintenanceRun.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this MaintenanceRun.
+        The OCID of the compartment.
+
+
+        :return: The compartment_id of this MaintenanceRun.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this MaintenanceRun.
+        The OCID of the compartment.
+
+
+        :param compartment_id: The compartment_id of this MaintenanceRun.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this MaintenanceRun.
+        The user-friendly name for the Maintenance Run.
+
+
+        :return: The display_name of this MaintenanceRun.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this MaintenanceRun.
+        The user-friendly name for the Maintenance Run.
+
+
+        :param display_name: The display_name of this MaintenanceRun.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this MaintenanceRun.
+        The text describing this Maintenance Run.
+
+
+        :return: The description of this MaintenanceRun.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this MaintenanceRun.
+        The text describing this Maintenance Run.
+
+
+        :param description: The description of this MaintenanceRun.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this MaintenanceRun.
+        The current state of the Maintenance Run.
+
+        Allowed values for this property are: "SCHEDULED", "IN_PROGRESS", "SUCCEEDED", "SKIPPED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this MaintenanceRun.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this MaintenanceRun.
+        The current state of the Maintenance Run.
+
+
+        :param lifecycle_state: The lifecycle_state of this MaintenanceRun.
+        :type: str
+        """
+        allowed_values = ["SCHEDULED", "IN_PROGRESS", "SUCCEEDED", "SKIPPED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this MaintenanceRun.
+        Additional information about the current lifecycleState.
+
+
+        :return: The lifecycle_details of this MaintenanceRun.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this MaintenanceRun.
+        Additional information about the current lifecycleState.
+
+
+        :param lifecycle_details: The lifecycle_details of this MaintenanceRun.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def time_scheduled(self):
+        """
+        **[Required]** Gets the time_scheduled of this MaintenanceRun.
+        The date and time the Maintenance Run is scheduled for.
+
+
+        :return: The time_scheduled of this MaintenanceRun.
+        :rtype: datetime
+        """
+        return self._time_scheduled
+
+    @time_scheduled.setter
+    def time_scheduled(self, time_scheduled):
+        """
+        Sets the time_scheduled of this MaintenanceRun.
+        The date and time the Maintenance Run is scheduled for.
+
+
+        :param time_scheduled: The time_scheduled of this MaintenanceRun.
+        :type: datetime
+        """
+        self._time_scheduled = time_scheduled
+
+    @property
+    def time_started(self):
+        """
+        Gets the time_started of this MaintenanceRun.
+        The date and time the Maintenance Run starts.
+
+
+        :return: The time_started of this MaintenanceRun.
+        :rtype: datetime
+        """
+        return self._time_started
+
+    @time_started.setter
+    def time_started(self, time_started):
+        """
+        Sets the time_started of this MaintenanceRun.
+        The date and time the Maintenance Run starts.
+
+
+        :param time_started: The time_started of this MaintenanceRun.
+        :type: datetime
+        """
+        self._time_started = time_started
+
+    @property
+    def time_ended(self):
+        """
+        Gets the time_ended of this MaintenanceRun.
+        The date and time the Maintenance Run was completed.
+
+
+        :return: The time_ended of this MaintenanceRun.
+        :rtype: datetime
+        """
+        return self._time_ended
+
+    @time_ended.setter
+    def time_ended(self, time_ended):
+        """
+        Sets the time_ended of this MaintenanceRun.
+        The date and time the Maintenance Run was completed.
+
+
+        :param time_ended: The time_ended of this MaintenanceRun.
+        :type: datetime
+        """
+        self._time_ended = time_ended
+
+    @property
+    def target_resource_type(self):
+        """
+        Gets the target_resource_type of this MaintenanceRun.
+        The type of the target resource on which the Maintenance Run occurs.
+
+        Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The target_resource_type of this MaintenanceRun.
+        :rtype: str
+        """
+        return self._target_resource_type
+
+    @target_resource_type.setter
+    def target_resource_type(self, target_resource_type):
+        """
+        Sets the target_resource_type of this MaintenanceRun.
+        The type of the target resource on which the Maintenance Run occurs.
+
+
+        :param target_resource_type: The target_resource_type of this MaintenanceRun.
+        :type: str
+        """
+        allowed_values = ["AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE"]
+        if not value_allowed_none_or_none_sentinel(target_resource_type, allowed_values):
+            target_resource_type = 'UNKNOWN_ENUM_VALUE'
+        self._target_resource_type = target_resource_type
+
+    @property
+    def target_resource_id(self):
+        """
+        Gets the target_resource_id of this MaintenanceRun.
+        The ID of the target resource on which the Maintenance Run occurs.
+
+
+        :return: The target_resource_id of this MaintenanceRun.
+        :rtype: str
+        """
+        return self._target_resource_id
+
+    @target_resource_id.setter
+    def target_resource_id(self, target_resource_id):
+        """
+        Sets the target_resource_id of this MaintenanceRun.
+        The ID of the target resource on which the Maintenance Run occurs.
+
+
+        :param target_resource_id: The target_resource_id of this MaintenanceRun.
+        :type: str
+        """
+        self._target_resource_id = target_resource_id
+
+    @property
+    def maintenance_type(self):
+        """
+        Gets the maintenance_type of this MaintenanceRun.
+        Maintenance type.
+
+        Allowed values for this property are: "PLANNED", "UNPLANNED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The maintenance_type of this MaintenanceRun.
+        :rtype: str
+        """
+        return self._maintenance_type
+
+    @maintenance_type.setter
+    def maintenance_type(self, maintenance_type):
+        """
+        Sets the maintenance_type of this MaintenanceRun.
+        Maintenance type.
+
+
+        :param maintenance_type: The maintenance_type of this MaintenanceRun.
+        :type: str
+        """
+        allowed_values = ["PLANNED", "UNPLANNED"]
+        if not value_allowed_none_or_none_sentinel(maintenance_type, allowed_values):
+            maintenance_type = 'UNKNOWN_ENUM_VALUE'
+        self._maintenance_type = maintenance_type
+
+    @property
+    def maintenance_subtype(self):
+        """
+        Gets the maintenance_subtype of this MaintenanceRun.
+        Maintenance sub-type.
+
+        Allowed values for this property are: "QUARTERLY", "HARDWARE", "CRITICAL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The maintenance_subtype of this MaintenanceRun.
+        :rtype: str
+        """
+        return self._maintenance_subtype
+
+    @maintenance_subtype.setter
+    def maintenance_subtype(self, maintenance_subtype):
+        """
+        Sets the maintenance_subtype of this MaintenanceRun.
+        Maintenance sub-type.
+
+
+        :param maintenance_subtype: The maintenance_subtype of this MaintenanceRun.
+        :type: str
+        """
+        allowed_values = ["QUARTERLY", "HARDWARE", "CRITICAL"]
+        if not value_allowed_none_or_none_sentinel(maintenance_subtype, allowed_values):
+            maintenance_subtype = 'UNKNOWN_ENUM_VALUE'
+        self._maintenance_subtype = maintenance_subtype
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/maintenance_run_summary.py
+++ b/src/oci/database/models/maintenance_run_summary.py
@@ -1,0 +1,521 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class MaintenanceRunSummary(object):
+    """
+    Details of a Maintenance Run.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a MaintenanceRunSummary.
+    #: This constant has a value of "SCHEDULED"
+    LIFECYCLE_STATE_SCHEDULED = "SCHEDULED"
+
+    #: A constant which can be used with the lifecycle_state property of a MaintenanceRunSummary.
+    #: This constant has a value of "IN_PROGRESS"
+    LIFECYCLE_STATE_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the lifecycle_state property of a MaintenanceRunSummary.
+    #: This constant has a value of "SUCCEEDED"
+    LIFECYCLE_STATE_SUCCEEDED = "SUCCEEDED"
+
+    #: A constant which can be used with the lifecycle_state property of a MaintenanceRunSummary.
+    #: This constant has a value of "SKIPPED"
+    LIFECYCLE_STATE_SKIPPED = "SKIPPED"
+
+    #: A constant which can be used with the lifecycle_state property of a MaintenanceRunSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the target_resource_type property of a MaintenanceRunSummary.
+    #: This constant has a value of "AUTONOMOUS_EXADATA_INFRASTRUCTURE"
+    TARGET_RESOURCE_TYPE_AUTONOMOUS_EXADATA_INFRASTRUCTURE = "AUTONOMOUS_EXADATA_INFRASTRUCTURE"
+
+    #: A constant which can be used with the target_resource_type property of a MaintenanceRunSummary.
+    #: This constant has a value of "AUTONOMOUS_CONTAINER_DATABASE"
+    TARGET_RESOURCE_TYPE_AUTONOMOUS_CONTAINER_DATABASE = "AUTONOMOUS_CONTAINER_DATABASE"
+
+    #: A constant which can be used with the maintenance_type property of a MaintenanceRunSummary.
+    #: This constant has a value of "PLANNED"
+    MAINTENANCE_TYPE_PLANNED = "PLANNED"
+
+    #: A constant which can be used with the maintenance_type property of a MaintenanceRunSummary.
+    #: This constant has a value of "UNPLANNED"
+    MAINTENANCE_TYPE_UNPLANNED = "UNPLANNED"
+
+    #: A constant which can be used with the maintenance_subtype property of a MaintenanceRunSummary.
+    #: This constant has a value of "QUARTERLY"
+    MAINTENANCE_SUBTYPE_QUARTERLY = "QUARTERLY"
+
+    #: A constant which can be used with the maintenance_subtype property of a MaintenanceRunSummary.
+    #: This constant has a value of "HARDWARE"
+    MAINTENANCE_SUBTYPE_HARDWARE = "HARDWARE"
+
+    #: A constant which can be used with the maintenance_subtype property of a MaintenanceRunSummary.
+    #: This constant has a value of "CRITICAL"
+    MAINTENANCE_SUBTYPE_CRITICAL = "CRITICAL"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new MaintenanceRunSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this MaintenanceRunSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this MaintenanceRunSummary.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this MaintenanceRunSummary.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this MaintenanceRunSummary.
+        :type description: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this MaintenanceRunSummary.
+            Allowed values for this property are: "SCHEDULED", "IN_PROGRESS", "SUCCEEDED", "SKIPPED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this MaintenanceRunSummary.
+        :type lifecycle_details: str
+
+        :param time_scheduled:
+            The value to assign to the time_scheduled property of this MaintenanceRunSummary.
+        :type time_scheduled: datetime
+
+        :param time_started:
+            The value to assign to the time_started property of this MaintenanceRunSummary.
+        :type time_started: datetime
+
+        :param time_ended:
+            The value to assign to the time_ended property of this MaintenanceRunSummary.
+        :type time_ended: datetime
+
+        :param target_resource_type:
+            The value to assign to the target_resource_type property of this MaintenanceRunSummary.
+            Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type target_resource_type: str
+
+        :param target_resource_id:
+            The value to assign to the target_resource_id property of this MaintenanceRunSummary.
+        :type target_resource_id: str
+
+        :param maintenance_type:
+            The value to assign to the maintenance_type property of this MaintenanceRunSummary.
+            Allowed values for this property are: "PLANNED", "UNPLANNED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type maintenance_type: str
+
+        :param maintenance_subtype:
+            The value to assign to the maintenance_subtype property of this MaintenanceRunSummary.
+            Allowed values for this property are: "QUARTERLY", "HARDWARE", "CRITICAL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type maintenance_subtype: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'description': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'time_scheduled': 'datetime',
+            'time_started': 'datetime',
+            'time_ended': 'datetime',
+            'target_resource_type': 'str',
+            'target_resource_id': 'str',
+            'maintenance_type': 'str',
+            'maintenance_subtype': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'description': 'description',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_scheduled': 'timeScheduled',
+            'time_started': 'timeStarted',
+            'time_ended': 'timeEnded',
+            'target_resource_type': 'targetResourceType',
+            'target_resource_id': 'targetResourceId',
+            'maintenance_type': 'maintenanceType',
+            'maintenance_subtype': 'maintenanceSubtype'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._display_name = None
+        self._description = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._time_scheduled = None
+        self._time_started = None
+        self._time_ended = None
+        self._target_resource_type = None
+        self._target_resource_id = None
+        self._maintenance_type = None
+        self._maintenance_subtype = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this MaintenanceRunSummary.
+        The OCID of the Maintenance Run.
+
+
+        :return: The id of this MaintenanceRunSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this MaintenanceRunSummary.
+        The OCID of the Maintenance Run.
+
+
+        :param id: The id of this MaintenanceRunSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this MaintenanceRunSummary.
+        The OCID of the compartment.
+
+
+        :return: The compartment_id of this MaintenanceRunSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this MaintenanceRunSummary.
+        The OCID of the compartment.
+
+
+        :param compartment_id: The compartment_id of this MaintenanceRunSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this MaintenanceRunSummary.
+        The user-friendly name for the Maintenance Run.
+
+
+        :return: The display_name of this MaintenanceRunSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this MaintenanceRunSummary.
+        The user-friendly name for the Maintenance Run.
+
+
+        :param display_name: The display_name of this MaintenanceRunSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this MaintenanceRunSummary.
+        The text describing this Maintenance Run.
+
+
+        :return: The description of this MaintenanceRunSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this MaintenanceRunSummary.
+        The text describing this Maintenance Run.
+
+
+        :param description: The description of this MaintenanceRunSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this MaintenanceRunSummary.
+        The current state of the Maintenance Run.
+
+        Allowed values for this property are: "SCHEDULED", "IN_PROGRESS", "SUCCEEDED", "SKIPPED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this MaintenanceRunSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this MaintenanceRunSummary.
+        The current state of the Maintenance Run.
+
+
+        :param lifecycle_state: The lifecycle_state of this MaintenanceRunSummary.
+        :type: str
+        """
+        allowed_values = ["SCHEDULED", "IN_PROGRESS", "SUCCEEDED", "SKIPPED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this MaintenanceRunSummary.
+        Additional information about the current lifecycleState.
+
+
+        :return: The lifecycle_details of this MaintenanceRunSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this MaintenanceRunSummary.
+        Additional information about the current lifecycleState.
+
+
+        :param lifecycle_details: The lifecycle_details of this MaintenanceRunSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def time_scheduled(self):
+        """
+        **[Required]** Gets the time_scheduled of this MaintenanceRunSummary.
+        The date and time the Maintenance Run is scheduled for.
+
+
+        :return: The time_scheduled of this MaintenanceRunSummary.
+        :rtype: datetime
+        """
+        return self._time_scheduled
+
+    @time_scheduled.setter
+    def time_scheduled(self, time_scheduled):
+        """
+        Sets the time_scheduled of this MaintenanceRunSummary.
+        The date and time the Maintenance Run is scheduled for.
+
+
+        :param time_scheduled: The time_scheduled of this MaintenanceRunSummary.
+        :type: datetime
+        """
+        self._time_scheduled = time_scheduled
+
+    @property
+    def time_started(self):
+        """
+        Gets the time_started of this MaintenanceRunSummary.
+        The date and time the Maintenance Run starts.
+
+
+        :return: The time_started of this MaintenanceRunSummary.
+        :rtype: datetime
+        """
+        return self._time_started
+
+    @time_started.setter
+    def time_started(self, time_started):
+        """
+        Sets the time_started of this MaintenanceRunSummary.
+        The date and time the Maintenance Run starts.
+
+
+        :param time_started: The time_started of this MaintenanceRunSummary.
+        :type: datetime
+        """
+        self._time_started = time_started
+
+    @property
+    def time_ended(self):
+        """
+        Gets the time_ended of this MaintenanceRunSummary.
+        The date and time the Maintenance Run was completed.
+
+
+        :return: The time_ended of this MaintenanceRunSummary.
+        :rtype: datetime
+        """
+        return self._time_ended
+
+    @time_ended.setter
+    def time_ended(self, time_ended):
+        """
+        Sets the time_ended of this MaintenanceRunSummary.
+        The date and time the Maintenance Run was completed.
+
+
+        :param time_ended: The time_ended of this MaintenanceRunSummary.
+        :type: datetime
+        """
+        self._time_ended = time_ended
+
+    @property
+    def target_resource_type(self):
+        """
+        Gets the target_resource_type of this MaintenanceRunSummary.
+        The type of the target resource on which the Maintenance Run occurs.
+
+        Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The target_resource_type of this MaintenanceRunSummary.
+        :rtype: str
+        """
+        return self._target_resource_type
+
+    @target_resource_type.setter
+    def target_resource_type(self, target_resource_type):
+        """
+        Sets the target_resource_type of this MaintenanceRunSummary.
+        The type of the target resource on which the Maintenance Run occurs.
+
+
+        :param target_resource_type: The target_resource_type of this MaintenanceRunSummary.
+        :type: str
+        """
+        allowed_values = ["AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE"]
+        if not value_allowed_none_or_none_sentinel(target_resource_type, allowed_values):
+            target_resource_type = 'UNKNOWN_ENUM_VALUE'
+        self._target_resource_type = target_resource_type
+
+    @property
+    def target_resource_id(self):
+        """
+        Gets the target_resource_id of this MaintenanceRunSummary.
+        The ID of the target resource on which the Maintenance Run occurs.
+
+
+        :return: The target_resource_id of this MaintenanceRunSummary.
+        :rtype: str
+        """
+        return self._target_resource_id
+
+    @target_resource_id.setter
+    def target_resource_id(self, target_resource_id):
+        """
+        Sets the target_resource_id of this MaintenanceRunSummary.
+        The ID of the target resource on which the Maintenance Run occurs.
+
+
+        :param target_resource_id: The target_resource_id of this MaintenanceRunSummary.
+        :type: str
+        """
+        self._target_resource_id = target_resource_id
+
+    @property
+    def maintenance_type(self):
+        """
+        Gets the maintenance_type of this MaintenanceRunSummary.
+        Maintenance type.
+
+        Allowed values for this property are: "PLANNED", "UNPLANNED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The maintenance_type of this MaintenanceRunSummary.
+        :rtype: str
+        """
+        return self._maintenance_type
+
+    @maintenance_type.setter
+    def maintenance_type(self, maintenance_type):
+        """
+        Sets the maintenance_type of this MaintenanceRunSummary.
+        Maintenance type.
+
+
+        :param maintenance_type: The maintenance_type of this MaintenanceRunSummary.
+        :type: str
+        """
+        allowed_values = ["PLANNED", "UNPLANNED"]
+        if not value_allowed_none_or_none_sentinel(maintenance_type, allowed_values):
+            maintenance_type = 'UNKNOWN_ENUM_VALUE'
+        self._maintenance_type = maintenance_type
+
+    @property
+    def maintenance_subtype(self):
+        """
+        Gets the maintenance_subtype of this MaintenanceRunSummary.
+        Maintenance sub-type.
+
+        Allowed values for this property are: "QUARTERLY", "HARDWARE", "CRITICAL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The maintenance_subtype of this MaintenanceRunSummary.
+        :rtype: str
+        """
+        return self._maintenance_subtype
+
+    @maintenance_subtype.setter
+    def maintenance_subtype(self, maintenance_subtype):
+        """
+        Sets the maintenance_subtype of this MaintenanceRunSummary.
+        Maintenance sub-type.
+
+
+        :param maintenance_subtype: The maintenance_subtype of this MaintenanceRunSummary.
+        :type: str
+        """
+        allowed_values = ["QUARTERLY", "HARDWARE", "CRITICAL"]
+        if not value_allowed_none_or_none_sentinel(maintenance_subtype, allowed_values):
+            maintenance_subtype = 'UNKNOWN_ENUM_VALUE'
+        self._maintenance_subtype = maintenance_subtype
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/maintenance_window.py
+++ b/src/oci/database/models/maintenance_window.py
@@ -1,0 +1,213 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class MaintenanceWindow(object):
+    """
+    The scheduling details for the quarterly maintenance window. Patching and system updates take place during the maintenance window.
+    """
+
+    #: A constant which can be used with the preference property of a MaintenanceWindow.
+    #: This constant has a value of "NO_PREFERENCE"
+    PREFERENCE_NO_PREFERENCE = "NO_PREFERENCE"
+
+    #: A constant which can be used with the preference property of a MaintenanceWindow.
+    #: This constant has a value of "CUSTOM_PREFERENCE"
+    PREFERENCE_CUSTOM_PREFERENCE = "CUSTOM_PREFERENCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new MaintenanceWindow object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param preference:
+            The value to assign to the preference property of this MaintenanceWindow.
+            Allowed values for this property are: "NO_PREFERENCE", "CUSTOM_PREFERENCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type preference: str
+
+        :param months:
+            The value to assign to the months property of this MaintenanceWindow.
+        :type months: list[Month]
+
+        :param weeks_of_month:
+            The value to assign to the weeks_of_month property of this MaintenanceWindow.
+        :type weeks_of_month: list[int]
+
+        :param days_of_week:
+            The value to assign to the days_of_week property of this MaintenanceWindow.
+        :type days_of_week: list[DayOfWeek]
+
+        :param hours_of_day:
+            The value to assign to the hours_of_day property of this MaintenanceWindow.
+        :type hours_of_day: list[int]
+
+        """
+        self.swagger_types = {
+            'preference': 'str',
+            'months': 'list[Month]',
+            'weeks_of_month': 'list[int]',
+            'days_of_week': 'list[DayOfWeek]',
+            'hours_of_day': 'list[int]'
+        }
+
+        self.attribute_map = {
+            'preference': 'preference',
+            'months': 'months',
+            'weeks_of_month': 'weeksOfMonth',
+            'days_of_week': 'daysOfWeek',
+            'hours_of_day': 'hoursOfDay'
+        }
+
+        self._preference = None
+        self._months = None
+        self._weeks_of_month = None
+        self._days_of_week = None
+        self._hours_of_day = None
+
+    @property
+    def preference(self):
+        """
+        **[Required]** Gets the preference of this MaintenanceWindow.
+        The maintenance window scheduling preference.
+
+        Allowed values for this property are: "NO_PREFERENCE", "CUSTOM_PREFERENCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The preference of this MaintenanceWindow.
+        :rtype: str
+        """
+        return self._preference
+
+    @preference.setter
+    def preference(self, preference):
+        """
+        Sets the preference of this MaintenanceWindow.
+        The maintenance window scheduling preference.
+
+
+        :param preference: The preference of this MaintenanceWindow.
+        :type: str
+        """
+        allowed_values = ["NO_PREFERENCE", "CUSTOM_PREFERENCE"]
+        if not value_allowed_none_or_none_sentinel(preference, allowed_values):
+            preference = 'UNKNOWN_ENUM_VALUE'
+        self._preference = preference
+
+    @property
+    def months(self):
+        """
+        Gets the months of this MaintenanceWindow.
+        Months during the year when maintenance should be performed.
+
+
+        :return: The months of this MaintenanceWindow.
+        :rtype: list[Month]
+        """
+        return self._months
+
+    @months.setter
+    def months(self, months):
+        """
+        Sets the months of this MaintenanceWindow.
+        Months during the year when maintenance should be performed.
+
+
+        :param months: The months of this MaintenanceWindow.
+        :type: list[Month]
+        """
+        self._months = months
+
+    @property
+    def weeks_of_month(self):
+        """
+        Gets the weeks_of_month of this MaintenanceWindow.
+        Weeks during the month when maintenance should be performed. Weeks start on the 1st, 8th, 15th, and 22nd days of the month, and have a duration of 7 days. Weeks start and end based on calendar dates, not days of the week.
+        For example, to allow maintenance during the 2nd week of the month (from the 8th day to the 14th day of the month), use the value 2. Maintenance cannot be scheduled for the fifth week of months that contain more than 28 days.
+        Note that this parameter works in conjunction with the  daysOfWeek and hoursOfDay parameters to allow you to specify specific days of the week and hours that maintenance will be performed.
+
+
+        :return: The weeks_of_month of this MaintenanceWindow.
+        :rtype: list[int]
+        """
+        return self._weeks_of_month
+
+    @weeks_of_month.setter
+    def weeks_of_month(self, weeks_of_month):
+        """
+        Sets the weeks_of_month of this MaintenanceWindow.
+        Weeks during the month when maintenance should be performed. Weeks start on the 1st, 8th, 15th, and 22nd days of the month, and have a duration of 7 days. Weeks start and end based on calendar dates, not days of the week.
+        For example, to allow maintenance during the 2nd week of the month (from the 8th day to the 14th day of the month), use the value 2. Maintenance cannot be scheduled for the fifth week of months that contain more than 28 days.
+        Note that this parameter works in conjunction with the  daysOfWeek and hoursOfDay parameters to allow you to specify specific days of the week and hours that maintenance will be performed.
+
+
+        :param weeks_of_month: The weeks_of_month of this MaintenanceWindow.
+        :type: list[int]
+        """
+        self._weeks_of_month = weeks_of_month
+
+    @property
+    def days_of_week(self):
+        """
+        Gets the days_of_week of this MaintenanceWindow.
+        Days during the week when maintenance should be performed.
+
+
+        :return: The days_of_week of this MaintenanceWindow.
+        :rtype: list[DayOfWeek]
+        """
+        return self._days_of_week
+
+    @days_of_week.setter
+    def days_of_week(self, days_of_week):
+        """
+        Sets the days_of_week of this MaintenanceWindow.
+        Days during the week when maintenance should be performed.
+
+
+        :param days_of_week: The days_of_week of this MaintenanceWindow.
+        :type: list[DayOfWeek]
+        """
+        self._days_of_week = days_of_week
+
+    @property
+    def hours_of_day(self):
+        """
+        Gets the hours_of_day of this MaintenanceWindow.
+        The window of hours during the day when maintenance should be performed.
+
+
+        :return: The hours_of_day of this MaintenanceWindow.
+        :rtype: list[int]
+        """
+        return self._hours_of_day
+
+    @hours_of_day.setter
+    def hours_of_day(self, hours_of_day):
+        """
+        Sets the hours_of_day of this MaintenanceWindow.
+        The window of hours during the day when maintenance should be performed.
+
+
+        :param hours_of_day: The hours_of_day of this MaintenanceWindow.
+        :type: list[int]
+        """
+        self._hours_of_day = hours_of_day
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/month.py
+++ b/src/oci/database/models/month.py
@@ -1,0 +1,125 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Month(object):
+    """
+    Month of the year.
+    """
+
+    #: A constant which can be used with the name property of a Month.
+    #: This constant has a value of "JANUARY"
+    NAME_JANUARY = "JANUARY"
+
+    #: A constant which can be used with the name property of a Month.
+    #: This constant has a value of "FEBRUARY"
+    NAME_FEBRUARY = "FEBRUARY"
+
+    #: A constant which can be used with the name property of a Month.
+    #: This constant has a value of "MARCH"
+    NAME_MARCH = "MARCH"
+
+    #: A constant which can be used with the name property of a Month.
+    #: This constant has a value of "APRIL"
+    NAME_APRIL = "APRIL"
+
+    #: A constant which can be used with the name property of a Month.
+    #: This constant has a value of "MAY"
+    NAME_MAY = "MAY"
+
+    #: A constant which can be used with the name property of a Month.
+    #: This constant has a value of "JUNE"
+    NAME_JUNE = "JUNE"
+
+    #: A constant which can be used with the name property of a Month.
+    #: This constant has a value of "JULY"
+    NAME_JULY = "JULY"
+
+    #: A constant which can be used with the name property of a Month.
+    #: This constant has a value of "AUGUST"
+    NAME_AUGUST = "AUGUST"
+
+    #: A constant which can be used with the name property of a Month.
+    #: This constant has a value of "SEPTEMBER"
+    NAME_SEPTEMBER = "SEPTEMBER"
+
+    #: A constant which can be used with the name property of a Month.
+    #: This constant has a value of "OCTOBER"
+    NAME_OCTOBER = "OCTOBER"
+
+    #: A constant which can be used with the name property of a Month.
+    #: This constant has a value of "NOVEMBER"
+    NAME_NOVEMBER = "NOVEMBER"
+
+    #: A constant which can be used with the name property of a Month.
+    #: This constant has a value of "DECEMBER"
+    NAME_DECEMBER = "DECEMBER"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Month object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this Month.
+            Allowed values for this property are: "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type name: str
+
+        """
+        self.swagger_types = {
+            'name': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name'
+        }
+
+        self._name = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this Month.
+        Name of the month of the year.
+
+        Allowed values for this property are: "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The name of this Month.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this Month.
+        Name of the month of the year.
+
+
+        :param name: The name of this Month.
+        :type: str
+        """
+        allowed_values = ["JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER"]
+        if not value_allowed_none_or_none_sentinel(name, allowed_values):
+            name = 'UNKNOWN_ENUM_VALUE'
+        self._name = name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/restore_autonomous_database_details.py
+++ b/src/oci/database/models/restore_autonomous_database_details.py
@@ -21,16 +21,30 @@ class RestoreAutonomousDatabaseDetails(object):
             The value to assign to the timestamp property of this RestoreAutonomousDatabaseDetails.
         :type timestamp: datetime
 
+        :param database_scn:
+            The value to assign to the database_scn property of this RestoreAutonomousDatabaseDetails.
+        :type database_scn: str
+
+        :param latest:
+            The value to assign to the latest property of this RestoreAutonomousDatabaseDetails.
+        :type latest: bool
+
         """
         self.swagger_types = {
-            'timestamp': 'datetime'
+            'timestamp': 'datetime',
+            'database_scn': 'str',
+            'latest': 'bool'
         }
 
         self.attribute_map = {
-            'timestamp': 'timestamp'
+            'timestamp': 'timestamp',
+            'database_scn': 'databaseSCN',
+            'latest': 'latest'
         }
 
         self._timestamp = None
+        self._database_scn = None
+        self._latest = None
 
     @property
     def timestamp(self):
@@ -55,6 +69,54 @@ class RestoreAutonomousDatabaseDetails(object):
         :type: datetime
         """
         self._timestamp = timestamp
+
+    @property
+    def database_scn(self):
+        """
+        Gets the database_scn of this RestoreAutonomousDatabaseDetails.
+        Restores using the backup with the System Change Number (SCN) specified.
+
+
+        :return: The database_scn of this RestoreAutonomousDatabaseDetails.
+        :rtype: str
+        """
+        return self._database_scn
+
+    @database_scn.setter
+    def database_scn(self, database_scn):
+        """
+        Sets the database_scn of this RestoreAutonomousDatabaseDetails.
+        Restores using the backup with the System Change Number (SCN) specified.
+
+
+        :param database_scn: The database_scn of this RestoreAutonomousDatabaseDetails.
+        :type: str
+        """
+        self._database_scn = database_scn
+
+    @property
+    def latest(self):
+        """
+        Gets the latest of this RestoreAutonomousDatabaseDetails.
+        Restores to the last known good state with the least possible data loss.
+
+
+        :return: The latest of this RestoreAutonomousDatabaseDetails.
+        :rtype: bool
+        """
+        return self._latest
+
+    @latest.setter
+    def latest(self, latest):
+        """
+        Sets the latest of this RestoreAutonomousDatabaseDetails.
+        Restores to the last known good state with the least possible data loss.
+
+
+        :param latest: The latest of this RestoreAutonomousDatabaseDetails.
+        :type: bool
+        """
+        self._latest = latest
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/update_autonomous_container_database_details.py
+++ b/src/oci/database/models/update_autonomous_container_database_details.py
@@ -1,0 +1,226 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateAutonomousContainerDatabaseDetails(object):
+    """
+    Describes the modification parameters for the Autonomous Container Database.
+    """
+
+    #: A constant which can be used with the patch_model property of a UpdateAutonomousContainerDatabaseDetails.
+    #: This constant has a value of "RELEASE_UPDATES"
+    PATCH_MODEL_RELEASE_UPDATES = "RELEASE_UPDATES"
+
+    #: A constant which can be used with the patch_model property of a UpdateAutonomousContainerDatabaseDetails.
+    #: This constant has a value of "RELEASE_UPDATE_REVISIONS"
+    PATCH_MODEL_RELEASE_UPDATE_REVISIONS = "RELEASE_UPDATE_REVISIONS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateAutonomousContainerDatabaseDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateAutonomousContainerDatabaseDetails.
+        :type display_name: str
+
+        :param patch_model:
+            The value to assign to the patch_model property of this UpdateAutonomousContainerDatabaseDetails.
+            Allowed values for this property are: "RELEASE_UPDATES", "RELEASE_UPDATE_REVISIONS"
+        :type patch_model: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateAutonomousContainerDatabaseDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateAutonomousContainerDatabaseDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param backup_config:
+            The value to assign to the backup_config property of this UpdateAutonomousContainerDatabaseDetails.
+        :type backup_config: AutonomousContainerDatabaseBackupConfig
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'patch_model': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'backup_config': 'AutonomousContainerDatabaseBackupConfig'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'patch_model': 'patchModel',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'backup_config': 'backupConfig'
+        }
+
+        self._display_name = None
+        self._patch_model = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._backup_config = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateAutonomousContainerDatabaseDetails.
+        The display name for the Autonomous Container Database.
+
+
+        :return: The display_name of this UpdateAutonomousContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateAutonomousContainerDatabaseDetails.
+        The display name for the Autonomous Container Database.
+
+
+        :param display_name: The display_name of this UpdateAutonomousContainerDatabaseDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def patch_model(self):
+        """
+        Gets the patch_model of this UpdateAutonomousContainerDatabaseDetails.
+        Database Patch model preference.
+
+        Allowed values for this property are: "RELEASE_UPDATES", "RELEASE_UPDATE_REVISIONS"
+
+
+        :return: The patch_model of this UpdateAutonomousContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._patch_model
+
+    @patch_model.setter
+    def patch_model(self, patch_model):
+        """
+        Sets the patch_model of this UpdateAutonomousContainerDatabaseDetails.
+        Database Patch model preference.
+
+
+        :param patch_model: The patch_model of this UpdateAutonomousContainerDatabaseDetails.
+        :type: str
+        """
+        allowed_values = ["RELEASE_UPDATES", "RELEASE_UPDATE_REVISIONS"]
+        if not value_allowed_none_or_none_sentinel(patch_model, allowed_values):
+            raise ValueError(
+                "Invalid value for `patch_model`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._patch_model = patch_model
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateAutonomousContainerDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateAutonomousContainerDatabaseDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateAutonomousContainerDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateAutonomousContainerDatabaseDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateAutonomousContainerDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateAutonomousContainerDatabaseDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateAutonomousContainerDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateAutonomousContainerDatabaseDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def backup_config(self):
+        """
+        Gets the backup_config of this UpdateAutonomousContainerDatabaseDetails.
+
+        :return: The backup_config of this UpdateAutonomousContainerDatabaseDetails.
+        :rtype: AutonomousContainerDatabaseBackupConfig
+        """
+        return self._backup_config
+
+    @backup_config.setter
+    def backup_config(self, backup_config):
+        """
+        Sets the backup_config of this UpdateAutonomousContainerDatabaseDetails.
+
+        :param backup_config: The backup_config of this UpdateAutonomousContainerDatabaseDetails.
+        :type: AutonomousContainerDatabaseBackupConfig
+        """
+        self._backup_config = backup_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_autonomous_database_details.py
+++ b/src/oci/database/models/update_autonomous_database_details.py
@@ -43,6 +43,10 @@ class UpdateAutonomousDatabaseDetails(object):
             The value to assign to the admin_password property of this UpdateAutonomousDatabaseDetails.
         :type admin_password: str
 
+        :param db_name:
+            The value to assign to the db_name property of this UpdateAutonomousDatabaseDetails.
+        :type db_name: str
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this UpdateAutonomousDatabaseDetails.
         :type freeform_tags: dict(str, str)
@@ -70,6 +74,7 @@ class UpdateAutonomousDatabaseDetails(object):
             'data_storage_size_in_tbs': 'int',
             'display_name': 'str',
             'admin_password': 'str',
+            'db_name': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'license_model': 'str',
@@ -82,6 +87,7 @@ class UpdateAutonomousDatabaseDetails(object):
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'display_name': 'displayName',
             'admin_password': 'adminPassword',
+            'db_name': 'dbName',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'license_model': 'licenseModel',
@@ -93,6 +99,7 @@ class UpdateAutonomousDatabaseDetails(object):
         self._data_storage_size_in_tbs = None
         self._display_name = None
         self._admin_password = None
+        self._db_name = None
         self._freeform_tags = None
         self._defined_tags = None
         self._license_model = None
@@ -194,6 +201,34 @@ class UpdateAutonomousDatabaseDetails(object):
         :type: str
         """
         self._admin_password = admin_password
+
+    @property
+    def db_name(self):
+        """
+        Gets the db_name of this UpdateAutonomousDatabaseDetails.
+        New name for this Autonomous Database. It must begin with an alphabetic character and can contain a
+        maximum of eight alphanumeric characters. Special characters are not permitted. This is valid only
+        for dedicated databases.
+
+
+        :return: The db_name of this UpdateAutonomousDatabaseDetails.
+        :rtype: str
+        """
+        return self._db_name
+
+    @db_name.setter
+    def db_name(self, db_name):
+        """
+        Sets the db_name of this UpdateAutonomousDatabaseDetails.
+        New name for this Autonomous Database. It must begin with an alphabetic character and can contain a
+        maximum of eight alphanumeric characters. Special characters are not permitted. This is valid only
+        for dedicated databases.
+
+
+        :param db_name: The db_name of this UpdateAutonomousDatabaseDetails.
+        :type: str
+        """
+        self._db_name = db_name
 
     @property
     def freeform_tags(self):

--- a/src/oci/database/models/update_autonomous_exadata_infrastructure_details.py
+++ b/src/oci/database/models/update_autonomous_exadata_infrastructure_details.py
@@ -1,0 +1,178 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateAutonomousExadataInfrastructureDetails(object):
+    """
+    Describes the modification parameters for the Autonomous Exadata Infrastructure.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateAutonomousExadataInfrastructureDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateAutonomousExadataInfrastructureDetails.
+        :type display_name: str
+
+        :param maintenance_window_details:
+            The value to assign to the maintenance_window_details property of this UpdateAutonomousExadataInfrastructureDetails.
+        :type maintenance_window_details: MaintenanceWindow
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateAutonomousExadataInfrastructureDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateAutonomousExadataInfrastructureDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'maintenance_window_details': 'MaintenanceWindow',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'maintenance_window_details': 'maintenanceWindowDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._maintenance_window_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateAutonomousExadataInfrastructureDetails.
+        The display name is a user-friendly name for the Autonomous Exadata Infrastructure. The display name does not have to be unique.
+
+
+        :return: The display_name of this UpdateAutonomousExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateAutonomousExadataInfrastructureDetails.
+        The display name is a user-friendly name for the Autonomous Exadata Infrastructure. The display name does not have to be unique.
+
+
+        :param display_name: The display_name of this UpdateAutonomousExadataInfrastructureDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def maintenance_window_details(self):
+        """
+        Gets the maintenance_window_details of this UpdateAutonomousExadataInfrastructureDetails.
+
+        :return: The maintenance_window_details of this UpdateAutonomousExadataInfrastructureDetails.
+        :rtype: MaintenanceWindow
+        """
+        return self._maintenance_window_details
+
+    @maintenance_window_details.setter
+    def maintenance_window_details(self, maintenance_window_details):
+        """
+        Sets the maintenance_window_details of this UpdateAutonomousExadataInfrastructureDetails.
+
+        :param maintenance_window_details: The maintenance_window_details of this UpdateAutonomousExadataInfrastructureDetails.
+        :type: MaintenanceWindow
+        """
+        self._maintenance_window_details = maintenance_window_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateAutonomousExadataInfrastructureDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateAutonomousExadataInfrastructureDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateAutonomousExadataInfrastructureDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateAutonomousExadataInfrastructureDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateAutonomousExadataInfrastructureDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateAutonomousExadataInfrastructureDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateAutonomousExadataInfrastructureDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateAutonomousExadataInfrastructureDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_maintenance_run_details.py
+++ b/src/oci/database/models/update_maintenance_run_details.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateMaintenanceRunDetails(object):
+    """
+    Describes the modification parameters for the Maintenance Run.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateMaintenanceRunDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param is_enabled:
+            The value to assign to the is_enabled property of this UpdateMaintenanceRunDetails.
+        :type is_enabled: bool
+
+        """
+        self.swagger_types = {
+            'is_enabled': 'bool'
+        }
+
+        self.attribute_map = {
+            'is_enabled': 'isEnabled'
+        }
+
+        self._is_enabled = None
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this UpdateMaintenanceRunDetails.
+        If set to false, skips the Maintenance Run.
+
+
+        :return: The is_enabled of this UpdateMaintenanceRunDetails.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this UpdateMaintenanceRunDetails.
+        If set to false, skips the Maintenance Run.
+
+
+        :param is_enabled: The is_enabled of this UpdateMaintenanceRunDetails.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "2.2.12"
+__version__ = "2.2.13"

--- a/src/oci/waiter.py
+++ b/src/oci/waiter.py
@@ -6,6 +6,7 @@ import time
 from .exceptions import MaximumWaitTimeExceeded, WaitUntilNotSupported, ServiceError
 from .util import WAIT_RESOURCE_NOT_FOUND
 from . import retry
+from oci.work_requests.models import WorkRequest
 
 
 def wait_until(client, response, property=None, state=None, max_interval_seconds=30, max_wait_seconds=1200, succeed_on_not_found=False, **kwargs):
@@ -108,3 +109,11 @@ def wait_until(client, response, property=None, state=None, max_interval_seconds
                     return WAIT_RESOURCE_NOT_FOUND
             else:
                 raise
+
+
+# list of termination states for work request service used by composite operation waiters
+_WORK_REQUEST_TERMINATION_STATES = [
+    WorkRequest.STATUS_SUCCEEDED,
+    WorkRequest.STATUS_FAILED,
+    WorkRequest.STATUS_CANCELED
+]


### PR DESCRIPTION
## Added

- Support for specifying custom boot volume sizes on instance configurations in the Compute Autoscaling service

- Support for 'Autonomous Transaction Processing - Dedicated' features, as well as maintenance run and backup operations on autonomous databases, autonomous container databases, and autonomous Exadata infrastructure in the Database service
