### PR TITLE
Releasing version 2.2.16

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+2.2.16 - 2019-07-02
+====================
+
+Added
+-----
+* Support for moving images, instance configurations, and instance pools across compartments in Core Services
+* Support for moving autoscaling configurations across compartments in the Compute Autoscaling service
+
+Fixed
+-----
+* Fixed a bug where the Streaming service's endpoints in Tokyo, Seoul, and future regions were not reachable from the SDK
+
+====================
 2.2.15 - 2019-06-25
 ====================
 

--- a/docs/api/autoscaling.rst
+++ b/docs/api/autoscaling.rst
@@ -24,6 +24,7 @@ Autoscaling
     oci.autoscaling.models.AutoScalingPolicy
     oci.autoscaling.models.AutoScalingPolicySummary
     oci.autoscaling.models.Capacity
+    oci.autoscaling.models.ChangeAutoScalingCompartmentDetails
     oci.autoscaling.models.Condition
     oci.autoscaling.models.CreateAutoScalingConfigurationDetails
     oci.autoscaling.models.CreateAutoScalingPolicyDetails

--- a/docs/api/autoscaling/models/oci.autoscaling.models.ChangeAutoScalingCompartmentDetails.rst
+++ b/docs/api/autoscaling/models/oci.autoscaling.models.ChangeAutoScalingCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeAutoScalingCompartmentDetails
+===================================
+
+.. currentmodule:: oci.autoscaling.models
+
+.. autoclass:: ChangeAutoScalingCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -52,6 +52,9 @@ Core Services
     oci.core.models.CaptureConsoleHistoryDetails
     oci.core.models.ChangeBootVolumeBackupCompartmentDetails
     oci.core.models.ChangeBootVolumeCompartmentDetails
+    oci.core.models.ChangeImageCompartmentDetails
+    oci.core.models.ChangeInstanceConfigurationCompartmentDetails
+    oci.core.models.ChangeInstancePoolCompartmentDetails
     oci.core.models.ChangeNatGatewayCompartmentDetails
     oci.core.models.ChangeServiceGatewayCompartmentDetails
     oci.core.models.ChangeVolumeBackupCompartmentDetails

--- a/docs/api/core/models/oci.core.models.ChangeImageCompartmentDetails.rst
+++ b/docs/api/core/models/oci.core.models.ChangeImageCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeImageCompartmentDetails
+=============================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: ChangeImageCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.ChangeInstanceConfigurationCompartmentDetails.rst
+++ b/docs/api/core/models/oci.core.models.ChangeInstanceConfigurationCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeInstanceConfigurationCompartmentDetails
+=============================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: ChangeInstanceConfigurationCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.ChangeInstancePoolCompartmentDetails.rst
+++ b/docs/api/core/models/oci.core.models.ChangeInstancePoolCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeInstancePoolCompartmentDetails
+====================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: ChangeInstancePoolCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -10,15 +10,26 @@
 Logging
 ~~~~~~~
 
-The Python SDK uses Python's `logging <https://docs.python.org/3.6/library/logging.html>`_ module. 
+The Python SDK uses Python's `logging <https://docs.python.org/3.6/library/logging.html>`_ module.
 
 Loggers for the Python SDK are ordered hierarchically, with the top level being ``oci`` (or ``oraclebmc`` if you are using the legacy OracleBMC package).
 
 Logger names are of the form ``<hierarchy>.<id>`` where the ``<hierarchy>`` is similar to ``oci.base_client`` and ``<id>`` is the result of Python's built-in ``id()`` function. The implication of this is that different instances of the same class have different loggers.
 
+The following code snippet is an example for configuring debug level logging for the oci package:
+
+.. code-block:: python
+    import oci
+    import logging
+
+    # Enable debug logging
+    logging.getLogger('oci').setLevel(logging.DEBUG)
+
+    # Rest of code ...
+
 Request Logging
 ================
-Logging of the requests which the Python SDK sends to Oracle Cloud Infrastructure services can be enabled by setting the ``log_requests`` attribute to ``True`` in your configuration. This could be done in your configuration file, for example:
+Request logging can be enabled for more detailed debugging information.  Request logging outputs the requests that the Python SDK sends to Oracle Cloud Infrastructure services.  This option can be enabled by setting the configuration attribute ``log_requests`` to ``True``. Alternatively, request logging can be enabled in your configuration file. For example:
 
 .. code-block:: text
 
@@ -43,9 +54,11 @@ Or programmatically, for example:
         "log_requests": True
     }
 
+Request logging enables debugging information in the Python http module.  This debugging information can be quite verbose and the output will go to standard out.  This http module does not use Python's logging module.
+
 Once you have request logging in your config, you can create the appropriate logging handler(s) for your use case. For example to log to an output stream such as ``stderr`` you could do:
 
-.. code-block:: python 
+.. code-block:: python
 
     import oci
     import logging
@@ -60,9 +73,10 @@ Once you have request logging in your config, you can create the appropriate log
     # This call will emit log information to stderr
     client.list_regions()
 
-Note that request logging occurs at the following levels:
+The oci module has logging at the following levels:
 
 * ``INFO``: Request method and request URL
 * ``DEBUG``: Request headers and body, and response headers
+
 
 The raw response body is not logged.

--- a/examples/database/adb_example.py
+++ b/examples/database/adb_example.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
 import oci
+import time
 
 # Overview of Autonomous Data Warehouse
 # https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/adboverview.htm
@@ -26,6 +27,8 @@ def create_adb(db_client):
     adb_request.display_name = "PYSDK-ADB-EXAMPLE"
     adb_request.db_workload = "OLTP"
     adb_request.license_model = adb_request.LICENSE_MODEL_BRING_YOUR_OWN_LICENSE
+    # For demonstration, we just passed the password here but for Production code you should have a better
+    # way to pass the password like env variable or commandline
     adb_request.admin_password = "Welcome1!SDK"
     adb_request.is_auto_scaling_enabled = True
 
@@ -38,8 +41,8 @@ def create_adb(db_client):
     return adb_response.data.id
 
 
+# Delete the autonomous database
 def delete_adb(db_client, adb_id):
-    # Delete the autonomous database
     response = db_client.delete_autonomous_database(adb_id)
     print(response)
 
@@ -62,8 +65,50 @@ def update_adb(db_client, adb_id):
     return adb_response.data.id
 
 
+def update_adb_acl(db_client, adb_id):
+    # Update adb Access Control List
+    adb_request = oci.database.models.UpdateAutonomousDatabaseDetails()
+
+    adb_request.whitelisted_ips = ["1.1.1.1/28", "3.3.3.3"]
+
+    adb_response = db_client.update_autonomous_database(adb_id,
+                                                        update_autonomous_database_details=adb_request,
+                                                        retry_strategy=oci.retry.DEFAULT_RETRY_STRATEGY)
+
+    print("ATP Shared instance Access Control List is being changed {}".format(adb_response.data.id))
+
+    return adb_response.data.id
+
+
+def update_adb_licesnse_type(db_client, adb_id):
+    # Update adb Licesnse Type
+    adb_request = oci.database.models.UpdateAutonomousDatabaseDetails()
+
+    adb_request.license_model = adb_request.LICENSE_MODEL_LICENSE_INCLUDED
+
+    adb_response = db_client.update_autonomous_database(adb_id,
+                                                        update_autonomous_database_details=adb_request,
+                                                        retry_strategy=oci.retry.DEFAULT_RETRY_STRATEGY)
+
+    print("ATP Shared instance License Type is being changed {}".format(adb_response.data.id))
+
+    return adb_response.data.id
+
+
 if __name__ == "__main__":
     # Initialize the client
     db_client = oci.database.DatabaseClient(config)
+    # Create adb
     adb_id = create_adb(db_client)
+    # sleep 5 mins
+    time.sleep(300)
+    # Update adb acl with specific adb_id.
+    update_adb_acl(db_client, adb_id)
+    # sleep 5 mins
+    time.sleep(300)
+    # Update adb license type
+    update_adb_licesnse_type(db_client, adb_id)
+    # sleep 5 mins
+    time.sleep(300)
+    # Delete adb
     delete_adb(db_client, adb_id)

--- a/src/oci/autoscaling/auto_scaling_client.py
+++ b/src/oci/autoscaling/auto_scaling_client.py
@@ -81,6 +81,108 @@ class AutoScalingClient(object):
         self.base_client = BaseClient("auto_scaling", config, signer, autoscaling_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 
+    def change_auto_scaling_configuration_compartment(self, auto_scaling_configuration_id, change_compartment_details, **kwargs):
+        """
+        ChangeAutoScalingConfigurationCompartment
+        Moves an autoscaling configuration into a different compartment within the same tenancy. For information
+        about moving resources between compartments, see
+        `Moving Resources to a Different Compartment`__.
+
+        When you move an autoscaling configuration to a different compartment, associated resources such as instance
+        pools are not moved.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes
+
+
+        :param str auto_scaling_configuration_id: (required)
+            The `OCID`__ of the autoscaling configuration.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param ChangeAutoScalingCompartmentDetails change_compartment_details: (required)
+            Request to change the compartment of given autoscaling configuration.
+
+        :param str opc_request_id: (optional)
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autoScalingConfigurations/{autoScalingConfigurationId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_auto_scaling_configuration_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "autoScalingConfigurationId": auto_scaling_configuration_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_compartment_details)
+
     def create_auto_scaling_configuration(self, create_auto_scaling_configuration_details, **kwargs):
         """
         CreateAutoScalingConfiguration

--- a/src/oci/autoscaling/models/__init__.py
+++ b/src/oci/autoscaling/models/__init__.py
@@ -9,6 +9,7 @@ from .auto_scaling_configuration_summary import AutoScalingConfigurationSummary
 from .auto_scaling_policy import AutoScalingPolicy
 from .auto_scaling_policy_summary import AutoScalingPolicySummary
 from .capacity import Capacity
+from .change_auto_scaling_compartment_details import ChangeAutoScalingCompartmentDetails
 from .condition import Condition
 from .create_auto_scaling_configuration_details import CreateAutoScalingConfigurationDetails
 from .create_auto_scaling_policy_details import CreateAutoScalingPolicyDetails
@@ -32,6 +33,7 @@ autoscaling_type_mapping = {
     "AutoScalingPolicy": AutoScalingPolicy,
     "AutoScalingPolicySummary": AutoScalingPolicySummary,
     "Capacity": Capacity,
+    "ChangeAutoScalingCompartmentDetails": ChangeAutoScalingCompartmentDetails,
     "Condition": Condition,
     "CreateAutoScalingConfigurationDetails": CreateAutoScalingConfigurationDetails,
     "CreateAutoScalingPolicyDetails": CreateAutoScalingPolicyDetails,

--- a/src/oci/autoscaling/models/change_auto_scaling_compartment_details.py
+++ b/src/oci/autoscaling/models/change_auto_scaling_compartment_details.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeAutoScalingCompartmentDetails(object):
+    """
+    The configuration details for the move operation.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeAutoScalingCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeAutoScalingCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeAutoScalingCompartmentDetails.
+        The `OCID`__ of the compartment to move the autoscaling configuration to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeAutoScalingCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeAutoScalingCompartmentDetails.
+        The `OCID`__ of the compartment to move the autoscaling configuration to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeAutoScalingCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/autoscaling/models/create_auto_scaling_configuration_details.py
+++ b/src/oci/autoscaling/models/create_auto_scaling_configuration_details.py
@@ -86,7 +86,6 @@ class CreateAutoScalingConfigurationDetails(object):
         """
         **[Required]** Gets the compartment_id of this CreateAutoScalingConfigurationDetails.
         The `OCID`__ of the compartment containing the autoscaling configuration.
-        The autoscaling configuration and the instance pool that it manages must be in the same compartment.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -101,7 +100,6 @@ class CreateAutoScalingConfigurationDetails(object):
         """
         Sets the compartment_id of this CreateAutoScalingConfigurationDetails.
         The `OCID`__ of the compartment containing the autoscaling configuration.
-        The autoscaling configuration and the instance pool that it manages must be in the same compartment.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 

--- a/src/oci/core/compute_client.py
+++ b/src/oci/core/compute_client.py
@@ -382,6 +382,107 @@ class ComputeClient(object):
                 body=capture_console_history_details,
                 response_type="ConsoleHistory")
 
+    def change_image_compartment(self, image_id, change_image_compartment_details, **kwargs):
+        """
+        ChangeImageCompartment
+        Moves an image into a different compartment within the same tenancy. For information about moving
+        resources between compartments, see
+        `Moving Resources to a Different Compartment`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes
+
+
+        :param str image_id: (required)
+            The `OCID`__ of the image.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param ChangeImageCompartmentDetails change_image_compartment_details: (required)
+            Request to change the compartment of a given image.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/images/{imageId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_image_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "imageId": image_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_image_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_image_compartment_details)
+
     def create_app_catalog_subscription(self, create_app_catalog_subscription_details, **kwargs):
         """
         CreateAppCatalogSubscription
@@ -769,7 +870,9 @@ class ComputeClient(object):
 
 
         :param str image_id: (required)
-            The OCID of the image.
+            The `OCID`__ of the image.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
@@ -1165,7 +1268,9 @@ class ComputeClient(object):
 
 
         :param str image_id: (required)
-            The OCID of the image.
+            The `OCID`__ of the image.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param ExportImageDetails export_image_details: (required)
             Details for the image export.
@@ -1671,7 +1776,9 @@ class ComputeClient(object):
 
 
         :param str image_id: (required)
-            The OCID of the image.
+            The `OCID`__ of the image.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -3441,7 +3548,9 @@ class ComputeClient(object):
             __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str image_id: (optional)
-            The OCID of an image.
+            The `OCID`__ of an image.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -3891,7 +4000,9 @@ class ComputeClient(object):
 
 
         :param str image_id: (required)
-            The OCID of the image.
+            The `OCID`__ of the image.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param UpdateImageDetails update_image_details: (required)
             Updates the image display name field. Avoid entering confidential information.

--- a/src/oci/core/compute_client_composite_operations.py
+++ b/src/oci/core/compute_client_composite_operations.py
@@ -342,7 +342,9 @@ class ComputeClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str image_id: (required)
-            The OCID of the image.
+            The `OCID`__ of the image.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.core.models.Image.lifecycle_state`
@@ -577,7 +579,9 @@ class ComputeClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str image_id: (required)
-            The OCID of the image.
+            The `OCID`__ of the image.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param ExportImageDetails export_image_details: (required)
             Details for the image export.
@@ -615,7 +619,9 @@ class ComputeClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str image_id: (required)
-            The OCID of the image.
+            The `OCID`__ of the image.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param ExportImageDetails export_image_details: (required)
             Details for the image export.
@@ -860,7 +866,9 @@ class ComputeClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str image_id: (required)
-            The OCID of the image.
+            The `OCID`__ of the image.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param UpdateImageDetails update_image_details: (required)
             Updates the image display name field. Avoid entering confidential information.

--- a/src/oci/core/compute_management_client.py
+++ b/src/oci/core/compute_management_client.py
@@ -177,6 +177,215 @@ class ComputeManagementClient(object):
                 body=attach_load_balancer_details,
                 response_type="InstancePool")
 
+    def change_instance_configuration_compartment(self, instance_configuration_id, change_instance_configuration_compartment_details, **kwargs):
+        """
+        ChangeInstanceConfigurationCompartment
+        Moves an instance configuration into a different compartment within the same tenancy.
+        For information about moving resources between compartments, see
+        `Moving Resources to a Different Compartment`__.
+
+        **Important:** Most of the properties for an existing instance configuration, including the compartment,
+        cannot be modified after you create the instance configuration. Although you can move an instance configuration
+        to a different compartment, you will not be able to use the instance configuration to manage instance pools
+        in the new compartment. If you want to update an instance configuration to point to a different compartment,
+        you should instead create a new instance configuration in the target compartment using
+        `CreateInstanceConfiguration`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes
+        __ https://docs.cloud.oracle.com/iaas/api/#/en/iaas/20160918/InstanceConfiguration/CreateInstanceConfiguration
+
+
+        :param str instance_configuration_id: (required)
+            The OCID of the instance configuration.
+
+        :param ChangeInstanceConfigurationCompartmentDetails change_instance_configuration_compartment_details: (required)
+            Request to change the compartment of given instance configuration.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/instanceConfigurations/{instanceConfigurationId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_instance_configuration_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "instanceConfigurationId": instance_configuration_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_instance_configuration_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_instance_configuration_compartment_details)
+
+    def change_instance_pool_compartment(self, instance_pool_id, change_instance_pool_compartment_details, **kwargs):
+        """
+        ChangeInstancePoolCompartment
+        Moves an instance pool into a different compartment within the same tenancy. For
+        information about moving resources between compartments, see
+        `Moving Resources to a Different Compartment`__.
+
+        When you move an instance pool to a different compartment, associated resources such as the instances in
+        the pool, boot volumes, VNICs, and autoscaling configurations are not moved.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes
+
+
+        :param str instance_pool_id: (required)
+            The OCID of the instance pool.
+
+        :param ChangeInstancePoolCompartmentDetails change_instance_pool_compartment_details: (required)
+            Request to change the compartment of given instance pool.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/instancePools/{instancePoolId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_instance_pool_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "instancePoolId": instance_pool_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_instance_pool_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_instance_pool_compartment_details)
+
     def create_instance_configuration(self, create_instance_configuration, **kwargs):
         """
         CreateInstanceConfiguration

--- a/src/oci/core/models/__init__.py
+++ b/src/oci/core/models/__init__.py
@@ -31,6 +31,9 @@ from .bulk_delete_virtual_circuit_public_prefixes_details import BulkDeleteVirtu
 from .capture_console_history_details import CaptureConsoleHistoryDetails
 from .change_boot_volume_backup_compartment_details import ChangeBootVolumeBackupCompartmentDetails
 from .change_boot_volume_compartment_details import ChangeBootVolumeCompartmentDetails
+from .change_image_compartment_details import ChangeImageCompartmentDetails
+from .change_instance_configuration_compartment_details import ChangeInstanceConfigurationCompartmentDetails
+from .change_instance_pool_compartment_details import ChangeInstancePoolCompartmentDetails
 from .change_nat_gateway_compartment_details import ChangeNatGatewayCompartmentDetails
 from .change_service_gateway_compartment_details import ChangeServiceGatewayCompartmentDetails
 from .change_volume_backup_compartment_details import ChangeVolumeBackupCompartmentDetails
@@ -264,6 +267,9 @@ core_type_mapping = {
     "CaptureConsoleHistoryDetails": CaptureConsoleHistoryDetails,
     "ChangeBootVolumeBackupCompartmentDetails": ChangeBootVolumeBackupCompartmentDetails,
     "ChangeBootVolumeCompartmentDetails": ChangeBootVolumeCompartmentDetails,
+    "ChangeImageCompartmentDetails": ChangeImageCompartmentDetails,
+    "ChangeInstanceConfigurationCompartmentDetails": ChangeInstanceConfigurationCompartmentDetails,
+    "ChangeInstancePoolCompartmentDetails": ChangeInstancePoolCompartmentDetails,
     "ChangeNatGatewayCompartmentDetails": ChangeNatGatewayCompartmentDetails,
     "ChangeServiceGatewayCompartmentDetails": ChangeServiceGatewayCompartmentDetails,
     "ChangeVolumeBackupCompartmentDetails": ChangeVolumeBackupCompartmentDetails,

--- a/src/oci/core/models/change_image_compartment_details.py
+++ b/src/oci/core/models/change_image_compartment_details.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeImageCompartmentDetails(object):
+    """
+    The configuration details for the move operation.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeImageCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeImageCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeImageCompartmentDetails.
+        The `OCID`__ of the compartment to move the image to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeImageCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeImageCompartmentDetails.
+        The `OCID`__ of the compartment to move the image to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeImageCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/change_instance_configuration_compartment_details.py
+++ b/src/oci/core/models/change_instance_configuration_compartment_details.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeInstanceConfigurationCompartmentDetails(object):
+    """
+    The configuration details for the move operation.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeInstanceConfigurationCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeInstanceConfigurationCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeInstanceConfigurationCompartmentDetails.
+        The `OCID`__ of the compartment to
+        move the instance configuration to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeInstanceConfigurationCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeInstanceConfigurationCompartmentDetails.
+        The `OCID`__ of the compartment to
+        move the instance configuration to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeInstanceConfigurationCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/change_instance_pool_compartment_details.py
+++ b/src/oci/core/models/change_instance_pool_compartment_details.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeInstancePoolCompartmentDetails(object):
+    """
+    The configuration details for the move operation.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeInstancePoolCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeInstancePoolCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeInstancePoolCompartmentDetails.
+        The `OCID`__ of the compartment to
+        move the instance pool to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeInstancePoolCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeInstancePoolCompartmentDetails.
+        The `OCID`__ of the compartment to
+        move the instance pool to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeInstancePoolCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/image.py
+++ b/src/oci/core/models/image.py
@@ -549,7 +549,8 @@ class Image(object):
     def size_in_mbs(self):
         """
         Gets the size_in_mbs of this Image.
-        Image size (1 MB = 1048576 bytes)
+        The boot volume size for an instance launched from this image, (1 MB = 1048576 bytes).
+        Note this is not the same as the size of the image when it was exported or the actual size of the image.
 
         Example: `47694`
 
@@ -563,7 +564,8 @@ class Image(object):
     def size_in_mbs(self, size_in_mbs):
         """
         Sets the size_in_mbs of this Image.
-        Image size (1 MB = 1048576 bytes)
+        The boot volume size for an instance launched from this image, (1 MB = 1048576 bytes).
+        Note this is not the same as the size of the image when it was exported or the actual size of the image.
 
         Example: `47694`
 

--- a/src/oci/core/models/instance_configuration.py
+++ b/src/oci/core/models/instance_configuration.py
@@ -9,7 +9,11 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class InstanceConfiguration(object):
     """
-    Instance Configuration
+    An instance configuration is a template that defines the settings to use when creating Compute instances
+    as part of an instance pool. For more information about instance pools and instance configurations, see
+    `Managing Compute Instances`__.
+
+    __ https://docs.cloud.oracle.com/Content/Compute/Concepts/instancemanagement.htm
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/core/models/instance_configuration_instance_source_via_image_details.py
+++ b/src/oci/core/models/instance_configuration_instance_source_via_image_details.py
@@ -52,7 +52,7 @@ class InstanceConfigurationInstanceSourceViaImageDetails(InstanceConfigurationIn
     def boot_volume_size_in_gbs(self):
         """
         Gets the boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.
-        The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 16384 GB (16TB).
+        The size of the boot volume in GBs. The minimum value is 50 GB and the maximum value is 16384 GB (16TB).
 
 
         :return: The boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.
@@ -64,7 +64,7 @@ class InstanceConfigurationInstanceSourceViaImageDetails(InstanceConfigurationIn
     def boot_volume_size_in_gbs(self, boot_volume_size_in_gbs):
         """
         Sets the boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.
-        The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 16384 GB (16TB).
+        The size of the boot volume in GBs. The minimum value is 50 GB and the maximum value is 16384 GB (16TB).
 
 
         :param boot_volume_size_in_gbs: The boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.

--- a/src/oci/core/models/instance_configuration_summary.py
+++ b/src/oci/core/models/instance_configuration_summary.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class InstanceConfigurationSummary(object):
     """
-    Instance Configuration Summary
+    Summary information for an instance configuration.
     """
 
     def __init__(self, **kwargs):
@@ -95,7 +95,7 @@ class InstanceConfigurationSummary(object):
     def display_name(self):
         """
         Gets the display_name of this InstanceConfigurationSummary.
-        A user-friendly name for the instance configuration
+        A user-friendly name for the instance configuration.
 
 
         :return: The display_name of this InstanceConfigurationSummary.
@@ -107,7 +107,7 @@ class InstanceConfigurationSummary(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this InstanceConfigurationSummary.
-        A user-friendly name for the instance configuration
+        A user-friendly name for the instance configuration.
 
 
         :param display_name: The display_name of this InstanceConfigurationSummary.
@@ -119,7 +119,7 @@ class InstanceConfigurationSummary(object):
     def id(self):
         """
         **[Required]** Gets the id of this InstanceConfigurationSummary.
-        The OCID of the instance configuration
+        The OCID of the instance configuration.
 
 
         :return: The id of this InstanceConfigurationSummary.
@@ -131,7 +131,7 @@ class InstanceConfigurationSummary(object):
     def id(self, id):
         """
         Sets the id of this InstanceConfigurationSummary.
-        The OCID of the instance configuration
+        The OCID of the instance configuration.
 
 
         :param id: The id of this InstanceConfigurationSummary.

--- a/src/oci/core/models/instance_pool.py
+++ b/src/oci/core/models/instance_pool.py
@@ -9,7 +9,11 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class InstancePool(object):
     """
-    Instance Pool
+    An instance pool is a group of instances within the same region that are created based off of the same
+    instance configuration. For more information about instance pools and instance configurations, see
+    `Managing Compute Instances`__.
+
+    __ https://docs.cloud.oracle.com/Content/Compute/Concepts/instancemanagement.htm
     """
 
     #: A constant which can be used with the lifecycle_state property of a InstancePool.

--- a/src/oci/core/models/instance_pool_summary.py
+++ b/src/oci/core/models/instance_pool_summary.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class InstancePoolSummary(object):
     """
-    Condensed InstancePool data when listing instance pools.
+    Summary information for an instance pool.
     """
 
     #: A constant which can be used with the lifecycle_state property of a InstancePoolSummary.
@@ -133,7 +133,7 @@ class InstancePoolSummary(object):
     def id(self):
         """
         **[Required]** Gets the id of this InstancePoolSummary.
-        The OCID of the instance pool
+        The OCID of the instance pool.
 
 
         :return: The id of this InstancePoolSummary.
@@ -145,7 +145,7 @@ class InstancePoolSummary(object):
     def id(self, id):
         """
         Sets the id of this InstancePoolSummary.
-        The OCID of the instance pool
+        The OCID of the instance pool.
 
 
         :param id: The id of this InstancePoolSummary.
@@ -157,7 +157,7 @@ class InstancePoolSummary(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this InstancePoolSummary.
-        The OCID of the compartment containing the instance pool
+        The OCID of the compartment containing the instance pool.
 
 
         :return: The compartment_id of this InstancePoolSummary.
@@ -169,7 +169,7 @@ class InstancePoolSummary(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this InstancePoolSummary.
-        The OCID of the compartment containing the instance pool
+        The OCID of the compartment containing the instance pool.
 
 
         :param compartment_id: The compartment_id of this InstancePoolSummary.

--- a/src/oci/object_storage/transfer/upload_manager.py
+++ b/src/oci/object_storage/transfer/upload_manager.py
@@ -129,11 +129,12 @@ class UploadManager:
             raise
 
         # It is possible we did not upload any parts (e.g. if the stream was empty). If we did
-        # upload parts then commit the upload, otherwise put an empty object into Object Storage
-        # to reflect what the customer intended
+        # upload parts then commit the upload, otherwise abort the upload and put an empty object
+        # into Object Storage to reflect what the customer intended.
         if len(ma.manifest['parts']) > 0:
             response = ma.commit()
         else:
+            ma.abort()
             copy_kwargs = kwargs.copy()
             # put_object expects 'opc_meta' not metadata
             if 'metadata' in copy_kwargs:

--- a/src/oci/streaming/stream_admin_client.py
+++ b/src/oci/streaming/stream_admin_client.py
@@ -74,7 +74,7 @@ class StreamAdminClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20180418',
-            'service_endpoint_template': 'https://streams.{region}.streaming.oci.{secondLevelDomain}',
+            'service_endpoint_template': 'https://streaming.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("stream_admin", config, signer, streaming_type_mapping, **base_client_init_kwargs)
@@ -150,7 +150,7 @@ class StreamAdminClient(object):
         """
         Deletes a stream.
         Deletes a stream and its content. Stream contents are deleted immediately. The service retains records of the stream itself for 90 days after deletion.
-        The `lifeCycleState` parameter of the `Stream` object changes to `DELETING` and the stream becomes inaccessible for read or write operations.
+        The `lifecycleState` parameter of the `Stream` object changes to `DELETING` and the stream becomes inaccessible for read or write operations.
         To verify that a stream has been deleted, make a :func:`get_stream` request. If the call returns the stream's
         lifecycle state as `DELETED`, then the stream has been deleted. If the call returns a \"404 Not Found\" error, that means all records of the
         stream have been deleted.

--- a/src/oci/streaming/stream_client.py
+++ b/src/oci/streaming/stream_client.py
@@ -74,7 +74,7 @@ class StreamClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20180418',
-            'service_endpoint_template': 'https://streams.{region}.streaming.oci.{secondLevelDomain}',
+            'service_endpoint_template': 'https://streaming.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("stream", config, signer, streaming_type_mapping, **base_client_init_kwargs)

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "2.2.15"
+__version__ = "2.2.16"


### PR DESCRIPTION
### Added

- Support for moving images, instance configurations, and instance pools across compartments in Core Services

- Support for moving autoscaling configurations across compartments in the Compute Autoscaling service



### Fixed

- Fixed a bug where the Streaming service's endpoints in Tokyo, Seoul, and future regions were not reachable from the SDK
