### PR TITLE
Releasing version 2.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+2.3.0 - 2019-08-13
+====================
+
+Added
+-----
+* Support for the Data Transfer service
+* Support for the Zurich (ZRH) region
+
+Breaking
+--------
+* oci.waas.WafLog.timestamp type changed from str to datetime
+* oci.waas.models.Certificate.issuer_name type changed from oci.waas.models.CertificateSubjectName to oci.waas.models.CerticateIssuerName
+* `"PURGE_WAAS_POLICY"` removed as option for oci.waas.models.WorkRequest.operation_type
+* `"PURGE_WAAS_POLICY"` removed as option for oci.waas.models.WorkRequestSummary.operation_type
+
+====================
 2.2.21 - 2019-08-06
 ====================
 

--- a/docs/api/dts.rst
+++ b/docs/api/dts.rst
@@ -1,0 +1,60 @@
+Dts 
+===
+
+.. autosummary::
+    :toctree: dts/client
+    :nosignatures:
+    :template: autosummary/service_client.rst
+
+    oci.dts.ShippingVendorsClient
+    oci.dts.TransferApplianceClient
+    oci.dts.TransferApplianceEntitlementClient
+    oci.dts.TransferDeviceClient
+    oci.dts.TransferJobClient
+    oci.dts.TransferPackageClient
+    oci.dts.ShippingVendorsClientCompositeOperations
+    oci.dts.TransferApplianceClientCompositeOperations
+    oci.dts.TransferApplianceEntitlementClientCompositeOperations
+    oci.dts.TransferDeviceClientCompositeOperations
+    oci.dts.TransferJobClientCompositeOperations
+    oci.dts.TransferPackageClientCompositeOperations
+
+--------
+ Models
+--------
+
+.. autosummary::
+    :toctree: dts/models
+    :nosignatures:
+    :template: autosummary/model_class.rst
+
+    oci.dts.models.AttachDevicesDetails
+    oci.dts.models.ChangeTransferJobCompartmentDetails
+    oci.dts.models.CreateTransferApplianceDetails
+    oci.dts.models.CreateTransferApplianceEntitlementDetails
+    oci.dts.models.CreateTransferDeviceDetails
+    oci.dts.models.CreateTransferJobDetails
+    oci.dts.models.CreateTransferPackageDetails
+    oci.dts.models.DetachDevicesDetails
+    oci.dts.models.MultipleTransferAppliances
+    oci.dts.models.MultipleTransferDevices
+    oci.dts.models.MultipleTransferPackages
+    oci.dts.models.NewTransferDevice
+    oci.dts.models.ShippingAddress
+    oci.dts.models.ShippingVendors
+    oci.dts.models.TransferAppliance
+    oci.dts.models.TransferApplianceCertificate
+    oci.dts.models.TransferApplianceEncryptionPassphrase
+    oci.dts.models.TransferApplianceEntitlement
+    oci.dts.models.TransferAppliancePublicKey
+    oci.dts.models.TransferApplianceSummary
+    oci.dts.models.TransferDevice
+    oci.dts.models.TransferDeviceSummary
+    oci.dts.models.TransferJob
+    oci.dts.models.TransferJobSummary
+    oci.dts.models.TransferPackage
+    oci.dts.models.TransferPackageSummary
+    oci.dts.models.UpdateTransferApplianceDetails
+    oci.dts.models.UpdateTransferDeviceDetails
+    oci.dts.models.UpdateTransferJobDetails
+    oci.dts.models.UpdateTransferPackageDetails

--- a/docs/api/dts/client/oci.dts.ShippingVendorsClient.rst
+++ b/docs/api/dts/client/oci.dts.ShippingVendorsClient.rst
@@ -1,0 +1,8 @@
+ShippingVendorsClient
+=====================
+
+.. currentmodule:: oci.dts
+
+.. autoclass:: ShippingVendorsClient
+    :special-members: __init__
+    :members:

--- a/docs/api/dts/client/oci.dts.ShippingVendorsClientCompositeOperations.rst
+++ b/docs/api/dts/client/oci.dts.ShippingVendorsClientCompositeOperations.rst
@@ -1,0 +1,8 @@
+ShippingVendorsClientCompositeOperations
+========================================
+
+.. currentmodule:: oci.dts
+
+.. autoclass:: ShippingVendorsClientCompositeOperations
+    :special-members: __init__
+    :members:

--- a/docs/api/dts/client/oci.dts.TransferApplianceClient.rst
+++ b/docs/api/dts/client/oci.dts.TransferApplianceClient.rst
@@ -1,0 +1,8 @@
+TransferApplianceClient
+=======================
+
+.. currentmodule:: oci.dts
+
+.. autoclass:: TransferApplianceClient
+    :special-members: __init__
+    :members:

--- a/docs/api/dts/client/oci.dts.TransferApplianceClientCompositeOperations.rst
+++ b/docs/api/dts/client/oci.dts.TransferApplianceClientCompositeOperations.rst
@@ -1,0 +1,8 @@
+TransferApplianceClientCompositeOperations
+==========================================
+
+.. currentmodule:: oci.dts
+
+.. autoclass:: TransferApplianceClientCompositeOperations
+    :special-members: __init__
+    :members:

--- a/docs/api/dts/client/oci.dts.TransferApplianceEntitlementClient.rst
+++ b/docs/api/dts/client/oci.dts.TransferApplianceEntitlementClient.rst
@@ -1,0 +1,8 @@
+TransferApplianceEntitlementClient
+==================================
+
+.. currentmodule:: oci.dts
+
+.. autoclass:: TransferApplianceEntitlementClient
+    :special-members: __init__
+    :members:

--- a/docs/api/dts/client/oci.dts.TransferApplianceEntitlementClientCompositeOperations.rst
+++ b/docs/api/dts/client/oci.dts.TransferApplianceEntitlementClientCompositeOperations.rst
@@ -1,0 +1,8 @@
+TransferApplianceEntitlementClientCompositeOperations
+=====================================================
+
+.. currentmodule:: oci.dts
+
+.. autoclass:: TransferApplianceEntitlementClientCompositeOperations
+    :special-members: __init__
+    :members:

--- a/docs/api/dts/client/oci.dts.TransferDeviceClient.rst
+++ b/docs/api/dts/client/oci.dts.TransferDeviceClient.rst
@@ -1,0 +1,8 @@
+TransferDeviceClient
+====================
+
+.. currentmodule:: oci.dts
+
+.. autoclass:: TransferDeviceClient
+    :special-members: __init__
+    :members:

--- a/docs/api/dts/client/oci.dts.TransferDeviceClientCompositeOperations.rst
+++ b/docs/api/dts/client/oci.dts.TransferDeviceClientCompositeOperations.rst
@@ -1,0 +1,8 @@
+TransferDeviceClientCompositeOperations
+=======================================
+
+.. currentmodule:: oci.dts
+
+.. autoclass:: TransferDeviceClientCompositeOperations
+    :special-members: __init__
+    :members:

--- a/docs/api/dts/client/oci.dts.TransferJobClient.rst
+++ b/docs/api/dts/client/oci.dts.TransferJobClient.rst
@@ -1,0 +1,8 @@
+TransferJobClient
+=================
+
+.. currentmodule:: oci.dts
+
+.. autoclass:: TransferJobClient
+    :special-members: __init__
+    :members:

--- a/docs/api/dts/client/oci.dts.TransferJobClientCompositeOperations.rst
+++ b/docs/api/dts/client/oci.dts.TransferJobClientCompositeOperations.rst
@@ -1,0 +1,8 @@
+TransferJobClientCompositeOperations
+====================================
+
+.. currentmodule:: oci.dts
+
+.. autoclass:: TransferJobClientCompositeOperations
+    :special-members: __init__
+    :members:

--- a/docs/api/dts/client/oci.dts.TransferPackageClient.rst
+++ b/docs/api/dts/client/oci.dts.TransferPackageClient.rst
@@ -1,0 +1,8 @@
+TransferPackageClient
+=====================
+
+.. currentmodule:: oci.dts
+
+.. autoclass:: TransferPackageClient
+    :special-members: __init__
+    :members:

--- a/docs/api/dts/client/oci.dts.TransferPackageClientCompositeOperations.rst
+++ b/docs/api/dts/client/oci.dts.TransferPackageClientCompositeOperations.rst
@@ -1,0 +1,8 @@
+TransferPackageClientCompositeOperations
+========================================
+
+.. currentmodule:: oci.dts
+
+.. autoclass:: TransferPackageClientCompositeOperations
+    :special-members: __init__
+    :members:

--- a/docs/api/dts/models/oci.dts.models.AttachDevicesDetails.rst
+++ b/docs/api/dts/models/oci.dts.models.AttachDevicesDetails.rst
@@ -1,0 +1,11 @@
+AttachDevicesDetails
+====================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: AttachDevicesDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.ChangeTransferJobCompartmentDetails.rst
+++ b/docs/api/dts/models/oci.dts.models.ChangeTransferJobCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeTransferJobCompartmentDetails
+===================================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: ChangeTransferJobCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.CreateTransferApplianceDetails.rst
+++ b/docs/api/dts/models/oci.dts.models.CreateTransferApplianceDetails.rst
@@ -1,0 +1,11 @@
+CreateTransferApplianceDetails
+==============================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: CreateTransferApplianceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.CreateTransferApplianceEntitlementDetails.rst
+++ b/docs/api/dts/models/oci.dts.models.CreateTransferApplianceEntitlementDetails.rst
@@ -1,0 +1,11 @@
+CreateTransferApplianceEntitlementDetails
+=========================================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: CreateTransferApplianceEntitlementDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.CreateTransferDeviceDetails.rst
+++ b/docs/api/dts/models/oci.dts.models.CreateTransferDeviceDetails.rst
@@ -1,0 +1,11 @@
+CreateTransferDeviceDetails
+===========================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: CreateTransferDeviceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.CreateTransferJobDetails.rst
+++ b/docs/api/dts/models/oci.dts.models.CreateTransferJobDetails.rst
@@ -1,0 +1,11 @@
+CreateTransferJobDetails
+========================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: CreateTransferJobDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.CreateTransferPackageDetails.rst
+++ b/docs/api/dts/models/oci.dts.models.CreateTransferPackageDetails.rst
@@ -1,0 +1,11 @@
+CreateTransferPackageDetails
+============================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: CreateTransferPackageDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.DetachDevicesDetails.rst
+++ b/docs/api/dts/models/oci.dts.models.DetachDevicesDetails.rst
@@ -1,0 +1,11 @@
+DetachDevicesDetails
+====================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: DetachDevicesDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.MultipleTransferAppliances.rst
+++ b/docs/api/dts/models/oci.dts.models.MultipleTransferAppliances.rst
@@ -1,0 +1,11 @@
+MultipleTransferAppliances
+==========================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: MultipleTransferAppliances
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.MultipleTransferDevices.rst
+++ b/docs/api/dts/models/oci.dts.models.MultipleTransferDevices.rst
@@ -1,0 +1,11 @@
+MultipleTransferDevices
+=======================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: MultipleTransferDevices
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.MultipleTransferPackages.rst
+++ b/docs/api/dts/models/oci.dts.models.MultipleTransferPackages.rst
@@ -1,0 +1,11 @@
+MultipleTransferPackages
+========================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: MultipleTransferPackages
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.NewTransferDevice.rst
+++ b/docs/api/dts/models/oci.dts.models.NewTransferDevice.rst
@@ -1,0 +1,11 @@
+NewTransferDevice
+=================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: NewTransferDevice
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.ShippingAddress.rst
+++ b/docs/api/dts/models/oci.dts.models.ShippingAddress.rst
@@ -1,0 +1,11 @@
+ShippingAddress
+===============
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: ShippingAddress
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.ShippingVendors.rst
+++ b/docs/api/dts/models/oci.dts.models.ShippingVendors.rst
@@ -1,0 +1,11 @@
+ShippingVendors
+===============
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: ShippingVendors
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.TransferAppliance.rst
+++ b/docs/api/dts/models/oci.dts.models.TransferAppliance.rst
@@ -1,0 +1,11 @@
+TransferAppliance
+=================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: TransferAppliance
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.TransferApplianceCertificate.rst
+++ b/docs/api/dts/models/oci.dts.models.TransferApplianceCertificate.rst
@@ -1,0 +1,11 @@
+TransferApplianceCertificate
+============================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: TransferApplianceCertificate
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.TransferApplianceEncryptionPassphrase.rst
+++ b/docs/api/dts/models/oci.dts.models.TransferApplianceEncryptionPassphrase.rst
@@ -1,0 +1,11 @@
+TransferApplianceEncryptionPassphrase
+=====================================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: TransferApplianceEncryptionPassphrase
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.TransferApplianceEntitlement.rst
+++ b/docs/api/dts/models/oci.dts.models.TransferApplianceEntitlement.rst
@@ -1,0 +1,11 @@
+TransferApplianceEntitlement
+============================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: TransferApplianceEntitlement
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.TransferAppliancePublicKey.rst
+++ b/docs/api/dts/models/oci.dts.models.TransferAppliancePublicKey.rst
@@ -1,0 +1,11 @@
+TransferAppliancePublicKey
+==========================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: TransferAppliancePublicKey
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.TransferApplianceSummary.rst
+++ b/docs/api/dts/models/oci.dts.models.TransferApplianceSummary.rst
@@ -1,0 +1,11 @@
+TransferApplianceSummary
+========================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: TransferApplianceSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.TransferDevice.rst
+++ b/docs/api/dts/models/oci.dts.models.TransferDevice.rst
@@ -1,0 +1,11 @@
+TransferDevice
+==============
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: TransferDevice
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.TransferDeviceSummary.rst
+++ b/docs/api/dts/models/oci.dts.models.TransferDeviceSummary.rst
@@ -1,0 +1,11 @@
+TransferDeviceSummary
+=====================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: TransferDeviceSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.TransferJob.rst
+++ b/docs/api/dts/models/oci.dts.models.TransferJob.rst
@@ -1,0 +1,11 @@
+TransferJob
+===========
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: TransferJob
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.TransferJobSummary.rst
+++ b/docs/api/dts/models/oci.dts.models.TransferJobSummary.rst
@@ -1,0 +1,11 @@
+TransferJobSummary
+==================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: TransferJobSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.TransferPackage.rst
+++ b/docs/api/dts/models/oci.dts.models.TransferPackage.rst
@@ -1,0 +1,11 @@
+TransferPackage
+===============
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: TransferPackage
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.TransferPackageSummary.rst
+++ b/docs/api/dts/models/oci.dts.models.TransferPackageSummary.rst
@@ -1,0 +1,11 @@
+TransferPackageSummary
+======================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: TransferPackageSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.UpdateTransferApplianceDetails.rst
+++ b/docs/api/dts/models/oci.dts.models.UpdateTransferApplianceDetails.rst
@@ -1,0 +1,11 @@
+UpdateTransferApplianceDetails
+==============================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: UpdateTransferApplianceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.UpdateTransferDeviceDetails.rst
+++ b/docs/api/dts/models/oci.dts.models.UpdateTransferDeviceDetails.rst
@@ -1,0 +1,11 @@
+UpdateTransferDeviceDetails
+===========================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: UpdateTransferDeviceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.UpdateTransferJobDetails.rst
+++ b/docs/api/dts/models/oci.dts.models.UpdateTransferJobDetails.rst
@@ -1,0 +1,11 @@
+UpdateTransferJobDetails
+========================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: UpdateTransferJobDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts/models/oci.dts.models.UpdateTransferPackageDetails.rst
+++ b/docs/api/dts/models/oci.dts.models.UpdateTransferPackageDetails.rst
@@ -1,0 +1,11 @@
+UpdateTransferPackageDetails
+============================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: UpdateTransferPackageDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/landing.rst
+++ b/docs/api/landing.rst
@@ -14,6 +14,12 @@ API Reference
 * :doc:`Virtual Network <core/client/oci.core.VirtualNetworkClient>`
 * :doc:`Database <database/client/oci.database.DatabaseClient>`
 * :doc:`DNS <dns/client/oci.dns.DnsClient>`
+* :doc:`Shipping Vendors <dts/client/oci.dts.ShippingVendorsClient>`
+* :doc:`Transfer Appliance <dts/client/oci.dts.TransferApplianceClient>`
+* :doc:`Transfer Appliance Entitlement <dts/client/oci.dts.TransferApplianceEntitlementClient>`
+* :doc:`Transfer Device <dts/client/oci.dts.TransferDeviceClient>`
+* :doc:`Transfer Job <dts/client/oci.dts.TransferJobClient>`
+* :doc:`Transfer Package <dts/client/oci.dts.TransferPackageClient>`
 * :doc:`Email <email/client/oci.email.EmailClient>`
 * :doc:`Events <events/client/oci.events.EventsClient>`
 * :doc:`File Storage <file_storage/client/oci.file_storage.FileStorageClient>`
@@ -62,6 +68,7 @@ API Reference
     core
     database
     dns
+    dts
     email
     events
     file_storage

--- a/docs/api/waas.rst
+++ b/docs/api/waas.rst
@@ -25,6 +25,7 @@ Waas
     oci.waas.models.Captcha
     oci.waas.models.Certificate
     oci.waas.models.CertificateExtensions
+    oci.waas.models.CertificateIssuerName
     oci.waas.models.CertificatePublicKeyInfo
     oci.waas.models.CertificateSubjectName
     oci.waas.models.CertificateSummary

--- a/docs/api/waas/models/oci.waas.models.CertificateIssuerName.rst
+++ b/docs/api/waas/models/oci.waas.models.CertificateIssuerName.rst
@@ -1,0 +1,11 @@
+CertificateIssuerName
+=====================
+
+.. currentmodule:: oci.waas.models
+
+.. autoclass:: CertificateIssuerName
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/src/oci/__init__.py
+++ b/src/oci/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-from . import announcements_service, audit, autoscaling, budget, container_engine, core, database, dns, email, events, file_storage, functions, healthchecks, identity, key_management, limits, load_balancer, monitoring, object_storage, ons, resource_manager, resource_search, streaming, waas, work_requests
+from . import announcements_service, audit, autoscaling, budget, container_engine, core, database, dns, dts, email, events, file_storage, functions, healthchecks, identity, key_management, limits, load_balancer, monitoring, object_storage, ons, resource_manager, resource_search, streaming, waas, work_requests
 from . import auth, config, constants, decorators, exceptions, regions, pagination, retry, fips
 from .base_client import BaseClient
 from .request import Request
@@ -14,5 +14,5 @@ fips.enable_fips_mode()
 
 __all__ = [
     "BaseClient", "Error", "Request", "Response", "Signer", "config", "constants", "decorators", "exceptions", "regions", "wait_until", "pagination", "auth", "retry", "fips",
-    "announcements_service", "audit", "autoscaling", "budget", "container_engine", "core", "database", "dns", "email", "events", "file_storage", "functions", "healthchecks", "identity", "key_management", "limits", "load_balancer", "monitoring", "object_storage", "ons", "resource_manager", "resource_search", "streaming", "waas", "work_requests"
+    "announcements_service", "audit", "autoscaling", "budget", "container_engine", "core", "database", "dns", "dts", "email", "events", "file_storage", "functions", "healthchecks", "identity", "key_management", "limits", "load_balancer", "monitoring", "object_storage", "ons", "resource_manager", "resource_search", "streaming", "waas", "work_requests"
 ]

--- a/src/oci/dts/__init__.py
+++ b/src/oci/dts/__init__.py
@@ -1,0 +1,21 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+
+from .shipping_vendors_client import ShippingVendorsClient
+from .shipping_vendors_client_composite_operations import ShippingVendorsClientCompositeOperations
+from .transfer_appliance_client import TransferApplianceClient
+from .transfer_appliance_client_composite_operations import TransferApplianceClientCompositeOperations
+from .transfer_appliance_entitlement_client import TransferApplianceEntitlementClient
+from .transfer_appliance_entitlement_client_composite_operations import TransferApplianceEntitlementClientCompositeOperations
+from .transfer_device_client import TransferDeviceClient
+from .transfer_device_client_composite_operations import TransferDeviceClientCompositeOperations
+from .transfer_job_client import TransferJobClient
+from .transfer_job_client_composite_operations import TransferJobClientCompositeOperations
+from .transfer_package_client import TransferPackageClient
+from .transfer_package_client_composite_operations import TransferPackageClientCompositeOperations
+from . import models
+
+__all__ = ["ShippingVendorsClient", "ShippingVendorsClientCompositeOperations", "TransferApplianceClient", "TransferApplianceClientCompositeOperations", "TransferApplianceEntitlementClient", "TransferApplianceEntitlementClientCompositeOperations", "TransferDeviceClient", "TransferDeviceClientCompositeOperations", "TransferJobClient", "TransferJobClientCompositeOperations", "TransferPackageClient", "TransferPackageClientCompositeOperations", "models"]

--- a/src/oci/dts/models/__init__.py
+++ b/src/oci/dts/models/__init__.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from .attach_devices_details import AttachDevicesDetails
+from .change_transfer_job_compartment_details import ChangeTransferJobCompartmentDetails
+from .create_transfer_appliance_details import CreateTransferApplianceDetails
+from .create_transfer_appliance_entitlement_details import CreateTransferApplianceEntitlementDetails
+from .create_transfer_device_details import CreateTransferDeviceDetails
+from .create_transfer_job_details import CreateTransferJobDetails
+from .create_transfer_package_details import CreateTransferPackageDetails
+from .detach_devices_details import DetachDevicesDetails
+from .multiple_transfer_appliances import MultipleTransferAppliances
+from .multiple_transfer_devices import MultipleTransferDevices
+from .multiple_transfer_packages import MultipleTransferPackages
+from .new_transfer_device import NewTransferDevice
+from .shipping_address import ShippingAddress
+from .shipping_vendors import ShippingVendors
+from .transfer_appliance import TransferAppliance
+from .transfer_appliance_certificate import TransferApplianceCertificate
+from .transfer_appliance_encryption_passphrase import TransferApplianceEncryptionPassphrase
+from .transfer_appliance_entitlement import TransferApplianceEntitlement
+from .transfer_appliance_public_key import TransferAppliancePublicKey
+from .transfer_appliance_summary import TransferApplianceSummary
+from .transfer_device import TransferDevice
+from .transfer_device_summary import TransferDeviceSummary
+from .transfer_job import TransferJob
+from .transfer_job_summary import TransferJobSummary
+from .transfer_package import TransferPackage
+from .transfer_package_summary import TransferPackageSummary
+from .update_transfer_appliance_details import UpdateTransferApplianceDetails
+from .update_transfer_device_details import UpdateTransferDeviceDetails
+from .update_transfer_job_details import UpdateTransferJobDetails
+from .update_transfer_package_details import UpdateTransferPackageDetails
+
+# Maps type names to classes for dts services.
+dts_type_mapping = {
+    "AttachDevicesDetails": AttachDevicesDetails,
+    "ChangeTransferJobCompartmentDetails": ChangeTransferJobCompartmentDetails,
+    "CreateTransferApplianceDetails": CreateTransferApplianceDetails,
+    "CreateTransferApplianceEntitlementDetails": CreateTransferApplianceEntitlementDetails,
+    "CreateTransferDeviceDetails": CreateTransferDeviceDetails,
+    "CreateTransferJobDetails": CreateTransferJobDetails,
+    "CreateTransferPackageDetails": CreateTransferPackageDetails,
+    "DetachDevicesDetails": DetachDevicesDetails,
+    "MultipleTransferAppliances": MultipleTransferAppliances,
+    "MultipleTransferDevices": MultipleTransferDevices,
+    "MultipleTransferPackages": MultipleTransferPackages,
+    "NewTransferDevice": NewTransferDevice,
+    "ShippingAddress": ShippingAddress,
+    "ShippingVendors": ShippingVendors,
+    "TransferAppliance": TransferAppliance,
+    "TransferApplianceCertificate": TransferApplianceCertificate,
+    "TransferApplianceEncryptionPassphrase": TransferApplianceEncryptionPassphrase,
+    "TransferApplianceEntitlement": TransferApplianceEntitlement,
+    "TransferAppliancePublicKey": TransferAppliancePublicKey,
+    "TransferApplianceSummary": TransferApplianceSummary,
+    "TransferDevice": TransferDevice,
+    "TransferDeviceSummary": TransferDeviceSummary,
+    "TransferJob": TransferJob,
+    "TransferJobSummary": TransferJobSummary,
+    "TransferPackage": TransferPackage,
+    "TransferPackageSummary": TransferPackageSummary,
+    "UpdateTransferApplianceDetails": UpdateTransferApplianceDetails,
+    "UpdateTransferDeviceDetails": UpdateTransferDeviceDetails,
+    "UpdateTransferJobDetails": UpdateTransferJobDetails,
+    "UpdateTransferPackageDetails": UpdateTransferPackageDetails
+}

--- a/src/oci/dts/models/attach_devices_details.py
+++ b/src/oci/dts/models/attach_devices_details.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AttachDevicesDetails(object):
+    """
+    AttachDevicesDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AttachDevicesDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param device_labels:
+            The value to assign to the device_labels property of this AttachDevicesDetails.
+        :type device_labels: list[str]
+
+        """
+        self.swagger_types = {
+            'device_labels': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'device_labels': 'deviceLabels'
+        }
+
+        self._device_labels = None
+
+    @property
+    def device_labels(self):
+        """
+        Gets the device_labels of this AttachDevicesDetails.
+        List of TransferDeviceLabel's
+
+
+        :return: The device_labels of this AttachDevicesDetails.
+        :rtype: list[str]
+        """
+        return self._device_labels
+
+    @device_labels.setter
+    def device_labels(self, device_labels):
+        """
+        Sets the device_labels of this AttachDevicesDetails.
+        List of TransferDeviceLabel's
+
+
+        :param device_labels: The device_labels of this AttachDevicesDetails.
+        :type: list[str]
+        """
+        self._device_labels = device_labels
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/change_transfer_job_compartment_details.py
+++ b/src/oci/dts/models/change_transfer_job_compartment_details.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeTransferJobCompartmentDetails(object):
+    """
+    ChangeTransferJobCompartmentDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeTransferJobCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeTransferJobCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeTransferJobCompartmentDetails.
+        The `OCID]`__ of the compartment into which the resources should be moved.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeTransferJobCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeTransferJobCompartmentDetails.
+        The `OCID]`__ of the compartment into which the resources should be moved.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeTransferJobCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/create_transfer_appliance_details.py
+++ b/src/oci/dts/models/create_transfer_appliance_details.py
@@ -1,0 +1,65 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateTransferApplianceDetails(object):
+    """
+    CreateTransferApplianceDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateTransferApplianceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param customer_shipping_address:
+            The value to assign to the customer_shipping_address property of this CreateTransferApplianceDetails.
+        :type customer_shipping_address: ShippingAddress
+
+        """
+        self.swagger_types = {
+            'customer_shipping_address': 'ShippingAddress'
+        }
+
+        self.attribute_map = {
+            'customer_shipping_address': 'customerShippingAddress'
+        }
+
+        self._customer_shipping_address = None
+
+    @property
+    def customer_shipping_address(self):
+        """
+        Gets the customer_shipping_address of this CreateTransferApplianceDetails.
+
+        :return: The customer_shipping_address of this CreateTransferApplianceDetails.
+        :rtype: ShippingAddress
+        """
+        return self._customer_shipping_address
+
+    @customer_shipping_address.setter
+    def customer_shipping_address(self, customer_shipping_address):
+        """
+        Sets the customer_shipping_address of this CreateTransferApplianceDetails.
+
+        :param customer_shipping_address: The customer_shipping_address of this CreateTransferApplianceDetails.
+        :type: ShippingAddress
+        """
+        self._customer_shipping_address = customer_shipping_address
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/create_transfer_appliance_entitlement_details.py
+++ b/src/oci/dts/models/create_transfer_appliance_entitlement_details.py
@@ -1,0 +1,119 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateTransferApplianceEntitlementDetails(object):
+    """
+    CreateTransferApplianceEntitlementDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateTransferApplianceEntitlementDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateTransferApplianceEntitlementDetails.
+        :type compartment_id: str
+
+        :param requestor_name:
+            The value to assign to the requestor_name property of this CreateTransferApplianceEntitlementDetails.
+        :type requestor_name: str
+
+        :param requestor_email:
+            The value to assign to the requestor_email property of this CreateTransferApplianceEntitlementDetails.
+        :type requestor_email: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'requestor_name': 'str',
+            'requestor_email': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'requestor_name': 'requestorName',
+            'requestor_email': 'requestorEmail'
+        }
+
+        self._compartment_id = None
+        self._requestor_name = None
+        self._requestor_email = None
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this CreateTransferApplianceEntitlementDetails.
+
+        :return: The compartment_id of this CreateTransferApplianceEntitlementDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateTransferApplianceEntitlementDetails.
+
+        :param compartment_id: The compartment_id of this CreateTransferApplianceEntitlementDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def requestor_name(self):
+        """
+        Gets the requestor_name of this CreateTransferApplianceEntitlementDetails.
+
+        :return: The requestor_name of this CreateTransferApplianceEntitlementDetails.
+        :rtype: str
+        """
+        return self._requestor_name
+
+    @requestor_name.setter
+    def requestor_name(self, requestor_name):
+        """
+        Sets the requestor_name of this CreateTransferApplianceEntitlementDetails.
+
+        :param requestor_name: The requestor_name of this CreateTransferApplianceEntitlementDetails.
+        :type: str
+        """
+        self._requestor_name = requestor_name
+
+    @property
+    def requestor_email(self):
+        """
+        Gets the requestor_email of this CreateTransferApplianceEntitlementDetails.
+
+        :return: The requestor_email of this CreateTransferApplianceEntitlementDetails.
+        :rtype: str
+        """
+        return self._requestor_email
+
+    @requestor_email.setter
+    def requestor_email(self, requestor_email):
+        """
+        Sets the requestor_email of this CreateTransferApplianceEntitlementDetails.
+
+        :param requestor_email: The requestor_email of this CreateTransferApplianceEntitlementDetails.
+        :type: str
+        """
+        self._requestor_email = requestor_email
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/create_transfer_device_details.py
+++ b/src/oci/dts/models/create_transfer_device_details.py
@@ -1,0 +1,92 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateTransferDeviceDetails(object):
+    """
+    CreateTransferDeviceDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateTransferDeviceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param serial_number:
+            The value to assign to the serial_number property of this CreateTransferDeviceDetails.
+        :type serial_number: str
+
+        :param iscsi_iqn:
+            The value to assign to the iscsi_iqn property of this CreateTransferDeviceDetails.
+        :type iscsi_iqn: str
+
+        """
+        self.swagger_types = {
+            'serial_number': 'str',
+            'iscsi_iqn': 'str'
+        }
+
+        self.attribute_map = {
+            'serial_number': 'serialNumber',
+            'iscsi_iqn': 'iscsiIQN'
+        }
+
+        self._serial_number = None
+        self._iscsi_iqn = None
+
+    @property
+    def serial_number(self):
+        """
+        Gets the serial_number of this CreateTransferDeviceDetails.
+
+        :return: The serial_number of this CreateTransferDeviceDetails.
+        :rtype: str
+        """
+        return self._serial_number
+
+    @serial_number.setter
+    def serial_number(self, serial_number):
+        """
+        Sets the serial_number of this CreateTransferDeviceDetails.
+
+        :param serial_number: The serial_number of this CreateTransferDeviceDetails.
+        :type: str
+        """
+        self._serial_number = serial_number
+
+    @property
+    def iscsi_iqn(self):
+        """
+        Gets the iscsi_iqn of this CreateTransferDeviceDetails.
+
+        :return: The iscsi_iqn of this CreateTransferDeviceDetails.
+        :rtype: str
+        """
+        return self._iscsi_iqn
+
+    @iscsi_iqn.setter
+    def iscsi_iqn(self, iscsi_iqn):
+        """
+        Sets the iscsi_iqn of this CreateTransferDeviceDetails.
+
+        :param iscsi_iqn: The iscsi_iqn of this CreateTransferDeviceDetails.
+        :type: str
+        """
+        self._iscsi_iqn = iscsi_iqn
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/create_transfer_job_details.py
+++ b/src/oci/dts/models/create_transfer_job_details.py
@@ -1,0 +1,229 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateTransferJobDetails(object):
+    """
+    CreateTransferJobDetails model.
+    """
+
+    #: A constant which can be used with the device_type property of a CreateTransferJobDetails.
+    #: This constant has a value of "DISK"
+    DEVICE_TYPE_DISK = "DISK"
+
+    #: A constant which can be used with the device_type property of a CreateTransferJobDetails.
+    #: This constant has a value of "APPLIANCE"
+    DEVICE_TYPE_APPLIANCE = "APPLIANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateTransferJobDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateTransferJobDetails.
+        :type compartment_id: str
+
+        :param upload_bucket_name:
+            The value to assign to the upload_bucket_name property of this CreateTransferJobDetails.
+        :type upload_bucket_name: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateTransferJobDetails.
+        :type display_name: str
+
+        :param device_type:
+            The value to assign to the device_type property of this CreateTransferJobDetails.
+            Allowed values for this property are: "DISK", "APPLIANCE"
+        :type device_type: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateTransferJobDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateTransferJobDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'upload_bucket_name': 'str',
+            'display_name': 'str',
+            'device_type': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'upload_bucket_name': 'uploadBucketName',
+            'display_name': 'displayName',
+            'device_type': 'deviceType',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._upload_bucket_name = None
+        self._display_name = None
+        self._device_type = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this CreateTransferJobDetails.
+
+        :return: The compartment_id of this CreateTransferJobDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateTransferJobDetails.
+
+        :param compartment_id: The compartment_id of this CreateTransferJobDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def upload_bucket_name(self):
+        """
+        Gets the upload_bucket_name of this CreateTransferJobDetails.
+
+        :return: The upload_bucket_name of this CreateTransferJobDetails.
+        :rtype: str
+        """
+        return self._upload_bucket_name
+
+    @upload_bucket_name.setter
+    def upload_bucket_name(self, upload_bucket_name):
+        """
+        Sets the upload_bucket_name of this CreateTransferJobDetails.
+
+        :param upload_bucket_name: The upload_bucket_name of this CreateTransferJobDetails.
+        :type: str
+        """
+        self._upload_bucket_name = upload_bucket_name
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateTransferJobDetails.
+
+        :return: The display_name of this CreateTransferJobDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateTransferJobDetails.
+
+        :param display_name: The display_name of this CreateTransferJobDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def device_type(self):
+        """
+        Gets the device_type of this CreateTransferJobDetails.
+        Allowed values for this property are: "DISK", "APPLIANCE"
+
+
+        :return: The device_type of this CreateTransferJobDetails.
+        :rtype: str
+        """
+        return self._device_type
+
+    @device_type.setter
+    def device_type(self, device_type):
+        """
+        Sets the device_type of this CreateTransferJobDetails.
+
+        :param device_type: The device_type of this CreateTransferJobDetails.
+        :type: str
+        """
+        allowed_values = ["DISK", "APPLIANCE"]
+        if not value_allowed_none_or_none_sentinel(device_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `device_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._device_type = device_type
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateTransferJobDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this CreateTransferJobDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateTransferJobDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this CreateTransferJobDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateTransferJobDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :return: The defined_tags of this CreateTransferJobDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateTransferJobDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :param defined_tags: The defined_tags of this CreateTransferJobDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/create_transfer_package_details.py
+++ b/src/oci/dts/models/create_transfer_package_details.py
@@ -1,0 +1,119 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateTransferPackageDetails(object):
+    """
+    CreateTransferPackageDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateTransferPackageDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param original_package_delivery_tracking_number:
+            The value to assign to the original_package_delivery_tracking_number property of this CreateTransferPackageDetails.
+        :type original_package_delivery_tracking_number: str
+
+        :param return_package_delivery_tracking_number:
+            The value to assign to the return_package_delivery_tracking_number property of this CreateTransferPackageDetails.
+        :type return_package_delivery_tracking_number: str
+
+        :param package_delivery_vendor:
+            The value to assign to the package_delivery_vendor property of this CreateTransferPackageDetails.
+        :type package_delivery_vendor: str
+
+        """
+        self.swagger_types = {
+            'original_package_delivery_tracking_number': 'str',
+            'return_package_delivery_tracking_number': 'str',
+            'package_delivery_vendor': 'str'
+        }
+
+        self.attribute_map = {
+            'original_package_delivery_tracking_number': 'originalPackageDeliveryTrackingNumber',
+            'return_package_delivery_tracking_number': 'returnPackageDeliveryTrackingNumber',
+            'package_delivery_vendor': 'packageDeliveryVendor'
+        }
+
+        self._original_package_delivery_tracking_number = None
+        self._return_package_delivery_tracking_number = None
+        self._package_delivery_vendor = None
+
+    @property
+    def original_package_delivery_tracking_number(self):
+        """
+        Gets the original_package_delivery_tracking_number of this CreateTransferPackageDetails.
+
+        :return: The original_package_delivery_tracking_number of this CreateTransferPackageDetails.
+        :rtype: str
+        """
+        return self._original_package_delivery_tracking_number
+
+    @original_package_delivery_tracking_number.setter
+    def original_package_delivery_tracking_number(self, original_package_delivery_tracking_number):
+        """
+        Sets the original_package_delivery_tracking_number of this CreateTransferPackageDetails.
+
+        :param original_package_delivery_tracking_number: The original_package_delivery_tracking_number of this CreateTransferPackageDetails.
+        :type: str
+        """
+        self._original_package_delivery_tracking_number = original_package_delivery_tracking_number
+
+    @property
+    def return_package_delivery_tracking_number(self):
+        """
+        Gets the return_package_delivery_tracking_number of this CreateTransferPackageDetails.
+
+        :return: The return_package_delivery_tracking_number of this CreateTransferPackageDetails.
+        :rtype: str
+        """
+        return self._return_package_delivery_tracking_number
+
+    @return_package_delivery_tracking_number.setter
+    def return_package_delivery_tracking_number(self, return_package_delivery_tracking_number):
+        """
+        Sets the return_package_delivery_tracking_number of this CreateTransferPackageDetails.
+
+        :param return_package_delivery_tracking_number: The return_package_delivery_tracking_number of this CreateTransferPackageDetails.
+        :type: str
+        """
+        self._return_package_delivery_tracking_number = return_package_delivery_tracking_number
+
+    @property
+    def package_delivery_vendor(self):
+        """
+        Gets the package_delivery_vendor of this CreateTransferPackageDetails.
+
+        :return: The package_delivery_vendor of this CreateTransferPackageDetails.
+        :rtype: str
+        """
+        return self._package_delivery_vendor
+
+    @package_delivery_vendor.setter
+    def package_delivery_vendor(self, package_delivery_vendor):
+        """
+        Sets the package_delivery_vendor of this CreateTransferPackageDetails.
+
+        :param package_delivery_vendor: The package_delivery_vendor of this CreateTransferPackageDetails.
+        :type: str
+        """
+        self._package_delivery_vendor = package_delivery_vendor
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/detach_devices_details.py
+++ b/src/oci/dts/models/detach_devices_details.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DetachDevicesDetails(object):
+    """
+    DetachDevicesDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DetachDevicesDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param device_labels:
+            The value to assign to the device_labels property of this DetachDevicesDetails.
+        :type device_labels: list[str]
+
+        """
+        self.swagger_types = {
+            'device_labels': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'device_labels': 'deviceLabels'
+        }
+
+        self._device_labels = None
+
+    @property
+    def device_labels(self):
+        """
+        Gets the device_labels of this DetachDevicesDetails.
+        List of TransferDeviceLabel's
+
+
+        :return: The device_labels of this DetachDevicesDetails.
+        :rtype: list[str]
+        """
+        return self._device_labels
+
+    @device_labels.setter
+    def device_labels(self, device_labels):
+        """
+        Sets the device_labels of this DetachDevicesDetails.
+        List of TransferDeviceLabel's
+
+
+        :param device_labels: The device_labels of this DetachDevicesDetails.
+        :type: list[str]
+        """
+        self._device_labels = device_labels
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/multiple_transfer_appliances.py
+++ b/src/oci/dts/models/multiple_transfer_appliances.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class MultipleTransferAppliances(object):
+    """
+    MultipleTransferAppliances model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new MultipleTransferAppliances object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param transfer_appliance_objects:
+            The value to assign to the transfer_appliance_objects property of this MultipleTransferAppliances.
+        :type transfer_appliance_objects: list[TransferApplianceSummary]
+
+        """
+        self.swagger_types = {
+            'transfer_appliance_objects': 'list[TransferApplianceSummary]'
+        }
+
+        self.attribute_map = {
+            'transfer_appliance_objects': 'transferApplianceObjects'
+        }
+
+        self._transfer_appliance_objects = None
+
+    @property
+    def transfer_appliance_objects(self):
+        """
+        Gets the transfer_appliance_objects of this MultipleTransferAppliances.
+        List of TransferAppliance summary's
+
+
+        :return: The transfer_appliance_objects of this MultipleTransferAppliances.
+        :rtype: list[TransferApplianceSummary]
+        """
+        return self._transfer_appliance_objects
+
+    @transfer_appliance_objects.setter
+    def transfer_appliance_objects(self, transfer_appliance_objects):
+        """
+        Sets the transfer_appliance_objects of this MultipleTransferAppliances.
+        List of TransferAppliance summary's
+
+
+        :param transfer_appliance_objects: The transfer_appliance_objects of this MultipleTransferAppliances.
+        :type: list[TransferApplianceSummary]
+        """
+        self._transfer_appliance_objects = transfer_appliance_objects
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/multiple_transfer_devices.py
+++ b/src/oci/dts/models/multiple_transfer_devices.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class MultipleTransferDevices(object):
+    """
+    MultipleTransferDevices model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new MultipleTransferDevices object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param transfer_device_objects:
+            The value to assign to the transfer_device_objects property of this MultipleTransferDevices.
+        :type transfer_device_objects: list[TransferDeviceSummary]
+
+        """
+        self.swagger_types = {
+            'transfer_device_objects': 'list[TransferDeviceSummary]'
+        }
+
+        self.attribute_map = {
+            'transfer_device_objects': 'transferDeviceObjects'
+        }
+
+        self._transfer_device_objects = None
+
+    @property
+    def transfer_device_objects(self):
+        """
+        Gets the transfer_device_objects of this MultipleTransferDevices.
+        List of TransferDeviceObject's
+
+
+        :return: The transfer_device_objects of this MultipleTransferDevices.
+        :rtype: list[TransferDeviceSummary]
+        """
+        return self._transfer_device_objects
+
+    @transfer_device_objects.setter
+    def transfer_device_objects(self, transfer_device_objects):
+        """
+        Sets the transfer_device_objects of this MultipleTransferDevices.
+        List of TransferDeviceObject's
+
+
+        :param transfer_device_objects: The transfer_device_objects of this MultipleTransferDevices.
+        :type: list[TransferDeviceSummary]
+        """
+        self._transfer_device_objects = transfer_device_objects
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/multiple_transfer_packages.py
+++ b/src/oci/dts/models/multiple_transfer_packages.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class MultipleTransferPackages(object):
+    """
+    MultipleTransferPackages model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new MultipleTransferPackages object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param transfer_package_objects:
+            The value to assign to the transfer_package_objects property of this MultipleTransferPackages.
+        :type transfer_package_objects: list[TransferPackageSummary]
+
+        """
+        self.swagger_types = {
+            'transfer_package_objects': 'list[TransferPackageSummary]'
+        }
+
+        self.attribute_map = {
+            'transfer_package_objects': 'transferPackageObjects'
+        }
+
+        self._transfer_package_objects = None
+
+    @property
+    def transfer_package_objects(self):
+        """
+        Gets the transfer_package_objects of this MultipleTransferPackages.
+        List of TransferPackage summary's
+
+
+        :return: The transfer_package_objects of this MultipleTransferPackages.
+        :rtype: list[TransferPackageSummary]
+        """
+        return self._transfer_package_objects
+
+    @transfer_package_objects.setter
+    def transfer_package_objects(self, transfer_package_objects):
+        """
+        Sets the transfer_package_objects of this MultipleTransferPackages.
+        List of TransferPackage summary's
+
+
+        :param transfer_package_objects: The transfer_package_objects of this MultipleTransferPackages.
+        :type: list[TransferPackageSummary]
+        """
+        self._transfer_package_objects = transfer_package_objects
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/new_transfer_device.py
+++ b/src/oci/dts/models/new_transfer_device.py
@@ -1,0 +1,239 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class NewTransferDevice(object):
+    """
+    NewTransferDevice model.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a NewTransferDevice.
+    #: This constant has a value of "PREPARING"
+    LIFECYCLE_STATE_PREPARING = "PREPARING"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new NewTransferDevice object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param label:
+            The value to assign to the label property of this NewTransferDevice.
+        :type label: str
+
+        :param serial_number:
+            The value to assign to the serial_number property of this NewTransferDevice.
+        :type serial_number: str
+
+        :param iscsi_iqn:
+            The value to assign to the iscsi_iqn property of this NewTransferDevice.
+        :type iscsi_iqn: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this NewTransferDevice.
+            Allowed values for this property are: "PREPARING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param encryption_passphrase:
+            The value to assign to the encryption_passphrase property of this NewTransferDevice.
+        :type encryption_passphrase: str
+
+        :param transfer_job_id:
+            The value to assign to the transfer_job_id property of this NewTransferDevice.
+        :type transfer_job_id: str
+
+        :param creation_time:
+            The value to assign to the creation_time property of this NewTransferDevice.
+        :type creation_time: datetime
+
+        """
+        self.swagger_types = {
+            'label': 'str',
+            'serial_number': 'str',
+            'iscsi_iqn': 'str',
+            'lifecycle_state': 'str',
+            'encryption_passphrase': 'str',
+            'transfer_job_id': 'str',
+            'creation_time': 'datetime'
+        }
+
+        self.attribute_map = {
+            'label': 'label',
+            'serial_number': 'serialNumber',
+            'iscsi_iqn': 'iscsiIQN',
+            'lifecycle_state': 'lifecycleState',
+            'encryption_passphrase': 'encryptionPassphrase',
+            'transfer_job_id': 'transferJobId',
+            'creation_time': 'creationTime'
+        }
+
+        self._label = None
+        self._serial_number = None
+        self._iscsi_iqn = None
+        self._lifecycle_state = None
+        self._encryption_passphrase = None
+        self._transfer_job_id = None
+        self._creation_time = None
+
+    @property
+    def label(self):
+        """
+        **[Required]** Gets the label of this NewTransferDevice.
+
+        :return: The label of this NewTransferDevice.
+        :rtype: str
+        """
+        return self._label
+
+    @label.setter
+    def label(self, label):
+        """
+        Sets the label of this NewTransferDevice.
+
+        :param label: The label of this NewTransferDevice.
+        :type: str
+        """
+        self._label = label
+
+    @property
+    def serial_number(self):
+        """
+        Gets the serial_number of this NewTransferDevice.
+
+        :return: The serial_number of this NewTransferDevice.
+        :rtype: str
+        """
+        return self._serial_number
+
+    @serial_number.setter
+    def serial_number(self, serial_number):
+        """
+        Sets the serial_number of this NewTransferDevice.
+
+        :param serial_number: The serial_number of this NewTransferDevice.
+        :type: str
+        """
+        self._serial_number = serial_number
+
+    @property
+    def iscsi_iqn(self):
+        """
+        Gets the iscsi_iqn of this NewTransferDevice.
+
+        :return: The iscsi_iqn of this NewTransferDevice.
+        :rtype: str
+        """
+        return self._iscsi_iqn
+
+    @iscsi_iqn.setter
+    def iscsi_iqn(self, iscsi_iqn):
+        """
+        Sets the iscsi_iqn of this NewTransferDevice.
+
+        :param iscsi_iqn: The iscsi_iqn of this NewTransferDevice.
+        :type: str
+        """
+        self._iscsi_iqn = iscsi_iqn
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this NewTransferDevice.
+        Allowed values for this property are: "PREPARING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this NewTransferDevice.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this NewTransferDevice.
+
+        :param lifecycle_state: The lifecycle_state of this NewTransferDevice.
+        :type: str
+        """
+        allowed_values = ["PREPARING"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def encryption_passphrase(self):
+        """
+        Gets the encryption_passphrase of this NewTransferDevice.
+
+        :return: The encryption_passphrase of this NewTransferDevice.
+        :rtype: str
+        """
+        return self._encryption_passphrase
+
+    @encryption_passphrase.setter
+    def encryption_passphrase(self, encryption_passphrase):
+        """
+        Sets the encryption_passphrase of this NewTransferDevice.
+
+        :param encryption_passphrase: The encryption_passphrase of this NewTransferDevice.
+        :type: str
+        """
+        self._encryption_passphrase = encryption_passphrase
+
+    @property
+    def transfer_job_id(self):
+        """
+        Gets the transfer_job_id of this NewTransferDevice.
+
+        :return: The transfer_job_id of this NewTransferDevice.
+        :rtype: str
+        """
+        return self._transfer_job_id
+
+    @transfer_job_id.setter
+    def transfer_job_id(self, transfer_job_id):
+        """
+        Sets the transfer_job_id of this NewTransferDevice.
+
+        :param transfer_job_id: The transfer_job_id of this NewTransferDevice.
+        :type: str
+        """
+        self._transfer_job_id = transfer_job_id
+
+    @property
+    def creation_time(self):
+        """
+        Gets the creation_time of this NewTransferDevice.
+
+        :return: The creation_time of this NewTransferDevice.
+        :rtype: datetime
+        """
+        return self._creation_time
+
+    @creation_time.setter
+    def creation_time(self, creation_time):
+        """
+        Sets the creation_time of this NewTransferDevice.
+
+        :param creation_time: The creation_time of this NewTransferDevice.
+        :type: datetime
+        """
+        self._creation_time = creation_time
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/shipping_address.py
+++ b/src/oci/dts/models/shipping_address.py
@@ -1,0 +1,362 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ShippingAddress(object):
+    """
+    ShippingAddress model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ShippingAddress object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param addressee:
+            The value to assign to the addressee property of this ShippingAddress.
+        :type addressee: str
+
+        :param care_of:
+            The value to assign to the care_of property of this ShippingAddress.
+        :type care_of: str
+
+        :param address1:
+            The value to assign to the address1 property of this ShippingAddress.
+        :type address1: str
+
+        :param address2:
+            The value to assign to the address2 property of this ShippingAddress.
+        :type address2: str
+
+        :param address3:
+            The value to assign to the address3 property of this ShippingAddress.
+        :type address3: str
+
+        :param address4:
+            The value to assign to the address4 property of this ShippingAddress.
+        :type address4: str
+
+        :param city_or_locality:
+            The value to assign to the city_or_locality property of this ShippingAddress.
+        :type city_or_locality: str
+
+        :param state_or_region:
+            The value to assign to the state_or_region property of this ShippingAddress.
+        :type state_or_region: str
+
+        :param zipcode:
+            The value to assign to the zipcode property of this ShippingAddress.
+        :type zipcode: str
+
+        :param country:
+            The value to assign to the country property of this ShippingAddress.
+        :type country: str
+
+        :param phone_number:
+            The value to assign to the phone_number property of this ShippingAddress.
+        :type phone_number: str
+
+        :param email:
+            The value to assign to the email property of this ShippingAddress.
+        :type email: str
+
+        """
+        self.swagger_types = {
+            'addressee': 'str',
+            'care_of': 'str',
+            'address1': 'str',
+            'address2': 'str',
+            'address3': 'str',
+            'address4': 'str',
+            'city_or_locality': 'str',
+            'state_or_region': 'str',
+            'zipcode': 'str',
+            'country': 'str',
+            'phone_number': 'str',
+            'email': 'str'
+        }
+
+        self.attribute_map = {
+            'addressee': 'addressee',
+            'care_of': 'careOf',
+            'address1': 'address1',
+            'address2': 'address2',
+            'address3': 'address3',
+            'address4': 'address4',
+            'city_or_locality': 'cityOrLocality',
+            'state_or_region': 'stateOrRegion',
+            'zipcode': 'zipcode',
+            'country': 'country',
+            'phone_number': 'phoneNumber',
+            'email': 'email'
+        }
+
+        self._addressee = None
+        self._care_of = None
+        self._address1 = None
+        self._address2 = None
+        self._address3 = None
+        self._address4 = None
+        self._city_or_locality = None
+        self._state_or_region = None
+        self._zipcode = None
+        self._country = None
+        self._phone_number = None
+        self._email = None
+
+    @property
+    def addressee(self):
+        """
+        Gets the addressee of this ShippingAddress.
+
+        :return: The addressee of this ShippingAddress.
+        :rtype: str
+        """
+        return self._addressee
+
+    @addressee.setter
+    def addressee(self, addressee):
+        """
+        Sets the addressee of this ShippingAddress.
+
+        :param addressee: The addressee of this ShippingAddress.
+        :type: str
+        """
+        self._addressee = addressee
+
+    @property
+    def care_of(self):
+        """
+        Gets the care_of of this ShippingAddress.
+
+        :return: The care_of of this ShippingAddress.
+        :rtype: str
+        """
+        return self._care_of
+
+    @care_of.setter
+    def care_of(self, care_of):
+        """
+        Sets the care_of of this ShippingAddress.
+
+        :param care_of: The care_of of this ShippingAddress.
+        :type: str
+        """
+        self._care_of = care_of
+
+    @property
+    def address1(self):
+        """
+        Gets the address1 of this ShippingAddress.
+
+        :return: The address1 of this ShippingAddress.
+        :rtype: str
+        """
+        return self._address1
+
+    @address1.setter
+    def address1(self, address1):
+        """
+        Sets the address1 of this ShippingAddress.
+
+        :param address1: The address1 of this ShippingAddress.
+        :type: str
+        """
+        self._address1 = address1
+
+    @property
+    def address2(self):
+        """
+        Gets the address2 of this ShippingAddress.
+
+        :return: The address2 of this ShippingAddress.
+        :rtype: str
+        """
+        return self._address2
+
+    @address2.setter
+    def address2(self, address2):
+        """
+        Sets the address2 of this ShippingAddress.
+
+        :param address2: The address2 of this ShippingAddress.
+        :type: str
+        """
+        self._address2 = address2
+
+    @property
+    def address3(self):
+        """
+        Gets the address3 of this ShippingAddress.
+
+        :return: The address3 of this ShippingAddress.
+        :rtype: str
+        """
+        return self._address3
+
+    @address3.setter
+    def address3(self, address3):
+        """
+        Sets the address3 of this ShippingAddress.
+
+        :param address3: The address3 of this ShippingAddress.
+        :type: str
+        """
+        self._address3 = address3
+
+    @property
+    def address4(self):
+        """
+        Gets the address4 of this ShippingAddress.
+
+        :return: The address4 of this ShippingAddress.
+        :rtype: str
+        """
+        return self._address4
+
+    @address4.setter
+    def address4(self, address4):
+        """
+        Sets the address4 of this ShippingAddress.
+
+        :param address4: The address4 of this ShippingAddress.
+        :type: str
+        """
+        self._address4 = address4
+
+    @property
+    def city_or_locality(self):
+        """
+        Gets the city_or_locality of this ShippingAddress.
+
+        :return: The city_or_locality of this ShippingAddress.
+        :rtype: str
+        """
+        return self._city_or_locality
+
+    @city_or_locality.setter
+    def city_or_locality(self, city_or_locality):
+        """
+        Sets the city_or_locality of this ShippingAddress.
+
+        :param city_or_locality: The city_or_locality of this ShippingAddress.
+        :type: str
+        """
+        self._city_or_locality = city_or_locality
+
+    @property
+    def state_or_region(self):
+        """
+        Gets the state_or_region of this ShippingAddress.
+
+        :return: The state_or_region of this ShippingAddress.
+        :rtype: str
+        """
+        return self._state_or_region
+
+    @state_or_region.setter
+    def state_or_region(self, state_or_region):
+        """
+        Sets the state_or_region of this ShippingAddress.
+
+        :param state_or_region: The state_or_region of this ShippingAddress.
+        :type: str
+        """
+        self._state_or_region = state_or_region
+
+    @property
+    def zipcode(self):
+        """
+        Gets the zipcode of this ShippingAddress.
+
+        :return: The zipcode of this ShippingAddress.
+        :rtype: str
+        """
+        return self._zipcode
+
+    @zipcode.setter
+    def zipcode(self, zipcode):
+        """
+        Sets the zipcode of this ShippingAddress.
+
+        :param zipcode: The zipcode of this ShippingAddress.
+        :type: str
+        """
+        self._zipcode = zipcode
+
+    @property
+    def country(self):
+        """
+        Gets the country of this ShippingAddress.
+
+        :return: The country of this ShippingAddress.
+        :rtype: str
+        """
+        return self._country
+
+    @country.setter
+    def country(self, country):
+        """
+        Sets the country of this ShippingAddress.
+
+        :param country: The country of this ShippingAddress.
+        :type: str
+        """
+        self._country = country
+
+    @property
+    def phone_number(self):
+        """
+        Gets the phone_number of this ShippingAddress.
+
+        :return: The phone_number of this ShippingAddress.
+        :rtype: str
+        """
+        return self._phone_number
+
+    @phone_number.setter
+    def phone_number(self, phone_number):
+        """
+        Sets the phone_number of this ShippingAddress.
+
+        :param phone_number: The phone_number of this ShippingAddress.
+        :type: str
+        """
+        self._phone_number = phone_number
+
+    @property
+    def email(self):
+        """
+        Gets the email of this ShippingAddress.
+
+        :return: The email of this ShippingAddress.
+        :rtype: str
+        """
+        return self._email
+
+    @email.setter
+    def email(self, email):
+        """
+        Sets the email of this ShippingAddress.
+
+        :param email: The email of this ShippingAddress.
+        :type: str
+        """
+        self._email = email
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/shipping_vendors.py
+++ b/src/oci/dts/models/shipping_vendors.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ShippingVendors(object):
+    """
+    ShippingVendors model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ShippingVendors object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param vendors:
+            The value to assign to the vendors property of this ShippingVendors.
+        :type vendors: list[str]
+
+        """
+        self.swagger_types = {
+            'vendors': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'vendors': 'vendors'
+        }
+
+        self._vendors = None
+
+    @property
+    def vendors(self):
+        """
+        Gets the vendors of this ShippingVendors.
+        List of available shipping vendors for package delivery
+
+
+        :return: The vendors of this ShippingVendors.
+        :rtype: list[str]
+        """
+        return self._vendors
+
+    @vendors.setter
+    def vendors(self, vendors):
+        """
+        Sets the vendors of this ShippingVendors.
+        List of available shipping vendors for package delivery
+
+
+        :param vendors: The vendors of this ShippingVendors.
+        :type: list[str]
+        """
+        self._vendors = vendors
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/transfer_appliance.py
+++ b/src/oci/dts/models/transfer_appliance.py
@@ -1,0 +1,527 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TransferAppliance(object):
+    """
+    TransferAppliance model.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "REQUESTED"
+    LIFECYCLE_STATE_REQUESTED = "REQUESTED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "ORACLE_PREPARING"
+    LIFECYCLE_STATE_ORACLE_PREPARING = "ORACLE_PREPARING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "SHIPPING"
+    LIFECYCLE_STATE_SHIPPING = "SHIPPING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "DELIVERED"
+    LIFECYCLE_STATE_DELIVERED = "DELIVERED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "PREPARING"
+    LIFECYCLE_STATE_PREPARING = "PREPARING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "RETURN_SHIPPED"
+    LIFECYCLE_STATE_RETURN_SHIPPED = "RETURN_SHIPPED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "RETURN_SHIPPED_CANCELLED"
+    LIFECYCLE_STATE_RETURN_SHIPPED_CANCELLED = "RETURN_SHIPPED_CANCELLED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "ORACLE_RECEIVED"
+    LIFECYCLE_STATE_ORACLE_RECEIVED = "ORACLE_RECEIVED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "ORACLE_RECEIVED_CANCELLED"
+    LIFECYCLE_STATE_ORACLE_RECEIVED_CANCELLED = "ORACLE_RECEIVED_CANCELLED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "PROCESSING"
+    LIFECYCLE_STATE_PROCESSING = "PROCESSING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "COMPLETE"
+    LIFECYCLE_STATE_COMPLETE = "COMPLETE"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "CUSTOMER_NEVER_RECEIVED"
+    LIFECYCLE_STATE_CUSTOMER_NEVER_RECEIVED = "CUSTOMER_NEVER_RECEIVED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "ORACLE_NEVER_RECEIVED"
+    LIFECYCLE_STATE_ORACLE_NEVER_RECEIVED = "ORACLE_NEVER_RECEIVED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "CUSTOMER_LOST"
+    LIFECYCLE_STATE_CUSTOMER_LOST = "CUSTOMER_LOST"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "CANCELLED"
+    LIFECYCLE_STATE_CANCELLED = "CANCELLED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "REJECTED"
+    LIFECYCLE_STATE_REJECTED = "REJECTED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "ERROR"
+    LIFECYCLE_STATE_ERROR = "ERROR"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TransferAppliance object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param label:
+            The value to assign to the label property of this TransferAppliance.
+        :type label: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TransferAppliance.
+            Allowed values for this property are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param transfer_job_id:
+            The value to assign to the transfer_job_id property of this TransferAppliance.
+        :type transfer_job_id: str
+
+        :param serial_number:
+            The value to assign to the serial_number property of this TransferAppliance.
+        :type serial_number: str
+
+        :param creation_time:
+            The value to assign to the creation_time property of this TransferAppliance.
+        :type creation_time: datetime
+
+        :param customer_received_time:
+            The value to assign to the customer_received_time property of this TransferAppliance.
+        :type customer_received_time: datetime
+
+        :param customer_returned_time:
+            The value to assign to the customer_returned_time property of this TransferAppliance.
+        :type customer_returned_time: datetime
+
+        :param next_billing_time:
+            The value to assign to the next_billing_time property of this TransferAppliance.
+        :type next_billing_time: datetime
+
+        :param delivery_security_tie_id:
+            The value to assign to the delivery_security_tie_id property of this TransferAppliance.
+        :type delivery_security_tie_id: str
+
+        :param return_security_tie_id:
+            The value to assign to the return_security_tie_id property of this TransferAppliance.
+        :type return_security_tie_id: str
+
+        :param appliance_delivery_tracking_number:
+            The value to assign to the appliance_delivery_tracking_number property of this TransferAppliance.
+        :type appliance_delivery_tracking_number: str
+
+        :param appliance_return_delivery_tracking_number:
+            The value to assign to the appliance_return_delivery_tracking_number property of this TransferAppliance.
+        :type appliance_return_delivery_tracking_number: str
+
+        :param appliance_delivery_vendor:
+            The value to assign to the appliance_delivery_vendor property of this TransferAppliance.
+        :type appliance_delivery_vendor: str
+
+        :param customer_shipping_address:
+            The value to assign to the customer_shipping_address property of this TransferAppliance.
+        :type customer_shipping_address: ShippingAddress
+
+        :param upload_status_log_uri:
+            The value to assign to the upload_status_log_uri property of this TransferAppliance.
+        :type upload_status_log_uri: str
+
+        """
+        self.swagger_types = {
+            'label': 'str',
+            'lifecycle_state': 'str',
+            'transfer_job_id': 'str',
+            'serial_number': 'str',
+            'creation_time': 'datetime',
+            'customer_received_time': 'datetime',
+            'customer_returned_time': 'datetime',
+            'next_billing_time': 'datetime',
+            'delivery_security_tie_id': 'str',
+            'return_security_tie_id': 'str',
+            'appliance_delivery_tracking_number': 'str',
+            'appliance_return_delivery_tracking_number': 'str',
+            'appliance_delivery_vendor': 'str',
+            'customer_shipping_address': 'ShippingAddress',
+            'upload_status_log_uri': 'str'
+        }
+
+        self.attribute_map = {
+            'label': 'label',
+            'lifecycle_state': 'lifecycleState',
+            'transfer_job_id': 'transferJobId',
+            'serial_number': 'serialNumber',
+            'creation_time': 'creationTime',
+            'customer_received_time': 'customerReceivedTime',
+            'customer_returned_time': 'customerReturnedTime',
+            'next_billing_time': 'nextBillingTime',
+            'delivery_security_tie_id': 'deliverySecurityTieId',
+            'return_security_tie_id': 'returnSecurityTieId',
+            'appliance_delivery_tracking_number': 'applianceDeliveryTrackingNumber',
+            'appliance_return_delivery_tracking_number': 'applianceReturnDeliveryTrackingNumber',
+            'appliance_delivery_vendor': 'applianceDeliveryVendor',
+            'customer_shipping_address': 'customerShippingAddress',
+            'upload_status_log_uri': 'uploadStatusLogUri'
+        }
+
+        self._label = None
+        self._lifecycle_state = None
+        self._transfer_job_id = None
+        self._serial_number = None
+        self._creation_time = None
+        self._customer_received_time = None
+        self._customer_returned_time = None
+        self._next_billing_time = None
+        self._delivery_security_tie_id = None
+        self._return_security_tie_id = None
+        self._appliance_delivery_tracking_number = None
+        self._appliance_return_delivery_tracking_number = None
+        self._appliance_delivery_vendor = None
+        self._customer_shipping_address = None
+        self._upload_status_log_uri = None
+
+    @property
+    def label(self):
+        """
+        **[Required]** Gets the label of this TransferAppliance.
+        Unique alpha-numeric identifier for a transfer appliance auto generated during create.
+
+
+        :return: The label of this TransferAppliance.
+        :rtype: str
+        """
+        return self._label
+
+    @label.setter
+    def label(self, label):
+        """
+        Sets the label of this TransferAppliance.
+        Unique alpha-numeric identifier for a transfer appliance auto generated during create.
+
+
+        :param label: The label of this TransferAppliance.
+        :type: str
+        """
+        self._label = label
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this TransferAppliance.
+        Allowed values for this property are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this TransferAppliance.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this TransferAppliance.
+
+        :param lifecycle_state: The lifecycle_state of this TransferAppliance.
+        :type: str
+        """
+        allowed_values = ["REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def transfer_job_id(self):
+        """
+        Gets the transfer_job_id of this TransferAppliance.
+
+        :return: The transfer_job_id of this TransferAppliance.
+        :rtype: str
+        """
+        return self._transfer_job_id
+
+    @transfer_job_id.setter
+    def transfer_job_id(self, transfer_job_id):
+        """
+        Sets the transfer_job_id of this TransferAppliance.
+
+        :param transfer_job_id: The transfer_job_id of this TransferAppliance.
+        :type: str
+        """
+        self._transfer_job_id = transfer_job_id
+
+    @property
+    def serial_number(self):
+        """
+        Gets the serial_number of this TransferAppliance.
+
+        :return: The serial_number of this TransferAppliance.
+        :rtype: str
+        """
+        return self._serial_number
+
+    @serial_number.setter
+    def serial_number(self, serial_number):
+        """
+        Sets the serial_number of this TransferAppliance.
+
+        :param serial_number: The serial_number of this TransferAppliance.
+        :type: str
+        """
+        self._serial_number = serial_number
+
+    @property
+    def creation_time(self):
+        """
+        Gets the creation_time of this TransferAppliance.
+
+        :return: The creation_time of this TransferAppliance.
+        :rtype: datetime
+        """
+        return self._creation_time
+
+    @creation_time.setter
+    def creation_time(self, creation_time):
+        """
+        Sets the creation_time of this TransferAppliance.
+
+        :param creation_time: The creation_time of this TransferAppliance.
+        :type: datetime
+        """
+        self._creation_time = creation_time
+
+    @property
+    def customer_received_time(self):
+        """
+        Gets the customer_received_time of this TransferAppliance.
+
+        :return: The customer_received_time of this TransferAppliance.
+        :rtype: datetime
+        """
+        return self._customer_received_time
+
+    @customer_received_time.setter
+    def customer_received_time(self, customer_received_time):
+        """
+        Sets the customer_received_time of this TransferAppliance.
+
+        :param customer_received_time: The customer_received_time of this TransferAppliance.
+        :type: datetime
+        """
+        self._customer_received_time = customer_received_time
+
+    @property
+    def customer_returned_time(self):
+        """
+        Gets the customer_returned_time of this TransferAppliance.
+
+        :return: The customer_returned_time of this TransferAppliance.
+        :rtype: datetime
+        """
+        return self._customer_returned_time
+
+    @customer_returned_time.setter
+    def customer_returned_time(self, customer_returned_time):
+        """
+        Sets the customer_returned_time of this TransferAppliance.
+
+        :param customer_returned_time: The customer_returned_time of this TransferAppliance.
+        :type: datetime
+        """
+        self._customer_returned_time = customer_returned_time
+
+    @property
+    def next_billing_time(self):
+        """
+        Gets the next_billing_time of this TransferAppliance.
+
+        :return: The next_billing_time of this TransferAppliance.
+        :rtype: datetime
+        """
+        return self._next_billing_time
+
+    @next_billing_time.setter
+    def next_billing_time(self, next_billing_time):
+        """
+        Sets the next_billing_time of this TransferAppliance.
+
+        :param next_billing_time: The next_billing_time of this TransferAppliance.
+        :type: datetime
+        """
+        self._next_billing_time = next_billing_time
+
+    @property
+    def delivery_security_tie_id(self):
+        """
+        Gets the delivery_security_tie_id of this TransferAppliance.
+
+        :return: The delivery_security_tie_id of this TransferAppliance.
+        :rtype: str
+        """
+        return self._delivery_security_tie_id
+
+    @delivery_security_tie_id.setter
+    def delivery_security_tie_id(self, delivery_security_tie_id):
+        """
+        Sets the delivery_security_tie_id of this TransferAppliance.
+
+        :param delivery_security_tie_id: The delivery_security_tie_id of this TransferAppliance.
+        :type: str
+        """
+        self._delivery_security_tie_id = delivery_security_tie_id
+
+    @property
+    def return_security_tie_id(self):
+        """
+        Gets the return_security_tie_id of this TransferAppliance.
+
+        :return: The return_security_tie_id of this TransferAppliance.
+        :rtype: str
+        """
+        return self._return_security_tie_id
+
+    @return_security_tie_id.setter
+    def return_security_tie_id(self, return_security_tie_id):
+        """
+        Sets the return_security_tie_id of this TransferAppliance.
+
+        :param return_security_tie_id: The return_security_tie_id of this TransferAppliance.
+        :type: str
+        """
+        self._return_security_tie_id = return_security_tie_id
+
+    @property
+    def appliance_delivery_tracking_number(self):
+        """
+        Gets the appliance_delivery_tracking_number of this TransferAppliance.
+
+        :return: The appliance_delivery_tracking_number of this TransferAppliance.
+        :rtype: str
+        """
+        return self._appliance_delivery_tracking_number
+
+    @appliance_delivery_tracking_number.setter
+    def appliance_delivery_tracking_number(self, appliance_delivery_tracking_number):
+        """
+        Sets the appliance_delivery_tracking_number of this TransferAppliance.
+
+        :param appliance_delivery_tracking_number: The appliance_delivery_tracking_number of this TransferAppliance.
+        :type: str
+        """
+        self._appliance_delivery_tracking_number = appliance_delivery_tracking_number
+
+    @property
+    def appliance_return_delivery_tracking_number(self):
+        """
+        Gets the appliance_return_delivery_tracking_number of this TransferAppliance.
+
+        :return: The appliance_return_delivery_tracking_number of this TransferAppliance.
+        :rtype: str
+        """
+        return self._appliance_return_delivery_tracking_number
+
+    @appliance_return_delivery_tracking_number.setter
+    def appliance_return_delivery_tracking_number(self, appliance_return_delivery_tracking_number):
+        """
+        Sets the appliance_return_delivery_tracking_number of this TransferAppliance.
+
+        :param appliance_return_delivery_tracking_number: The appliance_return_delivery_tracking_number of this TransferAppliance.
+        :type: str
+        """
+        self._appliance_return_delivery_tracking_number = appliance_return_delivery_tracking_number
+
+    @property
+    def appliance_delivery_vendor(self):
+        """
+        Gets the appliance_delivery_vendor of this TransferAppliance.
+
+        :return: The appliance_delivery_vendor of this TransferAppliance.
+        :rtype: str
+        """
+        return self._appliance_delivery_vendor
+
+    @appliance_delivery_vendor.setter
+    def appliance_delivery_vendor(self, appliance_delivery_vendor):
+        """
+        Sets the appliance_delivery_vendor of this TransferAppliance.
+
+        :param appliance_delivery_vendor: The appliance_delivery_vendor of this TransferAppliance.
+        :type: str
+        """
+        self._appliance_delivery_vendor = appliance_delivery_vendor
+
+    @property
+    def customer_shipping_address(self):
+        """
+        Gets the customer_shipping_address of this TransferAppliance.
+
+        :return: The customer_shipping_address of this TransferAppliance.
+        :rtype: ShippingAddress
+        """
+        return self._customer_shipping_address
+
+    @customer_shipping_address.setter
+    def customer_shipping_address(self, customer_shipping_address):
+        """
+        Sets the customer_shipping_address of this TransferAppliance.
+
+        :param customer_shipping_address: The customer_shipping_address of this TransferAppliance.
+        :type: ShippingAddress
+        """
+        self._customer_shipping_address = customer_shipping_address
+
+    @property
+    def upload_status_log_uri(self):
+        """
+        Gets the upload_status_log_uri of this TransferAppliance.
+
+        :return: The upload_status_log_uri of this TransferAppliance.
+        :rtype: str
+        """
+        return self._upload_status_log_uri
+
+    @upload_status_log_uri.setter
+    def upload_status_log_uri(self, upload_status_log_uri):
+        """
+        Sets the upload_status_log_uri of this TransferAppliance.
+
+        :param upload_status_log_uri: The upload_status_log_uri of this TransferAppliance.
+        :type: str
+        """
+        self._upload_status_log_uri = upload_status_log_uri
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/transfer_appliance_certificate.py
+++ b/src/oci/dts/models/transfer_appliance_certificate.py
@@ -1,0 +1,65 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TransferApplianceCertificate(object):
+    """
+    TransferApplianceCertificate model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TransferApplianceCertificate object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param certificate:
+            The value to assign to the certificate property of this TransferApplianceCertificate.
+        :type certificate: str
+
+        """
+        self.swagger_types = {
+            'certificate': 'str'
+        }
+
+        self.attribute_map = {
+            'certificate': 'certificate'
+        }
+
+        self._certificate = None
+
+    @property
+    def certificate(self):
+        """
+        Gets the certificate of this TransferApplianceCertificate.
+
+        :return: The certificate of this TransferApplianceCertificate.
+        :rtype: str
+        """
+        return self._certificate
+
+    @certificate.setter
+    def certificate(self, certificate):
+        """
+        Sets the certificate of this TransferApplianceCertificate.
+
+        :param certificate: The certificate of this TransferApplianceCertificate.
+        :type: str
+        """
+        self._certificate = certificate
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/transfer_appliance_encryption_passphrase.py
+++ b/src/oci/dts/models/transfer_appliance_encryption_passphrase.py
@@ -1,0 +1,65 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TransferApplianceEncryptionPassphrase(object):
+    """
+    TransferApplianceEncryptionPassphrase model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TransferApplianceEncryptionPassphrase object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param encryption_passphrase:
+            The value to assign to the encryption_passphrase property of this TransferApplianceEncryptionPassphrase.
+        :type encryption_passphrase: str
+
+        """
+        self.swagger_types = {
+            'encryption_passphrase': 'str'
+        }
+
+        self.attribute_map = {
+            'encryption_passphrase': 'encryptionPassphrase'
+        }
+
+        self._encryption_passphrase = None
+
+    @property
+    def encryption_passphrase(self):
+        """
+        Gets the encryption_passphrase of this TransferApplianceEncryptionPassphrase.
+
+        :return: The encryption_passphrase of this TransferApplianceEncryptionPassphrase.
+        :rtype: str
+        """
+        return self._encryption_passphrase
+
+    @encryption_passphrase.setter
+    def encryption_passphrase(self, encryption_passphrase):
+        """
+        Sets the encryption_passphrase of this TransferApplianceEncryptionPassphrase.
+
+        :param encryption_passphrase: The encryption_passphrase of this TransferApplianceEncryptionPassphrase.
+        :type: str
+        """
+        self._encryption_passphrase = encryption_passphrase
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/transfer_appliance_entitlement.py
+++ b/src/oci/dts/models/transfer_appliance_entitlement.py
@@ -1,0 +1,236 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TransferApplianceEntitlement(object):
+    """
+    TransferApplianceEntitlement model.
+    """
+
+    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
+    #: This constant has a value of "REQUESTED"
+    STATUS_REQUESTED = "REQUESTED"
+
+    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
+    #: This constant has a value of "PENDING_SIGNING"
+    STATUS_PENDING_SIGNING = "PENDING_SIGNING"
+
+    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
+    #: This constant has a value of "PENDING_APPROVAL"
+    STATUS_PENDING_APPROVAL = "PENDING_APPROVAL"
+
+    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
+    #: This constant has a value of "TERMS_EXPIRED"
+    STATUS_TERMS_EXPIRED = "TERMS_EXPIRED"
+
+    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
+    #: This constant has a value of "APPROVED"
+    STATUS_APPROVED = "APPROVED"
+
+    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
+    #: This constant has a value of "REJECTED"
+    STATUS_REJECTED = "REJECTED"
+
+    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
+    #: This constant has a value of "CANCELLED"
+    STATUS_CANCELLED = "CANCELLED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TransferApplianceEntitlement object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param tenant_id:
+            The value to assign to the tenant_id property of this TransferApplianceEntitlement.
+        :type tenant_id: str
+
+        :param requestor_name:
+            The value to assign to the requestor_name property of this TransferApplianceEntitlement.
+        :type requestor_name: str
+
+        :param requestor_email:
+            The value to assign to the requestor_email property of this TransferApplianceEntitlement.
+        :type requestor_email: str
+
+        :param status:
+            The value to assign to the status property of this TransferApplianceEntitlement.
+            Allowed values for this property are: "REQUESTED", "PENDING_SIGNING", "PENDING_APPROVAL", "TERMS_EXPIRED", "APPROVED", "REJECTED", "CANCELLED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param creation_time:
+            The value to assign to the creation_time property of this TransferApplianceEntitlement.
+        :type creation_time: datetime
+
+        :param update_time:
+            The value to assign to the update_time property of this TransferApplianceEntitlement.
+        :type update_time: datetime
+
+        """
+        self.swagger_types = {
+            'tenant_id': 'str',
+            'requestor_name': 'str',
+            'requestor_email': 'str',
+            'status': 'str',
+            'creation_time': 'datetime',
+            'update_time': 'datetime'
+        }
+
+        self.attribute_map = {
+            'tenant_id': 'tenantId',
+            'requestor_name': 'requestorName',
+            'requestor_email': 'requestorEmail',
+            'status': 'status',
+            'creation_time': 'creationTime',
+            'update_time': 'updateTime'
+        }
+
+        self._tenant_id = None
+        self._requestor_name = None
+        self._requestor_email = None
+        self._status = None
+        self._creation_time = None
+        self._update_time = None
+
+    @property
+    def tenant_id(self):
+        """
+        **[Required]** Gets the tenant_id of this TransferApplianceEntitlement.
+
+        :return: The tenant_id of this TransferApplianceEntitlement.
+        :rtype: str
+        """
+        return self._tenant_id
+
+    @tenant_id.setter
+    def tenant_id(self, tenant_id):
+        """
+        Sets the tenant_id of this TransferApplianceEntitlement.
+
+        :param tenant_id: The tenant_id of this TransferApplianceEntitlement.
+        :type: str
+        """
+        self._tenant_id = tenant_id
+
+    @property
+    def requestor_name(self):
+        """
+        Gets the requestor_name of this TransferApplianceEntitlement.
+
+        :return: The requestor_name of this TransferApplianceEntitlement.
+        :rtype: str
+        """
+        return self._requestor_name
+
+    @requestor_name.setter
+    def requestor_name(self, requestor_name):
+        """
+        Sets the requestor_name of this TransferApplianceEntitlement.
+
+        :param requestor_name: The requestor_name of this TransferApplianceEntitlement.
+        :type: str
+        """
+        self._requestor_name = requestor_name
+
+    @property
+    def requestor_email(self):
+        """
+        Gets the requestor_email of this TransferApplianceEntitlement.
+
+        :return: The requestor_email of this TransferApplianceEntitlement.
+        :rtype: str
+        """
+        return self._requestor_email
+
+    @requestor_email.setter
+    def requestor_email(self, requestor_email):
+        """
+        Sets the requestor_email of this TransferApplianceEntitlement.
+
+        :param requestor_email: The requestor_email of this TransferApplianceEntitlement.
+        :type: str
+        """
+        self._requestor_email = requestor_email
+
+    @property
+    def status(self):
+        """
+        **[Required]** Gets the status of this TransferApplianceEntitlement.
+        Allowed values for this property are: "REQUESTED", "PENDING_SIGNING", "PENDING_APPROVAL", "TERMS_EXPIRED", "APPROVED", "REJECTED", "CANCELLED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this TransferApplianceEntitlement.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this TransferApplianceEntitlement.
+
+        :param status: The status of this TransferApplianceEntitlement.
+        :type: str
+        """
+        allowed_values = ["REQUESTED", "PENDING_SIGNING", "PENDING_APPROVAL", "TERMS_EXPIRED", "APPROVED", "REJECTED", "CANCELLED"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def creation_time(self):
+        """
+        Gets the creation_time of this TransferApplianceEntitlement.
+
+        :return: The creation_time of this TransferApplianceEntitlement.
+        :rtype: datetime
+        """
+        return self._creation_time
+
+    @creation_time.setter
+    def creation_time(self, creation_time):
+        """
+        Sets the creation_time of this TransferApplianceEntitlement.
+
+        :param creation_time: The creation_time of this TransferApplianceEntitlement.
+        :type: datetime
+        """
+        self._creation_time = creation_time
+
+    @property
+    def update_time(self):
+        """
+        Gets the update_time of this TransferApplianceEntitlement.
+
+        :return: The update_time of this TransferApplianceEntitlement.
+        :rtype: datetime
+        """
+        return self._update_time
+
+    @update_time.setter
+    def update_time(self, update_time):
+        """
+        Sets the update_time of this TransferApplianceEntitlement.
+
+        :param update_time: The update_time of this TransferApplianceEntitlement.
+        :type: datetime
+        """
+        self._update_time = update_time
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/transfer_appliance_public_key.py
+++ b/src/oci/dts/models/transfer_appliance_public_key.py
@@ -1,0 +1,65 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TransferAppliancePublicKey(object):
+    """
+    TransferAppliancePublicKey model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TransferAppliancePublicKey object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param public_key:
+            The value to assign to the public_key property of this TransferAppliancePublicKey.
+        :type public_key: str
+
+        """
+        self.swagger_types = {
+            'public_key': 'str'
+        }
+
+        self.attribute_map = {
+            'public_key': 'publicKey'
+        }
+
+        self._public_key = None
+
+    @property
+    def public_key(self):
+        """
+        Gets the public_key of this TransferAppliancePublicKey.
+
+        :return: The public_key of this TransferAppliancePublicKey.
+        :rtype: str
+        """
+        return self._public_key
+
+    @public_key.setter
+    def public_key(self, public_key):
+        """
+        Sets the public_key of this TransferAppliancePublicKey.
+
+        :param public_key: The public_key of this TransferAppliancePublicKey.
+        :type: str
+        """
+        self._public_key = public_key
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/transfer_appliance_summary.py
+++ b/src/oci/dts/models/transfer_appliance_summary.py
@@ -1,0 +1,226 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TransferApplianceSummary(object):
+    """
+    TransferApplianceSummary model.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "REQUESTED"
+    LIFECYCLE_STATE_REQUESTED = "REQUESTED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "ORACLE_PREPARING"
+    LIFECYCLE_STATE_ORACLE_PREPARING = "ORACLE_PREPARING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "SHIPPING"
+    LIFECYCLE_STATE_SHIPPING = "SHIPPING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "DELIVERED"
+    LIFECYCLE_STATE_DELIVERED = "DELIVERED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "PREPARING"
+    LIFECYCLE_STATE_PREPARING = "PREPARING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "RETURN_SHIPPED"
+    LIFECYCLE_STATE_RETURN_SHIPPED = "RETURN_SHIPPED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "RETURN_SHIPPED_CANCELLED"
+    LIFECYCLE_STATE_RETURN_SHIPPED_CANCELLED = "RETURN_SHIPPED_CANCELLED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "ORACLE_RECEIVED"
+    LIFECYCLE_STATE_ORACLE_RECEIVED = "ORACLE_RECEIVED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "ORACLE_RECEIVED_CANCELLED"
+    LIFECYCLE_STATE_ORACLE_RECEIVED_CANCELLED = "ORACLE_RECEIVED_CANCELLED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "PROCESSING"
+    LIFECYCLE_STATE_PROCESSING = "PROCESSING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "COMPLETE"
+    LIFECYCLE_STATE_COMPLETE = "COMPLETE"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "CUSTOMER_NEVER_RECEIVED"
+    LIFECYCLE_STATE_CUSTOMER_NEVER_RECEIVED = "CUSTOMER_NEVER_RECEIVED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "ORACLE_NEVER_RECEIVED"
+    LIFECYCLE_STATE_ORACLE_NEVER_RECEIVED = "ORACLE_NEVER_RECEIVED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "CUSTOMER_LOST"
+    LIFECYCLE_STATE_CUSTOMER_LOST = "CUSTOMER_LOST"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "CANCELLED"
+    LIFECYCLE_STATE_CANCELLED = "CANCELLED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "REJECTED"
+    LIFECYCLE_STATE_REJECTED = "REJECTED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "ERROR"
+    LIFECYCLE_STATE_ERROR = "ERROR"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TransferApplianceSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param label:
+            The value to assign to the label property of this TransferApplianceSummary.
+        :type label: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TransferApplianceSummary.
+            Allowed values for this property are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param serial_number:
+            The value to assign to the serial_number property of this TransferApplianceSummary.
+        :type serial_number: str
+
+        :param creation_time:
+            The value to assign to the creation_time property of this TransferApplianceSummary.
+        :type creation_time: datetime
+
+        """
+        self.swagger_types = {
+            'label': 'str',
+            'lifecycle_state': 'str',
+            'serial_number': 'str',
+            'creation_time': 'datetime'
+        }
+
+        self.attribute_map = {
+            'label': 'label',
+            'lifecycle_state': 'lifecycleState',
+            'serial_number': 'serialNumber',
+            'creation_time': 'creationTime'
+        }
+
+        self._label = None
+        self._lifecycle_state = None
+        self._serial_number = None
+        self._creation_time = None
+
+    @property
+    def label(self):
+        """
+        Gets the label of this TransferApplianceSummary.
+
+        :return: The label of this TransferApplianceSummary.
+        :rtype: str
+        """
+        return self._label
+
+    @label.setter
+    def label(self, label):
+        """
+        Sets the label of this TransferApplianceSummary.
+
+        :param label: The label of this TransferApplianceSummary.
+        :type: str
+        """
+        self._label = label
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this TransferApplianceSummary.
+        Allowed values for this property are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this TransferApplianceSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this TransferApplianceSummary.
+
+        :param lifecycle_state: The lifecycle_state of this TransferApplianceSummary.
+        :type: str
+        """
+        allowed_values = ["REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def serial_number(self):
+        """
+        Gets the serial_number of this TransferApplianceSummary.
+
+        :return: The serial_number of this TransferApplianceSummary.
+        :rtype: str
+        """
+        return self._serial_number
+
+    @serial_number.setter
+    def serial_number(self, serial_number):
+        """
+        Sets the serial_number of this TransferApplianceSummary.
+
+        :param serial_number: The serial_number of this TransferApplianceSummary.
+        :type: str
+        """
+        self._serial_number = serial_number
+
+    @property
+    def creation_time(self):
+        """
+        Gets the creation_time of this TransferApplianceSummary.
+
+        :return: The creation_time of this TransferApplianceSummary.
+        :rtype: datetime
+        """
+        return self._creation_time
+
+    @creation_time.setter
+    def creation_time(self, creation_time):
+        """
+        Sets the creation_time of this TransferApplianceSummary.
+
+        :param creation_time: The creation_time of this TransferApplianceSummary.
+        :type: datetime
+        """
+        self._creation_time = creation_time
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/transfer_device.py
+++ b/src/oci/dts/models/transfer_device.py
@@ -1,0 +1,302 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TransferDevice(object):
+    """
+    TransferDevice model.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDevice.
+    #: This constant has a value of "PREPARING"
+    LIFECYCLE_STATE_PREPARING = "PREPARING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDevice.
+    #: This constant has a value of "READY"
+    LIFECYCLE_STATE_READY = "READY"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDevice.
+    #: This constant has a value of "PACKAGED"
+    LIFECYCLE_STATE_PACKAGED = "PACKAGED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDevice.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDevice.
+    #: This constant has a value of "PROCESSING"
+    LIFECYCLE_STATE_PROCESSING = "PROCESSING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDevice.
+    #: This constant has a value of "COMPLETE"
+    LIFECYCLE_STATE_COMPLETE = "COMPLETE"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDevice.
+    #: This constant has a value of "MISSING"
+    LIFECYCLE_STATE_MISSING = "MISSING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDevice.
+    #: This constant has a value of "ERROR"
+    LIFECYCLE_STATE_ERROR = "ERROR"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDevice.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDevice.
+    #: This constant has a value of "CANCELLED"
+    LIFECYCLE_STATE_CANCELLED = "CANCELLED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TransferDevice object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param serial_number:
+            The value to assign to the serial_number property of this TransferDevice.
+        :type serial_number: str
+
+        :param iscsi_iqn:
+            The value to assign to the iscsi_iqn property of this TransferDevice.
+        :type iscsi_iqn: str
+
+        :param label:
+            The value to assign to the label property of this TransferDevice.
+        :type label: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TransferDevice.
+            Allowed values for this property are: "PREPARING", "READY", "PACKAGED", "ACTIVE", "PROCESSING", "COMPLETE", "MISSING", "ERROR", "DELETED", "CANCELLED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param transfer_job_id:
+            The value to assign to the transfer_job_id property of this TransferDevice.
+        :type transfer_job_id: str
+
+        :param attached_transfer_package_label:
+            The value to assign to the attached_transfer_package_label property of this TransferDevice.
+        :type attached_transfer_package_label: str
+
+        :param creation_time:
+            The value to assign to the creation_time property of this TransferDevice.
+        :type creation_time: datetime
+
+        :param upload_status_log_uri:
+            The value to assign to the upload_status_log_uri property of this TransferDevice.
+        :type upload_status_log_uri: str
+
+        """
+        self.swagger_types = {
+            'serial_number': 'str',
+            'iscsi_iqn': 'str',
+            'label': 'str',
+            'lifecycle_state': 'str',
+            'transfer_job_id': 'str',
+            'attached_transfer_package_label': 'str',
+            'creation_time': 'datetime',
+            'upload_status_log_uri': 'str'
+        }
+
+        self.attribute_map = {
+            'serial_number': 'serialNumber',
+            'iscsi_iqn': 'iscsiIQN',
+            'label': 'label',
+            'lifecycle_state': 'lifecycleState',
+            'transfer_job_id': 'transferJobId',
+            'attached_transfer_package_label': 'attachedTransferPackageLabel',
+            'creation_time': 'creationTime',
+            'upload_status_log_uri': 'uploadStatusLogUri'
+        }
+
+        self._serial_number = None
+        self._iscsi_iqn = None
+        self._label = None
+        self._lifecycle_state = None
+        self._transfer_job_id = None
+        self._attached_transfer_package_label = None
+        self._creation_time = None
+        self._upload_status_log_uri = None
+
+    @property
+    def serial_number(self):
+        """
+        Gets the serial_number of this TransferDevice.
+
+        :return: The serial_number of this TransferDevice.
+        :rtype: str
+        """
+        return self._serial_number
+
+    @serial_number.setter
+    def serial_number(self, serial_number):
+        """
+        Sets the serial_number of this TransferDevice.
+
+        :param serial_number: The serial_number of this TransferDevice.
+        :type: str
+        """
+        self._serial_number = serial_number
+
+    @property
+    def iscsi_iqn(self):
+        """
+        Gets the iscsi_iqn of this TransferDevice.
+
+        :return: The iscsi_iqn of this TransferDevice.
+        :rtype: str
+        """
+        return self._iscsi_iqn
+
+    @iscsi_iqn.setter
+    def iscsi_iqn(self, iscsi_iqn):
+        """
+        Sets the iscsi_iqn of this TransferDevice.
+
+        :param iscsi_iqn: The iscsi_iqn of this TransferDevice.
+        :type: str
+        """
+        self._iscsi_iqn = iscsi_iqn
+
+    @property
+    def label(self):
+        """
+        **[Required]** Gets the label of this TransferDevice.
+
+        :return: The label of this TransferDevice.
+        :rtype: str
+        """
+        return self._label
+
+    @label.setter
+    def label(self, label):
+        """
+        Sets the label of this TransferDevice.
+
+        :param label: The label of this TransferDevice.
+        :type: str
+        """
+        self._label = label
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this TransferDevice.
+        Allowed values for this property are: "PREPARING", "READY", "PACKAGED", "ACTIVE", "PROCESSING", "COMPLETE", "MISSING", "ERROR", "DELETED", "CANCELLED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this TransferDevice.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this TransferDevice.
+
+        :param lifecycle_state: The lifecycle_state of this TransferDevice.
+        :type: str
+        """
+        allowed_values = ["PREPARING", "READY", "PACKAGED", "ACTIVE", "PROCESSING", "COMPLETE", "MISSING", "ERROR", "DELETED", "CANCELLED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def transfer_job_id(self):
+        """
+        Gets the transfer_job_id of this TransferDevice.
+
+        :return: The transfer_job_id of this TransferDevice.
+        :rtype: str
+        """
+        return self._transfer_job_id
+
+    @transfer_job_id.setter
+    def transfer_job_id(self, transfer_job_id):
+        """
+        Sets the transfer_job_id of this TransferDevice.
+
+        :param transfer_job_id: The transfer_job_id of this TransferDevice.
+        :type: str
+        """
+        self._transfer_job_id = transfer_job_id
+
+    @property
+    def attached_transfer_package_label(self):
+        """
+        Gets the attached_transfer_package_label of this TransferDevice.
+
+        :return: The attached_transfer_package_label of this TransferDevice.
+        :rtype: str
+        """
+        return self._attached_transfer_package_label
+
+    @attached_transfer_package_label.setter
+    def attached_transfer_package_label(self, attached_transfer_package_label):
+        """
+        Sets the attached_transfer_package_label of this TransferDevice.
+
+        :param attached_transfer_package_label: The attached_transfer_package_label of this TransferDevice.
+        :type: str
+        """
+        self._attached_transfer_package_label = attached_transfer_package_label
+
+    @property
+    def creation_time(self):
+        """
+        Gets the creation_time of this TransferDevice.
+
+        :return: The creation_time of this TransferDevice.
+        :rtype: datetime
+        """
+        return self._creation_time
+
+    @creation_time.setter
+    def creation_time(self, creation_time):
+        """
+        Sets the creation_time of this TransferDevice.
+
+        :param creation_time: The creation_time of this TransferDevice.
+        :type: datetime
+        """
+        self._creation_time = creation_time
+
+    @property
+    def upload_status_log_uri(self):
+        """
+        Gets the upload_status_log_uri of this TransferDevice.
+
+        :return: The upload_status_log_uri of this TransferDevice.
+        :rtype: str
+        """
+        return self._upload_status_log_uri
+
+    @upload_status_log_uri.setter
+    def upload_status_log_uri(self, upload_status_log_uri):
+        """
+        Sets the upload_status_log_uri of this TransferDevice.
+
+        :param upload_status_log_uri: The upload_status_log_uri of this TransferDevice.
+        :type: str
+        """
+        self._upload_status_log_uri = upload_status_log_uri
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/transfer_device_summary.py
+++ b/src/oci/dts/models/transfer_device_summary.py
@@ -1,0 +1,275 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TransferDeviceSummary(object):
+    """
+    TransferDeviceSummary model.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDeviceSummary.
+    #: This constant has a value of "PREPARING"
+    LIFECYCLE_STATE_PREPARING = "PREPARING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDeviceSummary.
+    #: This constant has a value of "READY"
+    LIFECYCLE_STATE_READY = "READY"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDeviceSummary.
+    #: This constant has a value of "PACKAGED"
+    LIFECYCLE_STATE_PACKAGED = "PACKAGED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDeviceSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDeviceSummary.
+    #: This constant has a value of "PROCESSING"
+    LIFECYCLE_STATE_PROCESSING = "PROCESSING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDeviceSummary.
+    #: This constant has a value of "COMPLETE"
+    LIFECYCLE_STATE_COMPLETE = "COMPLETE"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDeviceSummary.
+    #: This constant has a value of "MISSING"
+    LIFECYCLE_STATE_MISSING = "MISSING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDeviceSummary.
+    #: This constant has a value of "ERROR"
+    LIFECYCLE_STATE_ERROR = "ERROR"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDeviceSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferDeviceSummary.
+    #: This constant has a value of "CANCELLED"
+    LIFECYCLE_STATE_CANCELLED = "CANCELLED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TransferDeviceSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param serial_number:
+            The value to assign to the serial_number property of this TransferDeviceSummary.
+        :type serial_number: str
+
+        :param iscsi_iqn:
+            The value to assign to the iscsi_iqn property of this TransferDeviceSummary.
+        :type iscsi_iqn: str
+
+        :param label:
+            The value to assign to the label property of this TransferDeviceSummary.
+        :type label: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TransferDeviceSummary.
+            Allowed values for this property are: "PREPARING", "READY", "PACKAGED", "ACTIVE", "PROCESSING", "COMPLETE", "MISSING", "ERROR", "DELETED", "CANCELLED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param attached_transfer_package_label:
+            The value to assign to the attached_transfer_package_label property of this TransferDeviceSummary.
+        :type attached_transfer_package_label: str
+
+        :param creation_time:
+            The value to assign to the creation_time property of this TransferDeviceSummary.
+        :type creation_time: datetime
+
+        :param upload_status_log_uri:
+            The value to assign to the upload_status_log_uri property of this TransferDeviceSummary.
+        :type upload_status_log_uri: str
+
+        """
+        self.swagger_types = {
+            'serial_number': 'str',
+            'iscsi_iqn': 'str',
+            'label': 'str',
+            'lifecycle_state': 'str',
+            'attached_transfer_package_label': 'str',
+            'creation_time': 'datetime',
+            'upload_status_log_uri': 'str'
+        }
+
+        self.attribute_map = {
+            'serial_number': 'serialNumber',
+            'iscsi_iqn': 'iscsiIQN',
+            'label': 'label',
+            'lifecycle_state': 'lifecycleState',
+            'attached_transfer_package_label': 'attachedTransferPackageLabel',
+            'creation_time': 'creationTime',
+            'upload_status_log_uri': 'uploadStatusLogUri'
+        }
+
+        self._serial_number = None
+        self._iscsi_iqn = None
+        self._label = None
+        self._lifecycle_state = None
+        self._attached_transfer_package_label = None
+        self._creation_time = None
+        self._upload_status_log_uri = None
+
+    @property
+    def serial_number(self):
+        """
+        Gets the serial_number of this TransferDeviceSummary.
+
+        :return: The serial_number of this TransferDeviceSummary.
+        :rtype: str
+        """
+        return self._serial_number
+
+    @serial_number.setter
+    def serial_number(self, serial_number):
+        """
+        Sets the serial_number of this TransferDeviceSummary.
+
+        :param serial_number: The serial_number of this TransferDeviceSummary.
+        :type: str
+        """
+        self._serial_number = serial_number
+
+    @property
+    def iscsi_iqn(self):
+        """
+        Gets the iscsi_iqn of this TransferDeviceSummary.
+
+        :return: The iscsi_iqn of this TransferDeviceSummary.
+        :rtype: str
+        """
+        return self._iscsi_iqn
+
+    @iscsi_iqn.setter
+    def iscsi_iqn(self, iscsi_iqn):
+        """
+        Sets the iscsi_iqn of this TransferDeviceSummary.
+
+        :param iscsi_iqn: The iscsi_iqn of this TransferDeviceSummary.
+        :type: str
+        """
+        self._iscsi_iqn = iscsi_iqn
+
+    @property
+    def label(self):
+        """
+        Gets the label of this TransferDeviceSummary.
+
+        :return: The label of this TransferDeviceSummary.
+        :rtype: str
+        """
+        return self._label
+
+    @label.setter
+    def label(self, label):
+        """
+        Sets the label of this TransferDeviceSummary.
+
+        :param label: The label of this TransferDeviceSummary.
+        :type: str
+        """
+        self._label = label
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this TransferDeviceSummary.
+        Allowed values for this property are: "PREPARING", "READY", "PACKAGED", "ACTIVE", "PROCESSING", "COMPLETE", "MISSING", "ERROR", "DELETED", "CANCELLED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this TransferDeviceSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this TransferDeviceSummary.
+
+        :param lifecycle_state: The lifecycle_state of this TransferDeviceSummary.
+        :type: str
+        """
+        allowed_values = ["PREPARING", "READY", "PACKAGED", "ACTIVE", "PROCESSING", "COMPLETE", "MISSING", "ERROR", "DELETED", "CANCELLED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def attached_transfer_package_label(self):
+        """
+        Gets the attached_transfer_package_label of this TransferDeviceSummary.
+
+        :return: The attached_transfer_package_label of this TransferDeviceSummary.
+        :rtype: str
+        """
+        return self._attached_transfer_package_label
+
+    @attached_transfer_package_label.setter
+    def attached_transfer_package_label(self, attached_transfer_package_label):
+        """
+        Sets the attached_transfer_package_label of this TransferDeviceSummary.
+
+        :param attached_transfer_package_label: The attached_transfer_package_label of this TransferDeviceSummary.
+        :type: str
+        """
+        self._attached_transfer_package_label = attached_transfer_package_label
+
+    @property
+    def creation_time(self):
+        """
+        Gets the creation_time of this TransferDeviceSummary.
+
+        :return: The creation_time of this TransferDeviceSummary.
+        :rtype: datetime
+        """
+        return self._creation_time
+
+    @creation_time.setter
+    def creation_time(self, creation_time):
+        """
+        Sets the creation_time of this TransferDeviceSummary.
+
+        :param creation_time: The creation_time of this TransferDeviceSummary.
+        :type: datetime
+        """
+        self._creation_time = creation_time
+
+    @property
+    def upload_status_log_uri(self):
+        """
+        Gets the upload_status_log_uri of this TransferDeviceSummary.
+
+        :return: The upload_status_log_uri of this TransferDeviceSummary.
+        :rtype: str
+        """
+        return self._upload_status_log_uri
+
+    @upload_status_log_uri.setter
+    def upload_status_log_uri(self, upload_status_log_uri):
+        """
+        Sets the upload_status_log_uri of this TransferDeviceSummary.
+
+        :param upload_status_log_uri: The upload_status_log_uri of this TransferDeviceSummary.
+        :type: str
+        """
+        self._upload_status_log_uri = upload_status_log_uri
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/transfer_job.py
+++ b/src/oci/dts/models/transfer_job.py
@@ -1,0 +1,457 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TransferJob(object):
+    """
+    TransferJob model.
+    """
+
+    #: A constant which can be used with the device_type property of a TransferJob.
+    #: This constant has a value of "DISK"
+    DEVICE_TYPE_DISK = "DISK"
+
+    #: A constant which can be used with the device_type property of a TransferJob.
+    #: This constant has a value of "APPLIANCE"
+    DEVICE_TYPE_APPLIANCE = "APPLIANCE"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferJob.
+    #: This constant has a value of "INITIATED"
+    LIFECYCLE_STATE_INITIATED = "INITIATED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferJob.
+    #: This constant has a value of "PREPARING"
+    LIFECYCLE_STATE_PREPARING = "PREPARING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferJob.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferJob.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferJob.
+    #: This constant has a value of "CLOSED"
+    LIFECYCLE_STATE_CLOSED = "CLOSED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TransferJob object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this TransferJob.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this TransferJob.
+        :type compartment_id: str
+
+        :param upload_bucket_name:
+            The value to assign to the upload_bucket_name property of this TransferJob.
+        :type upload_bucket_name: str
+
+        :param display_name:
+            The value to assign to the display_name property of this TransferJob.
+        :type display_name: str
+
+        :param label:
+            The value to assign to the label property of this TransferJob.
+        :type label: str
+
+        :param creation_time:
+            The value to assign to the creation_time property of this TransferJob.
+        :type creation_time: datetime
+
+        :param device_type:
+            The value to assign to the device_type property of this TransferJob.
+            Allowed values for this property are: "DISK", "APPLIANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type device_type: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TransferJob.
+            Allowed values for this property are: "INITIATED", "PREPARING", "ACTIVE", "DELETED", "CLOSED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param attached_transfer_appliance_labels:
+            The value to assign to the attached_transfer_appliance_labels property of this TransferJob.
+        :type attached_transfer_appliance_labels: list[str]
+
+        :param attached_transfer_package_labels:
+            The value to assign to the attached_transfer_package_labels property of this TransferJob.
+        :type attached_transfer_package_labels: list[str]
+
+        :param attached_transfer_device_labels:
+            The value to assign to the attached_transfer_device_labels property of this TransferJob.
+        :type attached_transfer_device_labels: list[str]
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this TransferJob.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this TransferJob.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'upload_bucket_name': 'str',
+            'display_name': 'str',
+            'label': 'str',
+            'creation_time': 'datetime',
+            'device_type': 'str',
+            'lifecycle_state': 'str',
+            'attached_transfer_appliance_labels': 'list[str]',
+            'attached_transfer_package_labels': 'list[str]',
+            'attached_transfer_device_labels': 'list[str]',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'upload_bucket_name': 'uploadBucketName',
+            'display_name': 'displayName',
+            'label': 'label',
+            'creation_time': 'creationTime',
+            'device_type': 'deviceType',
+            'lifecycle_state': 'lifecycleState',
+            'attached_transfer_appliance_labels': 'attachedTransferApplianceLabels',
+            'attached_transfer_package_labels': 'attachedTransferPackageLabels',
+            'attached_transfer_device_labels': 'attachedTransferDeviceLabels',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._upload_bucket_name = None
+        self._display_name = None
+        self._label = None
+        self._creation_time = None
+        self._device_type = None
+        self._lifecycle_state = None
+        self._attached_transfer_appliance_labels = None
+        self._attached_transfer_package_labels = None
+        self._attached_transfer_device_labels = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this TransferJob.
+
+        :return: The id of this TransferJob.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this TransferJob.
+
+        :param id: The id of this TransferJob.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this TransferJob.
+
+        :return: The compartment_id of this TransferJob.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this TransferJob.
+
+        :param compartment_id: The compartment_id of this TransferJob.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def upload_bucket_name(self):
+        """
+        **[Required]** Gets the upload_bucket_name of this TransferJob.
+
+        :return: The upload_bucket_name of this TransferJob.
+        :rtype: str
+        """
+        return self._upload_bucket_name
+
+    @upload_bucket_name.setter
+    def upload_bucket_name(self, upload_bucket_name):
+        """
+        Sets the upload_bucket_name of this TransferJob.
+
+        :param upload_bucket_name: The upload_bucket_name of this TransferJob.
+        :type: str
+        """
+        self._upload_bucket_name = upload_bucket_name
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this TransferJob.
+
+        :return: The display_name of this TransferJob.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this TransferJob.
+
+        :param display_name: The display_name of this TransferJob.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def label(self):
+        """
+        Gets the label of this TransferJob.
+
+        :return: The label of this TransferJob.
+        :rtype: str
+        """
+        return self._label
+
+    @label.setter
+    def label(self, label):
+        """
+        Sets the label of this TransferJob.
+
+        :param label: The label of this TransferJob.
+        :type: str
+        """
+        self._label = label
+
+    @property
+    def creation_time(self):
+        """
+        Gets the creation_time of this TransferJob.
+
+        :return: The creation_time of this TransferJob.
+        :rtype: datetime
+        """
+        return self._creation_time
+
+    @creation_time.setter
+    def creation_time(self, creation_time):
+        """
+        Sets the creation_time of this TransferJob.
+
+        :param creation_time: The creation_time of this TransferJob.
+        :type: datetime
+        """
+        self._creation_time = creation_time
+
+    @property
+    def device_type(self):
+        """
+        **[Required]** Gets the device_type of this TransferJob.
+        Allowed values for this property are: "DISK", "APPLIANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The device_type of this TransferJob.
+        :rtype: str
+        """
+        return self._device_type
+
+    @device_type.setter
+    def device_type(self, device_type):
+        """
+        Sets the device_type of this TransferJob.
+
+        :param device_type: The device_type of this TransferJob.
+        :type: str
+        """
+        allowed_values = ["DISK", "APPLIANCE"]
+        if not value_allowed_none_or_none_sentinel(device_type, allowed_values):
+            device_type = 'UNKNOWN_ENUM_VALUE'
+        self._device_type = device_type
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this TransferJob.
+        Allowed values for this property are: "INITIATED", "PREPARING", "ACTIVE", "DELETED", "CLOSED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this TransferJob.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this TransferJob.
+
+        :param lifecycle_state: The lifecycle_state of this TransferJob.
+        :type: str
+        """
+        allowed_values = ["INITIATED", "PREPARING", "ACTIVE", "DELETED", "CLOSED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def attached_transfer_appliance_labels(self):
+        """
+        Gets the attached_transfer_appliance_labels of this TransferJob.
+        Transfer Appliance labels associated with this transfer Job
+
+
+        :return: The attached_transfer_appliance_labels of this TransferJob.
+        :rtype: list[str]
+        """
+        return self._attached_transfer_appliance_labels
+
+    @attached_transfer_appliance_labels.setter
+    def attached_transfer_appliance_labels(self, attached_transfer_appliance_labels):
+        """
+        Sets the attached_transfer_appliance_labels of this TransferJob.
+        Transfer Appliance labels associated with this transfer Job
+
+
+        :param attached_transfer_appliance_labels: The attached_transfer_appliance_labels of this TransferJob.
+        :type: list[str]
+        """
+        self._attached_transfer_appliance_labels = attached_transfer_appliance_labels
+
+    @property
+    def attached_transfer_package_labels(self):
+        """
+        Gets the attached_transfer_package_labels of this TransferJob.
+        Transfer Package labels associated with this transfer Job
+
+
+        :return: The attached_transfer_package_labels of this TransferJob.
+        :rtype: list[str]
+        """
+        return self._attached_transfer_package_labels
+
+    @attached_transfer_package_labels.setter
+    def attached_transfer_package_labels(self, attached_transfer_package_labels):
+        """
+        Sets the attached_transfer_package_labels of this TransferJob.
+        Transfer Package labels associated with this transfer Job
+
+
+        :param attached_transfer_package_labels: The attached_transfer_package_labels of this TransferJob.
+        :type: list[str]
+        """
+        self._attached_transfer_package_labels = attached_transfer_package_labels
+
+    @property
+    def attached_transfer_device_labels(self):
+        """
+        Gets the attached_transfer_device_labels of this TransferJob.
+        Transfer Device labels associated with this transfer Job
+
+
+        :return: The attached_transfer_device_labels of this TransferJob.
+        :rtype: list[str]
+        """
+        return self._attached_transfer_device_labels
+
+    @attached_transfer_device_labels.setter
+    def attached_transfer_device_labels(self, attached_transfer_device_labels):
+        """
+        Sets the attached_transfer_device_labels of this TransferJob.
+        Transfer Device labels associated with this transfer Job
+
+
+        :param attached_transfer_device_labels: The attached_transfer_device_labels of this TransferJob.
+        :type: list[str]
+        """
+        self._attached_transfer_device_labels = attached_transfer_device_labels
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this TransferJob.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this TransferJob.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this TransferJob.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this TransferJob.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this TransferJob.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :return: The defined_tags of this TransferJob.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this TransferJob.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :param defined_tags: The defined_tags of this TransferJob.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/transfer_job_summary.py
+++ b/src/oci/dts/models/transfer_job_summary.py
@@ -1,0 +1,337 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TransferJobSummary(object):
+    """
+    TransferJobSummary model.
+    """
+
+    #: A constant which can be used with the device_type property of a TransferJobSummary.
+    #: This constant has a value of "DISK"
+    DEVICE_TYPE_DISK = "DISK"
+
+    #: A constant which can be used with the device_type property of a TransferJobSummary.
+    #: This constant has a value of "APPLIANCE"
+    DEVICE_TYPE_APPLIANCE = "APPLIANCE"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferJobSummary.
+    #: This constant has a value of "INITIATED"
+    LIFECYCLE_STATE_INITIATED = "INITIATED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferJobSummary.
+    #: This constant has a value of "PREPARING"
+    LIFECYCLE_STATE_PREPARING = "PREPARING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferJobSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferJobSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferJobSummary.
+    #: This constant has a value of "CLOSED"
+    LIFECYCLE_STATE_CLOSED = "CLOSED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TransferJobSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this TransferJobSummary.
+        :type id: str
+
+        :param upload_bucket_name:
+            The value to assign to the upload_bucket_name property of this TransferJobSummary.
+        :type upload_bucket_name: str
+
+        :param display_name:
+            The value to assign to the display_name property of this TransferJobSummary.
+        :type display_name: str
+
+        :param label:
+            The value to assign to the label property of this TransferJobSummary.
+        :type label: str
+
+        :param device_type:
+            The value to assign to the device_type property of this TransferJobSummary.
+            Allowed values for this property are: "DISK", "APPLIANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type device_type: str
+
+        :param creation_time:
+            The value to assign to the creation_time property of this TransferJobSummary.
+        :type creation_time: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TransferJobSummary.
+            Allowed values for this property are: "INITIATED", "PREPARING", "ACTIVE", "DELETED", "CLOSED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this TransferJobSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this TransferJobSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'upload_bucket_name': 'str',
+            'display_name': 'str',
+            'label': 'str',
+            'device_type': 'str',
+            'creation_time': 'datetime',
+            'lifecycle_state': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'upload_bucket_name': 'uploadBucketName',
+            'display_name': 'displayName',
+            'label': 'label',
+            'device_type': 'deviceType',
+            'creation_time': 'creationTime',
+            'lifecycle_state': 'lifecycleState',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._upload_bucket_name = None
+        self._display_name = None
+        self._label = None
+        self._device_type = None
+        self._creation_time = None
+        self._lifecycle_state = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this TransferJobSummary.
+
+        :return: The id of this TransferJobSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this TransferJobSummary.
+
+        :param id: The id of this TransferJobSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def upload_bucket_name(self):
+        """
+        Gets the upload_bucket_name of this TransferJobSummary.
+
+        :return: The upload_bucket_name of this TransferJobSummary.
+        :rtype: str
+        """
+        return self._upload_bucket_name
+
+    @upload_bucket_name.setter
+    def upload_bucket_name(self, upload_bucket_name):
+        """
+        Sets the upload_bucket_name of this TransferJobSummary.
+
+        :param upload_bucket_name: The upload_bucket_name of this TransferJobSummary.
+        :type: str
+        """
+        self._upload_bucket_name = upload_bucket_name
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this TransferJobSummary.
+
+        :return: The display_name of this TransferJobSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this TransferJobSummary.
+
+        :param display_name: The display_name of this TransferJobSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def label(self):
+        """
+        Gets the label of this TransferJobSummary.
+
+        :return: The label of this TransferJobSummary.
+        :rtype: str
+        """
+        return self._label
+
+    @label.setter
+    def label(self, label):
+        """
+        Sets the label of this TransferJobSummary.
+
+        :param label: The label of this TransferJobSummary.
+        :type: str
+        """
+        self._label = label
+
+    @property
+    def device_type(self):
+        """
+        Gets the device_type of this TransferJobSummary.
+        Allowed values for this property are: "DISK", "APPLIANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The device_type of this TransferJobSummary.
+        :rtype: str
+        """
+        return self._device_type
+
+    @device_type.setter
+    def device_type(self, device_type):
+        """
+        Sets the device_type of this TransferJobSummary.
+
+        :param device_type: The device_type of this TransferJobSummary.
+        :type: str
+        """
+        allowed_values = ["DISK", "APPLIANCE"]
+        if not value_allowed_none_or_none_sentinel(device_type, allowed_values):
+            device_type = 'UNKNOWN_ENUM_VALUE'
+        self._device_type = device_type
+
+    @property
+    def creation_time(self):
+        """
+        Gets the creation_time of this TransferJobSummary.
+
+        :return: The creation_time of this TransferJobSummary.
+        :rtype: datetime
+        """
+        return self._creation_time
+
+    @creation_time.setter
+    def creation_time(self, creation_time):
+        """
+        Sets the creation_time of this TransferJobSummary.
+
+        :param creation_time: The creation_time of this TransferJobSummary.
+        :type: datetime
+        """
+        self._creation_time = creation_time
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this TransferJobSummary.
+        Allowed values for this property are: "INITIATED", "PREPARING", "ACTIVE", "DELETED", "CLOSED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this TransferJobSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this TransferJobSummary.
+
+        :param lifecycle_state: The lifecycle_state of this TransferJobSummary.
+        :type: str
+        """
+        allowed_values = ["INITIATED", "PREPARING", "ACTIVE", "DELETED", "CLOSED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this TransferJobSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this TransferJobSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this TransferJobSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this TransferJobSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this TransferJobSummary.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :return: The defined_tags of this TransferJobSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this TransferJobSummary.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :param defined_tags: The defined_tags of this TransferJobSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/transfer_package.py
+++ b/src/oci/dts/models/transfer_package.py
@@ -1,0 +1,329 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TransferPackage(object):
+    """
+    TransferPackage model.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackage.
+    #: This constant has a value of "PREPARING"
+    LIFECYCLE_STATE_PREPARING = "PREPARING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackage.
+    #: This constant has a value of "SHIPPING"
+    LIFECYCLE_STATE_SHIPPING = "SHIPPING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackage.
+    #: This constant has a value of "RECEIVED"
+    LIFECYCLE_STATE_RECEIVED = "RECEIVED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackage.
+    #: This constant has a value of "PROCESSING"
+    LIFECYCLE_STATE_PROCESSING = "PROCESSING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackage.
+    #: This constant has a value of "PROCESSED"
+    LIFECYCLE_STATE_PROCESSED = "PROCESSED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackage.
+    #: This constant has a value of "RETURNED"
+    LIFECYCLE_STATE_RETURNED = "RETURNED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackage.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackage.
+    #: This constant has a value of "CANCELLED"
+    LIFECYCLE_STATE_CANCELLED = "CANCELLED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackage.
+    #: This constant has a value of "CANCELLED_RETURNED"
+    LIFECYCLE_STATE_CANCELLED_RETURNED = "CANCELLED_RETURNED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TransferPackage object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param label:
+            The value to assign to the label property of this TransferPackage.
+        :type label: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TransferPackage.
+            Allowed values for this property are: "PREPARING", "SHIPPING", "RECEIVED", "PROCESSING", "PROCESSED", "RETURNED", "DELETED", "CANCELLED", "CANCELLED_RETURNED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param transfer_job_id:
+            The value to assign to the transfer_job_id property of this TransferPackage.
+        :type transfer_job_id: str
+
+        :param creation_time:
+            The value to assign to the creation_time property of this TransferPackage.
+        :type creation_time: datetime
+
+        :param original_package_delivery_tracking_number:
+            The value to assign to the original_package_delivery_tracking_number property of this TransferPackage.
+        :type original_package_delivery_tracking_number: str
+
+        :param return_package_delivery_tracking_number:
+            The value to assign to the return_package_delivery_tracking_number property of this TransferPackage.
+        :type return_package_delivery_tracking_number: str
+
+        :param package_delivery_vendor:
+            The value to assign to the package_delivery_vendor property of this TransferPackage.
+        :type package_delivery_vendor: str
+
+        :param transfer_site_shipping_address:
+            The value to assign to the transfer_site_shipping_address property of this TransferPackage.
+        :type transfer_site_shipping_address: str
+
+        :param attached_transfer_device_labels:
+            The value to assign to the attached_transfer_device_labels property of this TransferPackage.
+        :type attached_transfer_device_labels: list[str]
+
+        """
+        self.swagger_types = {
+            'label': 'str',
+            'lifecycle_state': 'str',
+            'transfer_job_id': 'str',
+            'creation_time': 'datetime',
+            'original_package_delivery_tracking_number': 'str',
+            'return_package_delivery_tracking_number': 'str',
+            'package_delivery_vendor': 'str',
+            'transfer_site_shipping_address': 'str',
+            'attached_transfer_device_labels': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'label': 'label',
+            'lifecycle_state': 'lifecycleState',
+            'transfer_job_id': 'transferJobId',
+            'creation_time': 'creationTime',
+            'original_package_delivery_tracking_number': 'originalPackageDeliveryTrackingNumber',
+            'return_package_delivery_tracking_number': 'returnPackageDeliveryTrackingNumber',
+            'package_delivery_vendor': 'packageDeliveryVendor',
+            'transfer_site_shipping_address': 'transferSiteShippingAddress',
+            'attached_transfer_device_labels': 'attachedTransferDeviceLabels'
+        }
+
+        self._label = None
+        self._lifecycle_state = None
+        self._transfer_job_id = None
+        self._creation_time = None
+        self._original_package_delivery_tracking_number = None
+        self._return_package_delivery_tracking_number = None
+        self._package_delivery_vendor = None
+        self._transfer_site_shipping_address = None
+        self._attached_transfer_device_labels = None
+
+    @property
+    def label(self):
+        """
+        **[Required]** Gets the label of this TransferPackage.
+
+        :return: The label of this TransferPackage.
+        :rtype: str
+        """
+        return self._label
+
+    @label.setter
+    def label(self, label):
+        """
+        Sets the label of this TransferPackage.
+
+        :param label: The label of this TransferPackage.
+        :type: str
+        """
+        self._label = label
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this TransferPackage.
+        Allowed values for this property are: "PREPARING", "SHIPPING", "RECEIVED", "PROCESSING", "PROCESSED", "RETURNED", "DELETED", "CANCELLED", "CANCELLED_RETURNED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this TransferPackage.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this TransferPackage.
+
+        :param lifecycle_state: The lifecycle_state of this TransferPackage.
+        :type: str
+        """
+        allowed_values = ["PREPARING", "SHIPPING", "RECEIVED", "PROCESSING", "PROCESSED", "RETURNED", "DELETED", "CANCELLED", "CANCELLED_RETURNED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def transfer_job_id(self):
+        """
+        Gets the transfer_job_id of this TransferPackage.
+
+        :return: The transfer_job_id of this TransferPackage.
+        :rtype: str
+        """
+        return self._transfer_job_id
+
+    @transfer_job_id.setter
+    def transfer_job_id(self, transfer_job_id):
+        """
+        Sets the transfer_job_id of this TransferPackage.
+
+        :param transfer_job_id: The transfer_job_id of this TransferPackage.
+        :type: str
+        """
+        self._transfer_job_id = transfer_job_id
+
+    @property
+    def creation_time(self):
+        """
+        Gets the creation_time of this TransferPackage.
+
+        :return: The creation_time of this TransferPackage.
+        :rtype: datetime
+        """
+        return self._creation_time
+
+    @creation_time.setter
+    def creation_time(self, creation_time):
+        """
+        Sets the creation_time of this TransferPackage.
+
+        :param creation_time: The creation_time of this TransferPackage.
+        :type: datetime
+        """
+        self._creation_time = creation_time
+
+    @property
+    def original_package_delivery_tracking_number(self):
+        """
+        Gets the original_package_delivery_tracking_number of this TransferPackage.
+
+        :return: The original_package_delivery_tracking_number of this TransferPackage.
+        :rtype: str
+        """
+        return self._original_package_delivery_tracking_number
+
+    @original_package_delivery_tracking_number.setter
+    def original_package_delivery_tracking_number(self, original_package_delivery_tracking_number):
+        """
+        Sets the original_package_delivery_tracking_number of this TransferPackage.
+
+        :param original_package_delivery_tracking_number: The original_package_delivery_tracking_number of this TransferPackage.
+        :type: str
+        """
+        self._original_package_delivery_tracking_number = original_package_delivery_tracking_number
+
+    @property
+    def return_package_delivery_tracking_number(self):
+        """
+        Gets the return_package_delivery_tracking_number of this TransferPackage.
+
+        :return: The return_package_delivery_tracking_number of this TransferPackage.
+        :rtype: str
+        """
+        return self._return_package_delivery_tracking_number
+
+    @return_package_delivery_tracking_number.setter
+    def return_package_delivery_tracking_number(self, return_package_delivery_tracking_number):
+        """
+        Sets the return_package_delivery_tracking_number of this TransferPackage.
+
+        :param return_package_delivery_tracking_number: The return_package_delivery_tracking_number of this TransferPackage.
+        :type: str
+        """
+        self._return_package_delivery_tracking_number = return_package_delivery_tracking_number
+
+    @property
+    def package_delivery_vendor(self):
+        """
+        Gets the package_delivery_vendor of this TransferPackage.
+
+        :return: The package_delivery_vendor of this TransferPackage.
+        :rtype: str
+        """
+        return self._package_delivery_vendor
+
+    @package_delivery_vendor.setter
+    def package_delivery_vendor(self, package_delivery_vendor):
+        """
+        Sets the package_delivery_vendor of this TransferPackage.
+
+        :param package_delivery_vendor: The package_delivery_vendor of this TransferPackage.
+        :type: str
+        """
+        self._package_delivery_vendor = package_delivery_vendor
+
+    @property
+    def transfer_site_shipping_address(self):
+        """
+        Gets the transfer_site_shipping_address of this TransferPackage.
+
+        :return: The transfer_site_shipping_address of this TransferPackage.
+        :rtype: str
+        """
+        return self._transfer_site_shipping_address
+
+    @transfer_site_shipping_address.setter
+    def transfer_site_shipping_address(self, transfer_site_shipping_address):
+        """
+        Sets the transfer_site_shipping_address of this TransferPackage.
+
+        :param transfer_site_shipping_address: The transfer_site_shipping_address of this TransferPackage.
+        :type: str
+        """
+        self._transfer_site_shipping_address = transfer_site_shipping_address
+
+    @property
+    def attached_transfer_device_labels(self):
+        """
+        Gets the attached_transfer_device_labels of this TransferPackage.
+        Transfer Devices attached to this Transfer Package
+
+
+        :return: The attached_transfer_device_labels of this TransferPackage.
+        :rtype: list[str]
+        """
+        return self._attached_transfer_device_labels
+
+    @attached_transfer_device_labels.setter
+    def attached_transfer_device_labels(self, attached_transfer_device_labels):
+        """
+        Sets the attached_transfer_device_labels of this TransferPackage.
+        Transfer Devices attached to this Transfer Package
+
+
+        :param attached_transfer_device_labels: The attached_transfer_device_labels of this TransferPackage.
+        :type: list[str]
+        """
+        self._attached_transfer_device_labels = attached_transfer_device_labels
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/transfer_package_summary.py
+++ b/src/oci/dts/models/transfer_package_summary.py
@@ -1,0 +1,163 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TransferPackageSummary(object):
+    """
+    TransferPackageSummary model.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackageSummary.
+    #: This constant has a value of "PREPARING"
+    LIFECYCLE_STATE_PREPARING = "PREPARING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackageSummary.
+    #: This constant has a value of "SHIPPING"
+    LIFECYCLE_STATE_SHIPPING = "SHIPPING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackageSummary.
+    #: This constant has a value of "RECEIVED"
+    LIFECYCLE_STATE_RECEIVED = "RECEIVED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackageSummary.
+    #: This constant has a value of "PROCESSING"
+    LIFECYCLE_STATE_PROCESSING = "PROCESSING"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackageSummary.
+    #: This constant has a value of "PROCESSED"
+    LIFECYCLE_STATE_PROCESSED = "PROCESSED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackageSummary.
+    #: This constant has a value of "RETURNED"
+    LIFECYCLE_STATE_RETURNED = "RETURNED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackageSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackageSummary.
+    #: This constant has a value of "CANCELLED"
+    LIFECYCLE_STATE_CANCELLED = "CANCELLED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferPackageSummary.
+    #: This constant has a value of "CANCELLED_RETURNED"
+    LIFECYCLE_STATE_CANCELLED_RETURNED = "CANCELLED_RETURNED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TransferPackageSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param label:
+            The value to assign to the label property of this TransferPackageSummary.
+        :type label: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TransferPackageSummary.
+            Allowed values for this property are: "PREPARING", "SHIPPING", "RECEIVED", "PROCESSING", "PROCESSED", "RETURNED", "DELETED", "CANCELLED", "CANCELLED_RETURNED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param creation_time:
+            The value to assign to the creation_time property of this TransferPackageSummary.
+        :type creation_time: datetime
+
+        """
+        self.swagger_types = {
+            'label': 'str',
+            'lifecycle_state': 'str',
+            'creation_time': 'datetime'
+        }
+
+        self.attribute_map = {
+            'label': 'label',
+            'lifecycle_state': 'lifecycleState',
+            'creation_time': 'creationTime'
+        }
+
+        self._label = None
+        self._lifecycle_state = None
+        self._creation_time = None
+
+    @property
+    def label(self):
+        """
+        Gets the label of this TransferPackageSummary.
+
+        :return: The label of this TransferPackageSummary.
+        :rtype: str
+        """
+        return self._label
+
+    @label.setter
+    def label(self, label):
+        """
+        Sets the label of this TransferPackageSummary.
+
+        :param label: The label of this TransferPackageSummary.
+        :type: str
+        """
+        self._label = label
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this TransferPackageSummary.
+        Allowed values for this property are: "PREPARING", "SHIPPING", "RECEIVED", "PROCESSING", "PROCESSED", "RETURNED", "DELETED", "CANCELLED", "CANCELLED_RETURNED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this TransferPackageSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this TransferPackageSummary.
+
+        :param lifecycle_state: The lifecycle_state of this TransferPackageSummary.
+        :type: str
+        """
+        allowed_values = ["PREPARING", "SHIPPING", "RECEIVED", "PROCESSING", "PROCESSED", "RETURNED", "DELETED", "CANCELLED", "CANCELLED_RETURNED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def creation_time(self):
+        """
+        Gets the creation_time of this TransferPackageSummary.
+
+        :return: The creation_time of this TransferPackageSummary.
+        :rtype: datetime
+        """
+        return self._creation_time
+
+    @creation_time.setter
+    def creation_time(self, creation_time):
+        """
+        Sets the creation_time of this TransferPackageSummary.
+
+        :param creation_time: The creation_time of this TransferPackageSummary.
+        :type: datetime
+        """
+        self._creation_time = creation_time
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/update_transfer_appliance_details.py
+++ b/src/oci/dts/models/update_transfer_appliance_details.py
@@ -1,0 +1,117 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateTransferApplianceDetails(object):
+    """
+    UpdateTransferApplianceDetails model.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateTransferApplianceDetails.
+    #: This constant has a value of "PREPARING"
+    LIFECYCLE_STATE_PREPARING = "PREPARING"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateTransferApplianceDetails.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateTransferApplianceDetails.
+    #: This constant has a value of "CUSTOMER_NEVER_RECEIVED"
+    LIFECYCLE_STATE_CUSTOMER_NEVER_RECEIVED = "CUSTOMER_NEVER_RECEIVED"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateTransferApplianceDetails.
+    #: This constant has a value of "CANCELLED"
+    LIFECYCLE_STATE_CANCELLED = "CANCELLED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateTransferApplianceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this UpdateTransferApplianceDetails.
+            Allowed values for this property are: "PREPARING", "DELETED", "CUSTOMER_NEVER_RECEIVED", "CANCELLED"
+        :type lifecycle_state: str
+
+        :param customer_shipping_address:
+            The value to assign to the customer_shipping_address property of this UpdateTransferApplianceDetails.
+        :type customer_shipping_address: ShippingAddress
+
+        """
+        self.swagger_types = {
+            'lifecycle_state': 'str',
+            'customer_shipping_address': 'ShippingAddress'
+        }
+
+        self.attribute_map = {
+            'lifecycle_state': 'lifecycleState',
+            'customer_shipping_address': 'customerShippingAddress'
+        }
+
+        self._lifecycle_state = None
+        self._customer_shipping_address = None
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this UpdateTransferApplianceDetails.
+        Allowed values for this property are: "PREPARING", "DELETED", "CUSTOMER_NEVER_RECEIVED", "CANCELLED"
+
+
+        :return: The lifecycle_state of this UpdateTransferApplianceDetails.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this UpdateTransferApplianceDetails.
+
+        :param lifecycle_state: The lifecycle_state of this UpdateTransferApplianceDetails.
+        :type: str
+        """
+        allowed_values = ["PREPARING", "DELETED", "CUSTOMER_NEVER_RECEIVED", "CANCELLED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            raise ValueError(
+                "Invalid value for `lifecycle_state`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def customer_shipping_address(self):
+        """
+        Gets the customer_shipping_address of this UpdateTransferApplianceDetails.
+
+        :return: The customer_shipping_address of this UpdateTransferApplianceDetails.
+        :rtype: ShippingAddress
+        """
+        return self._customer_shipping_address
+
+    @customer_shipping_address.setter
+    def customer_shipping_address(self, customer_shipping_address):
+        """
+        Sets the customer_shipping_address of this UpdateTransferApplianceDetails.
+
+        :param customer_shipping_address: The customer_shipping_address of this UpdateTransferApplianceDetails.
+        :type: ShippingAddress
+        """
+        self._customer_shipping_address = customer_shipping_address
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/update_transfer_device_details.py
+++ b/src/oci/dts/models/update_transfer_device_details.py
@@ -1,0 +1,86 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateTransferDeviceDetails(object):
+    """
+    UpdateTransferDeviceDetails model.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateTransferDeviceDetails.
+    #: This constant has a value of "PREPARING"
+    LIFECYCLE_STATE_PREPARING = "PREPARING"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateTransferDeviceDetails.
+    #: This constant has a value of "READY"
+    LIFECYCLE_STATE_READY = "READY"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateTransferDeviceDetails.
+    #: This constant has a value of "CANCELLED"
+    LIFECYCLE_STATE_CANCELLED = "CANCELLED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateTransferDeviceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this UpdateTransferDeviceDetails.
+            Allowed values for this property are: "PREPARING", "READY", "CANCELLED"
+        :type lifecycle_state: str
+
+        """
+        self.swagger_types = {
+            'lifecycle_state': 'str'
+        }
+
+        self.attribute_map = {
+            'lifecycle_state': 'lifecycleState'
+        }
+
+        self._lifecycle_state = None
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this UpdateTransferDeviceDetails.
+        Allowed values for this property are: "PREPARING", "READY", "CANCELLED"
+
+
+        :return: The lifecycle_state of this UpdateTransferDeviceDetails.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this UpdateTransferDeviceDetails.
+
+        :param lifecycle_state: The lifecycle_state of this UpdateTransferDeviceDetails.
+        :type: str
+        """
+        allowed_values = ["PREPARING", "READY", "CANCELLED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            raise ValueError(
+                "Invalid value for `lifecycle_state`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._lifecycle_state = lifecycle_state
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/update_transfer_job_details.py
+++ b/src/oci/dts/models/update_transfer_job_details.py
@@ -1,0 +1,215 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateTransferJobDetails(object):
+    """
+    UpdateTransferJobDetails model.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateTransferJobDetails.
+    #: This constant has a value of "CLOSED"
+    LIFECYCLE_STATE_CLOSED = "CLOSED"
+
+    #: A constant which can be used with the device_type property of a UpdateTransferJobDetails.
+    #: This constant has a value of "DISK"
+    DEVICE_TYPE_DISK = "DISK"
+
+    #: A constant which can be used with the device_type property of a UpdateTransferJobDetails.
+    #: This constant has a value of "APPLIANCE"
+    DEVICE_TYPE_APPLIANCE = "APPLIANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateTransferJobDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this UpdateTransferJobDetails.
+            Allowed values for this property are: "CLOSED"
+        :type lifecycle_state: str
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateTransferJobDetails.
+        :type display_name: str
+
+        :param device_type:
+            The value to assign to the device_type property of this UpdateTransferJobDetails.
+            Allowed values for this property are: "DISK", "APPLIANCE"
+        :type device_type: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateTransferJobDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateTransferJobDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'lifecycle_state': 'str',
+            'display_name': 'str',
+            'device_type': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'lifecycle_state': 'lifecycleState',
+            'display_name': 'displayName',
+            'device_type': 'deviceType',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._lifecycle_state = None
+        self._display_name = None
+        self._device_type = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this UpdateTransferJobDetails.
+        Allowed values for this property are: "CLOSED"
+
+
+        :return: The lifecycle_state of this UpdateTransferJobDetails.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this UpdateTransferJobDetails.
+
+        :param lifecycle_state: The lifecycle_state of this UpdateTransferJobDetails.
+        :type: str
+        """
+        allowed_values = ["CLOSED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            raise ValueError(
+                "Invalid value for `lifecycle_state`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateTransferJobDetails.
+
+        :return: The display_name of this UpdateTransferJobDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateTransferJobDetails.
+
+        :param display_name: The display_name of this UpdateTransferJobDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def device_type(self):
+        """
+        Gets the device_type of this UpdateTransferJobDetails.
+        Allowed values for this property are: "DISK", "APPLIANCE"
+
+
+        :return: The device_type of this UpdateTransferJobDetails.
+        :rtype: str
+        """
+        return self._device_type
+
+    @device_type.setter
+    def device_type(self, device_type):
+        """
+        Sets the device_type of this UpdateTransferJobDetails.
+
+        :param device_type: The device_type of this UpdateTransferJobDetails.
+        :type: str
+        """
+        allowed_values = ["DISK", "APPLIANCE"]
+        if not value_allowed_none_or_none_sentinel(device_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `device_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._device_type = device_type
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateTransferJobDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this UpdateTransferJobDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateTransferJobDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this UpdateTransferJobDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateTransferJobDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :return: The defined_tags of this UpdateTransferJobDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateTransferJobDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :param defined_tags: The defined_tags of this UpdateTransferJobDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/update_transfer_package_details.py
+++ b/src/oci/dts/models/update_transfer_package_details.py
@@ -1,0 +1,163 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateTransferPackageDetails(object):
+    """
+    UpdateTransferPackageDetails model.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateTransferPackageDetails.
+    #: This constant has a value of "SHIPPING"
+    LIFECYCLE_STATE_SHIPPING = "SHIPPING"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateTransferPackageDetails.
+    #: This constant has a value of "CANCELLED"
+    LIFECYCLE_STATE_CANCELLED = "CANCELLED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateTransferPackageDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param original_package_delivery_tracking_number:
+            The value to assign to the original_package_delivery_tracking_number property of this UpdateTransferPackageDetails.
+        :type original_package_delivery_tracking_number: str
+
+        :param return_package_delivery_tracking_number:
+            The value to assign to the return_package_delivery_tracking_number property of this UpdateTransferPackageDetails.
+        :type return_package_delivery_tracking_number: str
+
+        :param package_delivery_vendor:
+            The value to assign to the package_delivery_vendor property of this UpdateTransferPackageDetails.
+        :type package_delivery_vendor: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this UpdateTransferPackageDetails.
+            Allowed values for this property are: "SHIPPING", "CANCELLED"
+        :type lifecycle_state: str
+
+        """
+        self.swagger_types = {
+            'original_package_delivery_tracking_number': 'str',
+            'return_package_delivery_tracking_number': 'str',
+            'package_delivery_vendor': 'str',
+            'lifecycle_state': 'str'
+        }
+
+        self.attribute_map = {
+            'original_package_delivery_tracking_number': 'originalPackageDeliveryTrackingNumber',
+            'return_package_delivery_tracking_number': 'returnPackageDeliveryTrackingNumber',
+            'package_delivery_vendor': 'packageDeliveryVendor',
+            'lifecycle_state': 'lifecycleState'
+        }
+
+        self._original_package_delivery_tracking_number = None
+        self._return_package_delivery_tracking_number = None
+        self._package_delivery_vendor = None
+        self._lifecycle_state = None
+
+    @property
+    def original_package_delivery_tracking_number(self):
+        """
+        Gets the original_package_delivery_tracking_number of this UpdateTransferPackageDetails.
+
+        :return: The original_package_delivery_tracking_number of this UpdateTransferPackageDetails.
+        :rtype: str
+        """
+        return self._original_package_delivery_tracking_number
+
+    @original_package_delivery_tracking_number.setter
+    def original_package_delivery_tracking_number(self, original_package_delivery_tracking_number):
+        """
+        Sets the original_package_delivery_tracking_number of this UpdateTransferPackageDetails.
+
+        :param original_package_delivery_tracking_number: The original_package_delivery_tracking_number of this UpdateTransferPackageDetails.
+        :type: str
+        """
+        self._original_package_delivery_tracking_number = original_package_delivery_tracking_number
+
+    @property
+    def return_package_delivery_tracking_number(self):
+        """
+        Gets the return_package_delivery_tracking_number of this UpdateTransferPackageDetails.
+
+        :return: The return_package_delivery_tracking_number of this UpdateTransferPackageDetails.
+        :rtype: str
+        """
+        return self._return_package_delivery_tracking_number
+
+    @return_package_delivery_tracking_number.setter
+    def return_package_delivery_tracking_number(self, return_package_delivery_tracking_number):
+        """
+        Sets the return_package_delivery_tracking_number of this UpdateTransferPackageDetails.
+
+        :param return_package_delivery_tracking_number: The return_package_delivery_tracking_number of this UpdateTransferPackageDetails.
+        :type: str
+        """
+        self._return_package_delivery_tracking_number = return_package_delivery_tracking_number
+
+    @property
+    def package_delivery_vendor(self):
+        """
+        Gets the package_delivery_vendor of this UpdateTransferPackageDetails.
+
+        :return: The package_delivery_vendor of this UpdateTransferPackageDetails.
+        :rtype: str
+        """
+        return self._package_delivery_vendor
+
+    @package_delivery_vendor.setter
+    def package_delivery_vendor(self, package_delivery_vendor):
+        """
+        Sets the package_delivery_vendor of this UpdateTransferPackageDetails.
+
+        :param package_delivery_vendor: The package_delivery_vendor of this UpdateTransferPackageDetails.
+        :type: str
+        """
+        self._package_delivery_vendor = package_delivery_vendor
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this UpdateTransferPackageDetails.
+        Allowed values for this property are: "SHIPPING", "CANCELLED"
+
+
+        :return: The lifecycle_state of this UpdateTransferPackageDetails.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this UpdateTransferPackageDetails.
+
+        :param lifecycle_state: The lifecycle_state of this UpdateTransferPackageDetails.
+        :type: str
+        """
+        allowed_values = ["SHIPPING", "CANCELLED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            raise ValueError(
+                "Invalid value for `lifecycle_state`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._lifecycle_state = lifecycle_state
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/shipping_vendors_client.py
+++ b/src/oci/dts/shipping_vendors_client.py
@@ -1,0 +1,130 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import dts_type_mapping
+missing = Sentinel("Missing")
+
+
+class ShippingVendorsClient(object):
+    """
+    A description of the DTS API
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20171001',
+            'service_endpoint_template': 'https://datatransfer.{region}.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("shipping_vendors", config, signer, dts_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def list_shipping_vendors(self, **kwargs):
+        """
+        Lists available shipping vendors for Transfer Package delivery
+        Lists available shipping vendors for Transfer Package delivery
+
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.ShippingVendors`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/shippingVendors"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_shipping_vendors got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                response_type="ShippingVendors")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                response_type="ShippingVendors")

--- a/src/oci/dts/shipping_vendors_client_composite_operations.py
+++ b/src/oci/dts/shipping_vendors_client_composite_operations.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class ShippingVendorsClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.dts.ShippingVendorsClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new ShippingVendorsClientCompositeOperations object
+
+        :param ShippingVendorsClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client

--- a/src/oci/dts/transfer_appliance_client.py
+++ b/src/oci/dts/transfer_appliance_client.py
@@ -1,0 +1,673 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import dts_type_mapping
+missing = Sentinel("Missing")
+
+
+class TransferApplianceClient(object):
+    """
+    A description of the DTS API
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20171001',
+            'service_endpoint_template': 'https://datatransfer.{region}.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("transfer_appliance", config, signer, dts_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def create_transfer_appliance(self, id, **kwargs):
+        """
+        Create a new Transfer Appliance
+        Create a new Transfer Appliance
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str opc_retry_token: (optional)
+
+        :param CreateTransferApplianceDetails create_transfer_appliance_details: (optional)
+            Creates a New Transfer Appliance
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferAppliance`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferAppliances"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "create_transfer_appliance_details"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_transfer_appliance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=kwargs.get('create_transfer_appliance_details'),
+                response_type="TransferAppliance")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=kwargs.get('create_transfer_appliance_details'),
+                response_type="TransferAppliance")
+
+    def create_transfer_appliance_admin_credentials(self, id, transfer_appliance_label, admin_public_key, **kwargs):
+        """
+        Creates an X.509 certificate from a public key
+        Creates an X.509 certificate from a public key
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_appliance_label: (required)
+            Label of the Transfer Appliance
+
+        :param TransferAppliancePublicKey admin_public_key: (required)
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferApplianceCertificate`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferAppliances/{transferApplianceLabel}/admin_credentials"
+        method = "POST"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_transfer_appliance_admin_credentials got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferApplianceLabel": transfer_appliance_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=admin_public_key,
+                response_type="TransferApplianceCertificate")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=admin_public_key,
+                response_type="TransferApplianceCertificate")
+
+    def delete_transfer_appliance(self, id, transfer_appliance_label, **kwargs):
+        """
+        deletes a transfer Appliance
+        deletes a transfer Appliance
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_appliance_label: (required)
+            Label of the Transfer Appliance
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferAppliances/{transferApplianceLabel}"
+        method = "DELETE"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_transfer_appliance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferApplianceLabel": transfer_appliance_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def get_transfer_appliance(self, id, transfer_appliance_label, **kwargs):
+        """
+        Describes a transfer appliance in detail
+        Describes a transfer appliance in detail
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_appliance_label: (required)
+            Label of the Transfer Appliance
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferAppliance`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferAppliances/{transferApplianceLabel}"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_transfer_appliance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferApplianceLabel": transfer_appliance_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferAppliance")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferAppliance")
+
+    def get_transfer_appliance_certificate_authority_certificate(self, id, transfer_appliance_label, **kwargs):
+        """
+        Gets the x.509 certificate for the Transfer Appliance's dedicated Certificate Authority (CA)
+        Gets the x.509 certificate for the Transfer Appliance's dedicated Certificate Authority (CA)
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_appliance_label: (required)
+            Label of the Transfer Appliance
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferApplianceCertificate`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferAppliances/{transferApplianceLabel}/certificate_authority_certificate"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_transfer_appliance_certificate_authority_certificate got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferApplianceLabel": transfer_appliance_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferApplianceCertificate")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferApplianceCertificate")
+
+    def get_transfer_appliance_encryption_passphrase(self, id, transfer_appliance_label, **kwargs):
+        """
+        Describes a transfer appliance encryptionPassphrase
+        Describes a transfer appliance encryptionPassphrase in detail
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_appliance_label: (required)
+            Label of the Transfer Appliance
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferApplianceEncryptionPassphrase`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferAppliances/{transferApplianceLabel}/encryptionPassphrase"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_transfer_appliance_encryption_passphrase got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferApplianceLabel": transfer_appliance_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferApplianceEncryptionPassphrase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferApplianceEncryptionPassphrase")
+
+    def list_transfer_appliances(self, id, **kwargs):
+        """
+        Lists Transfer Appliances associated with a transferJob
+        Lists Transfer Appliances associated with a transferJob
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str lifecycle_state: (optional)
+            filtering by lifecycleState
+
+            Allowed values are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.MultipleTransferAppliances`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferAppliances"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "lifecycle_state"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_transfer_appliances got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="MultipleTransferAppliances")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="MultipleTransferAppliances")
+
+    def update_transfer_appliance(self, id, transfer_appliance_label, update_transfer_appliance_details, **kwargs):
+        """
+        Updates a Transfer Appliance
+        Updates a Transfer Appliance
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_appliance_label: (required)
+            Label of the Transfer Appliance
+
+        :param UpdateTransferApplianceDetails update_transfer_appliance_details: (required)
+            fields to update
+
+        :param str if_match: (optional)
+            The entity tag to match. Optional, if set, the update will be successful only if the
+            object's tag matches the tag specified in the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferAppliance`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferAppliances/{transferApplianceLabel}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_transfer_appliance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferApplianceLabel": transfer_appliance_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_transfer_appliance_details,
+                response_type="TransferAppliance")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_transfer_appliance_details,
+                response_type="TransferAppliance")

--- a/src/oci/dts/transfer_appliance_client_composite_operations.py
+++ b/src/oci/dts/transfer_appliance_client_composite_operations.py
@@ -1,0 +1,105 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class TransferApplianceClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.dts.TransferApplianceClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new TransferApplianceClientCompositeOperations object
+
+        :param TransferApplianceClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client
+
+    def create_transfer_appliance_and_wait_for_state(self, id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.dts.TransferApplianceClient.create_transfer_appliance` and waits for the :py:class:`~oci.dts.models.TransferAppliance` acted upon
+        to enter the given state(s).
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.dts.models.TransferAppliance.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.dts.TransferApplianceClient.create_transfer_appliance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_transfer_appliance(id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_transfer_appliance(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_transfer_appliance_and_wait_for_state(self, id, transfer_appliance_label, update_transfer_appliance_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.dts.TransferApplianceClient.update_transfer_appliance` and waits for the :py:class:`~oci.dts.models.TransferAppliance` acted upon
+        to enter the given state(s).
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_appliance_label: (required)
+            Label of the Transfer Appliance
+
+        :param UpdateTransferApplianceDetails update_transfer_appliance_details: (required)
+            fields to update
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.dts.models.TransferAppliance.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.dts.TransferApplianceClient.update_transfer_appliance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_transfer_appliance(id, transfer_appliance_label, update_transfer_appliance_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_transfer_appliance(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)

--- a/src/oci/dts/transfer_appliance_entitlement_client.py
+++ b/src/oci/dts/transfer_appliance_entitlement_client.py
@@ -1,0 +1,224 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import dts_type_mapping
+missing = Sentinel("Missing")
+
+
+class TransferApplianceEntitlementClient(object):
+    """
+    A description of the DTS API
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20171001',
+            'service_endpoint_template': 'https://datatransfer.{region}.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("transfer_appliance_entitlement", config, signer, dts_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def create_transfer_appliance_entitlement(self, create_transfer_appliance_entitlement_details, **kwargs):
+        """
+        Create the Transfer Appliance Entitlement
+        Create the Transfer Appliance Entitlement that allows customers to use Transfer Appliance
+
+
+        :param CreateTransferApplianceEntitlementDetails create_transfer_appliance_entitlement_details: (required)
+            Creates a Transfer Appliance Entitlement
+
+        :param str opc_retry_token: (optional)
+            opc retry token
+
+        :param str opc_request_id: (optional)
+            opc request id
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferApplianceEntitlement`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferApplianceEntitlement"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_transfer_appliance_entitlement got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_transfer_appliance_entitlement_details,
+                response_type="TransferApplianceEntitlement")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_transfer_appliance_entitlement_details,
+                response_type="TransferApplianceEntitlement")
+
+    def get_transfer_appliance_entitlement(self, tenant_id, **kwargs):
+        """
+        Describes the Transfer Appliance Entitlement in detail
+        Describes the Transfer Appliance Entitlement in detail
+
+
+        :param str tenant_id: (required)
+            Tenant Id
+
+        :param str opc_request_id: (optional)
+            opc request id
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferApplianceEntitlement`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferApplianceEntitlement/{tenantId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_transfer_appliance_entitlement got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "tenantId": tenant_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferApplianceEntitlement")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferApplianceEntitlement")

--- a/src/oci/dts/transfer_appliance_entitlement_client_composite_operations.py
+++ b/src/oci/dts/transfer_appliance_entitlement_client_composite_operations.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class TransferApplianceEntitlementClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.dts.TransferApplianceEntitlementClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new TransferApplianceEntitlementClientCompositeOperations object
+
+        :param TransferApplianceEntitlementClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client

--- a/src/oci/dts/transfer_device_client.py
+++ b/src/oci/dts/transfer_device_client.py
@@ -1,0 +1,469 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import dts_type_mapping
+missing = Sentinel("Missing")
+
+
+class TransferDeviceClient(object):
+    """
+    A description of the DTS API
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20171001',
+            'service_endpoint_template': 'https://datatransfer.{region}.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("transfer_device", config, signer, dts_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def create_transfer_device(self, id, create_transfer_device_details, **kwargs):
+        """
+        Create a new Transfer Device
+        Create a new Transfer Device
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param CreateTransferDeviceDetails create_transfer_device_details: (required)
+            Creates a New Transfer Device
+
+        :param str opc_retry_token: (optional)
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.NewTransferDevice`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferDevices"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_transfer_device got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_transfer_device_details,
+                response_type="NewTransferDevice")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_transfer_device_details,
+                response_type="NewTransferDevice")
+
+    def delete_transfer_device(self, id, transfer_device_label, **kwargs):
+        """
+        deletes a transfer Device
+        deletes a transfer Device
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_device_label: (required)
+            Label of the Transfer Device
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferDevices/{transferDeviceLabel}"
+        method = "DELETE"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_transfer_device got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferDeviceLabel": transfer_device_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def get_transfer_device(self, id, transfer_device_label, **kwargs):
+        """
+        Describes a transfer Device in detail
+        Describes a transfer package in detail
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_device_label: (required)
+            Label of the Transfer Device
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferDevice`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferDevices/{transferDeviceLabel}"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_transfer_device got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferDeviceLabel": transfer_device_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferDevice")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferDevice")
+
+    def list_transfer_devices(self, id, **kwargs):
+        """
+        Lists Transfer Devices associated with a transferJob
+        Lists Transfer Devices associated with a transferJob
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str lifecycle_state: (optional)
+            filtering by lifecycleState
+
+            Allowed values are: "PREPARING", "READY", "PACKAGED", "ACTIVE", "PROCESSING", "COMPLETE", "MISSING", "ERROR", "DELETED", "CANCELLED"
+
+        :param str display_name: (optional)
+            filtering by displayName
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.MultipleTransferDevices`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferDevices"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "lifecycle_state",
+            "display_name"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_transfer_devices got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["PREPARING", "READY", "PACKAGED", "ACTIVE", "PROCESSING", "COMPLETE", "MISSING", "ERROR", "DELETED", "CANCELLED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="MultipleTransferDevices")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="MultipleTransferDevices")
+
+    def update_transfer_device(self, id, transfer_device_label, update_transfer_device_details, **kwargs):
+        """
+        Updates a Transfer Device
+        Updates a Transfer Device
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_device_label: (required)
+            Label of the Transfer Device
+
+        :param UpdateTransferDeviceDetails update_transfer_device_details: (required)
+            fields to update
+
+        :param str if_match: (optional)
+            The entity tag to match. Optional, if set, the update will be successful only if the
+            object's tag matches the tag specified in the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferDevice`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferDevices/{transferDeviceLabel}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_transfer_device got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferDeviceLabel": transfer_device_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_transfer_device_details,
+                response_type="TransferDevice")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_transfer_device_details,
+                response_type="TransferDevice")

--- a/src/oci/dts/transfer_device_client_composite_operations.py
+++ b/src/oci/dts/transfer_device_client_composite_operations.py
@@ -1,0 +1,67 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class TransferDeviceClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.dts.TransferDeviceClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new TransferDeviceClientCompositeOperations object
+
+        :param TransferDeviceClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client
+
+    def update_transfer_device_and_wait_for_state(self, id, transfer_device_label, update_transfer_device_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.dts.TransferDeviceClient.update_transfer_device` and waits for the :py:class:`~oci.dts.models.TransferDevice` acted upon
+        to enter the given state(s).
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_device_label: (required)
+            Label of the Transfer Device
+
+        :param UpdateTransferDeviceDetails update_transfer_device_details: (required)
+            fields to update
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.dts.models.TransferDevice.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.dts.TransferDeviceClient.update_transfer_device`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_transfer_device(id, transfer_device_label, update_transfer_device_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_transfer_device(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)

--- a/src/oci/dts/transfer_job_client.py
+++ b/src/oci/dts/transfer_job_client.py
@@ -1,0 +1,525 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import dts_type_mapping
+missing = Sentinel("Missing")
+
+
+class TransferJobClient(object):
+    """
+    A description of the DTS API
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20171001',
+            'service_endpoint_template': 'https://datatransfer.{region}.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("transfer_job", config, signer, dts_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def change_transfer_job_compartment(self, transfer_job_id, change_transfer_job_compartment_details, **kwargs):
+        """
+        Move a job into a different compartment. When provided, if-Match is matched against ETag values of the resource.
+        Moves a TransferJob into a different compartment.
+
+
+        :param str transfer_job_id: (required)
+            ID of the Transfer Job
+
+        :param ChangeTransferJobCompartmentDetails change_transfer_job_compartment_details: (required)
+            CompartmentId of the destination compartment
+
+        :param str if_match: (optional)
+            The entity tag to match. Optional, if set, the update will be successful only if the
+            object's tag matches the tag specified in the request.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+            a particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{transferJobId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_transfer_job_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "transferJobId": transfer_job_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_transfer_job_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_transfer_job_compartment_details)
+
+    def create_transfer_job(self, create_transfer_job_details, **kwargs):
+        """
+        Create a new Transfer Job
+        Create a new Transfer Job that corresponds with customer's logical dataset e.g. a DB or a filesystem.
+
+
+        :param CreateTransferJobDetails create_transfer_job_details: (required)
+            Creates a New Transfer Job
+
+        :param str opc_retry_token: (optional)
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferJob`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_transfer_job got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_transfer_job_details,
+                response_type="TransferJob")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_transfer_job_details,
+                response_type="TransferJob")
+
+    def delete_transfer_job(self, id, **kwargs):
+        """
+        deletes a transfer job
+        deletes a transfer job
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}"
+        method = "DELETE"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_transfer_job got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def get_transfer_job(self, id, **kwargs):
+        """
+        Describes a transfer job in detail
+        Describes a transfer job in detail
+
+
+        :param str id: (required)
+            OCID of the Transfer Job
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferJob`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_transfer_job got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferJob")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferJob")
+
+    def list_transfer_jobs(self, compartment_id, **kwargs):
+        """
+        Lists Transfer Jobs in a given compartment
+        Lists Transfer Jobs in a given compartment
+
+
+        :param str compartment_id: (required)
+            compartment id
+
+        :param str lifecycle_state: (optional)
+            filtering by lifecycleState
+
+            Allowed values are: "INITIATED", "PREPARING", "ACTIVE", "DELETED", "CLOSED"
+
+        :param str display_name: (optional)
+            filtering by displayName
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.dts.models.TransferJobSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "lifecycle_state",
+            "display_name"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_transfer_jobs got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["INITIATED", "PREPARING", "ACTIVE", "DELETED", "CLOSED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[TransferJobSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[TransferJobSummary]")
+
+    def update_transfer_job(self, id, update_transfer_job_details, **kwargs):
+        """
+        Updates a Transfer Job
+        Updates a Transfer Job that corresponds with customer's logical dataset e.g. a DB or a filesystem.
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param UpdateTransferJobDetails update_transfer_job_details: (required)
+            fields to update
+
+        :param str if_match: (optional)
+            The entity tag to match. Optional, if set, the update will be successful only if the
+            object's tag matches the tag specified in the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferJob`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_transfer_job got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_transfer_job_details,
+                response_type="TransferJob")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_transfer_job_details,
+                response_type="TransferJob")

--- a/src/oci/dts/transfer_job_client_composite_operations.py
+++ b/src/oci/dts/transfer_job_client_composite_operations.py
@@ -1,0 +1,149 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class TransferJobClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.dts.TransferJobClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new TransferJobClientCompositeOperations object
+
+        :param TransferJobClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client
+
+    def create_transfer_job_and_wait_for_state(self, create_transfer_job_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.dts.TransferJobClient.create_transfer_job` and waits for the :py:class:`~oci.dts.models.TransferJob` acted upon
+        to enter the given state(s).
+
+        :param CreateTransferJobDetails create_transfer_job_details: (required)
+            Creates a New Transfer Job
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.dts.models.TransferJob.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.dts.TransferJobClient.create_transfer_job`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_transfer_job(create_transfer_job_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_transfer_job(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_transfer_job_and_wait_for_state(self, id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.dts.TransferJobClient.delete_transfer_job` and waits for the :py:class:`~oci.dts.models.TransferJob` acted upon
+        to enter the given state(s).
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.dts.models.TransferJob.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.dts.TransferJobClient.delete_transfer_job`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        initial_get_result = self.client.get_transfer_job(id)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_transfer_job(id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                initial_get_result,
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                succeed_on_not_found=True,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_transfer_job_and_wait_for_state(self, id, update_transfer_job_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.dts.TransferJobClient.update_transfer_job` and waits for the :py:class:`~oci.dts.models.TransferJob` acted upon
+        to enter the given state(s).
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param UpdateTransferJobDetails update_transfer_job_details: (required)
+            fields to update
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.dts.models.TransferJob.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.dts.TransferJobClient.update_transfer_job`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_transfer_job(id, update_transfer_job_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_transfer_job(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)

--- a/src/oci/dts/transfer_package_client.py
+++ b/src/oci/dts/transfer_package_client.py
@@ -1,0 +1,612 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import dts_type_mapping
+missing = Sentinel("Missing")
+
+
+class TransferPackageClient(object):
+    """
+    A description of the DTS API
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20171001',
+            'service_endpoint_template': 'https://datatransfer.{region}.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("transfer_package", config, signer, dts_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def attach_devices_to_transfer_package(self, id, transfer_package_label, attach_devices_details, **kwargs):
+        """
+        Attaches Devices to a Transfer Package
+        Attaches Devices to a Transfer Package
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_package_label: (required)
+            Label of the Transfer Package
+
+        :param AttachDevicesDetails attach_devices_details: (required)
+            Labels of Transfer Devices to attach
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferPackages/{transferPackageLabel}/actions/attachDevices"
+        method = "POST"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "attach_devices_to_transfer_package got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferPackageLabel": transfer_package_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=attach_devices_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=attach_devices_details)
+
+    def create_transfer_package(self, id, **kwargs):
+        """
+        Create a new Transfer Package
+        Create a new Transfer Package
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str opc_retry_token: (optional)
+
+        :param CreateTransferPackageDetails create_transfer_package_details: (optional)
+            Creates a New Transfer Package
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferPackage`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferPackages"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "create_transfer_package_details"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_transfer_package got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=kwargs.get('create_transfer_package_details'),
+                response_type="TransferPackage")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=kwargs.get('create_transfer_package_details'),
+                response_type="TransferPackage")
+
+    def delete_transfer_package(self, id, transfer_package_label, **kwargs):
+        """
+        deletes a transfer Package
+        deletes a transfer Package
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_package_label: (required)
+            Label of the Transfer Package
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferPackages/{transferPackageLabel}"
+        method = "DELETE"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_transfer_package got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferPackageLabel": transfer_package_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def detach_devices_from_transfer_package(self, id, transfer_package_label, detach_devices_details, **kwargs):
+        """
+        Detaches Devices from a Transfer Package
+        Detaches Devices from a Transfer Package
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_package_label: (required)
+            Label of the Transfer Package
+
+        :param DetachDevicesDetails detach_devices_details: (required)
+            Labels of Transfer Devices to detach
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferPackages/{transferPackageLabel}/actions/detachDevices"
+        method = "POST"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "detach_devices_from_transfer_package got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferPackageLabel": transfer_package_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=detach_devices_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=detach_devices_details)
+
+    def get_transfer_package(self, id, transfer_package_label, **kwargs):
+        """
+        Describes a transfer Package in detail
+        Describes a transfer package in detail
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_package_label: (required)
+            Label of the Transfer Package
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferPackage`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferPackages/{transferPackageLabel}"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_transfer_package got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferPackageLabel": transfer_package_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferPackage")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferPackage")
+
+    def list_transfer_packages(self, id, **kwargs):
+        """
+        Lists Transfer Packages associated with a transferJob
+        Lists Transfer Packages associated with a transferJob
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str lifecycle_state: (optional)
+            filtering by lifecycleState
+
+            Allowed values are: "PREPARING", "SHIPPING", "RECEIVED", "PROCESSING", "PROCESSED", "RETURNED", "DELETED", "CANCELLED", "CANCELLED_RETURNED"
+
+        :param str display_name: (optional)
+            filtering by displayName
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.MultipleTransferPackages`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferPackages"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "lifecycle_state",
+            "display_name"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_transfer_packages got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["PREPARING", "SHIPPING", "RECEIVED", "PROCESSING", "PROCESSED", "RETURNED", "DELETED", "CANCELLED", "CANCELLED_RETURNED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="MultipleTransferPackages")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="MultipleTransferPackages")
+
+    def update_transfer_package(self, id, transfer_package_label, update_transfer_package_details, **kwargs):
+        """
+        Updates a Transfer Package
+        Updates a Transfer Package
+
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_package_label: (required)
+            Label of the Transfer Package
+
+        :param UpdateTransferPackageDetails update_transfer_package_details: (required)
+            fields to update
+
+        :param str if_match: (optional)
+            The entity tag to match. Optional, if set, the update will be successful only if the
+            object's tag matches the tag specified in the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferPackage`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferJobs/{id}/transferPackages/{transferPackageLabel}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
+        extra_kwargs = [key for key in six.iterkeys(kwargs) if key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_transfer_package got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "id": id,
+            "transferPackageLabel": transfer_package_label
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_transfer_package_details,
+                response_type="TransferPackage")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_transfer_package_details,
+                response_type="TransferPackage")

--- a/src/oci/dts/transfer_package_client_composite_operations.py
+++ b/src/oci/dts/transfer_package_client_composite_operations.py
@@ -1,0 +1,105 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class TransferPackageClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.dts.TransferPackageClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new TransferPackageClientCompositeOperations object
+
+        :param TransferPackageClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client
+
+    def create_transfer_package_and_wait_for_state(self, id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.dts.TransferPackageClient.create_transfer_package` and waits for the :py:class:`~oci.dts.models.TransferPackage` acted upon
+        to enter the given state(s).
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.dts.models.TransferPackage.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.dts.TransferPackageClient.create_transfer_package`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_transfer_package(id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_transfer_package(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_transfer_package_and_wait_for_state(self, id, transfer_package_label, update_transfer_package_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.dts.TransferPackageClient.update_transfer_package` and waits for the :py:class:`~oci.dts.models.TransferPackage` acted upon
+        to enter the given state(s).
+
+        :param str id: (required)
+            ID of the Transfer Job
+
+        :param str transfer_package_label: (required)
+            Label of the Transfer Package
+
+        :param UpdateTransferPackageDetails update_transfer_package_details: (required)
+            fields to update
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.dts.models.TransferPackage.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.dts.TransferPackageClient.update_transfer_package`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_transfer_package(id, transfer_package_label, update_transfer_package_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_transfer_package(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)

--- a/src/oci/regions.py
+++ b/src/oci/regions.py
@@ -7,6 +7,7 @@ REGIONS_SHORT_NAMES = {
     'phx': 'us-phoenix-1',
     'iad': 'us-ashburn-1',
     'fra': 'eu-frankfurt-1',
+    'zrh': 'eu-zurich-1',
     'lhr': 'uk-london-1',
     'yyz': 'ca-toronto-1',
     'nrt': 'ap-tokyo-1',
@@ -20,6 +21,7 @@ REGION_REALMS = {
     'us-phoenix-1': 'oc1',
     'us-ashburn-1': 'oc1',
     'eu-frankfurt-1': 'oc1',
+    'eu-zurich-1': 'oc1',
     'uk-london-1': 'oc1',
     'ca-toronto-1': 'oc1',
 
@@ -42,6 +44,7 @@ REGIONS = [
     "us-phoenix-1",
     "us-ashburn-1",
     "eu-frankfurt-1",
+    "eu-zurich-1",
     "uk-london-1",
     "ca-toronto-1",
     "us-langley-1",

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "2.2.21"
+__version__ = "2.3.0"

--- a/src/oci/waas/models/__init__.py
+++ b/src/oci/waas/models/__init__.py
@@ -10,6 +10,7 @@ from .block_challenge_settings import BlockChallengeSettings
 from .captcha import Captcha
 from .certificate import Certificate
 from .certificate_extensions import CertificateExtensions
+from .certificate_issuer_name import CertificateIssuerName
 from .certificate_public_key_info import CertificatePublicKeyInfo
 from .certificate_subject_name import CertificateSubjectName
 from .certificate_summary import CertificateSummary
@@ -59,6 +60,7 @@ waas_type_mapping = {
     "Captcha": Captcha,
     "Certificate": Certificate,
     "CertificateExtensions": CertificateExtensions,
+    "CertificateIssuerName": CertificateIssuerName,
     "CertificatePublicKeyInfo": CertificatePublicKeyInfo,
     "CertificateSubjectName": CertificateSubjectName,
     "CertificateSummary": CertificateSummary,

--- a/src/oci/waas/models/access_rule.py
+++ b/src/oci/waas/models/access_rule.py
@@ -159,6 +159,12 @@ class AccessRule(object):
         **[Required]** Gets the action of this AccessRule.
         The action to take when the access criteria are met for a rule. If unspecified, defaults to `ALLOW`.
 
+        - **ALLOW:** Takes no action, just logs the request.
+
+        - **DETECT:** Takes no action, but creates an alert for the request.
+
+        - **BLOCK:** Blocks the request by returning specified response code or showing error page.
+
         Allowed values for this property are: "ALLOW", "DETECT", "BLOCK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
@@ -173,6 +179,12 @@ class AccessRule(object):
         """
         Sets the action of this AccessRule.
         The action to take when the access criteria are met for a rule. If unspecified, defaults to `ALLOW`.
+
+        - **ALLOW:** Takes no action, just logs the request.
+
+        - **DETECT:** Takes no action, but creates an alert for the request.
+
+        - **BLOCK:** Blocks the request by returning specified response code or showing error page.
 
 
         :param action: The action of this AccessRule.

--- a/src/oci/waas/models/access_rule_criteria.py
+++ b/src/oci/waas/models/access_rule_criteria.py
@@ -117,6 +117,8 @@ class AccessRuleCriteria(object):
         - **HTTP_HEADER_CONTAINS:** The HTTP_HEADER_CONTAINS criteria is defined using a compound value separated by a colon: a header field name and a header field value. `host:test.example.com` is an example of a criteria value where `host` is the header field name and `test.example.com` is the header field value. A request matches when the header field name is a case insensitive match and the header field value is a case insensitive, substring match.
         *Example:* With a criteria value of `host:test.example.com`, where `host` is the name of the field and `test.example.com` is the value of the host field, a request with the header values, `Host: www.test.example.com` will match, where as a request with header values of `host: www.example.com` or `host: test.sub.example.com` will not match.
 
+
+
         - **COUNTRY_IS:** Matches if the request originates from a country in the `value` field. Country codes are in ISO 3166-1 alpha-2 format. For a list of codes, see `ISO's website`__.
 
         - **COUNTRY_IS_NOT:** Matches if the request does not originate from a country in the `value` field. Country codes are in ISO 3166-1 alpha-2 format. For a list of codes, see `ISO's website`__.
@@ -160,6 +162,8 @@ class AccessRuleCriteria(object):
 
         - **HTTP_HEADER_CONTAINS:** The HTTP_HEADER_CONTAINS criteria is defined using a compound value separated by a colon: a header field name and a header field value. `host:test.example.com` is an example of a criteria value where `host` is the header field name and `test.example.com` is the header field value. A request matches when the header field name is a case insensitive match and the header field value is a case insensitive, substring match.
         *Example:* With a criteria value of `host:test.example.com`, where `host` is the name of the field and `test.example.com` is the value of the host field, a request with the header values, `Host: www.test.example.com` will match, where as a request with header values of `host: www.example.com` or `host: test.sub.example.com` will not match.
+
+
 
         - **COUNTRY_IS:** Matches if the request originates from a country in the `value` field. Country codes are in ISO 3166-1 alpha-2 format. For a list of codes, see `ISO's website`__.
 

--- a/src/oci/waas/models/certificate.py
+++ b/src/oci/waas/models/certificate.py
@@ -64,7 +64,7 @@ class Certificate(object):
 
         :param issuer_name:
             The value to assign to the issuer_name property of this Certificate.
-        :type issuer_name: CertificateSubjectName
+        :type issuer_name: CertificateIssuerName
 
         :param serial_number:
             The value to assign to the serial_number property of this Certificate.
@@ -119,7 +119,7 @@ class Certificate(object):
             'display_name': 'str',
             'issued_by': 'str',
             'subject_name': 'CertificateSubjectName',
-            'issuer_name': 'CertificateSubjectName',
+            'issuer_name': 'CertificateIssuerName',
             'serial_number': 'str',
             'version': 'int',
             'signature_algorithm': 'str',
@@ -174,7 +174,7 @@ class Certificate(object):
     @property
     def id(self):
         """
-        Gets the id of this Certificate.
+        **[Required]** Gets the id of this Certificate.
         The `OCID`__ of the certificate.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
@@ -202,7 +202,7 @@ class Certificate(object):
     @property
     def compartment_id(self):
         """
-        Gets the compartment_id of this Certificate.
+        **[Required]** Gets the compartment_id of this Certificate.
         The `OCID`__ of the certificate's compartment.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
@@ -230,7 +230,7 @@ class Certificate(object):
     @property
     def display_name(self):
         """
-        Gets the display_name of this Certificate.
+        **[Required]** Gets the display_name of this Certificate.
         The user-friendly name of the certificate.
 
 
@@ -297,7 +297,7 @@ class Certificate(object):
         Gets the issuer_name of this Certificate.
 
         :return: The issuer_name of this Certificate.
-        :rtype: CertificateSubjectName
+        :rtype: CertificateIssuerName
         """
         return self._issuer_name
 
@@ -307,14 +307,16 @@ class Certificate(object):
         Sets the issuer_name of this Certificate.
 
         :param issuer_name: The issuer_name of this Certificate.
-        :type: CertificateSubjectName
+        :type: CertificateIssuerName
         """
         self._issuer_name = issuer_name
 
     @property
     def serial_number(self):
         """
-        Gets the serial_number of this Certificate.
+        **[Required]** Gets the serial_number of this Certificate.
+        A unique, positive integer assigned by the Certificate Authority (CA). The issuer name and serial number identify a unique certificate.
+
 
         :return: The serial_number of this Certificate.
         :rtype: str
@@ -325,6 +327,8 @@ class Certificate(object):
     def serial_number(self, serial_number):
         """
         Sets the serial_number of this Certificate.
+        A unique, positive integer assigned by the Certificate Authority (CA). The issuer name and serial number identify a unique certificate.
+
 
         :param serial_number: The serial_number of this Certificate.
         :type: str
@@ -334,7 +338,9 @@ class Certificate(object):
     @property
     def version(self):
         """
-        Gets the version of this Certificate.
+        **[Required]** Gets the version of this Certificate.
+        The version of the encoded certificate.
+
 
         :return: The version of this Certificate.
         :rtype: int
@@ -345,6 +351,8 @@ class Certificate(object):
     def version(self, version):
         """
         Sets the version of this Certificate.
+        The version of the encoded certificate.
+
 
         :param version: The version of this Certificate.
         :type: int
@@ -354,7 +362,9 @@ class Certificate(object):
     @property
     def signature_algorithm(self):
         """
-        Gets the signature_algorithm of this Certificate.
+        **[Required]** Gets the signature_algorithm of this Certificate.
+        The identifier for the cryptographic algorithm used by the Certificate Authority (CA) to sign this certificate.
+
 
         :return: The signature_algorithm of this Certificate.
         :rtype: str
@@ -365,6 +375,8 @@ class Certificate(object):
     def signature_algorithm(self, signature_algorithm):
         """
         Sets the signature_algorithm of this Certificate.
+        The identifier for the cryptographic algorithm used by the Certificate Authority (CA) to sign this certificate.
+
 
         :param signature_algorithm: The signature_algorithm of this Certificate.
         :type: str
@@ -374,7 +386,9 @@ class Certificate(object):
     @property
     def time_not_valid_before(self):
         """
-        Gets the time_not_valid_before of this Certificate.
+        **[Required]** Gets the time_not_valid_before of this Certificate.
+        The date and time the certificate will become valid, expressed in RFC 3339 timestamp format.
+
 
         :return: The time_not_valid_before of this Certificate.
         :rtype: datetime
@@ -385,6 +399,8 @@ class Certificate(object):
     def time_not_valid_before(self, time_not_valid_before):
         """
         Sets the time_not_valid_before of this Certificate.
+        The date and time the certificate will become valid, expressed in RFC 3339 timestamp format.
+
 
         :param time_not_valid_before: The time_not_valid_before of this Certificate.
         :type: datetime
@@ -394,7 +410,7 @@ class Certificate(object):
     @property
     def time_not_valid_after(self):
         """
-        Gets the time_not_valid_after of this Certificate.
+        **[Required]** Gets the time_not_valid_after of this Certificate.
         The date and time the certificate will expire, expressed in RFC 3339 timestamp format.
 
 
@@ -439,6 +455,8 @@ class Certificate(object):
     def extensions(self):
         """
         Gets the extensions of this Certificate.
+        Additional attributes associated with users or public keys for managing relationships between Certificate Authorities.
+
 
         :return: The extensions of this Certificate.
         :rtype: list[CertificateExtensions]
@@ -449,6 +467,8 @@ class Certificate(object):
     def extensions(self, extensions):
         """
         Sets the extensions of this Certificate.
+        Additional attributes associated with users or public keys for managing relationships between Certificate Authorities.
+
 
         :param extensions: The extensions of this Certificate.
         :type: list[CertificateExtensions]
@@ -459,7 +479,12 @@ class Certificate(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this Certificate.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :return: The freeform_tags of this Certificate.
@@ -471,7 +496,12 @@ class Certificate(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this Certificate.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :param freeform_tags: The freeform_tags of this Certificate.
@@ -483,7 +513,12 @@ class Certificate(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this Certificate.
-        A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :return: The defined_tags of this Certificate.
@@ -495,7 +530,12 @@ class Certificate(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this Certificate.
-        A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :param defined_tags: The defined_tags of this Certificate.

--- a/src/oci/waas/models/certificate_extensions.py
+++ b/src/oci/waas/models/certificate_extensions.py
@@ -50,6 +50,8 @@ class CertificateExtensions(object):
     def name(self):
         """
         Gets the name of this CertificateExtensions.
+        The certificate extension name.
+
 
         :return: The name of this CertificateExtensions.
         :rtype: str
@@ -60,6 +62,8 @@ class CertificateExtensions(object):
     def name(self, name):
         """
         Sets the name of this CertificateExtensions.
+        The certificate extension name.
+
 
         :param name: The name of this CertificateExtensions.
         :type: str
@@ -70,6 +74,8 @@ class CertificateExtensions(object):
     def is_critical(self):
         """
         Gets the is_critical of this CertificateExtensions.
+        The critical flag of the extension. Critical extensions must be processed, non-critical extensions can be ignored.
+
 
         :return: The is_critical of this CertificateExtensions.
         :rtype: bool
@@ -80,6 +86,8 @@ class CertificateExtensions(object):
     def is_critical(self, is_critical):
         """
         Sets the is_critical of this CertificateExtensions.
+        The critical flag of the extension. Critical extensions must be processed, non-critical extensions can be ignored.
+
 
         :param is_critical: The is_critical of this CertificateExtensions.
         :type: bool
@@ -90,6 +98,8 @@ class CertificateExtensions(object):
     def value(self):
         """
         Gets the value of this CertificateExtensions.
+        The certificate extension value.
+
 
         :return: The value of this CertificateExtensions.
         :rtype: str
@@ -100,6 +110,8 @@ class CertificateExtensions(object):
     def value(self, value):
         """
         Sets the value of this CertificateExtensions.
+        The certificate extension value.
+
 
         :param value: The value of this CertificateExtensions.
         :type: str

--- a/src/oci/waas/models/certificate_issuer_name.py
+++ b/src/oci/waas/models/certificate_issuer_name.py
@@ -1,0 +1,259 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CertificateIssuerName(object):
+    """
+    The issuer of the certificate.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CertificateIssuerName object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param country:
+            The value to assign to the country property of this CertificateIssuerName.
+        :type country: str
+
+        :param state_province:
+            The value to assign to the state_province property of this CertificateIssuerName.
+        :type state_province: str
+
+        :param locality:
+            The value to assign to the locality property of this CertificateIssuerName.
+        :type locality: str
+
+        :param organization:
+            The value to assign to the organization property of this CertificateIssuerName.
+        :type organization: str
+
+        :param organizational_unit:
+            The value to assign to the organizational_unit property of this CertificateIssuerName.
+        :type organizational_unit: str
+
+        :param common_name:
+            The value to assign to the common_name property of this CertificateIssuerName.
+        :type common_name: str
+
+        :param email_address:
+            The value to assign to the email_address property of this CertificateIssuerName.
+        :type email_address: str
+
+        """
+        self.swagger_types = {
+            'country': 'str',
+            'state_province': 'str',
+            'locality': 'str',
+            'organization': 'str',
+            'organizational_unit': 'str',
+            'common_name': 'str',
+            'email_address': 'str'
+        }
+
+        self.attribute_map = {
+            'country': 'country',
+            'state_province': 'stateProvince',
+            'locality': 'locality',
+            'organization': 'organization',
+            'organizational_unit': 'organizationalUnit',
+            'common_name': 'commonName',
+            'email_address': 'emailAddress'
+        }
+
+        self._country = None
+        self._state_province = None
+        self._locality = None
+        self._organization = None
+        self._organizational_unit = None
+        self._common_name = None
+        self._email_address = None
+
+    @property
+    def country(self):
+        """
+        Gets the country of this CertificateIssuerName.
+        ISO 3166-1 alpha-2 code of the country where the organization is located. For a list of codes, see `ISO's website`__.
+
+        __ https://www.iso.org/obp/ui/#search/code/
+
+
+        :return: The country of this CertificateIssuerName.
+        :rtype: str
+        """
+        return self._country
+
+    @country.setter
+    def country(self, country):
+        """
+        Sets the country of this CertificateIssuerName.
+        ISO 3166-1 alpha-2 code of the country where the organization is located. For a list of codes, see `ISO's website`__.
+
+        __ https://www.iso.org/obp/ui/#search/code/
+
+
+        :param country: The country of this CertificateIssuerName.
+        :type: str
+        """
+        self._country = country
+
+    @property
+    def state_province(self):
+        """
+        Gets the state_province of this CertificateIssuerName.
+        The province where the organization is located.
+
+
+        :return: The state_province of this CertificateIssuerName.
+        :rtype: str
+        """
+        return self._state_province
+
+    @state_province.setter
+    def state_province(self, state_province):
+        """
+        Sets the state_province of this CertificateIssuerName.
+        The province where the organization is located.
+
+
+        :param state_province: The state_province of this CertificateIssuerName.
+        :type: str
+        """
+        self._state_province = state_province
+
+    @property
+    def locality(self):
+        """
+        Gets the locality of this CertificateIssuerName.
+        The city in which the organization is located.
+
+
+        :return: The locality of this CertificateIssuerName.
+        :rtype: str
+        """
+        return self._locality
+
+    @locality.setter
+    def locality(self, locality):
+        """
+        Sets the locality of this CertificateIssuerName.
+        The city in which the organization is located.
+
+
+        :param locality: The locality of this CertificateIssuerName.
+        :type: str
+        """
+        self._locality = locality
+
+    @property
+    def organization(self):
+        """
+        Gets the organization of this CertificateIssuerName.
+        The organization name.
+
+
+        :return: The organization of this CertificateIssuerName.
+        :rtype: str
+        """
+        return self._organization
+
+    @organization.setter
+    def organization(self, organization):
+        """
+        Sets the organization of this CertificateIssuerName.
+        The organization name.
+
+
+        :param organization: The organization of this CertificateIssuerName.
+        :type: str
+        """
+        self._organization = organization
+
+    @property
+    def organizational_unit(self):
+        """
+        Gets the organizational_unit of this CertificateIssuerName.
+        The field to differentiate between divisions within an organization.
+
+
+        :return: The organizational_unit of this CertificateIssuerName.
+        :rtype: str
+        """
+        return self._organizational_unit
+
+    @organizational_unit.setter
+    def organizational_unit(self, organizational_unit):
+        """
+        Sets the organizational_unit of this CertificateIssuerName.
+        The field to differentiate between divisions within an organization.
+
+
+        :param organizational_unit: The organizational_unit of this CertificateIssuerName.
+        :type: str
+        """
+        self._organizational_unit = organizational_unit
+
+    @property
+    def common_name(self):
+        """
+        Gets the common_name of this CertificateIssuerName.
+        The Certificate Authority (CA) name.
+
+
+        :return: The common_name of this CertificateIssuerName.
+        :rtype: str
+        """
+        return self._common_name
+
+    @common_name.setter
+    def common_name(self, common_name):
+        """
+        Sets the common_name of this CertificateIssuerName.
+        The Certificate Authority (CA) name.
+
+
+        :param common_name: The common_name of this CertificateIssuerName.
+        :type: str
+        """
+        self._common_name = common_name
+
+    @property
+    def email_address(self):
+        """
+        Gets the email_address of this CertificateIssuerName.
+        The email address of the server's administrator.
+
+
+        :return: The email_address of this CertificateIssuerName.
+        :rtype: str
+        """
+        return self._email_address
+
+    @email_address.setter
+    def email_address(self, email_address):
+        """
+        Sets the email_address of this CertificateIssuerName.
+        The email address of the server's administrator.
+
+
+        :param email_address: The email_address of this CertificateIssuerName.
+        :type: str
+        """
+        self._email_address = email_address
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/waas/models/certificate_public_key_info.py
+++ b/src/oci/waas/models/certificate_public_key_info.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CertificatePublicKeyInfo(object):
     """
-    CertificatePublicKeyInfo model.
+    Information about the public key and the algorithm used by the public key.
     """
 
     def __init__(self, **kwargs):
@@ -50,6 +50,8 @@ class CertificatePublicKeyInfo(object):
     def algorithm(self):
         """
         Gets the algorithm of this CertificatePublicKeyInfo.
+        The algorithm identifier and parameters for the public key.
+
 
         :return: The algorithm of this CertificatePublicKeyInfo.
         :rtype: str
@@ -60,6 +62,8 @@ class CertificatePublicKeyInfo(object):
     def algorithm(self, algorithm):
         """
         Sets the algorithm of this CertificatePublicKeyInfo.
+        The algorithm identifier and parameters for the public key.
+
 
         :param algorithm: The algorithm of this CertificatePublicKeyInfo.
         :type: str
@@ -70,6 +74,8 @@ class CertificatePublicKeyInfo(object):
     def exponent(self):
         """
         Gets the exponent of this CertificatePublicKeyInfo.
+        The private key exponent.
+
 
         :return: The exponent of this CertificatePublicKeyInfo.
         :rtype: int
@@ -80,6 +86,8 @@ class CertificatePublicKeyInfo(object):
     def exponent(self, exponent):
         """
         Sets the exponent of this CertificatePublicKeyInfo.
+        The private key exponent.
+
 
         :param exponent: The exponent of this CertificatePublicKeyInfo.
         :type: int
@@ -90,6 +98,8 @@ class CertificatePublicKeyInfo(object):
     def key_size(self):
         """
         Gets the key_size of this CertificatePublicKeyInfo.
+        The number of bits in a key used by a cryptographic algorithm.
+
 
         :return: The key_size of this CertificatePublicKeyInfo.
         :rtype: int
@@ -100,6 +110,8 @@ class CertificatePublicKeyInfo(object):
     def key_size(self, key_size):
         """
         Sets the key_size of this CertificatePublicKeyInfo.
+        The number of bits in a key used by a cryptographic algorithm.
+
 
         :param key_size: The key_size of this CertificatePublicKeyInfo.
         :type: int

--- a/src/oci/waas/models/certificate_subject_name.py
+++ b/src/oci/waas/models/certificate_subject_name.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CertificateSubjectName(object):
     """
-    CertificateSubjectName model.
+    The entity to be secured by the certificate.
     """
 
     def __init__(self, **kwargs):
@@ -78,6 +78,10 @@ class CertificateSubjectName(object):
     def country(self):
         """
         Gets the country of this CertificateSubjectName.
+        ISO 3166-1 alpha-2 code of the country where the organization is located. For a list of codes, see `ISO's website`__.
+
+        __ https://www.iso.org/obp/ui/#search/code/
+
 
         :return: The country of this CertificateSubjectName.
         :rtype: str
@@ -88,6 +92,10 @@ class CertificateSubjectName(object):
     def country(self, country):
         """
         Sets the country of this CertificateSubjectName.
+        ISO 3166-1 alpha-2 code of the country where the organization is located. For a list of codes, see `ISO's website`__.
+
+        __ https://www.iso.org/obp/ui/#search/code/
+
 
         :param country: The country of this CertificateSubjectName.
         :type: str
@@ -98,6 +106,8 @@ class CertificateSubjectName(object):
     def state_province(self):
         """
         Gets the state_province of this CertificateSubjectName.
+        The province where the organization is located.
+
 
         :return: The state_province of this CertificateSubjectName.
         :rtype: str
@@ -108,6 +118,8 @@ class CertificateSubjectName(object):
     def state_province(self, state_province):
         """
         Sets the state_province of this CertificateSubjectName.
+        The province where the organization is located.
+
 
         :param state_province: The state_province of this CertificateSubjectName.
         :type: str
@@ -118,6 +130,8 @@ class CertificateSubjectName(object):
     def locality(self):
         """
         Gets the locality of this CertificateSubjectName.
+        The city in which the organization is located.
+
 
         :return: The locality of this CertificateSubjectName.
         :rtype: str
@@ -128,6 +142,8 @@ class CertificateSubjectName(object):
     def locality(self, locality):
         """
         Sets the locality of this CertificateSubjectName.
+        The city in which the organization is located.
+
 
         :param locality: The locality of this CertificateSubjectName.
         :type: str
@@ -138,6 +154,8 @@ class CertificateSubjectName(object):
     def organization(self):
         """
         Gets the organization of this CertificateSubjectName.
+        The organization name.
+
 
         :return: The organization of this CertificateSubjectName.
         :rtype: str
@@ -148,6 +166,8 @@ class CertificateSubjectName(object):
     def organization(self, organization):
         """
         Sets the organization of this CertificateSubjectName.
+        The organization name.
+
 
         :param organization: The organization of this CertificateSubjectName.
         :type: str
@@ -158,6 +178,8 @@ class CertificateSubjectName(object):
     def organizational_unit(self):
         """
         Gets the organizational_unit of this CertificateSubjectName.
+        The field to differentiate between divisions within an organization.
+
 
         :return: The organizational_unit of this CertificateSubjectName.
         :rtype: str
@@ -168,6 +190,8 @@ class CertificateSubjectName(object):
     def organizational_unit(self, organizational_unit):
         """
         Sets the organizational_unit of this CertificateSubjectName.
+        The field to differentiate between divisions within an organization.
+
 
         :param organizational_unit: The organizational_unit of this CertificateSubjectName.
         :type: str
@@ -178,6 +202,8 @@ class CertificateSubjectName(object):
     def common_name(self):
         """
         Gets the common_name of this CertificateSubjectName.
+        The fully qualified domain name used for DNS lookups of the server.
+
 
         :return: The common_name of this CertificateSubjectName.
         :rtype: str
@@ -188,6 +214,8 @@ class CertificateSubjectName(object):
     def common_name(self, common_name):
         """
         Sets the common_name of this CertificateSubjectName.
+        The fully qualified domain name used for DNS lookups of the server.
+
 
         :param common_name: The common_name of this CertificateSubjectName.
         :type: str
@@ -198,6 +226,8 @@ class CertificateSubjectName(object):
     def email_address(self):
         """
         Gets the email_address of this CertificateSubjectName.
+        The email address of the server's administrator.
+
 
         :return: The email_address of this CertificateSubjectName.
         :rtype: str
@@ -208,6 +238,8 @@ class CertificateSubjectName(object):
     def email_address(self, email_address):
         """
         Sets the email_address of this CertificateSubjectName.
+        The email address of the server's administrator.
+
 
         :param email_address: The email_address of this CertificateSubjectName.
         :type: str

--- a/src/oci/waas/models/certificate_summary.py
+++ b/src/oci/waas/models/certificate_summary.py
@@ -216,7 +216,12 @@ class CertificateSummary(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this CertificateSummary.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :return: The freeform_tags of this CertificateSummary.
@@ -228,7 +233,12 @@ class CertificateSummary(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this CertificateSummary.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :param freeform_tags: The freeform_tags of this CertificateSummary.
@@ -240,7 +250,12 @@ class CertificateSummary(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CertificateSummary.
-        A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :return: The defined_tags of this CertificateSummary.
@@ -252,7 +267,12 @@ class CertificateSummary(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CertificateSummary.
-        A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :param defined_tags: The defined_tags of this CertificateSummary.

--- a/src/oci/waas/models/create_certificate_details.py
+++ b/src/oci/waas/models/create_certificate_details.py
@@ -135,6 +135,16 @@ class CreateCertificateDetails(object):
         The data of the SSL certificate.
 
 
+        **Note:** Many SSL certificate providers require an intermediate certificate chain to ensure a trusted status.
+        If your SSL certificate requires an intermediate certificate chain, please append the intermediate certificate
+        key in the `certificateData` field after the leaf certificate issued by the SSL certificate provider. If you
+        are unsure if your certificate requires an intermediate certificate chain, see your certificate
+        provider's documentation.
+
+
+        The example below shows an intermediate certificate appended to a leaf certificate.
+
+
         :return: The certificate_data of this CreateCertificateDetails.
         :rtype: str
         """
@@ -145,6 +155,16 @@ class CreateCertificateDetails(object):
         """
         Sets the certificate_data of this CreateCertificateDetails.
         The data of the SSL certificate.
+
+
+        **Note:** Many SSL certificate providers require an intermediate certificate chain to ensure a trusted status.
+        If your SSL certificate requires an intermediate certificate chain, please append the intermediate certificate
+        key in the `certificateData` field after the leaf certificate issued by the SSL certificate provider. If you
+        are unsure if your certificate requires an intermediate certificate chain, see your certificate
+        provider's documentation.
+
+
+        The example below shows an intermediate certificate appended to a leaf certificate.
 
 
         :param certificate_data: The certificate_data of this CreateCertificateDetails.
@@ -180,7 +200,7 @@ class CreateCertificateDetails(object):
     def is_trust_verification_disabled(self):
         """
         Gets the is_trust_verification_disabled of this CreateCertificateDetails.
-        Set to true if the SSL certificate is self-signed.
+        Set to `true` if the SSL certificate is self-signed.
 
 
         :return: The is_trust_verification_disabled of this CreateCertificateDetails.
@@ -192,7 +212,7 @@ class CreateCertificateDetails(object):
     def is_trust_verification_disabled(self, is_trust_verification_disabled):
         """
         Sets the is_trust_verification_disabled of this CreateCertificateDetails.
-        Set to true if the SSL certificate is self-signed.
+        Set to `true` if the SSL certificate is self-signed.
 
 
         :param is_trust_verification_disabled: The is_trust_verification_disabled of this CreateCertificateDetails.
@@ -204,7 +224,10 @@ class CreateCertificateDetails(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this CreateCertificateDetails.
-        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see `Resource Tags`__.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
@@ -218,7 +241,10 @@ class CreateCertificateDetails(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this CreateCertificateDetails.
-        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see `Resource Tags`__.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
@@ -232,7 +258,10 @@ class CreateCertificateDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateCertificateDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__. Example:
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
@@ -246,7 +275,10 @@ class CreateCertificateDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateCertificateDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__. Example:
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/waas/models/create_waas_policy_details.py
+++ b/src/oci/waas/models/create_waas_policy_details.py
@@ -122,7 +122,7 @@ class CreateWaasPolicyDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateWaasPolicyDetails.
-        A user-friendly name for the WAAS policy. The name is can be changed and does not need to be unique.
+        A user-friendly name for the WAAS policy. The name can be changed and does not need to be unique.
 
 
         :return: The display_name of this CreateWaasPolicyDetails.
@@ -134,7 +134,7 @@ class CreateWaasPolicyDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateWaasPolicyDetails.
-        A user-friendly name for the WAAS policy. The name is can be changed and does not need to be unique.
+        A user-friendly name for the WAAS policy. The name can be changed and does not need to be unique.
 
 
         :param display_name: The display_name of this CreateWaasPolicyDetails.
@@ -258,7 +258,12 @@ class CreateWaasPolicyDetails(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this CreateWaasPolicyDetails.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :return: The freeform_tags of this CreateWaasPolicyDetails.
@@ -270,7 +275,12 @@ class CreateWaasPolicyDetails(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this CreateWaasPolicyDetails.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :param freeform_tags: The freeform_tags of this CreateWaasPolicyDetails.
@@ -282,7 +292,12 @@ class CreateWaasPolicyDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateWaasPolicyDetails.
-        A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :return: The defined_tags of this CreateWaasPolicyDetails.
@@ -294,7 +309,12 @@ class CreateWaasPolicyDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateWaasPolicyDetails.
-        A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :param defined_tags: The defined_tags of this CreateWaasPolicyDetails.

--- a/src/oci/waas/models/protection_rule_exclusion.py
+++ b/src/oci/waas/models/protection_rule_exclusion.py
@@ -15,11 +15,11 @@ class ProtectionRuleExclusion(object):
     \"exclusions\": [
     {
     \"target\":\"REQUEST_COOKIES\",
-    \"exclusions\":[\"yourcompany.com\", \"Wed, 21 Oct 2015 07:28:00 GMT\", \"12345\", \"219ffwef9w0f\"]
+    \"exclusions\":[\"example.com\", \"Wed, 21 Oct 2015 07:28:00 GMT\", \"12345\", \"219ffwef9w0f\"]
     },
     {
     \"target\":\"REQUEST_COOKIES_NAMES\",
-    \"exclusions\":[\"domain\", \"expires\", \"id\", \"sessionid\"]
+    \"exclusions\":[\"OAMAuthnCookie\", \"JSESSIONID\", \"HCM-PSJSESSIONID\"]
     }
     ],
     \"key\": \"1000000\",

--- a/src/oci/waas/models/update_certificate_details.py
+++ b/src/oci/waas/models/update_certificate_details.py
@@ -76,7 +76,12 @@ class UpdateCertificateDetails(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this UpdateCertificateDetails.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :return: The freeform_tags of this UpdateCertificateDetails.
@@ -88,7 +93,12 @@ class UpdateCertificateDetails(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this UpdateCertificateDetails.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :param freeform_tags: The freeform_tags of this UpdateCertificateDetails.
@@ -100,7 +110,12 @@ class UpdateCertificateDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateCertificateDetails.
-        A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :return: The defined_tags of this UpdateCertificateDetails.
@@ -112,7 +127,12 @@ class UpdateCertificateDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateCertificateDetails.
-        A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :param defined_tags: The defined_tags of this UpdateCertificateDetails.

--- a/src/oci/waas/models/update_waas_policy_details.py
+++ b/src/oci/waas/models/update_waas_policy_details.py
@@ -80,7 +80,7 @@ class UpdateWaasPolicyDetails(object):
     def display_name(self):
         """
         Gets the display_name of this UpdateWaasPolicyDetails.
-        A user-friendly name for the WAAS policy. The name is can be changed and does not need to be unique.
+        A user-friendly name for the WAAS policy. The name can be changed and does not need to be unique.
 
 
         :return: The display_name of this UpdateWaasPolicyDetails.
@@ -92,7 +92,7 @@ class UpdateWaasPolicyDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this UpdateWaasPolicyDetails.
-        A user-friendly name for the WAAS policy. The name is can be changed and does not need to be unique.
+        A user-friendly name for the WAAS policy. The name can be changed and does not need to be unique.
 
 
         :param display_name: The display_name of this UpdateWaasPolicyDetails.
@@ -192,7 +192,12 @@ class UpdateWaasPolicyDetails(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this UpdateWaasPolicyDetails.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :return: The freeform_tags of this UpdateWaasPolicyDetails.
@@ -204,7 +209,12 @@ class UpdateWaasPolicyDetails(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this UpdateWaasPolicyDetails.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :param freeform_tags: The freeform_tags of this UpdateWaasPolicyDetails.
@@ -216,7 +226,10 @@ class UpdateWaasPolicyDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateWaasPolicyDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
@@ -230,7 +243,10 @@ class UpdateWaasPolicyDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateWaasPolicyDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/waas/models/waas_policy.py
+++ b/src/oci/waas/models/waas_policy.py
@@ -418,7 +418,12 @@ class WaasPolicy(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this WaasPolicy.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :return: The freeform_tags of this WaasPolicy.
@@ -430,7 +435,12 @@ class WaasPolicy(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this WaasPolicy.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :param freeform_tags: The freeform_tags of this WaasPolicy.
@@ -442,7 +452,12 @@ class WaasPolicy(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this WaasPolicy.
-        A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :return: The defined_tags of this WaasPolicy.
@@ -454,7 +469,12 @@ class WaasPolicy(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this WaasPolicy.
-        A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :param defined_tags: The defined_tags of this WaasPolicy.

--- a/src/oci/waas/models/waas_policy_summary.py
+++ b/src/oci/waas/models/waas_policy_summary.py
@@ -271,7 +271,12 @@ class WaasPolicySummary(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this WaasPolicySummary.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :return: The freeform_tags of this WaasPolicySummary.
@@ -283,7 +288,12 @@ class WaasPolicySummary(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this WaasPolicySummary.
-        A simple key-value pair without any defined schema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :param freeform_tags: The freeform_tags of this WaasPolicySummary.
@@ -295,7 +305,12 @@ class WaasPolicySummary(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this WaasPolicySummary.
-        A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :return: The defined_tags of this WaasPolicySummary.
@@ -307,7 +322,12 @@ class WaasPolicySummary(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this WaasPolicySummary.
-        A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
         :param defined_tags: The defined_tags of this WaasPolicySummary.

--- a/src/oci/waas/models/waf_log.py
+++ b/src/oci/waas/models/waf_log.py
@@ -117,7 +117,7 @@ class WafLog(object):
 
         :param timestamp:
             The value to assign to the timestamp property of this WafLog.
-        :type timestamp: str
+        :type timestamp: datetime
 
         :param log_type:
             The value to assign to the log_type property of this WafLog.
@@ -157,7 +157,7 @@ class WafLog(object):
             'threat_feed_key': 'str',
             'access_rule_key': 'str',
             'address_rate_limiting_key': 'str',
-            'timestamp': 'str',
+            'timestamp': 'datetime',
             'log_type': 'str',
             'origin_address': 'str',
             'origin_response_time': 'str'
@@ -833,7 +833,7 @@ class WafLog(object):
 
 
         :return: The timestamp of this WafLog.
-        :rtype: str
+        :rtype: datetime
         """
         return self._timestamp
 
@@ -845,7 +845,7 @@ class WafLog(object):
 
 
         :param timestamp: The timestamp of this WafLog.
-        :type: str
+        :type: datetime
         """
         self._timestamp = timestamp
 

--- a/src/oci/waas/models/work_request.py
+++ b/src/oci/waas/models/work_request.py
@@ -26,10 +26,6 @@ class WorkRequest(object):
     #: This constant has a value of "DELETE_WAAS_POLICY"
     OPERATION_TYPE_DELETE_WAAS_POLICY = "DELETE_WAAS_POLICY"
 
-    #: A constant which can be used with the operation_type property of a WorkRequest.
-    #: This constant has a value of "PURGE_WAAS_POLICY"
-    OPERATION_TYPE_PURGE_WAAS_POLICY = "PURGE_WAAS_POLICY"
-
     #: A constant which can be used with the status property of a WorkRequest.
     #: This constant has a value of "ACCEPTED"
     STATUS_ACCEPTED = "ACCEPTED"
@@ -65,7 +61,7 @@ class WorkRequest(object):
 
         :param operation_type:
             The value to assign to the operation_type property of this WorkRequest.
-            Allowed values for this property are: "CREATE_WAAS_POLICY", "UPDATE_WAAS_POLICY", "DELETE_WAAS_POLICY", "PURGE_WAAS_POLICY", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATE_WAAS_POLICY", "UPDATE_WAAS_POLICY", "DELETE_WAAS_POLICY", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type operation_type: str
 
@@ -182,7 +178,7 @@ class WorkRequest(object):
         **[Required]** Gets the operation_type of this WorkRequest.
         A description of the operation requested by the work request.
 
-        Allowed values for this property are: "CREATE_WAAS_POLICY", "UPDATE_WAAS_POLICY", "DELETE_WAAS_POLICY", "PURGE_WAAS_POLICY", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATE_WAAS_POLICY", "UPDATE_WAAS_POLICY", "DELETE_WAAS_POLICY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -201,7 +197,7 @@ class WorkRequest(object):
         :param operation_type: The operation_type of this WorkRequest.
         :type: str
         """
-        allowed_values = ["CREATE_WAAS_POLICY", "UPDATE_WAAS_POLICY", "DELETE_WAAS_POLICY", "PURGE_WAAS_POLICY"]
+        allowed_values = ["CREATE_WAAS_POLICY", "UPDATE_WAAS_POLICY", "DELETE_WAAS_POLICY"]
         if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
             operation_type = 'UNKNOWN_ENUM_VALUE'
         self._operation_type = operation_type

--- a/src/oci/waas/models/work_request_summary.py
+++ b/src/oci/waas/models/work_request_summary.py
@@ -24,10 +24,6 @@ class WorkRequestSummary(object):
     #: This constant has a value of "DELETE_WAAS_POLICY"
     OPERATION_TYPE_DELETE_WAAS_POLICY = "DELETE_WAAS_POLICY"
 
-    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
-    #: This constant has a value of "PURGE_WAAS_POLICY"
-    OPERATION_TYPE_PURGE_WAAS_POLICY = "PURGE_WAAS_POLICY"
-
     #: A constant which can be used with the status property of a WorkRequestSummary.
     #: This constant has a value of "ACCEPTED"
     STATUS_ACCEPTED = "ACCEPTED"
@@ -63,7 +59,7 @@ class WorkRequestSummary(object):
 
         :param operation_type:
             The value to assign to the operation_type property of this WorkRequestSummary.
-            Allowed values for this property are: "CREATE_WAAS_POLICY", "UPDATE_WAAS_POLICY", "DELETE_WAAS_POLICY", "PURGE_WAAS_POLICY", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATE_WAAS_POLICY", "UPDATE_WAAS_POLICY", "DELETE_WAAS_POLICY", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type operation_type: str
 
@@ -166,7 +162,7 @@ class WorkRequestSummary(object):
         **[Required]** Gets the operation_type of this WorkRequestSummary.
         A description of the operation requested by the work request.
 
-        Allowed values for this property are: "CREATE_WAAS_POLICY", "UPDATE_WAAS_POLICY", "DELETE_WAAS_POLICY", "PURGE_WAAS_POLICY", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATE_WAAS_POLICY", "UPDATE_WAAS_POLICY", "DELETE_WAAS_POLICY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -185,7 +181,7 @@ class WorkRequestSummary(object):
         :param operation_type: The operation_type of this WorkRequestSummary.
         :type: str
         """
-        allowed_values = ["CREATE_WAAS_POLICY", "UPDATE_WAAS_POLICY", "DELETE_WAAS_POLICY", "PURGE_WAAS_POLICY"]
+        allowed_values = ["CREATE_WAAS_POLICY", "UPDATE_WAAS_POLICY", "DELETE_WAAS_POLICY"]
         if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
             operation_type = 'UNKNOWN_ENUM_VALUE'
         self._operation_type = operation_type

--- a/src/oci/waas/waas_client.py
+++ b/src/oci/waas/waas_client.py
@@ -74,6 +74,7 @@ class WaasClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20181116',
+            'service_endpoint_template': 'https://waas.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("waas", config, signer, waas_type_mapping, **base_client_init_kwargs)
@@ -1594,7 +1595,7 @@ class WaasClient(object):
     def list_access_rules(self, waas_policy_id, **kwargs):
         """
         Returns a list of access rules for the Web Application Firewall.
-        Gets the currently configured access rules for the Web Application Firewall configration of a specified WAAS policy.
+        Gets the currently configured access rules for the Web Application Firewall configuration of a specified WAAS policy.
         The order of the access rules is important. The rules will be checked in the order they are specified and the first matching rule will be used.
 
 
@@ -1817,6 +1818,8 @@ class WaasClient(object):
         :param list[str] lifecycle_state: (optional)
             Filter certificates using a list of lifecycle states.
 
+            Allowed values are: "CREATING", "ACTIVE", "FAILED", "UPDATING", "DELETING", "DELETED"
+
         :param datetime time_created_greater_than_or_equal_to: (optional)
             A filter that matches certificates created on or after the specified date-time.
 
@@ -1869,6 +1872,14 @@ class WaasClient(object):
                 raise ValueError(
                     "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
                 )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "FAILED", "UPDATING", "DELETING", "DELETED"]
+            for lifecycle_state_item in kwargs['lifecycle_state']:
+                if lifecycle_state_item not in lifecycle_state_allowed_values:
+                    raise ValueError(
+                        "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                    )
 
         query_params = {
             "limit": kwargs.get("limit", missing),
@@ -2460,6 +2471,8 @@ class WaasClient(object):
         :param list[str] lifecycle_state: (optional)
             Filter policies using a list of lifecycle states.
 
+            Allowed values are: "CREATING", "ACTIVE", "FAILED", "UPDATING", "DELETING", "DELETED"
+
         :param datetime time_created_greater_than_or_equal_to: (optional)
             A filter that matches policies created on or after the specified date and time.
 
@@ -2512,6 +2525,14 @@ class WaasClient(object):
                 raise ValueError(
                     "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
                 )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "FAILED", "UPDATING", "DELETING", "DELETED"]
+            for lifecycle_state_item in kwargs['lifecycle_state']:
+                if lifecycle_state_item not in lifecycle_state_allowed_values:
+                    raise ValueError(
+                        "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                    )
 
         query_params = {
             "compartmentId": compartment_id,


### PR DESCRIPTION
## Added

- Support for the Data Transfer service

- Support for the Zurich (ZRH) region



## Breaking

- oci.waas.WafLog.timestamp type changed from str to datetime

- oci.waas.models.Certificate.issuer_name type changed from oci.waas.models.CertificateSubjectName to oci.waas.models.CerticateIssuerName

- `"PURGE_WAAS_POLICY"` removed as option for oci.waas.models.WorkRequest.operation_type

- `"PURGE_WAAS_POLICY"` removed as option for oci.waas.models.WorkRequestSummary.operation_type


