### PR TITLE
Releasing version 2.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+2.4.0 - 2019-09-10
+====================
+
+Added
+-----
+Support for specifying the autoBackupWindow field for scheduling backups in the Database service
+* Support for network security groups on autonomous Exadata infrastructure in the Database service
+* Support for Kubernetes secrets encryption in customer clusters, regional subnets, and cluster authentication for instance principals in the Container Engine for Kubernetes service
+* Support for the Oracle Content and Experience service
+
+Breaking
+--------
+* The etag header has been removed from the response for NotificationControlPlaneClient.change_topic_compartment and NotificationDataPlaneClient.change_subscription_compartment
+
+====================
 2.3.3 - 2019-09-03
 ====================
 

--- a/docs/api/container_engine.rst
+++ b/docs/api/container_engine.rst
@@ -28,15 +28,19 @@ Container Engine
     oci.container_engine.models.CreateClusterDetails
     oci.container_engine.models.CreateClusterKubeconfigContentDetails
     oci.container_engine.models.CreateNodePoolDetails
+    oci.container_engine.models.CreateNodePoolNodeConfigDetails
     oci.container_engine.models.KeyValue
     oci.container_engine.models.KubernetesNetworkConfig
     oci.container_engine.models.Node
     oci.container_engine.models.NodeError
     oci.container_engine.models.NodePool
+    oci.container_engine.models.NodePoolNodeConfigDetails
     oci.container_engine.models.NodePoolOptions
+    oci.container_engine.models.NodePoolPlacementConfigDetails
     oci.container_engine.models.NodePoolSummary
     oci.container_engine.models.UpdateClusterDetails
     oci.container_engine.models.UpdateNodePoolDetails
+    oci.container_engine.models.UpdateNodePoolNodeConfigDetails
     oci.container_engine.models.WorkRequest
     oci.container_engine.models.WorkRequestError
     oci.container_engine.models.WorkRequestLogEntry

--- a/docs/api/container_engine/models/oci.container_engine.models.CreateNodePoolNodeConfigDetails.rst
+++ b/docs/api/container_engine/models/oci.container_engine.models.CreateNodePoolNodeConfigDetails.rst
@@ -1,0 +1,11 @@
+CreateNodePoolNodeConfigDetails
+===============================
+
+.. currentmodule:: oci.container_engine.models
+
+.. autoclass:: CreateNodePoolNodeConfigDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/container_engine/models/oci.container_engine.models.NodePoolNodeConfigDetails.rst
+++ b/docs/api/container_engine/models/oci.container_engine.models.NodePoolNodeConfigDetails.rst
@@ -1,0 +1,11 @@
+NodePoolNodeConfigDetails
+=========================
+
+.. currentmodule:: oci.container_engine.models
+
+.. autoclass:: NodePoolNodeConfigDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/container_engine/models/oci.container_engine.models.NodePoolPlacementConfigDetails.rst
+++ b/docs/api/container_engine/models/oci.container_engine.models.NodePoolPlacementConfigDetails.rst
@@ -1,0 +1,11 @@
+NodePoolPlacementConfigDetails
+==============================
+
+.. currentmodule:: oci.container_engine.models
+
+.. autoclass:: NodePoolPlacementConfigDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/container_engine/models/oci.container_engine.models.UpdateNodePoolNodeConfigDetails.rst
+++ b/docs/api/container_engine/models/oci.container_engine.models.UpdateNodePoolNodeConfigDetails.rst
@@ -1,0 +1,11 @@
+UpdateNodePoolNodeConfigDetails
+===============================
+
+.. currentmodule:: oci.container_engine.models
+
+.. autoclass:: UpdateNodePoolNodeConfigDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/landing.rst
+++ b/docs/api/landing.rst
@@ -35,6 +35,7 @@ API Reference
 * :doc:`Load Balancer <load_balancer/client/oci.load_balancer.LoadBalancerClient>`
 * :doc:`Monitoring <monitoring/client/oci.monitoring.MonitoringClient>`
 * :doc:`Object Storage <object_storage/client/oci.object_storage.ObjectStorageClient>`
+* :doc:`Oce Instance <oce/client/oci.oce.OceInstanceClient>`
 * :doc:`Notification Control Plane <ons/client/oci.ons.NotificationControlPlaneClient>`
 * :doc:`Notification Data Plane <ons/client/oci.ons.NotificationDataPlaneClient>`
 * :doc:`Resource Manager <resource_manager/client/oci.resource_manager.ResourceManagerClient>`
@@ -81,6 +82,7 @@ API Reference
     load_balancer
     monitoring
     object_storage
+    oce
     ons
     resource_manager
     resource_search

--- a/docs/api/oce.rst
+++ b/docs/api/oce.rst
@@ -1,0 +1,32 @@
+Oce 
+===
+
+.. autosummary::
+    :toctree: oce/client
+    :nosignatures:
+    :template: autosummary/service_client.rst
+
+    oci.oce.OceInstanceClient
+    oci.oce.OceInstanceClientCompositeOperations
+
+--------
+ Models
+--------
+
+.. autosummary::
+    :toctree: oce/models
+    :nosignatures:
+    :template: autosummary/model_class.rst
+
+    oci.oce.models.ChangeOceInstanceCompartmentDetails
+    oci.oce.models.CreateOceInstanceDetails
+    oci.oce.models.DeleteOceInstanceDetails
+    oci.oce.models.OceInstance
+    oci.oce.models.OceInstanceSummary
+    oci.oce.models.UpdateOceInstanceDetails
+    oci.oce.models.WorkRequest
+    oci.oce.models.WorkRequestError
+    oci.oce.models.WorkRequestLogEntry
+    oci.oce.models.WorkRequestResource
+    oci.oce.models.WorkflowMonitor
+    oci.oce.models.WorkflowStep

--- a/docs/api/oce/client/oci.oce.OceInstanceClient.rst
+++ b/docs/api/oce/client/oci.oce.OceInstanceClient.rst
@@ -1,0 +1,8 @@
+OceInstanceClient
+=================
+
+.. currentmodule:: oci.oce
+
+.. autoclass:: OceInstanceClient
+    :special-members: __init__
+    :members:

--- a/docs/api/oce/client/oci.oce.OceInstanceClientCompositeOperations.rst
+++ b/docs/api/oce/client/oci.oce.OceInstanceClientCompositeOperations.rst
@@ -1,0 +1,8 @@
+OceInstanceClientCompositeOperations
+====================================
+
+.. currentmodule:: oci.oce
+
+.. autoclass:: OceInstanceClientCompositeOperations
+    :special-members: __init__
+    :members:

--- a/docs/api/oce/models/oci.oce.models.ChangeOceInstanceCompartmentDetails.rst
+++ b/docs/api/oce/models/oci.oce.models.ChangeOceInstanceCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeOceInstanceCompartmentDetails
+===================================
+
+.. currentmodule:: oci.oce.models
+
+.. autoclass:: ChangeOceInstanceCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/oce/models/oci.oce.models.CreateOceInstanceDetails.rst
+++ b/docs/api/oce/models/oci.oce.models.CreateOceInstanceDetails.rst
@@ -1,0 +1,11 @@
+CreateOceInstanceDetails
+========================
+
+.. currentmodule:: oci.oce.models
+
+.. autoclass:: CreateOceInstanceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/oce/models/oci.oce.models.DeleteOceInstanceDetails.rst
+++ b/docs/api/oce/models/oci.oce.models.DeleteOceInstanceDetails.rst
@@ -1,0 +1,11 @@
+DeleteOceInstanceDetails
+========================
+
+.. currentmodule:: oci.oce.models
+
+.. autoclass:: DeleteOceInstanceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/oce/models/oci.oce.models.OceInstance.rst
+++ b/docs/api/oce/models/oci.oce.models.OceInstance.rst
@@ -1,0 +1,11 @@
+OceInstance
+===========
+
+.. currentmodule:: oci.oce.models
+
+.. autoclass:: OceInstance
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/oce/models/oci.oce.models.OceInstanceSummary.rst
+++ b/docs/api/oce/models/oci.oce.models.OceInstanceSummary.rst
@@ -1,0 +1,11 @@
+OceInstanceSummary
+==================
+
+.. currentmodule:: oci.oce.models
+
+.. autoclass:: OceInstanceSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/oce/models/oci.oce.models.UpdateOceInstanceDetails.rst
+++ b/docs/api/oce/models/oci.oce.models.UpdateOceInstanceDetails.rst
@@ -1,0 +1,11 @@
+UpdateOceInstanceDetails
+========================
+
+.. currentmodule:: oci.oce.models
+
+.. autoclass:: UpdateOceInstanceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/oce/models/oci.oce.models.WorkRequest.rst
+++ b/docs/api/oce/models/oci.oce.models.WorkRequest.rst
@@ -1,0 +1,11 @@
+WorkRequest
+===========
+
+.. currentmodule:: oci.oce.models
+
+.. autoclass:: WorkRequest
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/oce/models/oci.oce.models.WorkRequestError.rst
+++ b/docs/api/oce/models/oci.oce.models.WorkRequestError.rst
@@ -1,0 +1,11 @@
+WorkRequestError
+================
+
+.. currentmodule:: oci.oce.models
+
+.. autoclass:: WorkRequestError
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/oce/models/oci.oce.models.WorkRequestLogEntry.rst
+++ b/docs/api/oce/models/oci.oce.models.WorkRequestLogEntry.rst
@@ -1,0 +1,11 @@
+WorkRequestLogEntry
+===================
+
+.. currentmodule:: oci.oce.models
+
+.. autoclass:: WorkRequestLogEntry
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/oce/models/oci.oce.models.WorkRequestResource.rst
+++ b/docs/api/oce/models/oci.oce.models.WorkRequestResource.rst
@@ -1,0 +1,11 @@
+WorkRequestResource
+===================
+
+.. currentmodule:: oci.oce.models
+
+.. autoclass:: WorkRequestResource
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/oce/models/oci.oce.models.WorkflowMonitor.rst
+++ b/docs/api/oce/models/oci.oce.models.WorkflowMonitor.rst
@@ -1,0 +1,11 @@
+WorkflowMonitor
+===============
+
+.. currentmodule:: oci.oce.models
+
+.. autoclass:: WorkflowMonitor
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/oce/models/oci.oce.models.WorkflowStep.rst
+++ b/docs/api/oce/models/oci.oce.models.WorkflowStep.rst
@@ -1,0 +1,11 @@
+WorkflowStep
+============
+
+.. currentmodule:: oci.oce.models
+
+.. autoclass:: WorkflowStep
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,8 @@ This is the public Python SDK for Oracle Cloud Infrastructure.  Python 2.7+ and 
 To get started, head over to the :ref:`installation instructions <install>` or see more examples in the
 :ref:`quickstart <quickstart>` section.
 
+The most recent list of supported services is located on the `Python SDK <https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/pythonsdk.htm#ServicesSupported>`_ page on the Oracle Cloud Infrastructure Documentation site.
+
 **Note**: The ``oraclebmc`` package is deprecated and will no longer be maintained starting March 2018. Please check the :ref:`Backward Compatibility <backward-compatibility>` section if you are using ``oraclebmc``.
 
 .. toctree::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,21 +13,6 @@ Installation
 ~~~~~~~~~~~~
 
 This topic describes how to install, configure, and use the Oracle Cloud Infrastructure Python SDK.
-The Python SDK supports operations for the following services:
-
-* Audit
-* Container Engine for Kubernetes
-* Core Services (Networking, Compute, and Block Volume)
-* Database
-* DNS
-* Email
-* File Storage
-* IAM
-* Load Balancing
-* Object Storage
-* Search
-* Key Management
-
 
 ===============
  Prerequisites
@@ -56,13 +41,13 @@ In addition, all Oracle Cloud Infrastructure SDKs require:
  Downloading and Installing the SDK
 ====================================
 
-You can install the Python SDK through the Python Package Index (PyPI), or alternatively through GitHub. 
+You can install the Python SDK through the Python Package Index (PyPI), or alternatively through GitHub.
 
 Set up a virtual environment
 -----------------------------
 
 Oracle recommends that you run the SDK in a virtual environment with virtualenv. This allows
-you to isolate the dependencies for the SDK and avoids any potential conflicts with other Python packages 
+you to isolate the dependencies for the SDK and avoids any potential conflicts with other Python packages
 which may already be installed (e.g. in your system-wide Python).
 
 With Linux, virtualenv is usually in a separate package from the main Python package.
@@ -134,7 +119,7 @@ If you don't want to use ``requests[security]`` you can update OpenSSL as you no
 
 .. note::
     If you need to configure your environment for FIPS-compliance, see :doc:`fips-libraries`
-    
+
 =================
  Troubleshooting
 =================

--- a/examples/showoci/CHANGELOG.rst
+++ b/examples/showoci/CHANGELOG.rst
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+19.9.11 - 2019-09-11
+====================
+* Fix instance configuration error when block volumes or vnic exist
+* Added 0.5 seconds sleep for every 10 backendsets call to avoid TooManyRequestErrors if customer has many load balancers
+* Added extract_date to each CSV
+* Added support for X6 Shapes (Standard.B1)
+* Added compute time for Region processing
+* Changed processing time to HH:MM:DD
+
+====================
 19.9.4 - 2019-09-04
 ====================
 * Added usage and available to the limits

--- a/examples/showoci/README.md
+++ b/examples/showoci/README.md
@@ -52,7 +52,6 @@ Required OCI IAM user with read only privileges
 
 ```
 ALLOW GROUP ReadOnlyUsers to read all-resources IN TENANCY
-Allow Group ReadOnlyUsers to use network-security-groups in tenancy /* use required for now to read security group rules */
 ```
 
 For restrictive privileges:

--- a/examples/showoci/showoci.py
+++ b/examples/showoci/showoci.py
@@ -62,7 +62,7 @@ import sys
 import argparse
 import datetime
 
-version = "19.9.4"
+version = "19.9.11"
 
 ##########################################################################
 # execute_extract
@@ -92,7 +92,7 @@ def execute_extract():
     ############################################
     output = ShowOCIOutput()
     summary = ShowOCISummary()
-    csv = ShowOCICSV()
+    csv = ShowOCICSV(start_time)
 
     ############################################
     # print showoci config
@@ -242,7 +242,7 @@ def set_parser_arguments():
     parser.add_argument('-p', default="", dest='proxy', help='Set Proxy (i.e. www-proxy-server.com:80) ')
     parser.add_argument('-rg', default="", dest='region', help='Filter by Region')
     parser.add_argument('-cp', default="", dest='compart', help='Filter by Compartment')
-    parser.add_argument('-cpath', default="", dest='compartpath', help='Filter by Compartment using path , example -cpath "Adi Main / Adi Sub"')
+    parser.add_argument('-cpath', default="", dest='compartpath', help='Filter by Compartment path ,(i.e. -cpath "Adi / Sub"')
     parser.add_argument('-cf', type=argparse.FileType('r'), dest='config', help="Config File")
     parser.add_argument('-csv', default="", dest='csv', help="Output to CSV files, Input as file header")
     parser.add_argument('-jf', type=argparse.FileType('w'), dest='joutfile', help="Output to file   (JSON format)")

--- a/examples/showoci/showoci_output.py
+++ b/examples/showoci/showoci_output.py
@@ -1886,12 +1886,14 @@ class ShowOCICSV(object):
     csv_load_balancer = []
     csv_load_balancer_bs = []
     csv_limits = []
+    start_time = ""
 
     ############################################
     # Init
+    # accept start time as string
     ############################################
-    def __init__(self):
-        pass
+    def __init__(self, start_time):
+        self.start_time = start_time
 
     ##########################################################################
     # generate_csv
@@ -1957,8 +1959,11 @@ class ShowOCICSV(object):
             # get the file name of the CSV
             file_name = self.csv_file_header + "_" + file_subject + ".csv"
 
+            # add start_date to each dictionary
+            result = [dict(item, extract_date=self.start_time) for item in data]
+
             # generate fields
-            fields = [key for key in data[0].keys()]
+            fields = [key for key in result[0].keys()]
 
             with open(file_name, mode='w', newline='') as csv_file:
                 writer = csv.DictWriter(csv_file, fieldnames=fields)
@@ -1966,7 +1971,7 @@ class ShowOCICSV(object):
                 # write header
                 writer.writeheader()
 
-                for row in data:
+                for row in result:
                     writer.writerow(row)
 
             print("CSV: " + file_subject.ljust(22) + " --> " + file_name)

--- a/src/oci/__init__.py
+++ b/src/oci/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-from . import announcements_service, audit, autoscaling, budget, container_engine, core, database, dns, dts, email, events, file_storage, functions, healthchecks, identity, key_management, limits, load_balancer, monitoring, object_storage, ons, resource_manager, resource_search, streaming, waas, work_requests
+from . import announcements_service, audit, autoscaling, budget, container_engine, core, database, dns, dts, email, events, file_storage, functions, healthchecks, identity, key_management, limits, load_balancer, monitoring, object_storage, oce, ons, resource_manager, resource_search, streaming, waas, work_requests
 from . import auth, config, constants, decorators, exceptions, regions, pagination, retry, fips
 from .base_client import BaseClient
 from .request import Request
@@ -14,5 +14,5 @@ fips.enable_fips_mode()
 
 __all__ = [
     "BaseClient", "Error", "Request", "Response", "Signer", "config", "constants", "decorators", "exceptions", "regions", "wait_until", "pagination", "auth", "retry", "fips",
-    "announcements_service", "audit", "autoscaling", "budget", "container_engine", "core", "database", "dns", "dts", "email", "events", "file_storage", "functions", "healthchecks", "identity", "key_management", "limits", "load_balancer", "monitoring", "object_storage", "ons", "resource_manager", "resource_search", "streaming", "waas", "work_requests"
+    "announcements_service", "audit", "autoscaling", "budget", "container_engine", "core", "database", "dns", "dts", "email", "events", "file_storage", "functions", "healthchecks", "identity", "key_management", "limits", "load_balancer", "monitoring", "object_storage", "oce", "ons", "resource_manager", "resource_search", "streaming", "waas", "work_requests"
 ]

--- a/src/oci/container_engine/models/__init__.py
+++ b/src/oci/container_engine/models/__init__.py
@@ -13,15 +13,19 @@ from .cluster_summary import ClusterSummary
 from .create_cluster_details import CreateClusterDetails
 from .create_cluster_kubeconfig_content_details import CreateClusterKubeconfigContentDetails
 from .create_node_pool_details import CreateNodePoolDetails
+from .create_node_pool_node_config_details import CreateNodePoolNodeConfigDetails
 from .key_value import KeyValue
 from .kubernetes_network_config import KubernetesNetworkConfig
 from .node import Node
 from .node_error import NodeError
 from .node_pool import NodePool
+from .node_pool_node_config_details import NodePoolNodeConfigDetails
 from .node_pool_options import NodePoolOptions
+from .node_pool_placement_config_details import NodePoolPlacementConfigDetails
 from .node_pool_summary import NodePoolSummary
 from .update_cluster_details import UpdateClusterDetails
 from .update_node_pool_details import UpdateNodePoolDetails
+from .update_node_pool_node_config_details import UpdateNodePoolNodeConfigDetails
 from .work_request import WorkRequest
 from .work_request_error import WorkRequestError
 from .work_request_log_entry import WorkRequestLogEntry
@@ -40,15 +44,19 @@ container_engine_type_mapping = {
     "CreateClusterDetails": CreateClusterDetails,
     "CreateClusterKubeconfigContentDetails": CreateClusterKubeconfigContentDetails,
     "CreateNodePoolDetails": CreateNodePoolDetails,
+    "CreateNodePoolNodeConfigDetails": CreateNodePoolNodeConfigDetails,
     "KeyValue": KeyValue,
     "KubernetesNetworkConfig": KubernetesNetworkConfig,
     "Node": Node,
     "NodeError": NodeError,
     "NodePool": NodePool,
+    "NodePoolNodeConfigDetails": NodePoolNodeConfigDetails,
     "NodePoolOptions": NodePoolOptions,
+    "NodePoolPlacementConfigDetails": NodePoolPlacementConfigDetails,
     "NodePoolSummary": NodePoolSummary,
     "UpdateClusterDetails": UpdateClusterDetails,
     "UpdateNodePoolDetails": UpdateNodePoolDetails,
+    "UpdateNodePoolNodeConfigDetails": UpdateNodePoolNodeConfigDetails,
     "WorkRequest": WorkRequest,
     "WorkRequestError": WorkRequestError,
     "WorkRequestLogEntry": WorkRequestLogEntry,

--- a/src/oci/container_engine/models/cluster.py
+++ b/src/oci/container_engine/models/cluster.py
@@ -61,6 +61,10 @@ class Cluster(object):
             The value to assign to the kubernetes_version property of this Cluster.
         :type kubernetes_version: str
 
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this Cluster.
+        :type kms_key_id: str
+
         :param options:
             The value to assign to the options property of this Cluster.
         :type options: ClusterCreateOptions
@@ -94,6 +98,7 @@ class Cluster(object):
             'compartment_id': 'str',
             'vcn_id': 'str',
             'kubernetes_version': 'str',
+            'kms_key_id': 'str',
             'options': 'ClusterCreateOptions',
             'metadata': 'ClusterMetadata',
             'lifecycle_state': 'str',
@@ -108,6 +113,7 @@ class Cluster(object):
             'compartment_id': 'compartmentId',
             'vcn_id': 'vcnId',
             'kubernetes_version': 'kubernetesVersion',
+            'kms_key_id': 'kmsKeyId',
             'options': 'options',
             'metadata': 'metadata',
             'lifecycle_state': 'lifecycleState',
@@ -121,6 +127,7 @@ class Cluster(object):
         self._compartment_id = None
         self._vcn_id = None
         self._kubernetes_version = None
+        self._kms_key_id = None
         self._options = None
         self._metadata = None
         self._lifecycle_state = None
@@ -247,6 +254,30 @@ class Cluster(object):
         :type: str
         """
         self._kubernetes_version = kubernetes_version
+
+    @property
+    def kms_key_id(self):
+        """
+        Gets the kms_key_id of this Cluster.
+        The OCID of the KMS key to be used as the master encryption key for Kubernetes secret encryption.
+
+
+        :return: The kms_key_id of this Cluster.
+        :rtype: str
+        """
+        return self._kms_key_id
+
+    @kms_key_id.setter
+    def kms_key_id(self, kms_key_id):
+        """
+        Sets the kms_key_id of this Cluster.
+        The OCID of the KMS key to be used as the master encryption key for Kubernetes secret encryption.
+
+
+        :param kms_key_id: The kms_key_id of this Cluster.
+        :type: str
+        """
+        self._kms_key_id = kms_key_id
 
     @property
     def options(self):

--- a/src/oci/container_engine/models/create_cluster_details.py
+++ b/src/oci/container_engine/models/create_cluster_details.py
@@ -33,6 +33,10 @@ class CreateClusterDetails(object):
             The value to assign to the kubernetes_version property of this CreateClusterDetails.
         :type kubernetes_version: str
 
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this CreateClusterDetails.
+        :type kms_key_id: str
+
         :param options:
             The value to assign to the options property of this CreateClusterDetails.
         :type options: ClusterCreateOptions
@@ -43,6 +47,7 @@ class CreateClusterDetails(object):
             'compartment_id': 'str',
             'vcn_id': 'str',
             'kubernetes_version': 'str',
+            'kms_key_id': 'str',
             'options': 'ClusterCreateOptions'
         }
 
@@ -51,6 +56,7 @@ class CreateClusterDetails(object):
             'compartment_id': 'compartmentId',
             'vcn_id': 'vcnId',
             'kubernetes_version': 'kubernetesVersion',
+            'kms_key_id': 'kmsKeyId',
             'options': 'options'
         }
 
@@ -58,6 +64,7 @@ class CreateClusterDetails(object):
         self._compartment_id = None
         self._vcn_id = None
         self._kubernetes_version = None
+        self._kms_key_id = None
         self._options = None
 
     @property
@@ -155,6 +162,32 @@ class CreateClusterDetails(object):
         :type: str
         """
         self._kubernetes_version = kubernetes_version
+
+    @property
+    def kms_key_id(self):
+        """
+        Gets the kms_key_id of this CreateClusterDetails.
+        The OCID of the KMS key to be used as the master encryption key for Kubernetes secret encryption.
+        When used, `kubernetesVersion` must be at least `v1.13.0`.
+
+
+        :return: The kms_key_id of this CreateClusterDetails.
+        :rtype: str
+        """
+        return self._kms_key_id
+
+    @kms_key_id.setter
+    def kms_key_id(self, kms_key_id):
+        """
+        Sets the kms_key_id of this CreateClusterDetails.
+        The OCID of the KMS key to be used as the master encryption key for Kubernetes secret encryption.
+        When used, `kubernetesVersion` must be at least `v1.13.0`.
+
+
+        :param kms_key_id: The kms_key_id of this CreateClusterDetails.
+        :type: str
+        """
+        self._kms_key_id = kms_key_id
 
     @property
     def options(self):

--- a/src/oci/container_engine/models/create_cluster_kubeconfig_content_details.py
+++ b/src/oci/container_engine/models/create_cluster_kubeconfig_content_details.py
@@ -43,7 +43,7 @@ class CreateClusterKubeconfigContentDetails(object):
     def token_version(self):
         """
         Gets the token_version of this CreateClusterKubeconfigContentDetails.
-        The version of the kubeconfig token.
+        The version of the kubeconfig token. Supported values 1.0.0 and 2.0.0
 
 
         :return: The token_version of this CreateClusterKubeconfigContentDetails.
@@ -55,7 +55,7 @@ class CreateClusterKubeconfigContentDetails(object):
     def token_version(self, token_version):
         """
         Sets the token_version of this CreateClusterKubeconfigContentDetails.
-        The version of the kubeconfig token.
+        The version of the kubeconfig token. Supported values 1.0.0 and 2.0.0
 
 
         :param token_version: The token_version of this CreateClusterKubeconfigContentDetails.
@@ -68,6 +68,7 @@ class CreateClusterKubeconfigContentDetails(object):
         """
         Gets the expiration of this CreateClusterKubeconfigContentDetails.
         The desired expiration, in seconds, to use for the kubeconfig token.
+        Important Note, expiration field is only honored for token version 1.0.0
 
 
         :return: The expiration of this CreateClusterKubeconfigContentDetails.
@@ -80,6 +81,7 @@ class CreateClusterKubeconfigContentDetails(object):
         """
         Sets the expiration of this CreateClusterKubeconfigContentDetails.
         The desired expiration, in seconds, to use for the kubeconfig token.
+        Important Note, expiration field is only honored for token version 1.0.0
 
 
         :param expiration: The expiration of this CreateClusterKubeconfigContentDetails.

--- a/src/oci/container_engine/models/create_node_pool_details.py
+++ b/src/oci/container_engine/models/create_node_pool_details.py
@@ -61,6 +61,10 @@ class CreateNodePoolDetails(object):
             The value to assign to the subnet_ids property of this CreateNodePoolDetails.
         :type subnet_ids: list[str]
 
+        :param node_config_details:
+            The value to assign to the node_config_details property of this CreateNodePoolDetails.
+        :type node_config_details: CreateNodePoolNodeConfigDetails
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
@@ -73,7 +77,8 @@ class CreateNodePoolDetails(object):
             'initial_node_labels': 'list[KeyValue]',
             'ssh_public_key': 'str',
             'quantity_per_subnet': 'int',
-            'subnet_ids': 'list[str]'
+            'subnet_ids': 'list[str]',
+            'node_config_details': 'CreateNodePoolNodeConfigDetails'
         }
 
         self.attribute_map = {
@@ -87,7 +92,8 @@ class CreateNodePoolDetails(object):
             'initial_node_labels': 'initialNodeLabels',
             'ssh_public_key': 'sshPublicKey',
             'quantity_per_subnet': 'quantityPerSubnet',
-            'subnet_ids': 'subnetIds'
+            'subnet_ids': 'subnetIds',
+            'node_config_details': 'nodeConfigDetails'
         }
 
         self._compartment_id = None
@@ -101,6 +107,7 @@ class CreateNodePoolDetails(object):
         self._ssh_public_key = None
         self._quantity_per_subnet = None
         self._subnet_ids = None
+        self._node_config_details = None
 
     @property
     def compartment_id(self):
@@ -322,7 +329,8 @@ class CreateNodePoolDetails(object):
     def quantity_per_subnet(self):
         """
         Gets the quantity_per_subnet of this CreateNodePoolDetails.
-        The number of nodes to create in each subnet.
+        Optional, default to 1. The number of nodes to create in each subnet specified in subnetIds property.
+        When used, subnetIds is required. This property is deprecated, use nodeConfigDetails instead.
 
 
         :return: The quantity_per_subnet of this CreateNodePoolDetails.
@@ -334,7 +342,8 @@ class CreateNodePoolDetails(object):
     def quantity_per_subnet(self, quantity_per_subnet):
         """
         Sets the quantity_per_subnet of this CreateNodePoolDetails.
-        The number of nodes to create in each subnet.
+        Optional, default to 1. The number of nodes to create in each subnet specified in subnetIds property.
+        When used, subnetIds is required. This property is deprecated, use nodeConfigDetails instead.
 
 
         :param quantity_per_subnet: The quantity_per_subnet of this CreateNodePoolDetails.
@@ -345,8 +354,10 @@ class CreateNodePoolDetails(object):
     @property
     def subnet_ids(self):
         """
-        **[Required]** Gets the subnet_ids of this CreateNodePoolDetails.
-        The OCIDs of the subnets in which to place nodes for this node pool.
+        Gets the subnet_ids of this CreateNodePoolDetails.
+        The OCIDs of the subnets in which to place nodes for this node pool. When used, quantityPerSubnet
+        can be provided. This property is deprecated, use nodeConfigDetails. Exactly one of the
+        subnetIds or nodeConfigDetails properties must be specified.
 
 
         :return: The subnet_ids of this CreateNodePoolDetails.
@@ -358,13 +369,41 @@ class CreateNodePoolDetails(object):
     def subnet_ids(self, subnet_ids):
         """
         Sets the subnet_ids of this CreateNodePoolDetails.
-        The OCIDs of the subnets in which to place nodes for this node pool.
+        The OCIDs of the subnets in which to place nodes for this node pool. When used, quantityPerSubnet
+        can be provided. This property is deprecated, use nodeConfigDetails. Exactly one of the
+        subnetIds or nodeConfigDetails properties must be specified.
 
 
         :param subnet_ids: The subnet_ids of this CreateNodePoolDetails.
         :type: list[str]
         """
         self._subnet_ids = subnet_ids
+
+    @property
+    def node_config_details(self):
+        """
+        Gets the node_config_details of this CreateNodePoolDetails.
+        The configuration of nodes in the node pool. Exactly one of the
+        subnetIds or nodeConfigDetails properties must be specified.
+
+
+        :return: The node_config_details of this CreateNodePoolDetails.
+        :rtype: CreateNodePoolNodeConfigDetails
+        """
+        return self._node_config_details
+
+    @node_config_details.setter
+    def node_config_details(self, node_config_details):
+        """
+        Sets the node_config_details of this CreateNodePoolDetails.
+        The configuration of nodes in the node pool. Exactly one of the
+        subnetIds or nodeConfigDetails properties must be specified.
+
+
+        :param node_config_details: The node_config_details of this CreateNodePoolDetails.
+        :type: CreateNodePoolNodeConfigDetails
+        """
+        self._node_config_details = node_config_details
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/container_engine/models/create_node_pool_node_config_details.py
+++ b/src/oci/container_engine/models/create_node_pool_node_config_details.py
@@ -1,0 +1,110 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateNodePoolNodeConfigDetails(object):
+    """
+    The size and placement configuration of nodes in the node pool.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateNodePoolNodeConfigDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param size:
+            The value to assign to the size property of this CreateNodePoolNodeConfigDetails.
+        :type size: int
+
+        :param placement_configs:
+            The value to assign to the placement_configs property of this CreateNodePoolNodeConfigDetails.
+        :type placement_configs: list[NodePoolPlacementConfigDetails]
+
+        """
+        self.swagger_types = {
+            'size': 'int',
+            'placement_configs': 'list[NodePoolPlacementConfigDetails]'
+        }
+
+        self.attribute_map = {
+            'size': 'size',
+            'placement_configs': 'placementConfigs'
+        }
+
+        self._size = None
+        self._placement_configs = None
+
+    @property
+    def size(self):
+        """
+        **[Required]** Gets the size of this CreateNodePoolNodeConfigDetails.
+        The number of nodes that should be in the node pool.
+
+
+        :return: The size of this CreateNodePoolNodeConfigDetails.
+        :rtype: int
+        """
+        return self._size
+
+    @size.setter
+    def size(self, size):
+        """
+        Sets the size of this CreateNodePoolNodeConfigDetails.
+        The number of nodes that should be in the node pool.
+
+
+        :param size: The size of this CreateNodePoolNodeConfigDetails.
+        :type: int
+        """
+        self._size = size
+
+    @property
+    def placement_configs(self):
+        """
+        **[Required]** Gets the placement_configs of this CreateNodePoolNodeConfigDetails.
+        The placement configurations for the node pool. Provide one placement
+        configuration for each availability domain in which you intend to launch a node.
+
+        To use the node pool with a regional subnet, provide a placement configuration for
+        each availability domain, and include the regional subnet in each placement
+        configuration.
+
+
+        :return: The placement_configs of this CreateNodePoolNodeConfigDetails.
+        :rtype: list[NodePoolPlacementConfigDetails]
+        """
+        return self._placement_configs
+
+    @placement_configs.setter
+    def placement_configs(self, placement_configs):
+        """
+        Sets the placement_configs of this CreateNodePoolNodeConfigDetails.
+        The placement configurations for the node pool. Provide one placement
+        configuration for each availability domain in which you intend to launch a node.
+
+        To use the node pool with a regional subnet, provide a placement configuration for
+        each availability domain, and include the regional subnet in each placement
+        configuration.
+
+
+        :param placement_configs: The placement_configs of this CreateNodePoolNodeConfigDetails.
+        :type: list[NodePoolPlacementConfigDetails]
+        """
+        self._placement_configs = placement_configs
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/container_engine/models/node_pool.py
+++ b/src/oci/container_engine/models/node_pool.py
@@ -73,6 +73,10 @@ class NodePool(object):
             The value to assign to the nodes property of this NodePool.
         :type nodes: list[Node]
 
+        :param node_config_details:
+            The value to assign to the node_config_details property of this NodePool.
+        :type node_config_details: NodePoolNodeConfigDetails
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -88,7 +92,8 @@ class NodePool(object):
             'ssh_public_key': 'str',
             'quantity_per_subnet': 'int',
             'subnet_ids': 'list[str]',
-            'nodes': 'list[Node]'
+            'nodes': 'list[Node]',
+            'node_config_details': 'NodePoolNodeConfigDetails'
         }
 
         self.attribute_map = {
@@ -105,7 +110,8 @@ class NodePool(object):
             'ssh_public_key': 'sshPublicKey',
             'quantity_per_subnet': 'quantityPerSubnet',
             'subnet_ids': 'subnetIds',
-            'nodes': 'nodes'
+            'nodes': 'nodes',
+            'node_config_details': 'nodeConfigDetails'
         }
 
         self._id = None
@@ -122,6 +128,7 @@ class NodePool(object):
         self._quantity_per_subnet = None
         self._subnet_ids = None
         self._nodes = None
+        self._node_config_details = None
 
     @property
     def id(self):
@@ -458,6 +465,30 @@ class NodePool(object):
         :type: list[Node]
         """
         self._nodes = nodes
+
+    @property
+    def node_config_details(self):
+        """
+        Gets the node_config_details of this NodePool.
+        The configuration of nodes in the node pool.
+
+
+        :return: The node_config_details of this NodePool.
+        :rtype: NodePoolNodeConfigDetails
+        """
+        return self._node_config_details
+
+    @node_config_details.setter
+    def node_config_details(self, node_config_details):
+        """
+        Sets the node_config_details of this NodePool.
+        The configuration of nodes in the node pool.
+
+
+        :param node_config_details: The node_config_details of this NodePool.
+        :type: NodePoolNodeConfigDetails
+        """
+        self._node_config_details = node_config_details
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/container_engine/models/node_pool_node_config_details.py
+++ b/src/oci/container_engine/models/node_pool_node_config_details.py
@@ -1,0 +1,110 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class NodePoolNodeConfigDetails(object):
+    """
+    The size and placement configuration of nodes in the node pool.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new NodePoolNodeConfigDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param size:
+            The value to assign to the size property of this NodePoolNodeConfigDetails.
+        :type size: int
+
+        :param placement_configs:
+            The value to assign to the placement_configs property of this NodePoolNodeConfigDetails.
+        :type placement_configs: list[NodePoolPlacementConfigDetails]
+
+        """
+        self.swagger_types = {
+            'size': 'int',
+            'placement_configs': 'list[NodePoolPlacementConfigDetails]'
+        }
+
+        self.attribute_map = {
+            'size': 'size',
+            'placement_configs': 'placementConfigs'
+        }
+
+        self._size = None
+        self._placement_configs = None
+
+    @property
+    def size(self):
+        """
+        Gets the size of this NodePoolNodeConfigDetails.
+        The number of nodes in the node pool.
+
+
+        :return: The size of this NodePoolNodeConfigDetails.
+        :rtype: int
+        """
+        return self._size
+
+    @size.setter
+    def size(self, size):
+        """
+        Sets the size of this NodePoolNodeConfigDetails.
+        The number of nodes in the node pool.
+
+
+        :param size: The size of this NodePoolNodeConfigDetails.
+        :type: int
+        """
+        self._size = size
+
+    @property
+    def placement_configs(self):
+        """
+        Gets the placement_configs of this NodePoolNodeConfigDetails.
+        The placement configurations for the node pool. Provide one placement
+        configuration for each availability domain in which you intend to launch a node.
+
+        To use the node pool with a regional subnet, provide a placement configuration for
+        each availability domain, and include the regional subnet in each placement
+        configuration.
+
+
+        :return: The placement_configs of this NodePoolNodeConfigDetails.
+        :rtype: list[NodePoolPlacementConfigDetails]
+        """
+        return self._placement_configs
+
+    @placement_configs.setter
+    def placement_configs(self, placement_configs):
+        """
+        Sets the placement_configs of this NodePoolNodeConfigDetails.
+        The placement configurations for the node pool. Provide one placement
+        configuration for each availability domain in which you intend to launch a node.
+
+        To use the node pool with a regional subnet, provide a placement configuration for
+        each availability domain, and include the regional subnet in each placement
+        configuration.
+
+
+        :param placement_configs: The placement_configs of this NodePoolNodeConfigDetails.
+        :type: list[NodePoolPlacementConfigDetails]
+        """
+        self._placement_configs = placement_configs
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/container_engine/models/node_pool_options.py
+++ b/src/oci/container_engine/models/node_pool_options.py
@@ -74,7 +74,7 @@ class NodePoolOptions(object):
     def images(self):
         """
         Gets the images of this NodePoolOptions.
-        Available Kubernetes versions.
+        Available image names.
 
 
         :return: The images of this NodePoolOptions.
@@ -86,7 +86,7 @@ class NodePoolOptions(object):
     def images(self, images):
         """
         Sets the images of this NodePoolOptions.
-        Available Kubernetes versions.
+        Available image names.
 
 
         :param images: The images of this NodePoolOptions.

--- a/src/oci/container_engine/models/node_pool_placement_config_details.py
+++ b/src/oci/container_engine/models/node_pool_placement_config_details.py
@@ -1,0 +1,102 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class NodePoolPlacementConfigDetails(object):
+    """
+    The location where a node pool will place nodes.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new NodePoolPlacementConfigDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this NodePoolPlacementConfigDetails.
+        :type availability_domain: str
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this NodePoolPlacementConfigDetails.
+        :type subnet_id: str
+
+        """
+        self.swagger_types = {
+            'availability_domain': 'str',
+            'subnet_id': 'str'
+        }
+
+        self.attribute_map = {
+            'availability_domain': 'availabilityDomain',
+            'subnet_id': 'subnetId'
+        }
+
+        self._availability_domain = None
+        self._subnet_id = None
+
+    @property
+    def availability_domain(self):
+        """
+        **[Required]** Gets the availability_domain of this NodePoolPlacementConfigDetails.
+        The availability domain in which to place nodes.
+        Example: `Uocm:PHX-AD-1`
+
+
+        :return: The availability_domain of this NodePoolPlacementConfigDetails.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this NodePoolPlacementConfigDetails.
+        The availability domain in which to place nodes.
+        Example: `Uocm:PHX-AD-1`
+
+
+        :param availability_domain: The availability_domain of this NodePoolPlacementConfigDetails.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def subnet_id(self):
+        """
+        **[Required]** Gets the subnet_id of this NodePoolPlacementConfigDetails.
+        The OCID of the subnet in which to place nodes.
+
+
+        :return: The subnet_id of this NodePoolPlacementConfigDetails.
+        :rtype: str
+        """
+        return self._subnet_id
+
+    @subnet_id.setter
+    def subnet_id(self, subnet_id):
+        """
+        Sets the subnet_id of this NodePoolPlacementConfigDetails.
+        The OCID of the subnet in which to place nodes.
+
+
+        :param subnet_id: The subnet_id of this NodePoolPlacementConfigDetails.
+        :type: str
+        """
+        self._subnet_id = subnet_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/container_engine/models/node_pool_summary.py
+++ b/src/oci/container_engine/models/node_pool_summary.py
@@ -65,6 +65,10 @@ class NodePoolSummary(object):
             The value to assign to the subnet_ids property of this NodePoolSummary.
         :type subnet_ids: list[str]
 
+        :param node_config_details:
+            The value to assign to the node_config_details property of this NodePoolSummary.
+        :type node_config_details: NodePoolNodeConfigDetails
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -78,7 +82,8 @@ class NodePoolSummary(object):
             'initial_node_labels': 'list[KeyValue]',
             'ssh_public_key': 'str',
             'quantity_per_subnet': 'int',
-            'subnet_ids': 'list[str]'
+            'subnet_ids': 'list[str]',
+            'node_config_details': 'NodePoolNodeConfigDetails'
         }
 
         self.attribute_map = {
@@ -93,7 +98,8 @@ class NodePoolSummary(object):
             'initial_node_labels': 'initialNodeLabels',
             'ssh_public_key': 'sshPublicKey',
             'quantity_per_subnet': 'quantityPerSubnet',
-            'subnet_ids': 'subnetIds'
+            'subnet_ids': 'subnetIds',
+            'node_config_details': 'nodeConfigDetails'
         }
 
         self._id = None
@@ -108,6 +114,7 @@ class NodePoolSummary(object):
         self._ssh_public_key = None
         self._quantity_per_subnet = None
         self._subnet_ids = None
+        self._node_config_details = None
 
     @property
     def id(self):
@@ -396,6 +403,30 @@ class NodePoolSummary(object):
         :type: list[str]
         """
         self._subnet_ids = subnet_ids
+
+    @property
+    def node_config_details(self):
+        """
+        Gets the node_config_details of this NodePoolSummary.
+        The configuration of nodes in the node pool.
+
+
+        :return: The node_config_details of this NodePoolSummary.
+        :rtype: NodePoolNodeConfigDetails
+        """
+        return self._node_config_details
+
+    @node_config_details.setter
+    def node_config_details(self, node_config_details):
+        """
+        Sets the node_config_details of this NodePoolSummary.
+        The configuration of nodes in the node pool.
+
+
+        :param node_config_details: The node_config_details of this NodePoolSummary.
+        :type: NodePoolNodeConfigDetails
+        """
+        self._node_config_details = node_config_details
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/container_engine/models/update_node_pool_details.py
+++ b/src/oci/container_engine/models/update_node_pool_details.py
@@ -25,40 +25,47 @@ class UpdateNodePoolDetails(object):
             The value to assign to the kubernetes_version property of this UpdateNodePoolDetails.
         :type kubernetes_version: str
 
-        :param quantity_per_subnet:
-            The value to assign to the quantity_per_subnet property of this UpdateNodePoolDetails.
-        :type quantity_per_subnet: int
-
         :param initial_node_labels:
             The value to assign to the initial_node_labels property of this UpdateNodePoolDetails.
         :type initial_node_labels: list[KeyValue]
+
+        :param quantity_per_subnet:
+            The value to assign to the quantity_per_subnet property of this UpdateNodePoolDetails.
+        :type quantity_per_subnet: int
 
         :param subnet_ids:
             The value to assign to the subnet_ids property of this UpdateNodePoolDetails.
         :type subnet_ids: list[str]
 
+        :param node_config_details:
+            The value to assign to the node_config_details property of this UpdateNodePoolDetails.
+        :type node_config_details: UpdateNodePoolNodeConfigDetails
+
         """
         self.swagger_types = {
             'name': 'str',
             'kubernetes_version': 'str',
-            'quantity_per_subnet': 'int',
             'initial_node_labels': 'list[KeyValue]',
-            'subnet_ids': 'list[str]'
+            'quantity_per_subnet': 'int',
+            'subnet_ids': 'list[str]',
+            'node_config_details': 'UpdateNodePoolNodeConfigDetails'
         }
 
         self.attribute_map = {
             'name': 'name',
             'kubernetes_version': 'kubernetesVersion',
-            'quantity_per_subnet': 'quantityPerSubnet',
             'initial_node_labels': 'initialNodeLabels',
-            'subnet_ids': 'subnetIds'
+            'quantity_per_subnet': 'quantityPerSubnet',
+            'subnet_ids': 'subnetIds',
+            'node_config_details': 'nodeConfigDetails'
         }
 
         self._name = None
         self._kubernetes_version = None
-        self._quantity_per_subnet = None
         self._initial_node_labels = None
+        self._quantity_per_subnet = None
         self._subnet_ids = None
+        self._node_config_details = None
 
     @property
     def name(self):
@@ -109,30 +116,6 @@ class UpdateNodePoolDetails(object):
         self._kubernetes_version = kubernetes_version
 
     @property
-    def quantity_per_subnet(self):
-        """
-        Gets the quantity_per_subnet of this UpdateNodePoolDetails.
-        The number of nodes to ensure in each subnet.
-
-
-        :return: The quantity_per_subnet of this UpdateNodePoolDetails.
-        :rtype: int
-        """
-        return self._quantity_per_subnet
-
-    @quantity_per_subnet.setter
-    def quantity_per_subnet(self, quantity_per_subnet):
-        """
-        Sets the quantity_per_subnet of this UpdateNodePoolDetails.
-        The number of nodes to ensure in each subnet.
-
-
-        :param quantity_per_subnet: The quantity_per_subnet of this UpdateNodePoolDetails.
-        :type: int
-        """
-        self._quantity_per_subnet = quantity_per_subnet
-
-    @property
     def initial_node_labels(self):
         """
         Gets the initial_node_labels of this UpdateNodePoolDetails.
@@ -157,10 +140,44 @@ class UpdateNodePoolDetails(object):
         self._initial_node_labels = initial_node_labels
 
     @property
+    def quantity_per_subnet(self):
+        """
+        Gets the quantity_per_subnet of this UpdateNodePoolDetails.
+        The number of nodes to have in each subnet specified in the subnetIds property. This property is deprecated,
+        use nodeConfigDetails instead. If the current value of quantityPerSubnet is greater than 0, you can only
+        use quantityPerSubnet to scale the node pool. If the current value of quantityPerSubnet is equal to 0 and
+        the current value of size in nodeConfigDetails is greater than 0, before you can use quantityPerSubnet,
+        you must first scale the node pool to 0 nodes using nodeConfigDetails.
+
+
+        :return: The quantity_per_subnet of this UpdateNodePoolDetails.
+        :rtype: int
+        """
+        return self._quantity_per_subnet
+
+    @quantity_per_subnet.setter
+    def quantity_per_subnet(self, quantity_per_subnet):
+        """
+        Sets the quantity_per_subnet of this UpdateNodePoolDetails.
+        The number of nodes to have in each subnet specified in the subnetIds property. This property is deprecated,
+        use nodeConfigDetails instead. If the current value of quantityPerSubnet is greater than 0, you can only
+        use quantityPerSubnet to scale the node pool. If the current value of quantityPerSubnet is equal to 0 and
+        the current value of size in nodeConfigDetails is greater than 0, before you can use quantityPerSubnet,
+        you must first scale the node pool to 0 nodes using nodeConfigDetails.
+
+
+        :param quantity_per_subnet: The quantity_per_subnet of this UpdateNodePoolDetails.
+        :type: int
+        """
+        self._quantity_per_subnet = quantity_per_subnet
+
+    @property
     def subnet_ids(self):
         """
         Gets the subnet_ids of this UpdateNodePoolDetails.
-        The OCIDs of the subnets in which to place nodes for this node pool.
+        The OCIDs of the subnets in which to place nodes for this node pool. This property is deprecated,
+        use nodeConfigDetails instead. Only one of the subnetIds or nodeConfigDetails
+        properties can be specified.
 
 
         :return: The subnet_ids of this UpdateNodePoolDetails.
@@ -172,13 +189,45 @@ class UpdateNodePoolDetails(object):
     def subnet_ids(self, subnet_ids):
         """
         Sets the subnet_ids of this UpdateNodePoolDetails.
-        The OCIDs of the subnets in which to place nodes for this node pool.
+        The OCIDs of the subnets in which to place nodes for this node pool. This property is deprecated,
+        use nodeConfigDetails instead. Only one of the subnetIds or nodeConfigDetails
+        properties can be specified.
 
 
         :param subnet_ids: The subnet_ids of this UpdateNodePoolDetails.
         :type: list[str]
         """
         self._subnet_ids = subnet_ids
+
+    @property
+    def node_config_details(self):
+        """
+        Gets the node_config_details of this UpdateNodePoolDetails.
+        The configuration of nodes in the node pool. Only one of the subnetIds or nodeConfigDetails
+        properties should be specified. If the current value of quantityPerSubnet is greater than 0, the node
+        pool may still be scaled using quantityPerSubnet. Before you can use nodeConfigDetails,
+        you must first scale the node pool to 0 nodes using quantityPerSubnet.
+
+
+        :return: The node_config_details of this UpdateNodePoolDetails.
+        :rtype: UpdateNodePoolNodeConfigDetails
+        """
+        return self._node_config_details
+
+    @node_config_details.setter
+    def node_config_details(self, node_config_details):
+        """
+        Sets the node_config_details of this UpdateNodePoolDetails.
+        The configuration of nodes in the node pool. Only one of the subnetIds or nodeConfigDetails
+        properties should be specified. If the current value of quantityPerSubnet is greater than 0, the node
+        pool may still be scaled using quantityPerSubnet. Before you can use nodeConfigDetails,
+        you must first scale the node pool to 0 nodes using quantityPerSubnet.
+
+
+        :param node_config_details: The node_config_details of this UpdateNodePoolDetails.
+        :type: UpdateNodePoolNodeConfigDetails
+        """
+        self._node_config_details = node_config_details
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/container_engine/models/update_node_pool_node_config_details.py
+++ b/src/oci/container_engine/models/update_node_pool_node_config_details.py
@@ -1,0 +1,110 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateNodePoolNodeConfigDetails(object):
+    """
+    The size and placement configuration of nodes in the node pool.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateNodePoolNodeConfigDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param size:
+            The value to assign to the size property of this UpdateNodePoolNodeConfigDetails.
+        :type size: int
+
+        :param placement_configs:
+            The value to assign to the placement_configs property of this UpdateNodePoolNodeConfigDetails.
+        :type placement_configs: list[NodePoolPlacementConfigDetails]
+
+        """
+        self.swagger_types = {
+            'size': 'int',
+            'placement_configs': 'list[NodePoolPlacementConfigDetails]'
+        }
+
+        self.attribute_map = {
+            'size': 'size',
+            'placement_configs': 'placementConfigs'
+        }
+
+        self._size = None
+        self._placement_configs = None
+
+    @property
+    def size(self):
+        """
+        Gets the size of this UpdateNodePoolNodeConfigDetails.
+        The number of nodes in the node pool.
+
+
+        :return: The size of this UpdateNodePoolNodeConfigDetails.
+        :rtype: int
+        """
+        return self._size
+
+    @size.setter
+    def size(self, size):
+        """
+        Sets the size of this UpdateNodePoolNodeConfigDetails.
+        The number of nodes in the node pool.
+
+
+        :param size: The size of this UpdateNodePoolNodeConfigDetails.
+        :type: int
+        """
+        self._size = size
+
+    @property
+    def placement_configs(self):
+        """
+        Gets the placement_configs of this UpdateNodePoolNodeConfigDetails.
+        The placement configurations for the node pool. Provide one placement
+        configuration for each availability domain in which you intend to launch a node.
+
+        To use the node pool with a regional subnet, provide a placement configuration for
+        each availability domain, and include the regional subnet in each placement
+        configuration.
+
+
+        :return: The placement_configs of this UpdateNodePoolNodeConfigDetails.
+        :rtype: list[NodePoolPlacementConfigDetails]
+        """
+        return self._placement_configs
+
+    @placement_configs.setter
+    def placement_configs(self, placement_configs):
+        """
+        Sets the placement_configs of this UpdateNodePoolNodeConfigDetails.
+        The placement configurations for the node pool. Provide one placement
+        configuration for each availability domain in which you intend to launch a node.
+
+        To use the node pool with a regional subnet, provide a placement configuration for
+        each availability domain, and include the regional subnet in each placement
+        configuration.
+
+
+        :param placement_configs: The placement_configs of this UpdateNodePoolNodeConfigDetails.
+        :type: list[NodePoolPlacementConfigDetails]
+        """
+        self._placement_configs = placement_configs
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/boot_volume.py
+++ b/src/oci/core/models/boot_volume.py
@@ -64,6 +64,10 @@ class BootVolume(object):
             The value to assign to the defined_tags property of this BootVolume.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param system_tags:
+            The value to assign to the system_tags property of this BootVolume.
+        :type system_tags: dict(str, dict(str, object))
+
         :param display_name:
             The value to assign to the display_name property of this BootVolume.
         :type display_name: str
@@ -119,6 +123,7 @@ class BootVolume(object):
             'availability_domain': 'str',
             'compartment_id': 'str',
             'defined_tags': 'dict(str, dict(str, object))',
+            'system_tags': 'dict(str, dict(str, object))',
             'display_name': 'str',
             'freeform_tags': 'dict(str, str)',
             'id': 'str',
@@ -137,6 +142,7 @@ class BootVolume(object):
             'availability_domain': 'availabilityDomain',
             'compartment_id': 'compartmentId',
             'defined_tags': 'definedTags',
+            'system_tags': 'systemTags',
             'display_name': 'displayName',
             'freeform_tags': 'freeformTags',
             'id': 'id',
@@ -154,6 +160,7 @@ class BootVolume(object):
         self._availability_domain = None
         self._compartment_id = None
         self._defined_tags = None
+        self._system_tags = None
         self._display_name = None
         self._freeform_tags = None
         self._id = None
@@ -252,6 +259,32 @@ class BootVolume(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def system_tags(self):
+        """
+        Gets the system_tags of this BootVolume.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The system_tags of this BootVolume.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._system_tags
+
+    @system_tags.setter
+    def system_tags(self, system_tags):
+        """
+        Sets the system_tags of this BootVolume.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param system_tags: The system_tags of this BootVolume.
+        :type: dict(str, dict(str, object))
+        """
+        self._system_tags = system_tags
 
     @property
     def display_name(self):

--- a/src/oci/core/models/boot_volume_backup.py
+++ b/src/oci/core/models/boot_volume_backup.py
@@ -81,6 +81,10 @@ class BootVolumeBackup(object):
             The value to assign to the defined_tags property of this BootVolumeBackup.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param system_tags:
+            The value to assign to the system_tags property of this BootVolumeBackup.
+        :type system_tags: dict(str, dict(str, object))
+
         :param display_name:
             The value to assign to the display_name property of this BootVolumeBackup.
         :type display_name: str
@@ -144,6 +148,7 @@ class BootVolumeBackup(object):
             'boot_volume_id': 'str',
             'compartment_id': 'str',
             'defined_tags': 'dict(str, dict(str, object))',
+            'system_tags': 'dict(str, dict(str, object))',
             'display_name': 'str',
             'expiration_time': 'datetime',
             'freeform_tags': 'dict(str, str)',
@@ -163,6 +168,7 @@ class BootVolumeBackup(object):
             'boot_volume_id': 'bootVolumeId',
             'compartment_id': 'compartmentId',
             'defined_tags': 'definedTags',
+            'system_tags': 'systemTags',
             'display_name': 'displayName',
             'expiration_time': 'expirationTime',
             'freeform_tags': 'freeformTags',
@@ -181,6 +187,7 @@ class BootVolumeBackup(object):
         self._boot_volume_id = None
         self._compartment_id = None
         self._defined_tags = None
+        self._system_tags = None
         self._display_name = None
         self._expiration_time = None
         self._freeform_tags = None
@@ -276,6 +283,32 @@ class BootVolumeBackup(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def system_tags(self):
+        """
+        Gets the system_tags of this BootVolumeBackup.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The system_tags of this BootVolumeBackup.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._system_tags
+
+    @system_tags.setter
+    def system_tags(self, system_tags):
+        """
+        Sets the system_tags of this BootVolumeBackup.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param system_tags: The system_tags of this BootVolumeBackup.
+        :type: dict(str, dict(str, object))
+        """
+        self._system_tags = system_tags
 
     @property
     def display_name(self):

--- a/src/oci/core/models/instance.py
+++ b/src/oci/core/models/instance.py
@@ -158,6 +158,10 @@ class Instance(object):
             The value to assign to the source_details property of this Instance.
         :type source_details: InstanceSourceDetails
 
+        :param system_tags:
+            The value to assign to the system_tags property of this Instance.
+        :type system_tags: dict(str, dict(str, object))
+
         :param time_created:
             The value to assign to the time_created property of this Instance.
         :type time_created: datetime
@@ -190,6 +194,7 @@ class Instance(object):
             'region': 'str',
             'shape': 'str',
             'source_details': 'InstanceSourceDetails',
+            'system_tags': 'dict(str, dict(str, object))',
             'time_created': 'datetime',
             'agent_config': 'InstanceAgentConfig',
             'time_maintenance_reboot_due': 'datetime'
@@ -214,6 +219,7 @@ class Instance(object):
             'region': 'region',
             'shape': 'shape',
             'source_details': 'sourceDetails',
+            'system_tags': 'systemTags',
             'time_created': 'timeCreated',
             'agent_config': 'agentConfig',
             'time_maintenance_reboot_due': 'timeMaintenanceRebootDue'
@@ -237,6 +243,7 @@ class Instance(object):
         self._region = None
         self._shape = None
         self._source_details = None
+        self._system_tags = None
         self._time_created = None
         self._agent_config = None
         self._time_maintenance_reboot_due = None
@@ -804,6 +811,32 @@ class Instance(object):
         :type: InstanceSourceDetails
         """
         self._source_details = source_details
+
+    @property
+    def system_tags(self):
+        """
+        Gets the system_tags of this Instance.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The system_tags of this Instance.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._system_tags
+
+    @system_tags.setter
+    def system_tags(self, system_tags):
+        """
+        Sets the system_tags of this Instance.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param system_tags: The system_tags of this Instance.
+        :type: dict(str, dict(str, object))
+        """
+        self._system_tags = system_tags
 
     @property
     def time_created(self):

--- a/src/oci/core/models/service_gateway.py
+++ b/src/oci/core/models/service_gateway.py
@@ -353,7 +353,6 @@ class ServiceGateway(object):
         """
         Gets the route_table_id of this ServiceGateway.
         The OCID of the route table the service gateway is using.
-
         For information about why you would associate a route table with a service gateway, see
         `Transit Routing: Private Access to Oracle Services`__.
 
@@ -370,7 +369,6 @@ class ServiceGateway(object):
         """
         Sets the route_table_id of this ServiceGateway.
         The OCID of the route table the service gateway is using.
-
         For information about why you would associate a route table with a service gateway, see
         `Transit Routing: Private Access to Oracle Services`__.
 

--- a/src/oci/core/models/update_service_gateway_details.py
+++ b/src/oci/core/models/update_service_gateway_details.py
@@ -196,7 +196,6 @@ class UpdateServiceGatewayDetails(object):
         """
         Gets the route_table_id of this UpdateServiceGatewayDetails.
         The OCID of the route table the service gateway will use.
-
         For information about why you would associate a route table with a service gateway, see
         `Transit Routing: Private Access to Oracle Services`__.
 
@@ -213,7 +212,6 @@ class UpdateServiceGatewayDetails(object):
         """
         Sets the route_table_id of this UpdateServiceGatewayDetails.
         The OCID of the route table the service gateway will use.
-
         For information about why you would associate a route table with a service gateway, see
         `Transit Routing: Private Access to Oracle Services`__.
 

--- a/src/oci/core/models/volume.py
+++ b/src/oci/core/models/volume.py
@@ -73,6 +73,10 @@ class Volume(object):
             The value to assign to the freeform_tags property of this Volume.
         :type freeform_tags: dict(str, str)
 
+        :param system_tags:
+            The value to assign to the system_tags property of this Volume.
+        :type system_tags: dict(str, dict(str, object))
+
         :param id:
             The value to assign to the id property of this Volume.
         :type id: str
@@ -118,6 +122,7 @@ class Volume(object):
             'defined_tags': 'dict(str, dict(str, object))',
             'display_name': 'str',
             'freeform_tags': 'dict(str, str)',
+            'system_tags': 'dict(str, dict(str, object))',
             'id': 'str',
             'is_hydrated': 'bool',
             'kms_key_id': 'str',
@@ -135,6 +140,7 @@ class Volume(object):
             'defined_tags': 'definedTags',
             'display_name': 'displayName',
             'freeform_tags': 'freeformTags',
+            'system_tags': 'systemTags',
             'id': 'id',
             'is_hydrated': 'isHydrated',
             'kms_key_id': 'kmsKeyId',
@@ -151,6 +157,7 @@ class Volume(object):
         self._defined_tags = None
         self._display_name = None
         self._freeform_tags = None
+        self._system_tags = None
         self._id = None
         self._is_hydrated = None
         self._kms_key_id = None
@@ -306,6 +313,32 @@ class Volume(object):
         :type: dict(str, str)
         """
         self._freeform_tags = freeform_tags
+
+    @property
+    def system_tags(self):
+        """
+        Gets the system_tags of this Volume.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The system_tags of this Volume.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._system_tags
+
+    @system_tags.setter
+    def system_tags(self, system_tags):
+        """
+        Sets the system_tags of this Volume.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param system_tags: The system_tags of this Volume.
+        :type: dict(str, dict(str, object))
+        """
+        self._system_tags = system_tags
 
     @property
     def id(self):

--- a/src/oci/core/models/volume_backup.py
+++ b/src/oci/core/models/volume_backup.py
@@ -77,6 +77,10 @@ class VolumeBackup(object):
             The value to assign to the defined_tags property of this VolumeBackup.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param system_tags:
+            The value to assign to the system_tags property of this VolumeBackup.
+        :type system_tags: dict(str, dict(str, object))
+
         :param display_name:
             The value to assign to the display_name property of this VolumeBackup.
         :type display_name: str
@@ -151,6 +155,7 @@ class VolumeBackup(object):
         self.swagger_types = {
             'compartment_id': 'str',
             'defined_tags': 'dict(str, dict(str, object))',
+            'system_tags': 'dict(str, dict(str, object))',
             'display_name': 'str',
             'expiration_time': 'datetime',
             'freeform_tags': 'dict(str, str)',
@@ -172,6 +177,7 @@ class VolumeBackup(object):
         self.attribute_map = {
             'compartment_id': 'compartmentId',
             'defined_tags': 'definedTags',
+            'system_tags': 'systemTags',
             'display_name': 'displayName',
             'expiration_time': 'expirationTime',
             'freeform_tags': 'freeformTags',
@@ -192,6 +198,7 @@ class VolumeBackup(object):
 
         self._compartment_id = None
         self._defined_tags = None
+        self._system_tags = None
         self._display_name = None
         self._expiration_time = None
         self._freeform_tags = None
@@ -266,6 +273,32 @@ class VolumeBackup(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def system_tags(self):
+        """
+        Gets the system_tags of this VolumeBackup.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The system_tags of this VolumeBackup.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._system_tags
+
+    @system_tags.setter
+    def system_tags(self, system_tags):
+        """
+        Sets the system_tags of this VolumeBackup.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param system_tags: The system_tags of this VolumeBackup.
+        :type: dict(str, dict(str, object))
+        """
+        self._system_tags = system_tags
 
     @property
     def display_name(self):

--- a/src/oci/database/database_client.py
+++ b/src/oci/database/database_client.py
@@ -3971,6 +3971,10 @@ class DatabaseClient(object):
 
             Allowed values are: "OLTP", "DW"
 
+        :param bool is_free_tier: (optional)
+            Filter on the value of the resource's 'isFreeTier' property. A value of `true` returns only Always Free resources.
+            A value of `false` excludes Always Free resources from the returned results. Omitting this parameter returns both Always Free and paid resources.
+
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
@@ -4001,6 +4005,7 @@ class DatabaseClient(object):
             "sort_order",
             "lifecycle_state",
             "db_workload",
+            "is_free_tier",
             "display_name",
             "opc_request_id"
         ]
@@ -4046,6 +4051,7 @@ class DatabaseClient(object):
             "sortOrder": kwargs.get("sort_order", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "dbWorkload": kwargs.get("db_workload", missing),
+            "isFreeTier": kwargs.get("is_free_tier", missing),
             "displayName": kwargs.get("display_name", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}

--- a/src/oci/database/models/autonomous_container_database.py
+++ b/src/oci/database/models/autonomous_container_database.py
@@ -527,8 +527,6 @@ class AutonomousContainerDatabase(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -543,8 +541,6 @@ class AutonomousContainerDatabase(object):
         Sets the defined_tags of this AutonomousContainerDatabase.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/autonomous_container_database_summary.py
+++ b/src/oci/database/models/autonomous_container_database_summary.py
@@ -527,8 +527,6 @@ class AutonomousContainerDatabaseSummary(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -543,8 +541,6 @@ class AutonomousContainerDatabaseSummary(object):
         Sets the defined_tags of this AutonomousContainerDatabaseSummary.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/autonomous_data_warehouse.py
+++ b/src/oci/database/models/autonomous_data_warehouse.py
@@ -543,8 +543,6 @@ class AutonomousDataWarehouse(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -559,8 +557,6 @@ class AutonomousDataWarehouse(object):
         Sets the defined_tags of this AutonomousDataWarehouse.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/autonomous_data_warehouse_summary.py
+++ b/src/oci/database/models/autonomous_data_warehouse_summary.py
@@ -545,8 +545,6 @@ class AutonomousDataWarehouseSummary(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -561,8 +559,6 @@ class AutonomousDataWarehouseSummary(object):
         Sets the defined_tags of this AutonomousDataWarehouseSummary.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/autonomous_database.py
+++ b/src/oci/database/models/autonomous_database.py
@@ -115,6 +115,22 @@ class AutonomousDatabase(object):
             The value to assign to the db_name property of this AutonomousDatabase.
         :type db_name: str
 
+        :param is_free_tier:
+            The value to assign to the is_free_tier property of this AutonomousDatabase.
+        :type is_free_tier: bool
+
+        :param system_tags:
+            The value to assign to the system_tags property of this AutonomousDatabase.
+        :type system_tags: dict(str, dict(str, object))
+
+        :param time_reclamation_of_free_autonomous_database:
+            The value to assign to the time_reclamation_of_free_autonomous_database property of this AutonomousDatabase.
+        :type time_reclamation_of_free_autonomous_database: datetime
+
+        :param time_deletion_of_free_autonomous_database:
+            The value to assign to the time_deletion_of_free_autonomous_database property of this AutonomousDatabase.
+        :type time_deletion_of_free_autonomous_database: datetime
+
         :param cpu_core_count:
             The value to assign to the cpu_core_count property of this AutonomousDatabase.
         :type cpu_core_count: int
@@ -198,6 +214,10 @@ class AutonomousDatabase(object):
             'lifecycle_state': 'str',
             'lifecycle_details': 'str',
             'db_name': 'str',
+            'is_free_tier': 'bool',
+            'system_tags': 'dict(str, dict(str, object))',
+            'time_reclamation_of_free_autonomous_database': 'datetime',
+            'time_deletion_of_free_autonomous_database': 'datetime',
             'cpu_core_count': 'int',
             'data_storage_size_in_tbs': 'int',
             'is_dedicated': 'bool',
@@ -224,6 +244,10 @@ class AutonomousDatabase(object):
             'lifecycle_state': 'lifecycleState',
             'lifecycle_details': 'lifecycleDetails',
             'db_name': 'dbName',
+            'is_free_tier': 'isFreeTier',
+            'system_tags': 'systemTags',
+            'time_reclamation_of_free_autonomous_database': 'timeReclamationOfFreeAutonomousDatabase',
+            'time_deletion_of_free_autonomous_database': 'timeDeletionOfFreeAutonomousDatabase',
             'cpu_core_count': 'cpuCoreCount',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'is_dedicated': 'isDedicated',
@@ -249,6 +273,10 @@ class AutonomousDatabase(object):
         self._lifecycle_state = None
         self._lifecycle_details = None
         self._db_name = None
+        self._is_free_tier = None
+        self._system_tags = None
+        self._time_reclamation_of_free_autonomous_database = None
+        self._time_deletion_of_free_autonomous_database = None
         self._cpu_core_count = None
         self._data_storage_size_in_tbs = None
         self._is_dedicated = None
@@ -401,6 +429,108 @@ class AutonomousDatabase(object):
         :type: str
         """
         self._db_name = db_name
+
+    @property
+    def is_free_tier(self):
+        """
+        Gets the is_free_tier of this AutonomousDatabase.
+        Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+
+
+        :return: The is_free_tier of this AutonomousDatabase.
+        :rtype: bool
+        """
+        return self._is_free_tier
+
+    @is_free_tier.setter
+    def is_free_tier(self, is_free_tier):
+        """
+        Sets the is_free_tier of this AutonomousDatabase.
+        Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+
+
+        :param is_free_tier: The is_free_tier of this AutonomousDatabase.
+        :type: bool
+        """
+        self._is_free_tier = is_free_tier
+
+    @property
+    def system_tags(self):
+        """
+        Gets the system_tags of this AutonomousDatabase.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The system_tags of this AutonomousDatabase.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._system_tags
+
+    @system_tags.setter
+    def system_tags(self, system_tags):
+        """
+        Sets the system_tags of this AutonomousDatabase.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param system_tags: The system_tags of this AutonomousDatabase.
+        :type: dict(str, dict(str, object))
+        """
+        self._system_tags = system_tags
+
+    @property
+    def time_reclamation_of_free_autonomous_database(self):
+        """
+        Gets the time_reclamation_of_free_autonomous_database of this AutonomousDatabase.
+        The date and time the Always Free database will be stopped because of inactivity. If this time is reached without any database activity, the database will automatically be put into the STOPPED state.
+
+
+        :return: The time_reclamation_of_free_autonomous_database of this AutonomousDatabase.
+        :rtype: datetime
+        """
+        return self._time_reclamation_of_free_autonomous_database
+
+    @time_reclamation_of_free_autonomous_database.setter
+    def time_reclamation_of_free_autonomous_database(self, time_reclamation_of_free_autonomous_database):
+        """
+        Sets the time_reclamation_of_free_autonomous_database of this AutonomousDatabase.
+        The date and time the Always Free database will be stopped because of inactivity. If this time is reached without any database activity, the database will automatically be put into the STOPPED state.
+
+
+        :param time_reclamation_of_free_autonomous_database: The time_reclamation_of_free_autonomous_database of this AutonomousDatabase.
+        :type: datetime
+        """
+        self._time_reclamation_of_free_autonomous_database = time_reclamation_of_free_autonomous_database
+
+    @property
+    def time_deletion_of_free_autonomous_database(self):
+        """
+        Gets the time_deletion_of_free_autonomous_database of this AutonomousDatabase.
+        The date and time the Always Free database will be automatically deleted because of inactivity. If the database is in the STOPPED state and without activity until this time, it will be deleted.
+
+
+        :return: The time_deletion_of_free_autonomous_database of this AutonomousDatabase.
+        :rtype: datetime
+        """
+        return self._time_deletion_of_free_autonomous_database
+
+    @time_deletion_of_free_autonomous_database.setter
+    def time_deletion_of_free_autonomous_database(self, time_deletion_of_free_autonomous_database):
+        """
+        Sets the time_deletion_of_free_autonomous_database of this AutonomousDatabase.
+        The date and time the Always Free database will be automatically deleted because of inactivity. If the database is in the STOPPED state and without activity until this time, it will be deleted.
+
+
+        :param time_deletion_of_free_autonomous_database: The time_deletion_of_free_autonomous_database of this AutonomousDatabase.
+        :type: datetime
+        """
+        self._time_deletion_of_free_autonomous_database = time_deletion_of_free_autonomous_database
 
     @property
     def cpu_core_count(self):
@@ -626,7 +756,9 @@ class AutonomousDatabase(object):
     def license_model(self):
         """
         Gets the license_model of this AutonomousDatabase.
-        The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE.
+        The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the `shared deployment] is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the [dedicated deployment`__ option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 
         Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -641,7 +773,9 @@ class AutonomousDatabase(object):
     def license_model(self, license_model):
         """
         Sets the license_model of this AutonomousDatabase.
-        The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE.
+        The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the `shared deployment] is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the [dedicated deployment`__ option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 
 
         :param license_model: The license_model of this AutonomousDatabase.
@@ -717,8 +851,6 @@ class AutonomousDatabase(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -733,8 +865,6 @@ class AutonomousDatabase(object):
         Sets the defined_tags of this AutonomousDatabase.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/autonomous_database_summary.py
+++ b/src/oci/database/models/autonomous_database_summary.py
@@ -117,6 +117,22 @@ class AutonomousDatabaseSummary(object):
             The value to assign to the db_name property of this AutonomousDatabaseSummary.
         :type db_name: str
 
+        :param is_free_tier:
+            The value to assign to the is_free_tier property of this AutonomousDatabaseSummary.
+        :type is_free_tier: bool
+
+        :param system_tags:
+            The value to assign to the system_tags property of this AutonomousDatabaseSummary.
+        :type system_tags: dict(str, dict(str, object))
+
+        :param time_reclamation_of_free_autonomous_database:
+            The value to assign to the time_reclamation_of_free_autonomous_database property of this AutonomousDatabaseSummary.
+        :type time_reclamation_of_free_autonomous_database: datetime
+
+        :param time_deletion_of_free_autonomous_database:
+            The value to assign to the time_deletion_of_free_autonomous_database property of this AutonomousDatabaseSummary.
+        :type time_deletion_of_free_autonomous_database: datetime
+
         :param cpu_core_count:
             The value to assign to the cpu_core_count property of this AutonomousDatabaseSummary.
         :type cpu_core_count: int
@@ -200,6 +216,10 @@ class AutonomousDatabaseSummary(object):
             'lifecycle_state': 'str',
             'lifecycle_details': 'str',
             'db_name': 'str',
+            'is_free_tier': 'bool',
+            'system_tags': 'dict(str, dict(str, object))',
+            'time_reclamation_of_free_autonomous_database': 'datetime',
+            'time_deletion_of_free_autonomous_database': 'datetime',
             'cpu_core_count': 'int',
             'data_storage_size_in_tbs': 'int',
             'is_dedicated': 'bool',
@@ -226,6 +246,10 @@ class AutonomousDatabaseSummary(object):
             'lifecycle_state': 'lifecycleState',
             'lifecycle_details': 'lifecycleDetails',
             'db_name': 'dbName',
+            'is_free_tier': 'isFreeTier',
+            'system_tags': 'systemTags',
+            'time_reclamation_of_free_autonomous_database': 'timeReclamationOfFreeAutonomousDatabase',
+            'time_deletion_of_free_autonomous_database': 'timeDeletionOfFreeAutonomousDatabase',
             'cpu_core_count': 'cpuCoreCount',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'is_dedicated': 'isDedicated',
@@ -251,6 +275,10 @@ class AutonomousDatabaseSummary(object):
         self._lifecycle_state = None
         self._lifecycle_details = None
         self._db_name = None
+        self._is_free_tier = None
+        self._system_tags = None
+        self._time_reclamation_of_free_autonomous_database = None
+        self._time_deletion_of_free_autonomous_database = None
         self._cpu_core_count = None
         self._data_storage_size_in_tbs = None
         self._is_dedicated = None
@@ -403,6 +431,108 @@ class AutonomousDatabaseSummary(object):
         :type: str
         """
         self._db_name = db_name
+
+    @property
+    def is_free_tier(self):
+        """
+        Gets the is_free_tier of this AutonomousDatabaseSummary.
+        Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+
+
+        :return: The is_free_tier of this AutonomousDatabaseSummary.
+        :rtype: bool
+        """
+        return self._is_free_tier
+
+    @is_free_tier.setter
+    def is_free_tier(self, is_free_tier):
+        """
+        Sets the is_free_tier of this AutonomousDatabaseSummary.
+        Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+
+
+        :param is_free_tier: The is_free_tier of this AutonomousDatabaseSummary.
+        :type: bool
+        """
+        self._is_free_tier = is_free_tier
+
+    @property
+    def system_tags(self):
+        """
+        Gets the system_tags of this AutonomousDatabaseSummary.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The system_tags of this AutonomousDatabaseSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._system_tags
+
+    @system_tags.setter
+    def system_tags(self, system_tags):
+        """
+        Sets the system_tags of this AutonomousDatabaseSummary.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param system_tags: The system_tags of this AutonomousDatabaseSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._system_tags = system_tags
+
+    @property
+    def time_reclamation_of_free_autonomous_database(self):
+        """
+        Gets the time_reclamation_of_free_autonomous_database of this AutonomousDatabaseSummary.
+        The date and time the Always Free database will be stopped because of inactivity. If this time is reached without any database activity, the database will automatically be put into the STOPPED state.
+
+
+        :return: The time_reclamation_of_free_autonomous_database of this AutonomousDatabaseSummary.
+        :rtype: datetime
+        """
+        return self._time_reclamation_of_free_autonomous_database
+
+    @time_reclamation_of_free_autonomous_database.setter
+    def time_reclamation_of_free_autonomous_database(self, time_reclamation_of_free_autonomous_database):
+        """
+        Sets the time_reclamation_of_free_autonomous_database of this AutonomousDatabaseSummary.
+        The date and time the Always Free database will be stopped because of inactivity. If this time is reached without any database activity, the database will automatically be put into the STOPPED state.
+
+
+        :param time_reclamation_of_free_autonomous_database: The time_reclamation_of_free_autonomous_database of this AutonomousDatabaseSummary.
+        :type: datetime
+        """
+        self._time_reclamation_of_free_autonomous_database = time_reclamation_of_free_autonomous_database
+
+    @property
+    def time_deletion_of_free_autonomous_database(self):
+        """
+        Gets the time_deletion_of_free_autonomous_database of this AutonomousDatabaseSummary.
+        The date and time the Always Free database will be automatically deleted because of inactivity. If the database is in the STOPPED state and without activity until this time, it will be deleted.
+
+
+        :return: The time_deletion_of_free_autonomous_database of this AutonomousDatabaseSummary.
+        :rtype: datetime
+        """
+        return self._time_deletion_of_free_autonomous_database
+
+    @time_deletion_of_free_autonomous_database.setter
+    def time_deletion_of_free_autonomous_database(self, time_deletion_of_free_autonomous_database):
+        """
+        Sets the time_deletion_of_free_autonomous_database of this AutonomousDatabaseSummary.
+        The date and time the Always Free database will be automatically deleted because of inactivity. If the database is in the STOPPED state and without activity until this time, it will be deleted.
+
+
+        :param time_deletion_of_free_autonomous_database: The time_deletion_of_free_autonomous_database of this AutonomousDatabaseSummary.
+        :type: datetime
+        """
+        self._time_deletion_of_free_autonomous_database = time_deletion_of_free_autonomous_database
 
     @property
     def cpu_core_count(self):
@@ -628,7 +758,9 @@ class AutonomousDatabaseSummary(object):
     def license_model(self):
         """
         Gets the license_model of this AutonomousDatabaseSummary.
-        The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE.
+        The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the `shared deployment] is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the [dedicated deployment`__ option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 
         Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -643,7 +775,9 @@ class AutonomousDatabaseSummary(object):
     def license_model(self, license_model):
         """
         Sets the license_model of this AutonomousDatabaseSummary.
-        The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE.
+        The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the `shared deployment] is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the [dedicated deployment`__ option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 
 
         :param license_model: The license_model of this AutonomousDatabaseSummary.
@@ -719,8 +853,6 @@ class AutonomousDatabaseSummary(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -735,8 +867,6 @@ class AutonomousDatabaseSummary(object):
         Sets the defined_tags of this AutonomousDatabaseSummary.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/autonomous_exadata_infrastructure.py
+++ b/src/oci/database/models/autonomous_exadata_infrastructure.py
@@ -73,6 +73,10 @@ class AutonomousExadataInfrastructure(object):
             The value to assign to the subnet_id property of this AutonomousExadataInfrastructure.
         :type subnet_id: str
 
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this AutonomousExadataInfrastructure.
+        :type nsg_ids: list[str]
+
         :param shape:
             The value to assign to the shape property of this AutonomousExadataInfrastructure.
         :type shape: str
@@ -132,6 +136,7 @@ class AutonomousExadataInfrastructure(object):
             'display_name': 'str',
             'availability_domain': 'str',
             'subnet_id': 'str',
+            'nsg_ids': 'list[str]',
             'shape': 'str',
             'hostname': 'str',
             'domain': 'str',
@@ -152,6 +157,7 @@ class AutonomousExadataInfrastructure(object):
             'display_name': 'displayName',
             'availability_domain': 'availabilityDomain',
             'subnet_id': 'subnetId',
+            'nsg_ids': 'nsgIds',
             'shape': 'shape',
             'hostname': 'hostname',
             'domain': 'domain',
@@ -171,6 +177,7 @@ class AutonomousExadataInfrastructure(object):
         self._display_name = None
         self._availability_domain = None
         self._subnet_id = None
+        self._nsg_ids = None
         self._shape = None
         self._hostname = None
         self._domain = None
@@ -317,6 +324,36 @@ class AutonomousExadataInfrastructure(object):
         :type: str
         """
         self._subnet_id = subnet_id
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this AutonomousExadataInfrastructure.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :return: The nsg_ids of this AutonomousExadataInfrastructure.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this AutonomousExadataInfrastructure.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :param nsg_ids: The nsg_ids of this AutonomousExadataInfrastructure.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
 
     @property
     def shape(self):
@@ -615,8 +652,6 @@ class AutonomousExadataInfrastructure(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -631,8 +666,6 @@ class AutonomousExadataInfrastructure(object):
         Sets the defined_tags of this AutonomousExadataInfrastructure.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/autonomous_exadata_infrastructure_summary.py
+++ b/src/oci/database/models/autonomous_exadata_infrastructure_summary.py
@@ -91,6 +91,10 @@ class AutonomousExadataInfrastructureSummary(object):
             The value to assign to the subnet_id property of this AutonomousExadataInfrastructureSummary.
         :type subnet_id: str
 
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this AutonomousExadataInfrastructureSummary.
+        :type nsg_ids: list[str]
+
         :param shape:
             The value to assign to the shape property of this AutonomousExadataInfrastructureSummary.
         :type shape: str
@@ -150,6 +154,7 @@ class AutonomousExadataInfrastructureSummary(object):
             'display_name': 'str',
             'availability_domain': 'str',
             'subnet_id': 'str',
+            'nsg_ids': 'list[str]',
             'shape': 'str',
             'hostname': 'str',
             'domain': 'str',
@@ -170,6 +175,7 @@ class AutonomousExadataInfrastructureSummary(object):
             'display_name': 'displayName',
             'availability_domain': 'availabilityDomain',
             'subnet_id': 'subnetId',
+            'nsg_ids': 'nsgIds',
             'shape': 'shape',
             'hostname': 'hostname',
             'domain': 'domain',
@@ -189,6 +195,7 @@ class AutonomousExadataInfrastructureSummary(object):
         self._display_name = None
         self._availability_domain = None
         self._subnet_id = None
+        self._nsg_ids = None
         self._shape = None
         self._hostname = None
         self._domain = None
@@ -335,6 +342,36 @@ class AutonomousExadataInfrastructureSummary(object):
         :type: str
         """
         self._subnet_id = subnet_id
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this AutonomousExadataInfrastructureSummary.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :return: The nsg_ids of this AutonomousExadataInfrastructureSummary.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this AutonomousExadataInfrastructureSummary.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :param nsg_ids: The nsg_ids of this AutonomousExadataInfrastructureSummary.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
 
     @property
     def shape(self):
@@ -633,8 +670,6 @@ class AutonomousExadataInfrastructureSummary(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -649,8 +684,6 @@ class AutonomousExadataInfrastructureSummary(object):
         Sets the defined_tags of this AutonomousExadataInfrastructureSummary.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/create_autonomous_container_database_details.py
+++ b/src/oci/database/models/create_autonomous_container_database_details.py
@@ -276,8 +276,6 @@ class CreateAutonomousContainerDatabaseDetails(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -292,8 +290,6 @@ class CreateAutonomousContainerDatabaseDetails(object):
         Sets the defined_tags of this CreateAutonomousContainerDatabaseDetails.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/create_autonomous_data_warehouse_details.py
+++ b/src/oci/database/models/create_autonomous_data_warehouse_details.py
@@ -320,8 +320,6 @@ class CreateAutonomousDataWarehouseDetails(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -336,8 +334,6 @@ class CreateAutonomousDataWarehouseDetails(object):
         Sets the defined_tags of this CreateAutonomousDataWarehouseDetails.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/create_autonomous_database_base.py
+++ b/src/oci/database/models/create_autonomous_database_base.py
@@ -69,6 +69,10 @@ class CreateAutonomousDatabaseBase(object):
             The value to assign to the data_storage_size_in_tbs property of this CreateAutonomousDatabaseBase.
         :type data_storage_size_in_tbs: int
 
+        :param is_free_tier:
+            The value to assign to the is_free_tier property of this CreateAutonomousDatabaseBase.
+        :type is_free_tier: bool
+
         :param admin_password:
             The value to assign to the admin_password property of this CreateAutonomousDatabaseBase.
         :type admin_password: str
@@ -118,6 +122,7 @@ class CreateAutonomousDatabaseBase(object):
             'cpu_core_count': 'int',
             'db_workload': 'str',
             'data_storage_size_in_tbs': 'int',
+            'is_free_tier': 'bool',
             'admin_password': 'str',
             'display_name': 'str',
             'license_model': 'str',
@@ -136,6 +141,7 @@ class CreateAutonomousDatabaseBase(object):
             'cpu_core_count': 'cpuCoreCount',
             'db_workload': 'dbWorkload',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
+            'is_free_tier': 'isFreeTier',
             'admin_password': 'adminPassword',
             'display_name': 'displayName',
             'license_model': 'licenseModel',
@@ -153,6 +159,7 @@ class CreateAutonomousDatabaseBase(object):
         self._cpu_core_count = None
         self._db_workload = None
         self._data_storage_size_in_tbs = None
+        self._is_free_tier = None
         self._admin_password = None
         self._display_name = None
         self._license_model = None
@@ -313,6 +320,30 @@ class CreateAutonomousDatabaseBase(object):
         self._data_storage_size_in_tbs = data_storage_size_in_tbs
 
     @property
+    def is_free_tier(self):
+        """
+        Gets the is_free_tier of this CreateAutonomousDatabaseBase.
+        Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+
+
+        :return: The is_free_tier of this CreateAutonomousDatabaseBase.
+        :rtype: bool
+        """
+        return self._is_free_tier
+
+    @is_free_tier.setter
+    def is_free_tier(self, is_free_tier):
+        """
+        Sets the is_free_tier of this CreateAutonomousDatabaseBase.
+        Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+
+
+        :param is_free_tier: The is_free_tier of this CreateAutonomousDatabaseBase.
+        :type: bool
+        """
+        self._is_free_tier = is_free_tier
+
+    @property
     def admin_password(self):
         """
         **[Required]** Gets the admin_password of this CreateAutonomousDatabaseBase.
@@ -364,7 +395,7 @@ class CreateAutonomousDatabaseBase(object):
     def license_model(self):
         """
         Gets the license_model of this CreateAutonomousDatabaseBase.
-        The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the `dedicated deployment`__ option, this attribute must be null.
+        The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the `shared deployment] is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the [dedicated deployment`__ option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 
@@ -380,7 +411,7 @@ class CreateAutonomousDatabaseBase(object):
     def license_model(self, license_model):
         """
         Sets the license_model of this CreateAutonomousDatabaseBase.
-        The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the `dedicated deployment`__ option, this attribute must be null.
+        The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the `shared deployment] is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the [dedicated deployment`__ option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 
@@ -549,8 +580,6 @@ class CreateAutonomousDatabaseBase(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -565,8 +594,6 @@ class CreateAutonomousDatabaseBase(object):
         Sets the defined_tags of this CreateAutonomousDatabaseBase.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/create_autonomous_database_clone_details.py
+++ b/src/oci/database/models/create_autonomous_database_clone_details.py
@@ -47,6 +47,10 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             The value to assign to the data_storage_size_in_tbs property of this CreateAutonomousDatabaseCloneDetails.
         :type data_storage_size_in_tbs: int
 
+        :param is_free_tier:
+            The value to assign to the is_free_tier property of this CreateAutonomousDatabaseCloneDetails.
+        :type is_free_tier: bool
+
         :param admin_password:
             The value to assign to the admin_password property of this CreateAutonomousDatabaseCloneDetails.
         :type admin_password: str
@@ -105,6 +109,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'cpu_core_count': 'int',
             'db_workload': 'str',
             'data_storage_size_in_tbs': 'int',
+            'is_free_tier': 'bool',
             'admin_password': 'str',
             'display_name': 'str',
             'license_model': 'str',
@@ -125,6 +130,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'cpu_core_count': 'cpuCoreCount',
             'db_workload': 'dbWorkload',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
+            'is_free_tier': 'isFreeTier',
             'admin_password': 'adminPassword',
             'display_name': 'displayName',
             'license_model': 'licenseModel',
@@ -144,6 +150,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
         self._cpu_core_count = None
         self._db_workload = None
         self._data_storage_size_in_tbs = None
+        self._is_free_tier = None
         self._admin_password = None
         self._display_name = None
         self._license_model = None

--- a/src/oci/database/models/create_autonomous_database_details.py
+++ b/src/oci/database/models/create_autonomous_database_details.py
@@ -39,6 +39,10 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             The value to assign to the data_storage_size_in_tbs property of this CreateAutonomousDatabaseDetails.
         :type data_storage_size_in_tbs: int
 
+        :param is_free_tier:
+            The value to assign to the is_free_tier property of this CreateAutonomousDatabaseDetails.
+        :type is_free_tier: bool
+
         :param admin_password:
             The value to assign to the admin_password property of this CreateAutonomousDatabaseDetails.
         :type admin_password: str
@@ -88,6 +92,7 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'cpu_core_count': 'int',
             'db_workload': 'str',
             'data_storage_size_in_tbs': 'int',
+            'is_free_tier': 'bool',
             'admin_password': 'str',
             'display_name': 'str',
             'license_model': 'str',
@@ -106,6 +111,7 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'cpu_core_count': 'cpuCoreCount',
             'db_workload': 'dbWorkload',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
+            'is_free_tier': 'isFreeTier',
             'admin_password': 'adminPassword',
             'display_name': 'displayName',
             'license_model': 'licenseModel',
@@ -123,6 +129,7 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
         self._cpu_core_count = None
         self._db_workload = None
         self._data_storage_size_in_tbs = None
+        self._is_free_tier = None
         self._admin_password = None
         self._display_name = None
         self._license_model = None

--- a/src/oci/database/models/create_database_details.py
+++ b/src/oci/database/models/create_database_details.py
@@ -318,8 +318,6 @@ class CreateDatabaseDetails(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -334,8 +332,6 @@ class CreateDatabaseDetails(object):
         Sets the defined_tags of this CreateDatabaseDetails.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/create_db_home_with_db_system_id_base.py
+++ b/src/oci/database/models/create_db_home_with_db_system_id_base.py
@@ -81,7 +81,7 @@ class CreateDbHomeWithDbSystemIdBase(object):
     @property
     def db_system_id(self):
         """
-        Gets the db_system_id of this CreateDbHomeWithDbSystemIdBase.
+        **[Required]** Gets the db_system_id of this CreateDbHomeWithDbSystemIdBase.
         The `OCID`__ of the DB system.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm

--- a/src/oci/database/models/database.py
+++ b/src/oci/database/models/database.py
@@ -538,8 +538,6 @@ class Database(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -554,8 +552,6 @@ class Database(object):
         Sets the defined_tags of this Database.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/database_summary.py
+++ b/src/oci/database/models/database_summary.py
@@ -545,8 +545,6 @@ class DatabaseSummary(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -561,8 +559,6 @@ class DatabaseSummary(object):
         Sets the defined_tags of this DatabaseSummary.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/db_backup_config.py
+++ b/src/oci/database/models/db_backup_config.py
@@ -15,6 +15,54 @@ class DbBackupConfig(object):
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """
 
+    #: A constant which can be used with the auto_backup_window property of a DbBackupConfig.
+    #: This constant has a value of "SLOT_ONE"
+    AUTO_BACKUP_WINDOW_SLOT_ONE = "SLOT_ONE"
+
+    #: A constant which can be used with the auto_backup_window property of a DbBackupConfig.
+    #: This constant has a value of "SLOT_TWO"
+    AUTO_BACKUP_WINDOW_SLOT_TWO = "SLOT_TWO"
+
+    #: A constant which can be used with the auto_backup_window property of a DbBackupConfig.
+    #: This constant has a value of "SLOT_THREE"
+    AUTO_BACKUP_WINDOW_SLOT_THREE = "SLOT_THREE"
+
+    #: A constant which can be used with the auto_backup_window property of a DbBackupConfig.
+    #: This constant has a value of "SLOT_FOUR"
+    AUTO_BACKUP_WINDOW_SLOT_FOUR = "SLOT_FOUR"
+
+    #: A constant which can be used with the auto_backup_window property of a DbBackupConfig.
+    #: This constant has a value of "SLOT_FIVE"
+    AUTO_BACKUP_WINDOW_SLOT_FIVE = "SLOT_FIVE"
+
+    #: A constant which can be used with the auto_backup_window property of a DbBackupConfig.
+    #: This constant has a value of "SLOT_SIX"
+    AUTO_BACKUP_WINDOW_SLOT_SIX = "SLOT_SIX"
+
+    #: A constant which can be used with the auto_backup_window property of a DbBackupConfig.
+    #: This constant has a value of "SLOT_SEVEN"
+    AUTO_BACKUP_WINDOW_SLOT_SEVEN = "SLOT_SEVEN"
+
+    #: A constant which can be used with the auto_backup_window property of a DbBackupConfig.
+    #: This constant has a value of "SLOT_EIGHT"
+    AUTO_BACKUP_WINDOW_SLOT_EIGHT = "SLOT_EIGHT"
+
+    #: A constant which can be used with the auto_backup_window property of a DbBackupConfig.
+    #: This constant has a value of "SLOT_NINE"
+    AUTO_BACKUP_WINDOW_SLOT_NINE = "SLOT_NINE"
+
+    #: A constant which can be used with the auto_backup_window property of a DbBackupConfig.
+    #: This constant has a value of "SLOT_TEN"
+    AUTO_BACKUP_WINDOW_SLOT_TEN = "SLOT_TEN"
+
+    #: A constant which can be used with the auto_backup_window property of a DbBackupConfig.
+    #: This constant has a value of "SLOT_ELEVEN"
+    AUTO_BACKUP_WINDOW_SLOT_ELEVEN = "SLOT_ELEVEN"
+
+    #: A constant which can be used with the auto_backup_window property of a DbBackupConfig.
+    #: This constant has a value of "SLOT_TWELVE"
+    AUTO_BACKUP_WINDOW_SLOT_TWELVE = "SLOT_TWELVE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new DbBackupConfig object with values from keyword arguments.
@@ -28,19 +76,28 @@ class DbBackupConfig(object):
             The value to assign to the recovery_window_in_days property of this DbBackupConfig.
         :type recovery_window_in_days: int
 
+        :param auto_backup_window:
+            The value to assign to the auto_backup_window property of this DbBackupConfig.
+            Allowed values for this property are: "SLOT_ONE", "SLOT_TWO", "SLOT_THREE", "SLOT_FOUR", "SLOT_FIVE", "SLOT_SIX", "SLOT_SEVEN", "SLOT_EIGHT", "SLOT_NINE", "SLOT_TEN", "SLOT_ELEVEN", "SLOT_TWELVE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type auto_backup_window: str
+
         """
         self.swagger_types = {
             'auto_backup_enabled': 'bool',
-            'recovery_window_in_days': 'int'
+            'recovery_window_in_days': 'int',
+            'auto_backup_window': 'str'
         }
 
         self.attribute_map = {
             'auto_backup_enabled': 'autoBackupEnabled',
-            'recovery_window_in_days': 'recoveryWindowInDays'
+            'recovery_window_in_days': 'recoveryWindowInDays',
+            'auto_backup_window': 'autoBackupWindow'
         }
 
         self._auto_backup_enabled = None
         self._recovery_window_in_days = None
+        self._auto_backup_window = None
 
     @property
     def auto_backup_enabled(self):
@@ -93,6 +150,40 @@ class DbBackupConfig(object):
         :type: int
         """
         self._recovery_window_in_days = recovery_window_in_days
+
+    @property
+    def auto_backup_window(self):
+        """
+        Gets the auto_backup_window of this DbBackupConfig.
+        Time window selected for initiating automatic backup for the database system. There are twelve available two-hour time windows. If no option is selected, a start time between 12:00 AM to 7:00 AM in the region of the database is automatically chosen. For example, if the user selects SLOT_TWO from the enum list, the automatic backup job will start in between 2:00 AM (inclusive) to 4:00 AM (exclusive).
+
+        Example: `SLOT_TWO`
+
+        Allowed values for this property are: "SLOT_ONE", "SLOT_TWO", "SLOT_THREE", "SLOT_FOUR", "SLOT_FIVE", "SLOT_SIX", "SLOT_SEVEN", "SLOT_EIGHT", "SLOT_NINE", "SLOT_TEN", "SLOT_ELEVEN", "SLOT_TWELVE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The auto_backup_window of this DbBackupConfig.
+        :rtype: str
+        """
+        return self._auto_backup_window
+
+    @auto_backup_window.setter
+    def auto_backup_window(self, auto_backup_window):
+        """
+        Sets the auto_backup_window of this DbBackupConfig.
+        Time window selected for initiating automatic backup for the database system. There are twelve available two-hour time windows. If no option is selected, a start time between 12:00 AM to 7:00 AM in the region of the database is automatically chosen. For example, if the user selects SLOT_TWO from the enum list, the automatic backup job will start in between 2:00 AM (inclusive) to 4:00 AM (exclusive).
+
+        Example: `SLOT_TWO`
+
+
+        :param auto_backup_window: The auto_backup_window of this DbBackupConfig.
+        :type: str
+        """
+        allowed_values = ["SLOT_ONE", "SLOT_TWO", "SLOT_THREE", "SLOT_FOUR", "SLOT_FIVE", "SLOT_SIX", "SLOT_SEVEN", "SLOT_EIGHT", "SLOT_NINE", "SLOT_TEN", "SLOT_ELEVEN", "SLOT_TWELVE"]
+        if not value_allowed_none_or_none_sentinel(auto_backup_window, allowed_values):
+            auto_backup_window = 'UNKNOWN_ENUM_VALUE'
+        self._auto_backup_window = auto_backup_window
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/db_system.py
+++ b/src/oci/database/models/db_system.py
@@ -1312,8 +1312,6 @@ class DbSystem(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -1328,8 +1326,6 @@ class DbSystem(object):
         Sets the defined_tags of this DbSystem.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/db_system_summary.py
+++ b/src/oci/database/models/db_system_summary.py
@@ -1307,8 +1307,6 @@ class DbSystemSummary(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -1323,8 +1321,6 @@ class DbSystemSummary(object):
         Sets the defined_tags of this DbSystemSummary.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/launch_autonomous_exadata_infrastructure_details.py
+++ b/src/oci/database/models/launch_autonomous_exadata_infrastructure_details.py
@@ -41,6 +41,10 @@ class LaunchAutonomousExadataInfrastructureDetails(object):
             The value to assign to the subnet_id property of this LaunchAutonomousExadataInfrastructureDetails.
         :type subnet_id: str
 
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this LaunchAutonomousExadataInfrastructureDetails.
+        :type nsg_ids: list[str]
+
         :param shape:
             The value to assign to the shape property of this LaunchAutonomousExadataInfrastructureDetails.
         :type shape: str
@@ -72,6 +76,7 @@ class LaunchAutonomousExadataInfrastructureDetails(object):
             'display_name': 'str',
             'availability_domain': 'str',
             'subnet_id': 'str',
+            'nsg_ids': 'list[str]',
             'shape': 'str',
             'domain': 'str',
             'license_model': 'str',
@@ -85,6 +90,7 @@ class LaunchAutonomousExadataInfrastructureDetails(object):
             'display_name': 'displayName',
             'availability_domain': 'availabilityDomain',
             'subnet_id': 'subnetId',
+            'nsg_ids': 'nsgIds',
             'shape': 'shape',
             'domain': 'domain',
             'license_model': 'licenseModel',
@@ -97,6 +103,7 @@ class LaunchAutonomousExadataInfrastructureDetails(object):
         self._display_name = None
         self._availability_domain = None
         self._subnet_id = None
+        self._nsg_ids = None
         self._shape = None
         self._domain = None
         self._license_model = None
@@ -221,6 +228,36 @@ class LaunchAutonomousExadataInfrastructureDetails(object):
         :type: str
         """
         self._subnet_id = subnet_id
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this LaunchAutonomousExadataInfrastructureDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :return: The nsg_ids of this LaunchAutonomousExadataInfrastructureDetails.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this LaunchAutonomousExadataInfrastructureDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :param nsg_ids: The nsg_ids of this LaunchAutonomousExadataInfrastructureDetails.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
 
     @property
     def shape(self):
@@ -367,8 +404,6 @@ class LaunchAutonomousExadataInfrastructureDetails(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -383,8 +418,6 @@ class LaunchAutonomousExadataInfrastructureDetails(object):
         Sets the defined_tags of this LaunchAutonomousExadataInfrastructureDetails.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/launch_db_system_base.py
+++ b/src/oci/database/models/launch_db_system_base.py
@@ -846,8 +846,6 @@ class LaunchDbSystemBase(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -862,8 +860,6 @@ class LaunchDbSystemBase(object):
         Sets the defined_tags of this LaunchDbSystemBase.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/update_autonomous_container_database_details.py
+++ b/src/oci/database/models/update_autonomous_container_database_details.py
@@ -166,8 +166,6 @@ class UpdateAutonomousContainerDatabaseDetails(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -182,8 +180,6 @@ class UpdateAutonomousContainerDatabaseDetails(object):
         Sets the defined_tags of this UpdateAutonomousContainerDatabaseDetails.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/update_autonomous_data_warehouse_details.py
+++ b/src/oci/database/models/update_autonomous_data_warehouse_details.py
@@ -206,8 +206,6 @@ class UpdateAutonomousDataWarehouseDetails(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -222,8 +220,6 @@ class UpdateAutonomousDataWarehouseDetails(object):
         Sets the defined_tags of this UpdateAutonomousDataWarehouseDetails.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/update_autonomous_database_details.py
+++ b/src/oci/database/models/update_autonomous_database_details.py
@@ -39,6 +39,10 @@ class UpdateAutonomousDatabaseDetails(object):
             The value to assign to the display_name property of this UpdateAutonomousDatabaseDetails.
         :type display_name: str
 
+        :param is_free_tier:
+            The value to assign to the is_free_tier property of this UpdateAutonomousDatabaseDetails.
+        :type is_free_tier: bool
+
         :param admin_password:
             The value to assign to the admin_password property of this UpdateAutonomousDatabaseDetails.
         :type admin_password: str
@@ -73,6 +77,7 @@ class UpdateAutonomousDatabaseDetails(object):
             'cpu_core_count': 'int',
             'data_storage_size_in_tbs': 'int',
             'display_name': 'str',
+            'is_free_tier': 'bool',
             'admin_password': 'str',
             'db_name': 'str',
             'freeform_tags': 'dict(str, str)',
@@ -86,6 +91,7 @@ class UpdateAutonomousDatabaseDetails(object):
             'cpu_core_count': 'cpuCoreCount',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'display_name': 'displayName',
+            'is_free_tier': 'isFreeTier',
             'admin_password': 'adminPassword',
             'db_name': 'dbName',
             'freeform_tags': 'freeformTags',
@@ -98,6 +104,7 @@ class UpdateAutonomousDatabaseDetails(object):
         self._cpu_core_count = None
         self._data_storage_size_in_tbs = None
         self._display_name = None
+        self._is_free_tier = None
         self._admin_password = None
         self._db_name = None
         self._freeform_tags = None
@@ -177,6 +184,30 @@ class UpdateAutonomousDatabaseDetails(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def is_free_tier(self):
+        """
+        Gets the is_free_tier of this UpdateAutonomousDatabaseDetails.
+        Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+
+
+        :return: The is_free_tier of this UpdateAutonomousDatabaseDetails.
+        :rtype: bool
+        """
+        return self._is_free_tier
+
+    @is_free_tier.setter
+    def is_free_tier(self, is_free_tier):
+        """
+        Sets the is_free_tier of this UpdateAutonomousDatabaseDetails.
+        Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+
+
+        :param is_free_tier: The is_free_tier of this UpdateAutonomousDatabaseDetails.
+        :type: bool
+        """
+        self._is_free_tier = is_free_tier
 
     @property
     def admin_password(self):
@@ -271,8 +302,6 @@ class UpdateAutonomousDatabaseDetails(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -288,8 +317,6 @@ class UpdateAutonomousDatabaseDetails(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -302,7 +329,7 @@ class UpdateAutonomousDatabaseDetails(object):
     def license_model(self):
         """
         Gets the license_model of this UpdateAutonomousDatabaseDetails.
-        The new Oracle license model that applies to the Oracle Autonomous Transaction Processing database. Note that when updating an Autonomous Database that uses the `dedicated deployment`__ option, this attribute must be null.
+        The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the `shared deployment] is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the [dedicated deployment`__ option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 
@@ -318,7 +345,7 @@ class UpdateAutonomousDatabaseDetails(object):
     def license_model(self, license_model):
         """
         Sets the license_model of this UpdateAutonomousDatabaseDetails.
-        The new Oracle license model that applies to the Oracle Autonomous Transaction Processing database. Note that when updating an Autonomous Database that uses the `dedicated deployment`__ option, this attribute must be null.
+        The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the `shared deployment] is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the [dedicated deployment`__ option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 

--- a/src/oci/database/models/update_autonomous_exadata_infrastructure_details.py
+++ b/src/oci/database/models/update_autonomous_exadata_infrastructure_details.py
@@ -25,6 +25,10 @@ class UpdateAutonomousExadataInfrastructureDetails(object):
             The value to assign to the maintenance_window_details property of this UpdateAutonomousExadataInfrastructureDetails.
         :type maintenance_window_details: MaintenanceWindow
 
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this UpdateAutonomousExadataInfrastructureDetails.
+        :type nsg_ids: list[str]
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this UpdateAutonomousExadataInfrastructureDetails.
         :type freeform_tags: dict(str, str)
@@ -37,6 +41,7 @@ class UpdateAutonomousExadataInfrastructureDetails(object):
         self.swagger_types = {
             'display_name': 'str',
             'maintenance_window_details': 'MaintenanceWindow',
+            'nsg_ids': 'list[str]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -44,12 +49,14 @@ class UpdateAutonomousExadataInfrastructureDetails(object):
         self.attribute_map = {
             'display_name': 'displayName',
             'maintenance_window_details': 'maintenanceWindowDetails',
+            'nsg_ids': 'nsgIds',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
 
         self._display_name = None
         self._maintenance_window_details = None
+        self._nsg_ids = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -98,6 +105,36 @@ class UpdateAutonomousExadataInfrastructureDetails(object):
         self._maintenance_window_details = maintenance_window_details
 
     @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this UpdateAutonomousExadataInfrastructureDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :return: The nsg_ids of this UpdateAutonomousExadataInfrastructureDetails.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this UpdateAutonomousExadataInfrastructureDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :param nsg_ids: The nsg_ids of this UpdateAutonomousExadataInfrastructureDetails.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
+
+    @property
     def freeform_tags(self):
         """
         Gets the freeform_tags of this UpdateAutonomousExadataInfrastructureDetails.
@@ -138,8 +175,6 @@ class UpdateAutonomousExadataInfrastructureDetails(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -154,8 +189,6 @@ class UpdateAutonomousExadataInfrastructureDetails(object):
         Sets the defined_tags of this UpdateAutonomousExadataInfrastructureDetails.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/update_database_details.py
+++ b/src/oci/database/models/update_database_details.py
@@ -109,8 +109,6 @@ class UpdateDatabaseDetails(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -125,8 +123,6 @@ class UpdateDatabaseDetails(object):
         Sets the defined_tags of this UpdateDatabaseDetails.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/database/models/update_db_system_details.py
+++ b/src/oci/database/models/update_db_system_details.py
@@ -216,8 +216,6 @@ class UpdateDbSystemDetails(object):
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
 
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
-
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 
 
@@ -232,8 +230,6 @@ class UpdateDbSystemDetails(object):
         Sets the defined_tags of this UpdateDbSystemDetails.
         Defined tags for this resource. Each key is predefined and scoped to a namespace.
         For more information, see `Resource Tags`__.
-
-        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/load_balancer/load_balancer_client.py
+++ b/src/oci/load_balancer/load_balancer_client.py
@@ -4203,14 +4203,14 @@ class LoadBalancerClient(object):
     def update_network_security_groups(self, update_network_security_groups_details, load_balancer_id, **kwargs):
         """
         UpdateNetworkSecurityGroups
-        Updates the network security groups to be used by a load balancer.
+        Updates the network security groups associated with the specified load balancer.
 
 
         :param UpdateNetworkSecurityGroupsDetails update_network_security_groups_details: (required)
-            The details for updating the NSGs of the load balancer.
+            The details for updating the NSGs associated with the specified load balancer.
 
         :param str load_balancer_id: (required)
-            The `OCID`__ of the load balancer on which update the NSGs.
+            The `OCID`__ of the load balancer to update the NSGs for.
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 

--- a/src/oci/load_balancer/load_balancer_client_composite_operations.py
+++ b/src/oci/load_balancer/load_balancer_client_composite_operations.py
@@ -1129,10 +1129,10 @@ class LoadBalancerClientCompositeOperations(object):
         to enter the given state(s).
 
         :param UpdateNetworkSecurityGroupsDetails update_network_security_groups_details: (required)
-            The details for updating the NSGs of the load balancer.
+            The details for updating the NSGs associated with the specified load balancer.
 
         :param str load_balancer_id: (required)
-            The `OCID`__ of the load balancer on which update the NSGs.
+            The `OCID`__ of the load balancer to update the NSGs for.
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 

--- a/src/oci/load_balancer/models/backend.py
+++ b/src/oci/load_balancer/models/backend.py
@@ -238,6 +238,8 @@ class Backend(object):
         Whether the load balancer should treat this server as a backup unit. If `true`, the load balancer forwards no ingress
         traffic to this backend server unless all other backend servers not marked as \"backup\" fail the health check policy.
 
+        **Note:** You cannot add a backend server marked as `backup` to a backend set that uses the IP Hash policy.
+
         Example: `false`
 
 
@@ -252,6 +254,8 @@ class Backend(object):
         Sets the backup of this Backend.
         Whether the load balancer should treat this server as a backup unit. If `true`, the load balancer forwards no ingress
         traffic to this backend server unless all other backend servers not marked as \"backup\" fail the health check policy.
+
+        **Note:** You cannot add a backend server marked as `backup` to a backend set that uses the IP Hash policy.
 
         Example: `false`
 

--- a/src/oci/load_balancer/models/backend_details.py
+++ b/src/oci/load_balancer/models/backend_details.py
@@ -170,6 +170,8 @@ class BackendDetails(object):
         Whether the load balancer should treat this server as a backup unit. If `true`, the load balancer forwards no ingress
         traffic to this backend server unless all other backend servers not marked as \"backup\" fail the health check policy.
 
+        **Note:** You cannot add a backend server marked as `backup` to a backend set that uses the IP Hash policy.
+
         Example: `false`
 
 
@@ -184,6 +186,8 @@ class BackendDetails(object):
         Sets the backup of this BackendDetails.
         Whether the load balancer should treat this server as a backup unit. If `true`, the load balancer forwards no ingress
         traffic to this backend server unless all other backend servers not marked as \"backup\" fail the health check policy.
+
+        **Note:** You cannot add a backend server marked as `backup` to a backend set that uses the IP Hash policy.
 
         Example: `false`
 

--- a/src/oci/load_balancer/models/create_backend_details.py
+++ b/src/oci/load_balancer/models/create_backend_details.py
@@ -174,6 +174,8 @@ class CreateBackendDetails(object):
         Whether the load balancer should treat this server as a backup unit. If `true`, the load balancer forwards no ingress
         traffic to this backend server unless all other backend servers not marked as \"backup\" fail the health check policy.
 
+        **Note:** You cannot add a backend server marked as `backup` to a backend set that uses the IP Hash policy.
+
         Example: `false`
 
 
@@ -188,6 +190,8 @@ class CreateBackendDetails(object):
         Sets the backup of this CreateBackendDetails.
         Whether the load balancer should treat this server as a backup unit. If `true`, the load balancer forwards no ingress
         traffic to this backend server unless all other backend servers not marked as \"backup\" fail the health check policy.
+
+        **Note:** You cannot add a backend server marked as `backup` to a backend set that uses the IP Hash policy.
 
         Example: `false`
 

--- a/src/oci/load_balancer/models/create_load_balancer_details.py
+++ b/src/oci/load_balancer/models/create_load_balancer_details.py
@@ -389,7 +389,18 @@ class CreateLoadBalancerDetails(object):
     def network_security_group_ids(self):
         """
         Gets the network_security_group_ids of this CreateLoadBalancerDetails.
-        The array of NSG `OCIDs`__ to be used by this Load Balancer.
+        An array of NSG `OCIDs`__ associated with this load balancer.
+
+        During the load balancer's creation, the service adds the new load balancer to the specified NSGs.
+
+        The benefits of using NSGs with the load balancer include:
+
+        *  NSGs define network security rules to govern ingress and egress traffic for the load balancer.
+
+        *  The network security rules of other resources can reference the NSGs associated with the load balancer
+           to ensure access.
+
+        Example: `[\"ocid1.nsg.oc1.phx.unique_ID\"]`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -403,7 +414,18 @@ class CreateLoadBalancerDetails(object):
     def network_security_group_ids(self, network_security_group_ids):
         """
         Sets the network_security_group_ids of this CreateLoadBalancerDetails.
-        The array of NSG `OCIDs`__ to be used by this Load Balancer.
+        An array of NSG `OCIDs`__ associated with this load balancer.
+
+        During the load balancer's creation, the service adds the new load balancer to the specified NSGs.
+
+        The benefits of using NSGs with the load balancer include:
+
+        *  NSGs define network security rules to govern ingress and egress traffic for the load balancer.
+
+        *  The network security rules of other resources can reference the NSGs associated with the load balancer
+           to ensure access.
+
+        Example: `[\"ocid1.nsg.oc1.phx.unique_ID\"]`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 

--- a/src/oci/load_balancer/models/health_checker.py
+++ b/src/oci/load_balancer/models/health_checker.py
@@ -204,7 +204,8 @@ class HealthChecker(object):
     def retries(self):
         """
         Gets the retries of this HealthChecker.
-        The number of retries to attempt before a backend server is considered \"unhealthy\". Defaults to 3.
+        The number of retries to attempt before a backend server is considered \"unhealthy\". This number also applies
+        when recovering a server to the \"healthy\" state. Defaults to 3.
 
         Example: `3`
 
@@ -218,7 +219,8 @@ class HealthChecker(object):
     def retries(self, retries):
         """
         Sets the retries of this HealthChecker.
-        The number of retries to attempt before a backend server is considered \"unhealthy\". Defaults to 3.
+        The number of retries to attempt before a backend server is considered \"unhealthy\". This number also applies
+        when recovering a server to the \"healthy\" state. Defaults to 3.
 
         Example: `3`
 

--- a/src/oci/load_balancer/models/health_checker_details.py
+++ b/src/oci/load_balancer/models/health_checker_details.py
@@ -199,7 +199,8 @@ class HealthCheckerDetails(object):
     def retries(self):
         """
         Gets the retries of this HealthCheckerDetails.
-        The number of retries to attempt before a backend server is considered \"unhealthy\".
+        The number of retries to attempt before a backend server is considered \"unhealthy\". This number also applies
+        when recovering a server to the \"healthy\" state.
 
         Example: `3`
 
@@ -213,7 +214,8 @@ class HealthCheckerDetails(object):
     def retries(self, retries):
         """
         Sets the retries of this HealthCheckerDetails.
-        The number of retries to attempt before a backend server is considered \"unhealthy\".
+        The number of retries to attempt before a backend server is considered \"unhealthy\". This number also applies
+        when recovering a server to the \"healthy\" state.
 
         Example: `3`
 

--- a/src/oci/load_balancer/models/lb_cookie_session_persistence_configuration_details.py
+++ b/src/oci/load_balancer/models/lb_cookie_session_persistence_configuration_details.py
@@ -19,7 +19,7 @@ class LBCookieSessionPersistenceConfigurationDetails(object):
     in the cookie enable session stickiness. This method is useful when you have applications and Web backend services
     that cannot generate their own cookies.
 
-    Path route rules take precedence to determine the target backend server. The load balancer verfies that session stickiness
+    Path route rules take precedence to determine the target backend server. The load balancer verifies that session stickiness
     is enabled for the backend server and that the cookie configuration (domain, path, and cookie hash) is valid for the
     target. The system ignores invalid cookies.
 
@@ -203,7 +203,7 @@ class LBCookieSessionPersistenceConfigurationDetails(object):
            If the value of the `Domain` attribute is `example.com` in the `Set-cookie` header, the client includes
            the same cookie in the `Cookie` header when making HTTP requests to `example.com`, `www.example.com`, and
            `www.abc.example.com`. If the `Domain` attribute is not present, the client returns the cookie only for
-           the domain to which the origianl request was made.
+           the domain to which the original request was made.
 
         *  Ensure that this attribute specifies the correct domain value. If the `Domain` attribute in the `Set-cookie`
            header does not include the domain to which the original request was made, the client or browser might reject
@@ -239,7 +239,7 @@ class LBCookieSessionPersistenceConfigurationDetails(object):
            If the value of the `Domain` attribute is `example.com` in the `Set-cookie` header, the client includes
            the same cookie in the `Cookie` header when making HTTP requests to `example.com`, `www.example.com`, and
            `www.abc.example.com`. If the `Domain` attribute is not present, the client returns the cookie only for
-           the domain to which the origianl request was made.
+           the domain to which the original request was made.
 
         *  Ensure that this attribute specifies the correct domain value. If the `Domain` attribute in the `Set-cookie`
            header does not include the domain to which the original request was made, the client or browser might reject

--- a/src/oci/load_balancer/models/load_balancer.py
+++ b/src/oci/load_balancer/models/load_balancer.py
@@ -121,6 +121,10 @@ class LoadBalancer(object):
             The value to assign to the defined_tags property of this LoadBalancer.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param system_tags:
+            The value to assign to the system_tags property of this LoadBalancer.
+        :type system_tags: dict(str, dict(str, object))
+
         :param rule_sets:
             The value to assign to the rule_sets property of this LoadBalancer.
         :type rule_sets: dict(str, RuleSet)
@@ -144,6 +148,7 @@ class LoadBalancer(object):
             'path_route_sets': 'dict(str, PathRouteSet)',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
+            'system_tags': 'dict(str, dict(str, object))',
             'rule_sets': 'dict(str, RuleSet)'
         }
 
@@ -165,6 +170,7 @@ class LoadBalancer(object):
             'path_route_sets': 'pathRouteSets',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
+            'system_tags': 'systemTags',
             'rule_sets': 'ruleSets'
         }
 
@@ -185,6 +191,7 @@ class LoadBalancer(object):
         self._path_route_sets = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._system_tags = None
         self._rule_sets = None
 
     @property
@@ -467,7 +474,19 @@ class LoadBalancer(object):
     def network_security_group_ids(self):
         """
         Gets the network_security_group_ids of this LoadBalancer.
-        The array of NSG `OCIDs`__ in use by this Load Balancer.
+        An array of NSG `OCIDs`__ associated with the load
+        balancer.
+
+        During the load balancer's creation, the service adds the new load balancer to the specified NSGs.
+
+        The benefits of associating the load balancer with NSGs include:
+
+        *  NSGs define network security rules to govern ingress and egress traffic for the load balancer.
+
+        *  The network security rules of other resources can reference the NSGs associated with the load balancer
+           to ensure access.
+
+        Example: [\"ocid1.nsg.oc1.phx.unique_ID\"]
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -481,7 +500,19 @@ class LoadBalancer(object):
     def network_security_group_ids(self, network_security_group_ids):
         """
         Sets the network_security_group_ids of this LoadBalancer.
-        The array of NSG `OCIDs`__ in use by this Load Balancer.
+        An array of NSG `OCIDs`__ associated with the load
+        balancer.
+
+        During the load balancer's creation, the service adds the new load balancer to the specified NSGs.
+
+        The benefits of associating the load balancer with NSGs include:
+
+        *  NSGs define network security rules to govern ingress and egress traffic for the load balancer.
+
+        *  The network security rules of other resources can reference the NSGs associated with the load balancer
+           to ensure access.
+
+        Example: [\"ocid1.nsg.oc1.phx.unique_ID\"]
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -658,6 +689,42 @@ class LoadBalancer(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def system_tags(self):
+        """
+        Gets the system_tags of this LoadBalancer.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        System tags can be viewed by users, but can only be created by the system.
+
+        Example: `{\"orcl-cloud\": {\"free-tier-retained\": \"true\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The system_tags of this LoadBalancer.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._system_tags
+
+    @system_tags.setter
+    def system_tags(self, system_tags):
+        """
+        Sets the system_tags of this LoadBalancer.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        System tags can be viewed by users, but can only be created by the system.
+
+        Example: `{\"orcl-cloud\": {\"free-tier-retained\": \"true\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param system_tags: The system_tags of this LoadBalancer.
+        :type: dict(str, dict(str, object))
+        """
+        self._system_tags = system_tags
 
     @property
     def rule_sets(self):

--- a/src/oci/load_balancer/models/update_backend_details.py
+++ b/src/oci/load_balancer/models/update_backend_details.py
@@ -100,6 +100,8 @@ class UpdateBackendDetails(object):
         Whether the load balancer should treat this server as a backup unit. If `true`, the load balancer forwards no ingress
         traffic to this backend server unless all other backend servers not marked as \"backup\" fail the health check policy.
 
+        **Note:** You cannot add a backend server marked as `backup` to a backend set that uses the IP Hash policy.
+
         Example: `false`
 
 
@@ -114,6 +116,8 @@ class UpdateBackendDetails(object):
         Sets the backup of this UpdateBackendDetails.
         Whether the load balancer should treat this server as a backup unit. If `true`, the load balancer forwards no ingress
         traffic to this backend server unless all other backend servers not marked as \"backup\" fail the health check policy.
+
+        **Note:** You cannot add a backend server marked as `backup` to a backend set that uses the IP Hash policy.
 
         Example: `false`
 

--- a/src/oci/load_balancer/models/update_health_checker_details.py
+++ b/src/oci/load_balancer/models/update_health_checker_details.py
@@ -197,7 +197,8 @@ class UpdateHealthCheckerDetails(object):
     def retries(self):
         """
         **[Required]** Gets the retries of this UpdateHealthCheckerDetails.
-        The number of retries to attempt before a backend server is considered \"unhealthy\".
+        The number of retries to attempt before a backend server is considered \"unhealthy\". This number also applies
+        when recovering a server to the \"healthy\" state.
 
         Example: `3`
 
@@ -211,7 +212,8 @@ class UpdateHealthCheckerDetails(object):
     def retries(self, retries):
         """
         Sets the retries of this UpdateHealthCheckerDetails.
-        The number of retries to attempt before a backend server is considered \"unhealthy\".
+        The number of retries to attempt before a backend server is considered \"unhealthy\". This number also applies
+        when recovering a server to the \"healthy\" state.
 
         Example: `3`
 

--- a/src/oci/load_balancer/models/update_network_security_groups_details.py
+++ b/src/oci/load_balancer/models/update_network_security_groups_details.py
@@ -9,7 +9,10 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateNetworkSecurityGroupsDetails(object):
     """
-    An object representing an updated list of NSGs that overwrites the existing list of NSGs. In particular, if the load balancer had no prior NSGs configured, these with be the new NSGs to be used by the load balancer. If the load balancer used to have a list of NSGs configured, and this list contains no entries, then the load balancer will contain no NSGs after this call completes.
+    An object representing an updated list of network security groups (NSGs) that overwrites the existing list of NSGs.
+    *  If the load balancer has no NSGs configured, it uses the NSGs in this list.
+    *  If the load balancer has a list of NSGs configured, this list replaces the existing list.
+    *  If the load balancer has a list of NSGs configured and this list is empty, the operation removes all of the load balancer's NSG associations.
     """
 
     def __init__(self, **kwargs):
@@ -36,7 +39,17 @@ class UpdateNetworkSecurityGroupsDetails(object):
     def network_security_group_ids(self):
         """
         Gets the network_security_group_ids of this UpdateNetworkSecurityGroupsDetails.
-        The array of NSG `OCIDs`__ to be used by this Load Balancer.
+        An array of NSG `OCIDs`__ associated with the load
+        balancer.
+
+        During the load balancer's creation, the service adds the new load balancer to the specified NSGs.
+
+        The benefits of associating the load balancer with NSGs include:
+
+        *  NSGs define network security rules to govern ingress and egress traffic for the load balancer.
+
+        *  The network security rules of other resources can reference the NSGs associated with the load balancer
+           to ensure access.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -50,7 +63,17 @@ class UpdateNetworkSecurityGroupsDetails(object):
     def network_security_group_ids(self, network_security_group_ids):
         """
         Sets the network_security_group_ids of this UpdateNetworkSecurityGroupsDetails.
-        The array of NSG `OCIDs`__ to be used by this Load Balancer.
+        An array of NSG `OCIDs`__ associated with the load
+        balancer.
+
+        During the load balancer's creation, the service adds the new load balancer to the specified NSGs.
+
+        The benefits of associating the load balancer with NSGs include:
+
+        *  NSGs define network security rules to govern ingress and egress traffic for the load balancer.
+
+        *  The network security rules of other resources can reference the NSGs associated with the load balancer
+           to ensure access.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 

--- a/src/oci/oce/__init__.py
+++ b/src/oci/oce/__init__.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+
+from .oce_instance_client import OceInstanceClient
+from .oce_instance_client_composite_operations import OceInstanceClientCompositeOperations
+from . import models
+
+__all__ = ["OceInstanceClient", "OceInstanceClientCompositeOperations", "models"]

--- a/src/oci/oce/models/__init__.py
+++ b/src/oci/oce/models/__init__.py
@@ -1,0 +1,33 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from .change_oce_instance_compartment_details import ChangeOceInstanceCompartmentDetails
+from .create_oce_instance_details import CreateOceInstanceDetails
+from .delete_oce_instance_details import DeleteOceInstanceDetails
+from .oce_instance import OceInstance
+from .oce_instance_summary import OceInstanceSummary
+from .update_oce_instance_details import UpdateOceInstanceDetails
+from .work_request import WorkRequest
+from .work_request_error import WorkRequestError
+from .work_request_log_entry import WorkRequestLogEntry
+from .work_request_resource import WorkRequestResource
+from .workflow_monitor import WorkflowMonitor
+from .workflow_step import WorkflowStep
+
+# Maps type names to classes for oce services.
+oce_type_mapping = {
+    "ChangeOceInstanceCompartmentDetails": ChangeOceInstanceCompartmentDetails,
+    "CreateOceInstanceDetails": CreateOceInstanceDetails,
+    "DeleteOceInstanceDetails": DeleteOceInstanceDetails,
+    "OceInstance": OceInstance,
+    "OceInstanceSummary": OceInstanceSummary,
+    "UpdateOceInstanceDetails": UpdateOceInstanceDetails,
+    "WorkRequest": WorkRequest,
+    "WorkRequestError": WorkRequestError,
+    "WorkRequestLogEntry": WorkRequestLogEntry,
+    "WorkRequestResource": WorkRequestResource,
+    "WorkflowMonitor": WorkflowMonitor,
+    "WorkflowStep": WorkflowStep
+}

--- a/src/oci/oce/models/change_oce_instance_compartment_details.py
+++ b/src/oci/oce/models/change_oce_instance_compartment_details.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeOceInstanceCompartmentDetails(object):
+    """
+    The information about compartment details.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeOceInstanceCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeOceInstanceCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeOceInstanceCompartmentDetails.
+        The `OCID`__ of the compartment
+        into which the OceInstance should be moved.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeOceInstanceCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeOceInstanceCompartmentDetails.
+        The `OCID`__ of the compartment
+        into which the OceInstance should be moved.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeOceInstanceCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/oce/models/create_oce_instance_details.py
+++ b/src/oci/oce/models/create_oce_instance_details.py
@@ -1,0 +1,352 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateOceInstanceDetails(object):
+    """
+    The information about new OceInstance.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateOceInstanceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param description:
+            The value to assign to the description property of this CreateOceInstanceDetails.
+        :type description: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateOceInstanceDetails.
+        :type compartment_id: str
+
+        :param name:
+            The value to assign to the name property of this CreateOceInstanceDetails.
+        :type name: str
+
+        :param tenancy_id:
+            The value to assign to the tenancy_id property of this CreateOceInstanceDetails.
+        :type tenancy_id: str
+
+        :param idcs_access_token:
+            The value to assign to the idcs_access_token property of this CreateOceInstanceDetails.
+        :type idcs_access_token: str
+
+        :param tenancy_name:
+            The value to assign to the tenancy_name property of this CreateOceInstanceDetails.
+        :type tenancy_name: str
+
+        :param object_storage_namespace:
+            The value to assign to the object_storage_namespace property of this CreateOceInstanceDetails.
+        :type object_storage_namespace: str
+
+        :param admin_email:
+            The value to assign to the admin_email property of this CreateOceInstanceDetails.
+        :type admin_email: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateOceInstanceDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateOceInstanceDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'description': 'str',
+            'compartment_id': 'str',
+            'name': 'str',
+            'tenancy_id': 'str',
+            'idcs_access_token': 'str',
+            'tenancy_name': 'str',
+            'object_storage_namespace': 'str',
+            'admin_email': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'description': 'description',
+            'compartment_id': 'compartmentId',
+            'name': 'name',
+            'tenancy_id': 'tenancyId',
+            'idcs_access_token': 'idcsAccessToken',
+            'tenancy_name': 'tenancyName',
+            'object_storage_namespace': 'objectStorageNamespace',
+            'admin_email': 'adminEmail',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._description = None
+        self._compartment_id = None
+        self._name = None
+        self._tenancy_id = None
+        self._idcs_access_token = None
+        self._tenancy_name = None
+        self._object_storage_namespace = None
+        self._admin_email = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def description(self):
+        """
+        Gets the description of this CreateOceInstanceDetails.
+        OceInstance description
+
+
+        :return: The description of this CreateOceInstanceDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this CreateOceInstanceDetails.
+        OceInstance description
+
+
+        :param description: The description of this CreateOceInstanceDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateOceInstanceDetails.
+        Compartment Identifier
+
+
+        :return: The compartment_id of this CreateOceInstanceDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateOceInstanceDetails.
+        Compartment Identifier
+
+
+        :param compartment_id: The compartment_id of this CreateOceInstanceDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this CreateOceInstanceDetails.
+        OceInstance Name
+
+
+        :return: The name of this CreateOceInstanceDetails.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this CreateOceInstanceDetails.
+        OceInstance Name
+
+
+        :param name: The name of this CreateOceInstanceDetails.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def tenancy_id(self):
+        """
+        **[Required]** Gets the tenancy_id of this CreateOceInstanceDetails.
+        Tenancy Identifier
+
+
+        :return: The tenancy_id of this CreateOceInstanceDetails.
+        :rtype: str
+        """
+        return self._tenancy_id
+
+    @tenancy_id.setter
+    def tenancy_id(self, tenancy_id):
+        """
+        Sets the tenancy_id of this CreateOceInstanceDetails.
+        Tenancy Identifier
+
+
+        :param tenancy_id: The tenancy_id of this CreateOceInstanceDetails.
+        :type: str
+        """
+        self._tenancy_id = tenancy_id
+
+    @property
+    def idcs_access_token(self):
+        """
+        **[Required]** Gets the idcs_access_token of this CreateOceInstanceDetails.
+        Identity Cloud Service access token identifying a stripe and service administrator user
+
+
+        :return: The idcs_access_token of this CreateOceInstanceDetails.
+        :rtype: str
+        """
+        return self._idcs_access_token
+
+    @idcs_access_token.setter
+    def idcs_access_token(self, idcs_access_token):
+        """
+        Sets the idcs_access_token of this CreateOceInstanceDetails.
+        Identity Cloud Service access token identifying a stripe and service administrator user
+
+
+        :param idcs_access_token: The idcs_access_token of this CreateOceInstanceDetails.
+        :type: str
+        """
+        self._idcs_access_token = idcs_access_token
+
+    @property
+    def tenancy_name(self):
+        """
+        **[Required]** Gets the tenancy_name of this CreateOceInstanceDetails.
+        Tenancy Name
+
+
+        :return: The tenancy_name of this CreateOceInstanceDetails.
+        :rtype: str
+        """
+        return self._tenancy_name
+
+    @tenancy_name.setter
+    def tenancy_name(self, tenancy_name):
+        """
+        Sets the tenancy_name of this CreateOceInstanceDetails.
+        Tenancy Name
+
+
+        :param tenancy_name: The tenancy_name of this CreateOceInstanceDetails.
+        :type: str
+        """
+        self._tenancy_name = tenancy_name
+
+    @property
+    def object_storage_namespace(self):
+        """
+        **[Required]** Gets the object_storage_namespace of this CreateOceInstanceDetails.
+        Object Storage Namespace of Tenancy
+
+
+        :return: The object_storage_namespace of this CreateOceInstanceDetails.
+        :rtype: str
+        """
+        return self._object_storage_namespace
+
+    @object_storage_namespace.setter
+    def object_storage_namespace(self, object_storage_namespace):
+        """
+        Sets the object_storage_namespace of this CreateOceInstanceDetails.
+        Object Storage Namespace of Tenancy
+
+
+        :param object_storage_namespace: The object_storage_namespace of this CreateOceInstanceDetails.
+        :type: str
+        """
+        self._object_storage_namespace = object_storage_namespace
+
+    @property
+    def admin_email(self):
+        """
+        **[Required]** Gets the admin_email of this CreateOceInstanceDetails.
+        Admin Email for Notification
+
+
+        :return: The admin_email of this CreateOceInstanceDetails.
+        :rtype: str
+        """
+        return self._admin_email
+
+    @admin_email.setter
+    def admin_email(self, admin_email):
+        """
+        Sets the admin_email of this CreateOceInstanceDetails.
+        Admin Email for Notification
+
+
+        :param admin_email: The admin_email of this CreateOceInstanceDetails.
+        :type: str
+        """
+        self._admin_email = admin_email
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateOceInstanceDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this CreateOceInstanceDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateOceInstanceDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this CreateOceInstanceDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateOceInstanceDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this CreateOceInstanceDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateOceInstanceDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this CreateOceInstanceDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/oce/models/delete_oce_instance_details.py
+++ b/src/oci/oce/models/delete_oce_instance_details.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DeleteOceInstanceDetails(object):
+    """
+    The information about the resource to be deleted.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DeleteOceInstanceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param idcs_access_token:
+            The value to assign to the idcs_access_token property of this DeleteOceInstanceDetails.
+        :type idcs_access_token: str
+
+        """
+        self.swagger_types = {
+            'idcs_access_token': 'str'
+        }
+
+        self.attribute_map = {
+            'idcs_access_token': 'idcsAccessToken'
+        }
+
+        self._idcs_access_token = None
+
+    @property
+    def idcs_access_token(self):
+        """
+        **[Required]** Gets the idcs_access_token of this DeleteOceInstanceDetails.
+        IDCS access token identifying a stripe and service administrator user
+
+
+        :return: The idcs_access_token of this DeleteOceInstanceDetails.
+        :rtype: str
+        """
+        return self._idcs_access_token
+
+    @idcs_access_token.setter
+    def idcs_access_token(self, idcs_access_token):
+        """
+        Sets the idcs_access_token of this DeleteOceInstanceDetails.
+        IDCS access token identifying a stripe and service administrator user
+
+
+        :param idcs_access_token: The idcs_access_token of this DeleteOceInstanceDetails.
+        :type: str
+        """
+        self._idcs_access_token = idcs_access_token
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/oce/models/oce_instance.py
+++ b/src/oci/oce/models/oce_instance.py
@@ -1,0 +1,603 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OceInstance(object):
+    """
+    Details of OceInstance.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a OceInstance.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a OceInstance.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a OceInstance.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a OceInstance.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a OceInstance.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a OceInstance.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OceInstance object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this OceInstance.
+        :type id: str
+
+        :param guid:
+            The value to assign to the guid property of this OceInstance.
+        :type guid: str
+
+        :param description:
+            The value to assign to the description property of this OceInstance.
+        :type description: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this OceInstance.
+        :type compartment_id: str
+
+        :param name:
+            The value to assign to the name property of this OceInstance.
+        :type name: str
+
+        :param tenancy_id:
+            The value to assign to the tenancy_id property of this OceInstance.
+        :type tenancy_id: str
+
+        :param idcs_tenancy:
+            The value to assign to the idcs_tenancy property of this OceInstance.
+        :type idcs_tenancy: str
+
+        :param tenancy_name:
+            The value to assign to the tenancy_name property of this OceInstance.
+        :type tenancy_name: str
+
+        :param object_storage_namespace:
+            The value to assign to the object_storage_namespace property of this OceInstance.
+        :type object_storage_namespace: str
+
+        :param admin_email:
+            The value to assign to the admin_email property of this OceInstance.
+        :type admin_email: str
+
+        :param time_created:
+            The value to assign to the time_created property of this OceInstance.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this OceInstance.
+        :type time_updated: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this OceInstance.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param state_message:
+            The value to assign to the state_message property of this OceInstance.
+        :type state_message: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this OceInstance.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this OceInstance.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param service:
+            The value to assign to the service property of this OceInstance.
+        :type service: dict(str, object)
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'guid': 'str',
+            'description': 'str',
+            'compartment_id': 'str',
+            'name': 'str',
+            'tenancy_id': 'str',
+            'idcs_tenancy': 'str',
+            'tenancy_name': 'str',
+            'object_storage_namespace': 'str',
+            'admin_email': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'lifecycle_state': 'str',
+            'state_message': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'service': 'dict(str, object)'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'guid': 'guid',
+            'description': 'description',
+            'compartment_id': 'compartmentId',
+            'name': 'name',
+            'tenancy_id': 'tenancyId',
+            'idcs_tenancy': 'idcsTenancy',
+            'tenancy_name': 'tenancyName',
+            'object_storage_namespace': 'objectStorageNamespace',
+            'admin_email': 'adminEmail',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'lifecycle_state': 'lifecycleState',
+            'state_message': 'stateMessage',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'service': 'service'
+        }
+
+        self._id = None
+        self._guid = None
+        self._description = None
+        self._compartment_id = None
+        self._name = None
+        self._tenancy_id = None
+        self._idcs_tenancy = None
+        self._tenancy_name = None
+        self._object_storage_namespace = None
+        self._admin_email = None
+        self._time_created = None
+        self._time_updated = None
+        self._lifecycle_state = None
+        self._state_message = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._service = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this OceInstance.
+        Unique identifier that is immutable on creation
+
+
+        :return: The id of this OceInstance.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this OceInstance.
+        Unique identifier that is immutable on creation
+
+
+        :param id: The id of this OceInstance.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def guid(self):
+        """
+        **[Required]** Gets the guid of this OceInstance.
+        Unique GUID identifier that is immutable on creation
+
+
+        :return: The guid of this OceInstance.
+        :rtype: str
+        """
+        return self._guid
+
+    @guid.setter
+    def guid(self, guid):
+        """
+        Sets the guid of this OceInstance.
+        Unique GUID identifier that is immutable on creation
+
+
+        :param guid: The guid of this OceInstance.
+        :type: str
+        """
+        self._guid = guid
+
+    @property
+    def description(self):
+        """
+        Gets the description of this OceInstance.
+        OceInstance description, can be updated
+
+
+        :return: The description of this OceInstance.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this OceInstance.
+        OceInstance description, can be updated
+
+
+        :param description: The description of this OceInstance.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this OceInstance.
+        Compartment Identifier
+
+
+        :return: The compartment_id of this OceInstance.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this OceInstance.
+        Compartment Identifier
+
+
+        :param compartment_id: The compartment_id of this OceInstance.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this OceInstance.
+        OceInstance Name
+
+
+        :return: The name of this OceInstance.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this OceInstance.
+        OceInstance Name
+
+
+        :param name: The name of this OceInstance.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def tenancy_id(self):
+        """
+        **[Required]** Gets the tenancy_id of this OceInstance.
+        Tenancy Identifier
+
+
+        :return: The tenancy_id of this OceInstance.
+        :rtype: str
+        """
+        return self._tenancy_id
+
+    @tenancy_id.setter
+    def tenancy_id(self, tenancy_id):
+        """
+        Sets the tenancy_id of this OceInstance.
+        Tenancy Identifier
+
+
+        :param tenancy_id: The tenancy_id of this OceInstance.
+        :type: str
+        """
+        self._tenancy_id = tenancy_id
+
+    @property
+    def idcs_tenancy(self):
+        """
+        **[Required]** Gets the idcs_tenancy of this OceInstance.
+        IDCS Tenancy Identifier
+
+
+        :return: The idcs_tenancy of this OceInstance.
+        :rtype: str
+        """
+        return self._idcs_tenancy
+
+    @idcs_tenancy.setter
+    def idcs_tenancy(self, idcs_tenancy):
+        """
+        Sets the idcs_tenancy of this OceInstance.
+        IDCS Tenancy Identifier
+
+
+        :param idcs_tenancy: The idcs_tenancy of this OceInstance.
+        :type: str
+        """
+        self._idcs_tenancy = idcs_tenancy
+
+    @property
+    def tenancy_name(self):
+        """
+        **[Required]** Gets the tenancy_name of this OceInstance.
+        Tenancy Name
+
+
+        :return: The tenancy_name of this OceInstance.
+        :rtype: str
+        """
+        return self._tenancy_name
+
+    @tenancy_name.setter
+    def tenancy_name(self, tenancy_name):
+        """
+        Sets the tenancy_name of this OceInstance.
+        Tenancy Name
+
+
+        :param tenancy_name: The tenancy_name of this OceInstance.
+        :type: str
+        """
+        self._tenancy_name = tenancy_name
+
+    @property
+    def object_storage_namespace(self):
+        """
+        **[Required]** Gets the object_storage_namespace of this OceInstance.
+        Object Storage Namespace of tenancy
+
+
+        :return: The object_storage_namespace of this OceInstance.
+        :rtype: str
+        """
+        return self._object_storage_namespace
+
+    @object_storage_namespace.setter
+    def object_storage_namespace(self, object_storage_namespace):
+        """
+        Sets the object_storage_namespace of this OceInstance.
+        Object Storage Namespace of tenancy
+
+
+        :param object_storage_namespace: The object_storage_namespace of this OceInstance.
+        :type: str
+        """
+        self._object_storage_namespace = object_storage_namespace
+
+    @property
+    def admin_email(self):
+        """
+        **[Required]** Gets the admin_email of this OceInstance.
+        Admin Email for Notification
+
+
+        :return: The admin_email of this OceInstance.
+        :rtype: str
+        """
+        return self._admin_email
+
+    @admin_email.setter
+    def admin_email(self, admin_email):
+        """
+        Sets the admin_email of this OceInstance.
+        Admin Email for Notification
+
+
+        :param admin_email: The admin_email of this OceInstance.
+        :type: str
+        """
+        self._admin_email = admin_email
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this OceInstance.
+        The time the the OceInstance was created. An RFC3339 formatted datetime string
+
+
+        :return: The time_created of this OceInstance.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this OceInstance.
+        The time the the OceInstance was created. An RFC3339 formatted datetime string
+
+
+        :param time_created: The time_created of this OceInstance.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this OceInstance.
+        The time the OceInstance was updated. An RFC3339 formatted datetime string
+
+
+        :return: The time_updated of this OceInstance.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this OceInstance.
+        The time the OceInstance was updated. An RFC3339 formatted datetime string
+
+
+        :param time_updated: The time_updated of this OceInstance.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this OceInstance.
+        The current state of the file system.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this OceInstance.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this OceInstance.
+        The current state of the file system.
+
+
+        :param lifecycle_state: The lifecycle_state of this OceInstance.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def state_message(self):
+        """
+        Gets the state_message of this OceInstance.
+        An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+
+
+        :return: The state_message of this OceInstance.
+        :rtype: str
+        """
+        return self._state_message
+
+    @state_message.setter
+    def state_message(self, state_message):
+        """
+        Sets the state_message of this OceInstance.
+        An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+
+
+        :param state_message: The state_message of this OceInstance.
+        :type: str
+        """
+        self._state_message = state_message
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this OceInstance.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this OceInstance.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this OceInstance.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this OceInstance.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this OceInstance.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this OceInstance.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this OceInstance.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this OceInstance.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def service(self):
+        """
+        Gets the service of this OceInstance.
+        SERVICE data.
+        Example: `{\"service\": {\"IDCS\": \"value\"}}`
+
+
+        :return: The service of this OceInstance.
+        :rtype: dict(str, object)
+        """
+        return self._service
+
+    @service.setter
+    def service(self, service):
+        """
+        Sets the service of this OceInstance.
+        SERVICE data.
+        Example: `{\"service\": {\"IDCS\": \"value\"}}`
+
+
+        :param service: The service of this OceInstance.
+        :type: dict(str, object)
+        """
+        self._service = service
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/oce/models/oce_instance_summary.py
+++ b/src/oci/oce/models/oce_instance_summary.py
@@ -1,0 +1,603 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OceInstanceSummary(object):
+    """
+    Summary of the OceInstance.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a OceInstanceSummary.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a OceInstanceSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a OceInstanceSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a OceInstanceSummary.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a OceInstanceSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a OceInstanceSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OceInstanceSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this OceInstanceSummary.
+        :type id: str
+
+        :param guid:
+            The value to assign to the guid property of this OceInstanceSummary.
+        :type guid: str
+
+        :param description:
+            The value to assign to the description property of this OceInstanceSummary.
+        :type description: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this OceInstanceSummary.
+        :type compartment_id: str
+
+        :param name:
+            The value to assign to the name property of this OceInstanceSummary.
+        :type name: str
+
+        :param tenancy_id:
+            The value to assign to the tenancy_id property of this OceInstanceSummary.
+        :type tenancy_id: str
+
+        :param idcs_tenancy:
+            The value to assign to the idcs_tenancy property of this OceInstanceSummary.
+        :type idcs_tenancy: str
+
+        :param tenancy_name:
+            The value to assign to the tenancy_name property of this OceInstanceSummary.
+        :type tenancy_name: str
+
+        :param object_storage_namespace:
+            The value to assign to the object_storage_namespace property of this OceInstanceSummary.
+        :type object_storage_namespace: str
+
+        :param admin_email:
+            The value to assign to the admin_email property of this OceInstanceSummary.
+        :type admin_email: str
+
+        :param time_created:
+            The value to assign to the time_created property of this OceInstanceSummary.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this OceInstanceSummary.
+        :type time_updated: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this OceInstanceSummary.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param state_message:
+            The value to assign to the state_message property of this OceInstanceSummary.
+        :type state_message: str
+
+        :param service:
+            The value to assign to the service property of this OceInstanceSummary.
+        :type service: dict(str, object)
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this OceInstanceSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this OceInstanceSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'guid': 'str',
+            'description': 'str',
+            'compartment_id': 'str',
+            'name': 'str',
+            'tenancy_id': 'str',
+            'idcs_tenancy': 'str',
+            'tenancy_name': 'str',
+            'object_storage_namespace': 'str',
+            'admin_email': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'lifecycle_state': 'str',
+            'state_message': 'str',
+            'service': 'dict(str, object)',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'guid': 'guid',
+            'description': 'description',
+            'compartment_id': 'compartmentId',
+            'name': 'name',
+            'tenancy_id': 'tenancyId',
+            'idcs_tenancy': 'idcsTenancy',
+            'tenancy_name': 'tenancyName',
+            'object_storage_namespace': 'objectStorageNamespace',
+            'admin_email': 'adminEmail',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'lifecycle_state': 'lifecycleState',
+            'state_message': 'stateMessage',
+            'service': 'service',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._guid = None
+        self._description = None
+        self._compartment_id = None
+        self._name = None
+        self._tenancy_id = None
+        self._idcs_tenancy = None
+        self._tenancy_name = None
+        self._object_storage_namespace = None
+        self._admin_email = None
+        self._time_created = None
+        self._time_updated = None
+        self._lifecycle_state = None
+        self._state_message = None
+        self._service = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this OceInstanceSummary.
+        Unique identifier that is immutable on creation
+
+
+        :return: The id of this OceInstanceSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this OceInstanceSummary.
+        Unique identifier that is immutable on creation
+
+
+        :param id: The id of this OceInstanceSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def guid(self):
+        """
+        **[Required]** Gets the guid of this OceInstanceSummary.
+        Unique GUID identifier that is immutable on creation
+
+
+        :return: The guid of this OceInstanceSummary.
+        :rtype: str
+        """
+        return self._guid
+
+    @guid.setter
+    def guid(self, guid):
+        """
+        Sets the guid of this OceInstanceSummary.
+        Unique GUID identifier that is immutable on creation
+
+
+        :param guid: The guid of this OceInstanceSummary.
+        :type: str
+        """
+        self._guid = guid
+
+    @property
+    def description(self):
+        """
+        Gets the description of this OceInstanceSummary.
+        OceInstance description, can be updated
+
+
+        :return: The description of this OceInstanceSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this OceInstanceSummary.
+        OceInstance description, can be updated
+
+
+        :param description: The description of this OceInstanceSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this OceInstanceSummary.
+        Compartment Identifier
+
+
+        :return: The compartment_id of this OceInstanceSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this OceInstanceSummary.
+        Compartment Identifier
+
+
+        :param compartment_id: The compartment_id of this OceInstanceSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this OceInstanceSummary.
+        OceInstance Name
+
+
+        :return: The name of this OceInstanceSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this OceInstanceSummary.
+        OceInstance Name
+
+
+        :param name: The name of this OceInstanceSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def tenancy_id(self):
+        """
+        **[Required]** Gets the tenancy_id of this OceInstanceSummary.
+        Tenancy Identifier
+
+
+        :return: The tenancy_id of this OceInstanceSummary.
+        :rtype: str
+        """
+        return self._tenancy_id
+
+    @tenancy_id.setter
+    def tenancy_id(self, tenancy_id):
+        """
+        Sets the tenancy_id of this OceInstanceSummary.
+        Tenancy Identifier
+
+
+        :param tenancy_id: The tenancy_id of this OceInstanceSummary.
+        :type: str
+        """
+        self._tenancy_id = tenancy_id
+
+    @property
+    def idcs_tenancy(self):
+        """
+        **[Required]** Gets the idcs_tenancy of this OceInstanceSummary.
+        IDCS Tenancy Identifier
+
+
+        :return: The idcs_tenancy of this OceInstanceSummary.
+        :rtype: str
+        """
+        return self._idcs_tenancy
+
+    @idcs_tenancy.setter
+    def idcs_tenancy(self, idcs_tenancy):
+        """
+        Sets the idcs_tenancy of this OceInstanceSummary.
+        IDCS Tenancy Identifier
+
+
+        :param idcs_tenancy: The idcs_tenancy of this OceInstanceSummary.
+        :type: str
+        """
+        self._idcs_tenancy = idcs_tenancy
+
+    @property
+    def tenancy_name(self):
+        """
+        **[Required]** Gets the tenancy_name of this OceInstanceSummary.
+        Tenancy Name
+
+
+        :return: The tenancy_name of this OceInstanceSummary.
+        :rtype: str
+        """
+        return self._tenancy_name
+
+    @tenancy_name.setter
+    def tenancy_name(self, tenancy_name):
+        """
+        Sets the tenancy_name of this OceInstanceSummary.
+        Tenancy Name
+
+
+        :param tenancy_name: The tenancy_name of this OceInstanceSummary.
+        :type: str
+        """
+        self._tenancy_name = tenancy_name
+
+    @property
+    def object_storage_namespace(self):
+        """
+        **[Required]** Gets the object_storage_namespace of this OceInstanceSummary.
+        Object Storage Namespace of tenancy
+
+
+        :return: The object_storage_namespace of this OceInstanceSummary.
+        :rtype: str
+        """
+        return self._object_storage_namespace
+
+    @object_storage_namespace.setter
+    def object_storage_namespace(self, object_storage_namespace):
+        """
+        Sets the object_storage_namespace of this OceInstanceSummary.
+        Object Storage Namespace of tenancy
+
+
+        :param object_storage_namespace: The object_storage_namespace of this OceInstanceSummary.
+        :type: str
+        """
+        self._object_storage_namespace = object_storage_namespace
+
+    @property
+    def admin_email(self):
+        """
+        **[Required]** Gets the admin_email of this OceInstanceSummary.
+        Admin Email for Notification
+
+
+        :return: The admin_email of this OceInstanceSummary.
+        :rtype: str
+        """
+        return self._admin_email
+
+    @admin_email.setter
+    def admin_email(self, admin_email):
+        """
+        Sets the admin_email of this OceInstanceSummary.
+        Admin Email for Notification
+
+
+        :param admin_email: The admin_email of this OceInstanceSummary.
+        :type: str
+        """
+        self._admin_email = admin_email
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this OceInstanceSummary.
+        The time the the OceInstance was created. An RFC3339 formatted datetime string
+
+
+        :return: The time_created of this OceInstanceSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this OceInstanceSummary.
+        The time the the OceInstance was created. An RFC3339 formatted datetime string
+
+
+        :param time_created: The time_created of this OceInstanceSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this OceInstanceSummary.
+        The time the OceInstance was updated. An RFC3339 formatted datetime string
+
+
+        :return: The time_updated of this OceInstanceSummary.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this OceInstanceSummary.
+        The time the OceInstance was updated. An RFC3339 formatted datetime string
+
+
+        :param time_updated: The time_updated of this OceInstanceSummary.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this OceInstanceSummary.
+        The current state of the file system.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this OceInstanceSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this OceInstanceSummary.
+        The current state of the file system.
+
+
+        :param lifecycle_state: The lifecycle_state of this OceInstanceSummary.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def state_message(self):
+        """
+        Gets the state_message of this OceInstanceSummary.
+        An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+
+
+        :return: The state_message of this OceInstanceSummary.
+        :rtype: str
+        """
+        return self._state_message
+
+    @state_message.setter
+    def state_message(self, state_message):
+        """
+        Sets the state_message of this OceInstanceSummary.
+        An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+
+
+        :param state_message: The state_message of this OceInstanceSummary.
+        :type: str
+        """
+        self._state_message = state_message
+
+    @property
+    def service(self):
+        """
+        Gets the service of this OceInstanceSummary.
+        SERVICE data.
+        Example: `{\"service\": {\"IDCS\": \"value\"}}`
+
+
+        :return: The service of this OceInstanceSummary.
+        :rtype: dict(str, object)
+        """
+        return self._service
+
+    @service.setter
+    def service(self, service):
+        """
+        Sets the service of this OceInstanceSummary.
+        SERVICE data.
+        Example: `{\"service\": {\"IDCS\": \"value\"}}`
+
+
+        :param service: The service of this OceInstanceSummary.
+        :type: dict(str, object)
+        """
+        self._service = service
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this OceInstanceSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this OceInstanceSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this OceInstanceSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this OceInstanceSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this OceInstanceSummary.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this OceInstanceSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this OceInstanceSummary.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this OceInstanceSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/oce/models/update_oce_instance_details.py
+++ b/src/oci/oce/models/update_oce_instance_details.py
@@ -1,0 +1,135 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateOceInstanceDetails(object):
+    """
+    The information to be updated.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateOceInstanceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param description:
+            The value to assign to the description property of this UpdateOceInstanceDetails.
+        :type description: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateOceInstanceDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateOceInstanceDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'description': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'description': 'description',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._description = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def description(self):
+        """
+        Gets the description of this UpdateOceInstanceDetails.
+        OceInstance description
+
+
+        :return: The description of this UpdateOceInstanceDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this UpdateOceInstanceDetails.
+        OceInstance description
+
+
+        :param description: The description of this UpdateOceInstanceDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateOceInstanceDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this UpdateOceInstanceDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateOceInstanceDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this UpdateOceInstanceDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateOceInstanceDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this UpdateOceInstanceDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateOceInstanceDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this UpdateOceInstanceDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/oce/models/work_request.py
+++ b/src/oci/oce/models/work_request.py
@@ -1,0 +1,418 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequest(object):
+    """
+    A description of workrequest status
+    """
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "CREATE_OCE_INSTANCE"
+    OPERATION_TYPE_CREATE_OCE_INSTANCE = "CREATE_OCE_INSTANCE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "UPDATE_OCE_INSTANCE"
+    OPERATION_TYPE_UPDATE_OCE_INSTANCE = "UPDATE_OCE_INSTANCE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "DELETE_OCE_INSTANCE"
+    OPERATION_TYPE_DELETE_OCE_INSTANCE = "DELETE_OCE_INSTANCE"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "ACCEPTED"
+    STATUS_ACCEPTED = "ACCEPTED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "IN_PROGRESS"
+    STATUS_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "FAILED"
+    STATUS_FAILED = "FAILED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "SUCCEEDED"
+    STATUS_SUCCEEDED = "SUCCEEDED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "CANCELING"
+    STATUS_CANCELING = "CANCELING"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "CANCELED"
+    STATUS_CANCELED = "CANCELED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequest object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation_type:
+            The value to assign to the operation_type property of this WorkRequest.
+            Allowed values for this property are: "CREATE_OCE_INSTANCE", "UPDATE_OCE_INSTANCE", "DELETE_OCE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type operation_type: str
+
+        :param status:
+            The value to assign to the status property of this WorkRequest.
+            Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param id:
+            The value to assign to the id property of this WorkRequest.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this WorkRequest.
+        :type compartment_id: str
+
+        :param resources:
+            The value to assign to the resources property of this WorkRequest.
+        :type resources: list[WorkRequestResource]
+
+        :param workflow_monitor:
+            The value to assign to the workflow_monitor property of this WorkRequest.
+        :type workflow_monitor: WorkflowMonitor
+
+        :param percent_complete:
+            The value to assign to the percent_complete property of this WorkRequest.
+        :type percent_complete: float
+
+        :param time_accepted:
+            The value to assign to the time_accepted property of this WorkRequest.
+        :type time_accepted: datetime
+
+        :param time_started:
+            The value to assign to the time_started property of this WorkRequest.
+        :type time_started: datetime
+
+        :param time_finished:
+            The value to assign to the time_finished property of this WorkRequest.
+        :type time_finished: datetime
+
+        """
+        self.swagger_types = {
+            'operation_type': 'str',
+            'status': 'str',
+            'id': 'str',
+            'compartment_id': 'str',
+            'resources': 'list[WorkRequestResource]',
+            'workflow_monitor': 'WorkflowMonitor',
+            'percent_complete': 'float',
+            'time_accepted': 'datetime',
+            'time_started': 'datetime',
+            'time_finished': 'datetime'
+        }
+
+        self.attribute_map = {
+            'operation_type': 'operationType',
+            'status': 'status',
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'resources': 'resources',
+            'workflow_monitor': 'workflowMonitor',
+            'percent_complete': 'percentComplete',
+            'time_accepted': 'timeAccepted',
+            'time_started': 'timeStarted',
+            'time_finished': 'timeFinished'
+        }
+
+        self._operation_type = None
+        self._status = None
+        self._id = None
+        self._compartment_id = None
+        self._resources = None
+        self._workflow_monitor = None
+        self._percent_complete = None
+        self._time_accepted = None
+        self._time_started = None
+        self._time_finished = None
+
+    @property
+    def operation_type(self):
+        """
+        **[Required]** Gets the operation_type of this WorkRequest.
+        type of the work request
+
+        Allowed values for this property are: "CREATE_OCE_INSTANCE", "UPDATE_OCE_INSTANCE", "DELETE_OCE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The operation_type of this WorkRequest.
+        :rtype: str
+        """
+        return self._operation_type
+
+    @operation_type.setter
+    def operation_type(self, operation_type):
+        """
+        Sets the operation_type of this WorkRequest.
+        type of the work request
+
+
+        :param operation_type: The operation_type of this WorkRequest.
+        :type: str
+        """
+        allowed_values = ["CREATE_OCE_INSTANCE", "UPDATE_OCE_INSTANCE", "DELETE_OCE_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
+            operation_type = 'UNKNOWN_ENUM_VALUE'
+        self._operation_type = operation_type
+
+    @property
+    def status(self):
+        """
+        **[Required]** Gets the status of this WorkRequest.
+        status of current work request.
+
+        Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this WorkRequest.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this WorkRequest.
+        status of current work request.
+
+
+        :param status: The status of this WorkRequest.
+        :type: str
+        """
+        allowed_values = ["ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this WorkRequest.
+        The id of the work request.
+
+
+        :return: The id of this WorkRequest.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this WorkRequest.
+        The id of the work request.
+
+
+        :param id: The id of this WorkRequest.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this WorkRequest.
+        The ocid of the compartment that contains the work request. Work requests should be scoped to
+        the same compartment as the resource the work request affects. If the work request affects multiple resources,
+        and those resources are not in the same compartment, it is up to the service team to pick the primary
+        resource whose compartment should be used
+
+
+        :return: The compartment_id of this WorkRequest.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this WorkRequest.
+        The ocid of the compartment that contains the work request. Work requests should be scoped to
+        the same compartment as the resource the work request affects. If the work request affects multiple resources,
+        and those resources are not in the same compartment, it is up to the service team to pick the primary
+        resource whose compartment should be used
+
+
+        :param compartment_id: The compartment_id of this WorkRequest.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def resources(self):
+        """
+        **[Required]** Gets the resources of this WorkRequest.
+        The resources affected by this work request.
+
+
+        :return: The resources of this WorkRequest.
+        :rtype: list[WorkRequestResource]
+        """
+        return self._resources
+
+    @resources.setter
+    def resources(self, resources):
+        """
+        Sets the resources of this WorkRequest.
+        The resources affected by this work request.
+
+
+        :param resources: The resources of this WorkRequest.
+        :type: list[WorkRequestResource]
+        """
+        self._resources = resources
+
+    @property
+    def workflow_monitor(self):
+        """
+        Gets the workflow_monitor of this WorkRequest.
+
+        :return: The workflow_monitor of this WorkRequest.
+        :rtype: WorkflowMonitor
+        """
+        return self._workflow_monitor
+
+    @workflow_monitor.setter
+    def workflow_monitor(self, workflow_monitor):
+        """
+        Sets the workflow_monitor of this WorkRequest.
+
+        :param workflow_monitor: The workflow_monitor of this WorkRequest.
+        :type: WorkflowMonitor
+        """
+        self._workflow_monitor = workflow_monitor
+
+    @property
+    def percent_complete(self):
+        """
+        **[Required]** Gets the percent_complete of this WorkRequest.
+        Percentage of the request completed.
+
+
+        :return: The percent_complete of this WorkRequest.
+        :rtype: float
+        """
+        return self._percent_complete
+
+    @percent_complete.setter
+    def percent_complete(self, percent_complete):
+        """
+        Sets the percent_complete of this WorkRequest.
+        Percentage of the request completed.
+
+
+        :param percent_complete: The percent_complete of this WorkRequest.
+        :type: float
+        """
+        self._percent_complete = percent_complete
+
+    @property
+    def time_accepted(self):
+        """
+        **[Required]** Gets the time_accepted of this WorkRequest.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_accepted of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_accepted
+
+    @time_accepted.setter
+    def time_accepted(self, time_accepted):
+        """
+        Sets the time_accepted of this WorkRequest.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_accepted: The time_accepted of this WorkRequest.
+        :type: datetime
+        """
+        self._time_accepted = time_accepted
+
+    @property
+    def time_started(self):
+        """
+        Gets the time_started of this WorkRequest.
+        The date and time the request was started, as described in `RFC 3339`__,
+        section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_started of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_started
+
+    @time_started.setter
+    def time_started(self, time_started):
+        """
+        Sets the time_started of this WorkRequest.
+        The date and time the request was started, as described in `RFC 3339`__,
+        section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_started: The time_started of this WorkRequest.
+        :type: datetime
+        """
+        self._time_started = time_started
+
+    @property
+    def time_finished(self):
+        """
+        Gets the time_finished of this WorkRequest.
+        The date and time the object was finished, as described in `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_finished of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_finished
+
+    @time_finished.setter
+    def time_finished(self, time_finished):
+        """
+        Sets the time_finished of this WorkRequest.
+        The date and time the object was finished, as described in `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_finished: The time_finished of this WorkRequest.
+        :type: datetime
+        """
+        self._time_finished = time_finished
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/oce/models/work_request_error.py
+++ b/src/oci/oce/models/work_request_error.py
@@ -1,0 +1,133 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestError(object):
+    """
+    An error encountered while executing a work request.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestError object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param code:
+            The value to assign to the code property of this WorkRequestError.
+        :type code: str
+
+        :param message:
+            The value to assign to the message property of this WorkRequestError.
+        :type message: str
+
+        :param timestamp:
+            The value to assign to the timestamp property of this WorkRequestError.
+        :type timestamp: datetime
+
+        """
+        self.swagger_types = {
+            'code': 'str',
+            'message': 'str',
+            'timestamp': 'datetime'
+        }
+
+        self.attribute_map = {
+            'code': 'code',
+            'message': 'message',
+            'timestamp': 'timestamp'
+        }
+
+        self._code = None
+        self._message = None
+        self._timestamp = None
+
+    @property
+    def code(self):
+        """
+        **[Required]** Gets the code of this WorkRequestError.
+        A machine-usable code for the error that occured. Error codes are listed on
+        (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
+
+
+        :return: The code of this WorkRequestError.
+        :rtype: str
+        """
+        return self._code
+
+    @code.setter
+    def code(self, code):
+        """
+        Sets the code of this WorkRequestError.
+        A machine-usable code for the error that occured. Error codes are listed on
+        (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
+
+
+        :param code: The code of this WorkRequestError.
+        :type: str
+        """
+        self._code = code
+
+    @property
+    def message(self):
+        """
+        **[Required]** Gets the message of this WorkRequestError.
+        A human readable description of the issue encountered.
+
+
+        :return: The message of this WorkRequestError.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this WorkRequestError.
+        A human readable description of the issue encountered.
+
+
+        :param message: The message of this WorkRequestError.
+        :type: str
+        """
+        self._message = message
+
+    @property
+    def timestamp(self):
+        """
+        **[Required]** Gets the timestamp of this WorkRequestError.
+        The time the error occured. An RFC3339 formatted datetime string.
+
+
+        :return: The timestamp of this WorkRequestError.
+        :rtype: datetime
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp):
+        """
+        Sets the timestamp of this WorkRequestError.
+        The time the error occured. An RFC3339 formatted datetime string.
+
+
+        :param timestamp: The timestamp of this WorkRequestError.
+        :type: datetime
+        """
+        self._timestamp = timestamp
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/oce/models/work_request_log_entry.py
+++ b/src/oci/oce/models/work_request_log_entry.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestLogEntry(object):
+    """
+    A log message from the execution of a work request.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestLogEntry object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param message:
+            The value to assign to the message property of this WorkRequestLogEntry.
+        :type message: str
+
+        :param timestamp:
+            The value to assign to the timestamp property of this WorkRequestLogEntry.
+        :type timestamp: datetime
+
+        """
+        self.swagger_types = {
+            'message': 'str',
+            'timestamp': 'datetime'
+        }
+
+        self.attribute_map = {
+            'message': 'message',
+            'timestamp': 'timestamp'
+        }
+
+        self._message = None
+        self._timestamp = None
+
+    @property
+    def message(self):
+        """
+        **[Required]** Gets the message of this WorkRequestLogEntry.
+        Human-readable log message.
+
+
+        :return: The message of this WorkRequestLogEntry.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this WorkRequestLogEntry.
+        Human-readable log message.
+
+
+        :param message: The message of this WorkRequestLogEntry.
+        :type: str
+        """
+        self._message = message
+
+    @property
+    def timestamp(self):
+        """
+        **[Required]** Gets the timestamp of this WorkRequestLogEntry.
+        The time the log message was written. An RFC3339 formatted datetime string
+
+
+        :return: The timestamp of this WorkRequestLogEntry.
+        :rtype: datetime
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp):
+        """
+        Sets the timestamp of this WorkRequestLogEntry.
+        The time the log message was written. An RFC3339 formatted datetime string
+
+
+        :param timestamp: The timestamp of this WorkRequestLogEntry.
+        :type: datetime
+        """
+        self._timestamp = timestamp
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/oce/models/work_request_resource.py
+++ b/src/oci/oce/models/work_request_resource.py
@@ -1,0 +1,192 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestResource(object):
+    """
+    A resource created or operated on by a work request.
+    """
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "CREATED"
+    ACTION_TYPE_CREATED = "CREATED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "UPDATED"
+    ACTION_TYPE_UPDATED = "UPDATED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "DELETED"
+    ACTION_TYPE_DELETED = "DELETED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "IN_PROGRESS"
+    ACTION_TYPE_IN_PROGRESS = "IN_PROGRESS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestResource object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param entity_type:
+            The value to assign to the entity_type property of this WorkRequestResource.
+        :type entity_type: str
+
+        :param action_type:
+            The value to assign to the action_type property of this WorkRequestResource.
+            Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type action_type: str
+
+        :param identifier:
+            The value to assign to the identifier property of this WorkRequestResource.
+        :type identifier: str
+
+        :param entity_uri:
+            The value to assign to the entity_uri property of this WorkRequestResource.
+        :type entity_uri: str
+
+        """
+        self.swagger_types = {
+            'entity_type': 'str',
+            'action_type': 'str',
+            'identifier': 'str',
+            'entity_uri': 'str'
+        }
+
+        self.attribute_map = {
+            'entity_type': 'entityType',
+            'action_type': 'actionType',
+            'identifier': 'identifier',
+            'entity_uri': 'entityUri'
+        }
+
+        self._entity_type = None
+        self._action_type = None
+        self._identifier = None
+        self._entity_uri = None
+
+    @property
+    def entity_type(self):
+        """
+        **[Required]** Gets the entity_type of this WorkRequestResource.
+        The resource type the work request is affects.
+
+
+        :return: The entity_type of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._entity_type
+
+    @entity_type.setter
+    def entity_type(self, entity_type):
+        """
+        Sets the entity_type of this WorkRequestResource.
+        The resource type the work request is affects.
+
+
+        :param entity_type: The entity_type of this WorkRequestResource.
+        :type: str
+        """
+        self._entity_type = entity_type
+
+    @property
+    def action_type(self):
+        """
+        **[Required]** Gets the action_type of this WorkRequestResource.
+        The way in which this resource is affected by the work tracked in the work request.
+        A resource being created, updated, or deleted will remain in the IN_PROGRESS state until
+        work is complete for that resource at which point it will transition to CREATED, UPDATED,
+        or DELETED, respectively.
+
+        Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The action_type of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._action_type
+
+    @action_type.setter
+    def action_type(self, action_type):
+        """
+        Sets the action_type of this WorkRequestResource.
+        The way in which this resource is affected by the work tracked in the work request.
+        A resource being created, updated, or deleted will remain in the IN_PROGRESS state until
+        work is complete for that resource at which point it will transition to CREATED, UPDATED,
+        or DELETED, respectively.
+
+
+        :param action_type: The action_type of this WorkRequestResource.
+        :type: str
+        """
+        allowed_values = ["CREATED", "UPDATED", "DELETED", "IN_PROGRESS"]
+        if not value_allowed_none_or_none_sentinel(action_type, allowed_values):
+            action_type = 'UNKNOWN_ENUM_VALUE'
+        self._action_type = action_type
+
+    @property
+    def identifier(self):
+        """
+        **[Required]** Gets the identifier of this WorkRequestResource.
+        The identifier of the resource the work request affects.
+
+
+        :return: The identifier of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this WorkRequestResource.
+        The identifier of the resource the work request affects.
+
+
+        :param identifier: The identifier of this WorkRequestResource.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def entity_uri(self):
+        """
+        Gets the entity_uri of this WorkRequestResource.
+        The URI path that the user can do a GET on to access the resource metadata
+
+
+        :return: The entity_uri of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._entity_uri
+
+    @entity_uri.setter
+    def entity_uri(self, entity_uri):
+        """
+        Sets the entity_uri of this WorkRequestResource.
+        The URI path that the user can do a GET on to access the resource metadata
+
+
+        :param entity_uri: The entity_uri of this WorkRequestResource.
+        :type: str
+        """
+        self._entity_uri = entity_uri
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/oce/models/workflow_monitor.py
+++ b/src/oci/oce/models/workflow_monitor.py
@@ -1,0 +1,131 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkflowMonitor(object):
+    """
+    The workflow monitor for this work request.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkflowMonitor object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param workflow_name:
+            The value to assign to the workflow_name property of this WorkflowMonitor.
+        :type workflow_name: str
+
+        :param resource_name:
+            The value to assign to the resource_name property of this WorkflowMonitor.
+        :type resource_name: str
+
+        :param workflow_steps:
+            The value to assign to the workflow_steps property of this WorkflowMonitor.
+        :type workflow_steps: list[WorkflowStep]
+
+        """
+        self.swagger_types = {
+            'workflow_name': 'str',
+            'resource_name': 'str',
+            'workflow_steps': 'list[WorkflowStep]'
+        }
+
+        self.attribute_map = {
+            'workflow_name': 'workflowName',
+            'resource_name': 'resourceName',
+            'workflow_steps': 'workflowSteps'
+        }
+
+        self._workflow_name = None
+        self._resource_name = None
+        self._workflow_steps = None
+
+    @property
+    def workflow_name(self):
+        """
+        Gets the workflow_name of this WorkflowMonitor.
+        workflow name for this work request
+
+
+        :return: The workflow_name of this WorkflowMonitor.
+        :rtype: str
+        """
+        return self._workflow_name
+
+    @workflow_name.setter
+    def workflow_name(self, workflow_name):
+        """
+        Sets the workflow_name of this WorkflowMonitor.
+        workflow name for this work request
+
+
+        :param workflow_name: The workflow_name of this WorkflowMonitor.
+        :type: str
+        """
+        self._workflow_name = workflow_name
+
+    @property
+    def resource_name(self):
+        """
+        Gets the resource_name of this WorkflowMonitor.
+        resource name for this work request
+
+
+        :return: The resource_name of this WorkflowMonitor.
+        :rtype: str
+        """
+        return self._resource_name
+
+    @resource_name.setter
+    def resource_name(self, resource_name):
+        """
+        Sets the resource_name of this WorkflowMonitor.
+        resource name for this work request
+
+
+        :param resource_name: The resource_name of this WorkflowMonitor.
+        :type: str
+        """
+        self._resource_name = resource_name
+
+    @property
+    def workflow_steps(self):
+        """
+        Gets the workflow_steps of this WorkflowMonitor.
+        Workflow step of workflow monitor.
+
+
+        :return: The workflow_steps of this WorkflowMonitor.
+        :rtype: list[WorkflowStep]
+        """
+        return self._workflow_steps
+
+    @workflow_steps.setter
+    def workflow_steps(self, workflow_steps):
+        """
+        Sets the workflow_steps of this WorkflowMonitor.
+        Workflow step of workflow monitor.
+
+
+        :param workflow_steps: The workflow_steps of this WorkflowMonitor.
+        :type: list[WorkflowStep]
+        """
+        self._workflow_steps = workflow_steps
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/oce/models/workflow_step.py
+++ b/src/oci/oce/models/workflow_step.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkflowStep(object):
+    """
+    Workflow step of workflow monitor.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkflowStep object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param step_name:
+            The value to assign to the step_name property of this WorkflowStep.
+        :type step_name: str
+
+        :param status:
+            The value to assign to the status property of this WorkflowStep.
+        :type status: str
+
+        """
+        self.swagger_types = {
+            'step_name': 'str',
+            'status': 'str'
+        }
+
+        self.attribute_map = {
+            'step_name': 'stepName',
+            'status': 'status'
+        }
+
+        self._step_name = None
+        self._status = None
+
+    @property
+    def step_name(self):
+        """
+        Gets the step_name of this WorkflowStep.
+        workflow step name
+
+
+        :return: The step_name of this WorkflowStep.
+        :rtype: str
+        """
+        return self._step_name
+
+    @step_name.setter
+    def step_name(self, step_name):
+        """
+        Sets the step_name of this WorkflowStep.
+        workflow step name
+
+
+        :param step_name: The step_name of this WorkflowStep.
+        :type: str
+        """
+        self._step_name = step_name
+
+    @property
+    def status(self):
+        """
+        Gets the status of this WorkflowStep.
+        workflow step status
+
+
+        :return: The status of this WorkflowStep.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this WorkflowStep.
+        workflow step status
+
+
+        :param status: The status of this WorkflowStep.
+        :type: str
+        """
+        self._status = status
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/oce/oce_instance_client.py
+++ b/src/oci/oce/oce_instance_client.py
@@ -1,0 +1,953 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import oce_type_mapping
+missing = Sentinel("Missing")
+
+
+class OceInstanceClient(object):
+    """
+    Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20190912',
+            'service_endpoint_template': 'https://cp.oce.{region}.ocp.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("oce_instance", config, signer, oce_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def change_oce_instance_compartment(self, oce_instance_id, change_oce_instance_compartment_details, **kwargs):
+        """
+        Moves a OceInstance into a different compartment. When provided, If-Match is checked against ETag values of the OceInstance.
+        Moves a OceInstance into a different compartment
+
+
+        :param str oce_instance_id: (required)
+            unique OceInstance identifier
+
+        :param ChangeOceInstanceCompartmentDetails change_oce_instance_compartment_details: (required)
+            The information about compartment details to be moved.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/oceInstances/{oceInstanceId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_oce_instance_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "oceInstanceId": oce_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_oce_instance_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_oce_instance_compartment_details)
+
+    def create_oce_instance(self, create_oce_instance_details, **kwargs):
+        """
+        Creates a new OceInstance
+        Creates a new OceInstance.
+
+
+        :param CreateOceInstanceDetails create_oce_instance_details: (required)
+            Details for the new OceInstance.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/oceInstances"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_oce_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_oce_instance_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_oce_instance_details)
+
+    def delete_oce_instance(self, oce_instance_id, delete_oce_instance_details, **kwargs):
+        """
+        Delete a provisioned OceInstance
+        Deletes a OceInstance resource by identifier
+
+
+        :param str oce_instance_id: (required)
+            unique OceInstance identifier
+
+        :param DeleteOceInstanceDetails delete_oce_instance_details: (required)
+            The information about resource to be deleted.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/oceInstances/{oceInstanceId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_oce_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "oceInstanceId": oce_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=delete_oce_instance_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=delete_oce_instance_details)
+
+    def get_oce_instance(self, oce_instance_id, **kwargs):
+        """
+        Get OceInstance
+        Gets a OceInstance by identifier
+
+
+        :param str oce_instance_id: (required)
+            unique OceInstance identifier
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.oce.models.OceInstance`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/oceInstances/{oceInstanceId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_oce_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "oceInstanceId": oce_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="OceInstance")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="OceInstance")
+
+    def get_work_request(self, work_request_id, **kwargs):
+        """
+        GET Work Request Status
+        Gets the status of the work request with the given ID.
+
+
+        :param str work_request_id: (required)
+            The ID of the asynchronous request.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.oce.models.WorkRequest`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_work_request got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="WorkRequest")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="WorkRequest")
+
+    def list_oce_instances(self, compartment_id, **kwargs):
+        """
+        Gets a list of all OceInstances in a compartment
+        Returns a list of OceInstances.
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for displayName is ascending. If no value is specified timeCreated is default.
+
+            Allowed values are: "timeCreated", "displayName"
+
+        :param str lifecycle_state: (optional)
+            Filter results on lifecycleState.
+
+            Allowed values are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.oce.models.OceInstanceSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/oceInstances"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "lifecycle_state",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_oce_instances got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["timeCreated", "displayName"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "displayName": kwargs.get("display_name", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[OceInstanceSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[OceInstanceSummary]")
+
+    def list_work_request_errors(self, work_request_id, **kwargs):
+        """
+        Lists work request errors
+        Return a (paginated) list of errors for a given work request.
+
+
+        :param str work_request_id: (required)
+            The ID of the asynchronous request.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.oce.models.WorkRequestError`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}/errors"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "page",
+            "limit"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_request_errors got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestError]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestError]")
+
+    def list_work_request_logs(self, work_request_id, **kwargs):
+        """
+        Lists work request logs
+        Return a (paginated) list of logs for a given work request.
+
+
+        :param str work_request_id: (required)
+            The ID of the asynchronous request.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.oce.models.WorkRequestLogEntry`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}/logs"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "page",
+            "limit"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_request_logs got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestLogEntry]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestLogEntry]")
+
+    def list_work_requests(self, compartment_id, **kwargs):
+        """
+        List Work Requests
+        Lists the work requests in a compartment.
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str resource_id: (optional)
+            The resource Identifier for which to list resources.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.oce.models.WorkRequest`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "resource_id",
+            "opc_request_id",
+            "page",
+            "limit"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_requests got unknown kwargs: {!r}".format(extra_kwargs))
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "resourceId": kwargs.get("resource_id", missing),
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequest]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequest]")
+
+    def update_oce_instance(self, oce_instance_id, update_oce_instance_details, **kwargs):
+        """
+        Update the OceInstance identified by the id
+        Updates the OceInstance
+
+
+        :param str oce_instance_id: (required)
+            unique OceInstance identifier
+
+        :param UpdateOceInstanceDetails update_oce_instance_details: (required)
+            The information to be updated.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/oceInstances/{oceInstanceId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_oce_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "oceInstanceId": oce_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_oce_instance_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_oce_instance_details)

--- a/src/oci/oce/oce_instance_client_composite_operations.py
+++ b/src/oci/oce/oce_instance_client_composite_operations.py
@@ -1,0 +1,192 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class OceInstanceClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.oce.OceInstanceClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new OceInstanceClientCompositeOperations object
+
+        :param OceInstanceClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client
+
+    def change_oce_instance_compartment_and_wait_for_state(self, oce_instance_id, change_oce_instance_compartment_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.oce.OceInstanceClient.change_oce_instance_compartment` and waits for the :py:class:`~oci.oce.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str oce_instance_id: (required)
+            unique OceInstance identifier
+
+        :param ChangeOceInstanceCompartmentDetails change_oce_instance_compartment_details: (required)
+            The information about compartment details to be moved.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.oce.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.oce.OceInstanceClient.change_oce_instance_compartment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.change_oce_instance_compartment(oce_instance_id, change_oce_instance_compartment_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_oce_instance_and_wait_for_state(self, create_oce_instance_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.oce.OceInstanceClient.create_oce_instance` and waits for the :py:class:`~oci.oce.models.WorkRequest`
+        to enter the given state(s).
+
+        :param CreateOceInstanceDetails create_oce_instance_details: (required)
+            Details for the new OceInstance.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.oce.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.oce.OceInstanceClient.create_oce_instance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_oce_instance(create_oce_instance_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_oce_instance_and_wait_for_state(self, oce_instance_id, delete_oce_instance_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.oce.OceInstanceClient.delete_oce_instance` and waits for the :py:class:`~oci.oce.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str oce_instance_id: (required)
+            unique OceInstance identifier
+
+        :param DeleteOceInstanceDetails delete_oce_instance_details: (required)
+            The information about resource to be deleted.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.oce.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.oce.OceInstanceClient.delete_oce_instance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = None
+        try:
+            operation_result = self.client.delete_oce_instance(oce_instance_id, delete_oce_instance_details, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_oce_instance_and_wait_for_state(self, oce_instance_id, update_oce_instance_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.oce.OceInstanceClient.update_oce_instance` and waits for the :py:class:`~oci.oce.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str oce_instance_id: (required)
+            unique OceInstance identifier
+
+        :param UpdateOceInstanceDetails update_oce_instance_details: (required)
+            The information to be updated.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.oce.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.oce.OceInstanceClient.update_oce_instance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_oce_instance(oce_instance_id, update_oce_instance_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)

--- a/src/oci/ons/models/backoff_retry_policy.py
+++ b/src/oci/ons/models/backoff_retry_policy.py
@@ -9,7 +9,10 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class BackoffRetryPolicy(object):
     """
-    The backoff retry portion of the subscription delivery policy.
+    The backoff retry portion of the subscription delivery policy. For information about retry durations for subscriptions, see
+    `How Notifications Works`__.
+
+    __ https://docs.cloud.oracle.com/iaas/Content/Notification/Concepts/notificationoverview.htm#how
     """
 
     #: A constant which can be used with the policy_type property of a BackoffRetryPolicy.

--- a/src/oci/ons/models/confirmation_result.py
+++ b/src/oci/ons/models/confirmation_result.py
@@ -10,6 +10,10 @@ from oci.decorators import init_model_state_from_kwargs
 class ConfirmationResult(object):
     """
     The confirmation details for the specified subscription.
+    For information about confirming subscriptions, see
+    `To confirm a subscription`__.
+
+    __ https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#confirmSub
     """
 
     def __init__(self, **kwargs):
@@ -123,8 +127,8 @@ class ConfirmationResult(object):
     def endpoint(self):
         """
         **[Required]** Gets the endpoint of this ConfirmationResult.
-        The endpoint of the subscription. Valid values depend on the protocol.
-        For EMAIL, only an email address is valid. For HTTPS, only a PagerDuty URL is valid. A URL cannot exceed 512 characters.
+        A locator that corresponds to the subscription protocol.
+        For example, an email address for a subscription that uses the `EMAIL` protocol, or a URL for a subscription that uses an HTTP-based protocol.
 
 
         :return: The endpoint of this ConfirmationResult.
@@ -136,8 +140,8 @@ class ConfirmationResult(object):
     def endpoint(self, endpoint):
         """
         Sets the endpoint of this ConfirmationResult.
-        The endpoint of the subscription. Valid values depend on the protocol.
-        For EMAIL, only an email address is valid. For HTTPS, only a PagerDuty URL is valid. A URL cannot exceed 512 characters.
+        A locator that corresponds to the subscription protocol.
+        For example, an email address for a subscription that uses the `EMAIL` protocol, or a URL for a subscription that uses an HTTP-based protocol.
 
 
         :param endpoint: The endpoint of this ConfirmationResult.

--- a/src/oci/ons/models/create_subscription_details.py
+++ b/src/oci/ons/models/create_subscription_details.py
@@ -134,7 +134,12 @@ class CreateSubscriptionDetails(object):
     def protocol(self):
         """
         **[Required]** Gets the protocol of this CreateSubscriptionDetails.
-        The protocol to use for delivering messages. Valid values: EMAIL, HTTPS.
+        The protocol used for the subscription.
+
+        For information about subscription protocols, see
+        `To create a subscription`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub
 
 
         :return: The protocol of this CreateSubscriptionDetails.
@@ -146,7 +151,12 @@ class CreateSubscriptionDetails(object):
     def protocol(self, protocol):
         """
         Sets the protocol of this CreateSubscriptionDetails.
-        The protocol to use for delivering messages. Valid values: EMAIL, HTTPS.
+        The protocol used for the subscription.
+
+        For information about subscription protocols, see
+        `To create a subscription`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub
 
 
         :param protocol: The protocol of this CreateSubscriptionDetails.
@@ -158,9 +168,16 @@ class CreateSubscriptionDetails(object):
     def endpoint(self):
         """
         **[Required]** Gets the endpoint of this CreateSubscriptionDetails.
-        The endpoint of the subscription. Valid values depend on the protocol.
-        For EMAIL, only an email address is valid. For HTTPS, only a PagerDuty URL is valid. A URL cannot exceed 512 characters.
+        A locator that corresponds to the subscription protocol.
+        For example, an email address for a subscription that uses the `EMAIL` protocol, or a URL for a subscription that uses an HTTP-based protocol.
+        HTTP-based protocols use URL endpoints that begin with \"http:\" or \"https:\".
+        A URL cannot exceed 512 characters.
         Avoid entering confidential information.
+
+        For protocol-specific endpoint formats and steps to get or create endpoints, see
+        `To create a subscription`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub
 
 
         :return: The endpoint of this CreateSubscriptionDetails.
@@ -172,9 +189,16 @@ class CreateSubscriptionDetails(object):
     def endpoint(self, endpoint):
         """
         Sets the endpoint of this CreateSubscriptionDetails.
-        The endpoint of the subscription. Valid values depend on the protocol.
-        For EMAIL, only an email address is valid. For HTTPS, only a PagerDuty URL is valid. A URL cannot exceed 512 characters.
+        A locator that corresponds to the subscription protocol.
+        For example, an email address for a subscription that uses the `EMAIL` protocol, or a URL for a subscription that uses an HTTP-based protocol.
+        HTTP-based protocols use URL endpoints that begin with \"http:\" or \"https:\".
+        A URL cannot exceed 512 characters.
         Avoid entering confidential information.
+
+        For protocol-specific endpoint formats and steps to get or create endpoints, see
+        `To create a subscription`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub
 
 
         :param endpoint: The endpoint of this CreateSubscriptionDetails.
@@ -186,7 +210,7 @@ class CreateSubscriptionDetails(object):
     def metadata(self):
         """
         Gets the metadata of this CreateSubscriptionDetails.
-        Metadata for the subscription. Avoid entering confidential information.
+        Metadata for the subscription.
 
 
         :return: The metadata of this CreateSubscriptionDetails.
@@ -198,7 +222,7 @@ class CreateSubscriptionDetails(object):
     def metadata(self, metadata):
         """
         Sets the metadata of this CreateSubscriptionDetails.
-        Metadata for the subscription. Avoid entering confidential information.
+        Metadata for the subscription.
 
 
         :param metadata: The metadata of this CreateSubscriptionDetails.

--- a/src/oci/ons/models/notification_topic.py
+++ b/src/oci/ons/models/notification_topic.py
@@ -9,7 +9,10 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class NotificationTopic(object):
     """
-    The properties that define a topic.
+    The properties that define a topic. For general information about topics, see
+    `Notifications Overview`__.
+
+    __ https://docs.cloud.oracle.com/iaas/Content/Notification/Concepts/notificationoverview.htm
     """
 
     #: A constant which can be used with the lifecycle_state property of a NotificationTopic.

--- a/src/oci/ons/models/subscription.py
+++ b/src/oci/ons/models/subscription.py
@@ -9,7 +9,10 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Subscription(object):
     """
-    The subscription's configuration.
+    The subscription's configuration. For general information about subscriptions, see
+    `Notifications Overview`__.
+
+    __ https://docs.cloud.oracle.com/iaas/Content/Notification/Concepts/notificationoverview.htm
     """
 
     #: A constant which can be used with the lifecycle_state property of a Subscription.
@@ -176,7 +179,11 @@ class Subscription(object):
     def protocol(self):
         """
         **[Required]** Gets the protocol of this Subscription.
+        The protocol used for the subscription.
+        For information about subscription protocols, see
+        `To create a subscription`__.
 
+        __ https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub
 
 
         :return: The protocol of this Subscription.
@@ -188,7 +195,11 @@ class Subscription(object):
     def protocol(self, protocol):
         """
         Sets the protocol of this Subscription.
+        The protocol used for the subscription.
+        For information about subscription protocols, see
+        `To create a subscription`__.
 
+        __ https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub
 
 
         :param protocol: The protocol of this Subscription.
@@ -200,8 +211,8 @@ class Subscription(object):
     def endpoint(self):
         """
         **[Required]** Gets the endpoint of this Subscription.
-        The endpoint of the subscription. Valid values depend on the protocol.
-        For EMAIL, only an email address is valid. For HTTPS, only a PagerDuty URL is valid. A URL cannot exceed 512 characters.
+        A locator that corresponds to the subscription protocol.
+        For example, an email address for a subscription that uses the `EMAIL` protocol, or a URL for a subscription that uses an HTTP-based protocol.
 
 
         :return: The endpoint of this Subscription.
@@ -213,8 +224,8 @@ class Subscription(object):
     def endpoint(self, endpoint):
         """
         Sets the endpoint of this Subscription.
-        The endpoint of the subscription. Valid values depend on the protocol.
-        For EMAIL, only an email address is valid. For HTTPS, only a PagerDuty URL is valid. A URL cannot exceed 512 characters.
+        A locator that corresponds to the subscription protocol.
+        For example, an email address for a subscription that uses the `EMAIL` protocol, or a URL for a subscription that uses an HTTP-based protocol.
 
 
         :param endpoint: The endpoint of this Subscription.

--- a/src/oci/ons/models/subscription_summary.py
+++ b/src/oci/ons/models/subscription_summary.py
@@ -176,7 +176,11 @@ class SubscriptionSummary(object):
     def protocol(self):
         """
         **[Required]** Gets the protocol of this SubscriptionSummary.
-        The protocol used for the subscription. Valid values: EMAIL, HTTPS.
+        The protocol used for the subscription.
+        For information about subscription protocols, see
+        `To create a subscription`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub
 
 
         :return: The protocol of this SubscriptionSummary.
@@ -188,7 +192,11 @@ class SubscriptionSummary(object):
     def protocol(self, protocol):
         """
         Sets the protocol of this SubscriptionSummary.
-        The protocol used for the subscription. Valid values: EMAIL, HTTPS.
+        The protocol used for the subscription.
+        For information about subscription protocols, see
+        `To create a subscription`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub
 
 
         :param protocol: The protocol of this SubscriptionSummary.
@@ -200,8 +208,8 @@ class SubscriptionSummary(object):
     def endpoint(self):
         """
         **[Required]** Gets the endpoint of this SubscriptionSummary.
-        The endpoint of the subscription. Valid values depend on the protocol.
-        For EMAIL, only an email address is valid. For HTTPS, only a PagerDuty URL is valid. A URL cannot exceed 512 characters.
+        A locator that corresponds to the subscription protocol.
+        For example, an email address for a subscription that uses the `EMAIL` protocol, or a URL for a subscription that uses an HTTP-based protocol.
 
 
         :return: The endpoint of this SubscriptionSummary.
@@ -213,8 +221,8 @@ class SubscriptionSummary(object):
     def endpoint(self, endpoint):
         """
         Sets the endpoint of this SubscriptionSummary.
-        The endpoint of the subscription. Valid values depend on the protocol.
-        For EMAIL, only an email address is valid. For HTTPS, only a PagerDuty URL is valid. A URL cannot exceed 512 characters.
+        A locator that corresponds to the subscription protocol.
+        For example, an email address for a subscription that uses the `EMAIL` protocol, or a URL for a subscription that uses an HTTP-based protocol.
 
 
         :param endpoint: The endpoint of this SubscriptionSummary.

--- a/src/oci/ons/notification_data_plane_client.py
+++ b/src/oci/ons/notification_data_plane_client.py
@@ -185,9 +185,13 @@ class NotificationDataPlaneClient(object):
 
     def create_subscription(self, create_subscription_details, **kwargs):
         """
-        Creates a subscription for the specified topic.
+        Creates a subscription for the specified topic and sends a subscription confirmation URL to the endpoint. The subscription remains in \"Pending\" status until it has been confirmed.
+        For information about confirming subscriptions, see
+        `To confirm a subscription`__.
 
         Transactions Per Minute (TPM) per-tenancy limit for this operation: 60.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#confirmSub
 
 
         :param CreateSubscriptionDetails create_subscription_details: (required)
@@ -357,7 +361,12 @@ class NotificationDataPlaneClient(object):
             The subscription confirmation token.
 
         :param str protocol: (required)
-            The subscription protocol. Valid values: EMAIL, HTTPS.
+            The protocol used for the subscription.
+
+            For information about subscription protocols, see
+            `To create a subscription`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub
 
         :param str opc_request_id: (optional)
             The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
@@ -525,7 +534,12 @@ class NotificationDataPlaneClient(object):
             The subscription confirmation token.
 
         :param str protocol: (required)
-            The subscription protocol. Valid values: EMAIL, HTTPS.
+            The protocol used for the subscription.
+
+            For information about subscription protocols, see
+            `To create a subscription`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub
 
         :param str opc_request_id: (optional)
             The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
@@ -699,13 +713,16 @@ class NotificationDataPlaneClient(object):
 
         Message size limit per request: 64KB.
 
-        Message delivery rate limit per endpoint: 60 messages per minute for HTTPS (PagerDuty) protocol, 10 messages per minute for Email protocol.
+        Message delivery rate limit per endpoint: 60 messages per minute for HTTP-based protocols, 10 messages per minute for the `EMAIL` protocol.
+        HTTP-based protocols use URL endpoints that begin with \"http:\" or \"https:\".
 
         Transactions Per Minute (TPM) per-tenancy limit for this operation: 60 per topic.
 
         For more information about publishing messages, see `Publishing Messages`__.
+        For steps to request a limit increase, see `Requesting a Service Limit Increase`__.
 
         __ https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/publishingmessages.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/servicelimits.htm#three
 
 
         :param str topic_id: (required)

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "2.3.3"
+__version__ = "2.4.0"


### PR DESCRIPTION
## Added

Support for specifying the autoBackupWindow field for scheduling backups in the Database service

- Support for network security groups on autonomous Exadata infrastructure in the Database service

- Support for Kubernetes secrets encryption in customer clusters, regional subnets, and cluster authentication for instance principals in the Container Engine for Kubernetes service

- Support for the Oracle Content and Experience service



Breaking

--------

- The etag header has been removed from the response for NotificationControlPlaneClient.change_topic_compartment and NotificationDataPlaneClient.change_subscription_compartment
