### PR TITLE
Releasing version 2.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+2.5.0 - 2019-09-17
+====================
+
+Added
+-----
+* Support for importing state files in the Resource Manager service
+* Support for Exadata Cloud at Customer in the Database service
+* Support for free tier resources and system tags in the Load Balancing service
+* Support for free tier resources and system tags in the Compute service
+* Support for free tier resources and system tags in the Block Storage service
+* Support for free tier and system tags on autonomous databases in the Database service
+
+Breaking
+--------
+* The availability_domain parameter is now a kwarg for list_db_system_shapes in DatabaseClient
+* The model CreateDbHomeWithDbSystemIdBase was renamed CreateDbHomeBase and the parameter db_system_id was removed
+* The parameter create_db_home_with_db_system_id_details for create_db_home in DatabaseClient changed from CreateDbHomeWithDbSystemIdBase to CreateDbHomeBase
+
+====================
 2.4.0 - 2019-09-10
 ====================
 

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -18,6 +18,8 @@ Database
     :nosignatures:
     :template: autosummary/model_class.rst
 
+    oci.database.models.ActivateExadataInfrastructureDetails
+    oci.database.models.AssociatedDatabaseDetails
     oci.database.models.AutonomousContainerDatabase
     oci.database.models.AutonomousContainerDatabaseBackupConfig
     oci.database.models.AutonomousContainerDatabaseSummary
@@ -40,8 +42,13 @@ Database
     oci.database.models.AutonomousExadataInfrastructureShapeSummary
     oci.database.models.AutonomousExadataInfrastructureSummary
     oci.database.models.Backup
+    oci.database.models.BackupDestination
+    oci.database.models.BackupDestinationDetails
+    oci.database.models.BackupDestinationSummary
     oci.database.models.BackupSummary
     oci.database.models.ChangeCompartmentDetails
+    oci.database.models.ChangeExadataInfrastructureCompartmentDetails
+    oci.database.models.ChangeVmClusterCompartmentDetails
     oci.database.models.CompleteExternalBackupJobDetails
     oci.database.models.CreateAutonomousContainerDatabaseDetails
     oci.database.models.CreateAutonomousDataWarehouseBackupDetails
@@ -50,18 +57,25 @@ Database
     oci.database.models.CreateAutonomousDatabaseBase
     oci.database.models.CreateAutonomousDatabaseCloneDetails
     oci.database.models.CreateAutonomousDatabaseDetails
+    oci.database.models.CreateBackupDestinationDetails
     oci.database.models.CreateBackupDetails
     oci.database.models.CreateDataGuardAssociationDetails
     oci.database.models.CreateDataGuardAssociationToExistingDbSystemDetails
     oci.database.models.CreateDataGuardAssociationWithNewDbSystemDetails
     oci.database.models.CreateDatabaseDetails
     oci.database.models.CreateDatabaseFromBackupDetails
+    oci.database.models.CreateDbHomeBase
     oci.database.models.CreateDbHomeDetails
     oci.database.models.CreateDbHomeFromBackupDetails
-    oci.database.models.CreateDbHomeWithDbSystemIdBase
     oci.database.models.CreateDbHomeWithDbSystemIdDetails
     oci.database.models.CreateDbHomeWithDbSystemIdFromBackupDetails
+    oci.database.models.CreateDbHomeWithVmClusterIdDetails
+    oci.database.models.CreateDbHomeWithVmClusterIdFromBackupDetails
+    oci.database.models.CreateExadataInfrastructureDetails
     oci.database.models.CreateExternalBackupJobDetails
+    oci.database.models.CreateNFSBackupDestinationDetails
+    oci.database.models.CreateRecoveryApplianceBackupDestinationDetails
+    oci.database.models.CreateVmClusterDetails
     oci.database.models.DataGuardAssociation
     oci.database.models.DataGuardAssociationSummary
     oci.database.models.Database
@@ -79,12 +93,17 @@ Database
     oci.database.models.DbSystemShapeSummary
     oci.database.models.DbSystemSummary
     oci.database.models.DbVersionSummary
+    oci.database.models.ExadataInfrastructure
+    oci.database.models.ExadataInfrastructureSummary
     oci.database.models.ExadataIormConfig
     oci.database.models.ExadataIormConfigUpdateDetails
     oci.database.models.ExternalBackupJob
     oci.database.models.FailoverDataGuardAssociationDetails
     oci.database.models.GenerateAutonomousDataWarehouseWalletDetails
     oci.database.models.GenerateAutonomousDatabaseWalletDetails
+    oci.database.models.GenerateRecommendedNetworkDetails
+    oci.database.models.GiVersionSummary
+    oci.database.models.InfoForNetworkGenDetails
     oci.database.models.LaunchAutonomousExadataInfrastructureDetails
     oci.database.models.LaunchDbSystemBase
     oci.database.models.LaunchDbSystemDetails
@@ -93,6 +112,7 @@ Database
     oci.database.models.MaintenanceRunSummary
     oci.database.models.MaintenanceWindow
     oci.database.models.Month
+    oci.database.models.NodeDetails
     oci.database.models.Patch
     oci.database.models.PatchDetails
     oci.database.models.PatchHistoryEntry
@@ -102,12 +122,23 @@ Database
     oci.database.models.RestoreAutonomousDataWarehouseDetails
     oci.database.models.RestoreAutonomousDatabaseDetails
     oci.database.models.RestoreDatabaseDetails
+    oci.database.models.ScanDetails
     oci.database.models.SwitchoverDataGuardAssociationDetails
     oci.database.models.UpdateAutonomousContainerDatabaseDetails
     oci.database.models.UpdateAutonomousDataWarehouseDetails
     oci.database.models.UpdateAutonomousDatabaseDetails
     oci.database.models.UpdateAutonomousExadataInfrastructureDetails
+    oci.database.models.UpdateBackupDestinationDetails
     oci.database.models.UpdateDatabaseDetails
     oci.database.models.UpdateDbHomeDetails
     oci.database.models.UpdateDbSystemDetails
+    oci.database.models.UpdateExadataInfrastructureDetails
     oci.database.models.UpdateMaintenanceRunDetails
+    oci.database.models.UpdateVmClusterDetails
+    oci.database.models.UpdateVmClusterNetworkDetails
+    oci.database.models.VmCluster
+    oci.database.models.VmClusterNetwork
+    oci.database.models.VmClusterNetworkDetails
+    oci.database.models.VmClusterNetworkSummary
+    oci.database.models.VmClusterSummary
+    oci.database.models.VmNetworkDetails

--- a/docs/api/database/models/oci.database.models.ActivateExadataInfrastructureDetails.rst
+++ b/docs/api/database/models/oci.database.models.ActivateExadataInfrastructureDetails.rst
@@ -1,0 +1,11 @@
+ActivateExadataInfrastructureDetails
+====================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ActivateExadataInfrastructureDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.AssociatedDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.AssociatedDatabaseDetails.rst
@@ -1,0 +1,11 @@
+AssociatedDatabaseDetails
+=========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: AssociatedDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.BackupDestination.rst
+++ b/docs/api/database/models/oci.database.models.BackupDestination.rst
@@ -1,0 +1,11 @@
+BackupDestination
+=================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: BackupDestination
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.BackupDestinationDetails.rst
+++ b/docs/api/database/models/oci.database.models.BackupDestinationDetails.rst
@@ -1,0 +1,11 @@
+BackupDestinationDetails
+========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: BackupDestinationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.BackupDestinationSummary.rst
+++ b/docs/api/database/models/oci.database.models.BackupDestinationSummary.rst
@@ -1,0 +1,11 @@
+BackupDestinationSummary
+========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: BackupDestinationSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ChangeExadataInfrastructureCompartmentDetails.rst
+++ b/docs/api/database/models/oci.database.models.ChangeExadataInfrastructureCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeExadataInfrastructureCompartmentDetails
+=============================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ChangeExadataInfrastructureCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ChangeVmClusterCompartmentDetails.rst
+++ b/docs/api/database/models/oci.database.models.ChangeVmClusterCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeVmClusterCompartmentDetails
+=================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ChangeVmClusterCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateBackupDestinationDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateBackupDestinationDetails.rst
@@ -1,0 +1,11 @@
+CreateBackupDestinationDetails
+==============================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateBackupDestinationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateDbHomeBase.rst
+++ b/docs/api/database/models/oci.database.models.CreateDbHomeBase.rst
@@ -1,0 +1,11 @@
+CreateDbHomeBase
+================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateDbHomeBase
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateDbHomeWithVmClusterIdDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateDbHomeWithVmClusterIdDetails.rst
@@ -1,0 +1,11 @@
+CreateDbHomeWithVmClusterIdDetails
+==================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateDbHomeWithVmClusterIdDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateDbHomeWithVmClusterIdFromBackupDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateDbHomeWithVmClusterIdFromBackupDetails.rst
@@ -1,0 +1,11 @@
+CreateDbHomeWithVmClusterIdFromBackupDetails
+============================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateDbHomeWithVmClusterIdFromBackupDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateExadataInfrastructureDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateExadataInfrastructureDetails.rst
@@ -1,0 +1,11 @@
+CreateExadataInfrastructureDetails
+==================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateExadataInfrastructureDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateNFSBackupDestinationDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateNFSBackupDestinationDetails.rst
@@ -1,0 +1,11 @@
+CreateNFSBackupDestinationDetails
+=================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateNFSBackupDestinationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateRecoveryApplianceBackupDestinationDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateRecoveryApplianceBackupDestinationDetails.rst
@@ -1,0 +1,11 @@
+CreateRecoveryApplianceBackupDestinationDetails
+===============================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateRecoveryApplianceBackupDestinationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateVmClusterDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateVmClusterDetails.rst
@@ -1,0 +1,11 @@
+CreateVmClusterDetails
+======================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateVmClusterDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExadataInfrastructure.rst
+++ b/docs/api/database/models/oci.database.models.ExadataInfrastructure.rst
@@ -1,0 +1,11 @@
+ExadataInfrastructure
+=====================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExadataInfrastructure
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExadataInfrastructureSummary.rst
+++ b/docs/api/database/models/oci.database.models.ExadataInfrastructureSummary.rst
@@ -1,0 +1,11 @@
+ExadataInfrastructureSummary
+============================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExadataInfrastructureSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.GenerateRecommendedNetworkDetails.rst
+++ b/docs/api/database/models/oci.database.models.GenerateRecommendedNetworkDetails.rst
@@ -1,0 +1,11 @@
+GenerateRecommendedNetworkDetails
+=================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: GenerateRecommendedNetworkDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.GiVersionSummary.rst
+++ b/docs/api/database/models/oci.database.models.GiVersionSummary.rst
@@ -1,0 +1,11 @@
+GiVersionSummary
+================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: GiVersionSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.InfoForNetworkGenDetails.rst
+++ b/docs/api/database/models/oci.database.models.InfoForNetworkGenDetails.rst
@@ -1,0 +1,11 @@
+InfoForNetworkGenDetails
+========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: InfoForNetworkGenDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.NodeDetails.rst
+++ b/docs/api/database/models/oci.database.models.NodeDetails.rst
@@ -1,0 +1,11 @@
+NodeDetails
+===========
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: NodeDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ScanDetails.rst
+++ b/docs/api/database/models/oci.database.models.ScanDetails.rst
@@ -1,0 +1,11 @@
+ScanDetails
+===========
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ScanDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateBackupDestinationDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateBackupDestinationDetails.rst
@@ -1,0 +1,11 @@
+UpdateBackupDestinationDetails
+==============================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateBackupDestinationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateExadataInfrastructureDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateExadataInfrastructureDetails.rst
@@ -1,9 +1,9 @@
-CreateDbHomeWithDbSystemIdBase
-==============================
+UpdateExadataInfrastructureDetails
+==================================
 
 .. currentmodule:: oci.database.models
 
-.. autoclass:: CreateDbHomeWithDbSystemIdBase
+.. autoclass:: UpdateExadataInfrastructureDetails
     :show-inheritance:
     :special-members: __init__
     :members:

--- a/docs/api/database/models/oci.database.models.UpdateVmClusterDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateVmClusterDetails.rst
@@ -1,0 +1,11 @@
+UpdateVmClusterDetails
+======================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateVmClusterDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateVmClusterNetworkDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateVmClusterNetworkDetails.rst
@@ -1,0 +1,11 @@
+UpdateVmClusterNetworkDetails
+=============================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateVmClusterNetworkDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.VmCluster.rst
+++ b/docs/api/database/models/oci.database.models.VmCluster.rst
@@ -1,0 +1,11 @@
+VmCluster
+=========
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: VmCluster
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.VmClusterNetwork.rst
+++ b/docs/api/database/models/oci.database.models.VmClusterNetwork.rst
@@ -1,0 +1,11 @@
+VmClusterNetwork
+================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: VmClusterNetwork
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.VmClusterNetworkDetails.rst
+++ b/docs/api/database/models/oci.database.models.VmClusterNetworkDetails.rst
@@ -1,0 +1,11 @@
+VmClusterNetworkDetails
+=======================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: VmClusterNetworkDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.VmClusterNetworkSummary.rst
+++ b/docs/api/database/models/oci.database.models.VmClusterNetworkSummary.rst
@@ -1,0 +1,11 @@
+VmClusterNetworkSummary
+=======================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: VmClusterNetworkSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.VmClusterSummary.rst
+++ b/docs/api/database/models/oci.database.models.VmClusterSummary.rst
@@ -1,0 +1,11 @@
+VmClusterSummary
+================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: VmClusterSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.VmNetworkDetails.rst
+++ b/docs/api/database/models/oci.database.models.VmNetworkDetails.rst
@@ -1,0 +1,11 @@
+VmNetworkDetails
+================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: VmNetworkDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager.rst
+++ b/docs/api/resource_manager.rst
@@ -18,17 +18,32 @@ Resource Manager
     :nosignatures:
     :template: autosummary/model_class.rst
 
+    oci.resource_manager.models.ApplyJobOperationDetails
+    oci.resource_manager.models.ApplyJobOperationDetailsSummary
     oci.resource_manager.models.ApplyJobPlanResolution
     oci.resource_manager.models.ChangeStackCompartmentDetails
     oci.resource_manager.models.ConfigSource
+    oci.resource_manager.models.CreateApplyJobOperationDetails
     oci.resource_manager.models.CreateConfigSourceDetails
+    oci.resource_manager.models.CreateDestroyJobOperationDetails
+    oci.resource_manager.models.CreateImportTfStateJobOperationDetails
     oci.resource_manager.models.CreateJobDetails
+    oci.resource_manager.models.CreateJobOperationDetails
+    oci.resource_manager.models.CreatePlanJobOperationDetails
     oci.resource_manager.models.CreateStackDetails
     oci.resource_manager.models.CreateZipUploadConfigSourceDetails
+    oci.resource_manager.models.DestroyJobOperationDetails
+    oci.resource_manager.models.DestroyJobOperationDetailsSummary
     oci.resource_manager.models.FailureDetails
+    oci.resource_manager.models.ImportTfStateJobOperationDetails
+    oci.resource_manager.models.ImportTfStateJobOperationDetailsSummary
     oci.resource_manager.models.Job
+    oci.resource_manager.models.JobOperationDetails
+    oci.resource_manager.models.JobOperationDetailsSummary
     oci.resource_manager.models.JobSummary
     oci.resource_manager.models.LogEntry
+    oci.resource_manager.models.PlanJobOperationDetails
+    oci.resource_manager.models.PlanJobOperationDetailsSummary
     oci.resource_manager.models.Stack
     oci.resource_manager.models.StackSummary
     oci.resource_manager.models.UpdateConfigSourceDetails

--- a/docs/api/resource_manager/models/oci.resource_manager.models.ApplyJobOperationDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.ApplyJobOperationDetails.rst
@@ -1,0 +1,11 @@
+ApplyJobOperationDetails
+========================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: ApplyJobOperationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.ApplyJobOperationDetailsSummary.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.ApplyJobOperationDetailsSummary.rst
@@ -1,0 +1,11 @@
+ApplyJobOperationDetailsSummary
+===============================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: ApplyJobOperationDetailsSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.CreateApplyJobOperationDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.CreateApplyJobOperationDetails.rst
@@ -1,0 +1,11 @@
+CreateApplyJobOperationDetails
+==============================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: CreateApplyJobOperationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.CreateDestroyJobOperationDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.CreateDestroyJobOperationDetails.rst
@@ -1,0 +1,11 @@
+CreateDestroyJobOperationDetails
+================================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: CreateDestroyJobOperationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.CreateImportTfStateJobOperationDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.CreateImportTfStateJobOperationDetails.rst
@@ -1,0 +1,11 @@
+CreateImportTfStateJobOperationDetails
+======================================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: CreateImportTfStateJobOperationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.CreateJobOperationDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.CreateJobOperationDetails.rst
@@ -1,0 +1,11 @@
+CreateJobOperationDetails
+=========================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: CreateJobOperationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.CreatePlanJobOperationDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.CreatePlanJobOperationDetails.rst
@@ -1,0 +1,11 @@
+CreatePlanJobOperationDetails
+=============================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: CreatePlanJobOperationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.DestroyJobOperationDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.DestroyJobOperationDetails.rst
@@ -1,0 +1,11 @@
+DestroyJobOperationDetails
+==========================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: DestroyJobOperationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.DestroyJobOperationDetailsSummary.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.DestroyJobOperationDetailsSummary.rst
@@ -1,0 +1,11 @@
+DestroyJobOperationDetailsSummary
+=================================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: DestroyJobOperationDetailsSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.ImportTfStateJobOperationDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.ImportTfStateJobOperationDetails.rst
@@ -1,0 +1,11 @@
+ImportTfStateJobOperationDetails
+================================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: ImportTfStateJobOperationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.ImportTfStateJobOperationDetailsSummary.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.ImportTfStateJobOperationDetailsSummary.rst
@@ -1,0 +1,11 @@
+ImportTfStateJobOperationDetailsSummary
+=======================================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: ImportTfStateJobOperationDetailsSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.JobOperationDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.JobOperationDetails.rst
@@ -1,0 +1,11 @@
+JobOperationDetails
+===================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: JobOperationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.JobOperationDetailsSummary.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.JobOperationDetailsSummary.rst
@@ -1,0 +1,11 @@
+JobOperationDetailsSummary
+==========================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: JobOperationDetailsSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.PlanJobOperationDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.PlanJobOperationDetails.rst
@@ -1,0 +1,11 @@
+PlanJobOperationDetails
+=======================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: PlanJobOperationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.PlanJobOperationDetailsSummary.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.PlanJobOperationDetailsSummary.rst
@@ -1,0 +1,11 @@
+PlanJobOperationDetailsSummary
+==============================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: PlanJobOperationDetailsSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/database/adb_example.py
+++ b/examples/database/adb_example.py
@@ -128,6 +128,32 @@ def update_adb_licesnse_type(db_client, adb_id):
     return adb_response.data.id
 
 
+def create_free_adb(db_client):
+    # Create the model and populate the values
+    # See: https://docs.cloud.oracle.com/iaas/Content/Database/Tasks/adbcreating.htm
+    adb_request = oci.database.models.CreateAutonomousDatabaseDetails()
+
+    adb_request.compartment_id = compartment_id
+    adb_request.cpu_core_count = 1
+    adb_request.data_storage_size_in_tbs = 1
+    adb_request.db_name = "freeadbexample"
+    adb_request.display_name = "PYSDK-ADB-EXAMPLE"
+    adb_request.db_workload = "OLTP"
+    adb_request.license_model = adb_request.LICENSE_MODEL_BRING_YOUR_OWN_LICENSE
+    # For demonstration, we just passed the password here but for Production code you should have a better
+    # way to pass the password like env variable or commandline
+    adb_request.admin_password = "Welcome1!SDK"
+    adb_request.is_free_tier = True
+
+    adb_response = db_client.create_autonomous_database(
+        create_autonomous_database_details=adb_request,
+        retry_strategy=oci.retry.DEFAULT_RETRY_STRATEGY)
+
+    print("Created Free Autonomous Database {}".format(adb_response.data.id))
+
+    return adb_response.data.id
+
+
 if __name__ == "__main__":
     # Initialize the client
     db_client = oci.database.DatabaseClient(config)
@@ -137,6 +163,8 @@ if __name__ == "__main__":
     adb_id = create_adb(db_client)
     # Create preview
     adb__preview_id = create_adb_preview(db_client)
+    # Create Free ADB
+    free_adb_id = create_free_adb(db_client)
     # sleep 5 mins
     time.sleep(300)
     # Update adb acl with specific adb_id.
@@ -150,3 +178,4 @@ if __name__ == "__main__":
     # Delete adb
     delete_adb(db_client, adb_id)
     delete_adb(db_client, adb__preview_id)
+    delete_adb(db_client, free_adb_id)

--- a/examples/exacc_backup_destination.py
+++ b/examples/exacc_backup_destination.py
@@ -1,0 +1,68 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+# This script provides an example of CRUD(Create, Read, Update, Delete) operations
+# on BackupDestination resource.
+
+# Usage: python exacc_backup_destination.py
+
+import oci
+
+# Load the default configuration
+config = oci.config.from_file()
+
+# Set the compartment_id.
+compartment_id = config["tenancy"]
+
+
+def create_backup_destination(db_client):
+    backup_destination_request = oci.database.models.CreateNFSBackupDestinationDetails()
+
+    backup_destination_request.compartment_id = compartment_id
+    backup_destination_request.display_name = "PYSDK-EXAMPLE"
+    backup_destination_request.local_mount_point_path = "Users/path"
+    backup_destination_request.defined_tags = None
+    backup_destination_request.freeform_tags = None
+
+    backup_destination_response = db_client.create_backup_destination(
+        create_backup_destination_details=backup_destination_request
+    )
+
+    backup_destination_id = backup_destination_response.data.id
+    print("Created Backup Destination {}".format(backup_destination_id))
+
+    return backup_destination_id
+
+
+def update_backup_destination(db_client, backup_destination_id):
+    backup_destination_request = oci.database.models.UpdateBackupDestinationDetails()
+    backup_destination_request.localMountPointPath = "Users/updated_path"
+
+    backup_destination_response = db_client.update_backup_destination(
+        backup_destination_id=backup_destination_id,
+        update_backup_destination_details=backup_destination_request)
+
+    print(backup_destination_response.data)
+
+
+def delete_backup_destination(db_client, backup_destination_id):
+    response = db_client.delete_backup_destination(backup_destination_id)
+    print(response.data)
+
+
+def get_backup_destination(db_client, backup_destination_id):
+    response = db_client.get_backup_destination(backup_destination_id)
+    print(response.data)
+
+
+if __name__ == "__main__":
+    # Initialize the client
+    db_client = oci.database.DatabaseClient(config)
+
+    backup_destination_id = create_backup_destination(db_client)
+
+    update_backup_destination(db_client, backup_destination_id)
+
+    get_backup_destination(db_client, backup_destination_id)
+
+    delete_backup_destination(db_client, backup_destination_id)

--- a/examples/exacc_create_dbhome_backup_destination.py
+++ b/examples/exacc_create_dbhome_backup_destination.py
@@ -1,0 +1,83 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+# This script provides an example of how use database CLI in terms of:
+#   - Creating a DbHome within a given VmCluster with BackupDestination
+
+# Usage: python exacc_create_dbhome_backup_destination.py <OCID of a VmCluster> <OCID of compartment>
+
+import oci
+import sys
+import random
+import string
+
+
+def random_string(elements, num):
+    result = ''
+    for _ in range(num):
+        result += random.choice(elements)
+    return result
+
+
+if len(sys.argv) < 3:
+    print("Missing arguments! an OCID for a VmCluster and compartment OCID are the required arguments")
+
+
+vm_cluster_id = sys.argv[1]
+db_name = ''.join(random_string(string.ascii_lowercase, 8))
+db_unique_name = db_name + '_' + ''.join(random_string(string.ascii_lowercase, 20))
+admin_password = '_#' + ''.join(random_string(string.ascii_lowercase + string.ascii_uppercase + string.digits + "_-#", 16))
+
+config = oci.config.from_file()
+db_client = oci.database.DatabaseClient(config)
+compartment_id = sys.argv[2]
+
+
+def create_backup_destination():
+    backup_destination_request = oci.database.models.CreateNFSBackupDestinationDetails()
+
+    backup_destination_request.compartment_id = compartment_id
+    backup_destination_request.display_name = "PYSDK-EXAMPLE"
+    backup_destination_request.local_mount_point_path = "Users/path"
+
+    backup_destination_response = db_client.create_backup_destination(
+        create_backup_destination_details=backup_destination_request)
+
+    backup_destination = backup_destination_response.data
+    print("Created Backup Destination {}".format(backup_destination))
+
+    return backup_destination
+
+
+backup_destination = create_backup_destination()
+
+backup_destination_details = oci.database.models.BackupDestinationDetails()
+backup_destination_details.id = backup_destination.id
+backup_destination_details.type = backup_destination_details.TYPE_NFS
+
+backup_destination_list = [backup_destination_details]
+
+db_backup_config = oci.database.models.db_backup_config.DbBackupConfig(
+    backup_destination_details=backup_destination_list
+)
+
+
+create_database_details = oci.database.models.CreateDatabaseDetails(
+    db_name=db_name,
+    db_unique_name=db_unique_name,
+    admin_password=admin_password,
+    db_backup_config=db_backup_config
+)
+
+create_db_home_details = oci.database.models.CreateDbHomeWithVmClusterIdDetails(
+    source='VM_CLUSTER_NEW',
+    vm_cluster_id=vm_cluster_id,
+    display_name=''.join(random_string(string.ascii_lowercase + ' ', 32)),
+    db_version='18.0.0.0',
+    database=create_database_details
+)
+
+response = db_client.create_db_home(create_db_home_details)
+
+print(response.data)
+# ExaCC DB_Home with backup destination is created

--- a/examples/exacc_dbhome_create_example.py
+++ b/examples/exacc_dbhome_create_example.py
@@ -1,0 +1,49 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+# This script provides an example of how use database CLI in terms of:
+#   - Creating a DbHome within a given VmCluster
+
+# Usage: python exacc_dbhome_create_example.py <OCID of a VmCluster>
+
+import oci
+import sys
+import random
+import string
+
+
+def random_string(elements, num):
+    result = ''
+    for _ in range(num):
+        result += random.choice(elements)
+    return result
+
+
+if len(sys.argv) < 2:
+    print("Missing argument! an OCID for a VmCluster")
+
+vm_cluster_id = sys.argv[1]
+db_name = ''.join(random_string(string.ascii_lowercase, 8))
+db_unique_name = db_name + '_' + ''.join(random_string(string.ascii_lowercase, 20))
+admin_password = '_#' + ''.join(random_string(string.ascii_lowercase + string.ascii_uppercase + string.digits + "_-#", 16))
+
+config = oci.config.from_file()
+client = oci.database.DatabaseClient(config)
+
+create_database_details = oci.database.models.CreateDatabaseDetails(
+    db_name=db_name,
+    db_unique_name=db_unique_name,
+    admin_password=admin_password
+)
+
+create_db_home_details = oci.database.models.CreateDbHomeWithVmClusterIdDetails(
+    source='VM_CLUSTER_NEW',
+    vm_cluster_id=vm_cluster_id,
+    display_name=''.join(random_string(string.ascii_lowercase + ' ', 32)),
+    db_version='18.0.0.0',
+    database=create_database_details
+)
+
+response = client.create_db_home(create_db_home_details)
+
+print(response.data)

--- a/examples/exacc_dbhome_get_example.py
+++ b/examples/exacc_dbhome_get_example.py
@@ -1,0 +1,22 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+# This script provides an example of how use database CLI in terms of:
+#   - Retrieving a DbHome within a given VmCluster
+
+# Usage: python exacc_dbhome_get_example.py <OCID of a DbHome>
+
+import oci
+import sys
+
+if len(sys.argv) < 2:
+    print("Missing argument! an OCID for a DbHome!")
+
+db_home_id = sys.argv[1]
+
+config = oci.config.from_file()
+client = oci.database.DatabaseClient(config)
+
+response = client.get_db_home(db_home_id=db_home_id)
+
+print(response.data)

--- a/examples/exacc_dbhome_list_example.py
+++ b/examples/exacc_dbhome_list_example.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+# This script provides an example of how use database CLI in terms of:
+#   - Retrieving a list of DbHomes within a given VmCluster
+#
+
+# Usage: python exacc_dbhome_list_example.py <OCID of a VmCluster>
+
+import oci
+import sys
+
+if len(sys.argv) < 2:
+    print("Missing argument! an OCID for a VmCluster")
+
+vm_cluster_id = sys.argv[1]
+
+config = oci.config.from_file()
+client = oci.database.DatabaseClient(config)
+
+get_vm_cluster_response = client.get_vm_cluster(vm_cluster_id=vm_cluster_id)
+compartment_id = get_vm_cluster_response.data.compartment_id
+
+response = client.list_db_homes(vm_cluster_id=vm_cluster_id, compartment_id=compartment_id)
+
+print(response.data)

--- a/examples/exacc_infrastructure_example.py
+++ b/examples/exacc_infrastructure_example.py
@@ -1,0 +1,107 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+# This script provides an example of how use database CLI in terms of:
+#   - Creating an Exadata Infrastructure at Customer Cloud
+
+# Usage: python exacc_infrastructure_example.py <Compartment OCID> <Activation Key File Path>
+
+# This script takes the following arguments:
+#
+#   * The compartment in which infrastructure will be created
+#   * The path to the key file for activation
+
+
+import oci
+import sys
+import random
+import string
+
+
+def random_string(elements, num):
+    result = ''
+    for _ in range(num):
+        result += random.choice(elements)
+    return result
+
+
+shape = 'Exadata.Quarter3.100'
+time_zone = 'UTC'
+display_name = 'Exacc_Infra_'.join(random_string(string.ascii_lowercase, 8))
+
+if len(sys.argv) < 3:
+    print("Missing the required arguments! an OCID of the compartment and path to the key file for activation")
+
+# cloud_control_plane_server1 and cloud_control_plane_server1 must be a valid unused IP within the admin network CIDR
+admin_network_cidr = '0.31.16.0/20'
+cloud_control_plane_server1 = '10.31.153.83'
+cloud_control_plane_server2 = '10.31.153.84'
+corporate_proxy = 'fake-proxy.us.oracle.com'
+dns_server = ['10.89.138.33']
+ntp_server = ['10.89.138.33']
+infini_band_network_cidr = ['192.168.31.0/24']
+gateway = '10.31.16.1'
+netmask = '255.255.240.0'
+
+compartment_id = sys.argv[1]
+activation_key_file = sys.argv[2]
+
+
+config = oci.config.from_file()
+client = oci.database.DatabaseClient(config)
+client_composite_ops = oci.database.DatabaseClientCompositeOperations(client)
+
+create_infrastructure_details = oci.database.models.CreateExadataInfrastructureDetails(
+    compartment_id=compartment_id,
+    display_name=display_name,
+    shape=shape,
+    time_zone=time_zone,
+    cloud_control_plane_server1=cloud_control_plane_server1,
+    cloud_control_plane_server2=cloud_control_plane_server2,
+    gateway=gateway,
+    netmask=netmask,
+    infini_band_network_cidr=infini_band_network_cidr,
+    corporate_proxy=corporate_proxy,
+    admin_network_cidr=admin_network_cidr,
+    dns_server=dns_server,
+    ntp_server=ntp_server
+)
+
+# Create exadata infrastructure
+# We can wait until the Exadata Infrastructure is in REQUIRES_ACTIVATION state.
+
+life_cycle_creation_succeed_state = oci.database.models.ExadataInfrastructure.LIFECYCLE_STATE_REQUIRES_ACTIVATION
+exacc_infra = client_composite_ops.create_exadata_infrastructure_and_wait_for_state(
+    create_infrastructure_details,
+    [life_cycle_creation_succeed_state]
+)
+
+infrastructure_ocid = exacc_infra.data.id
+
+
+new_netmask = '255.255.240.1'
+
+update_infrastructure_details = oci.database.models.UpdateExadataInfrastructureDetails(
+    netmask=new_netmask
+)
+
+exacc_infra_updated = client_composite_ops.update_exadata_infrastructure_and_wait_for_state(infrastructure_ocid, update_infrastructure_details, [life_cycle_creation_succeed_state])
+
+print(exacc_infra_updated.data)
+
+activate_exadata_infrastructure_details = oci.database.models.ActivateExadataInfrastructureDetails(
+    activation_file=activation_key_file
+)
+
+
+life_cycle_activation_succeed_state = oci.database.models.ExadataInfrastructure.LIFECYCLE_STATE_ACTIVE
+exacc_infra_activated = client_composite_ops.activate_exadata_infrastructure_and_wait_for_state(infrastructure_ocid, activate_exadata_infrastructure_details, [life_cycle_activation_succeed_state])
+
+print(exacc_infra_activated.data)
+
+life_cycle_deletion_succeed_state = oci.database.models.ExadataInfrastructure.LIFECYCLE_STATE_DELETED
+exacc_infra_deleted = client_composite_ops.delete_exadata_infrastructure_and_wait_for_state(infrastructure_ocid, [life_cycle_deletion_succeed_state])
+
+print(exacc_infra_deleted.data)
+
+print('Deleted Exadata Infrastructure')

--- a/examples/exacc_update_db_backup_destination.py
+++ b/examples/exacc_update_db_backup_destination.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+# This script provides an example of how use database CLI in terms of:
+#   - Updating a DB with BackupDestination
+
+# Usage: python exacc_update_db_backup_destination.py <OCID of a DB> <OCID of Backup Destination>
+
+import sys
+import oci
+
+if len(sys.argv) < 3:
+    print("Missing arguments! an OCID for a database and backup destination OCID are the required arguments")
+
+database_id = sys.argv[1]
+backup_destination_id = sys.argv[2]
+
+config = oci.config.from_file()
+db_client = oci.database.DatabaseClient(config)
+
+backup_destination_details = oci.database.models.BackupDestinationDetails(
+    id=backup_destination_id,
+    type="NFS"
+)
+
+backup_destination_list = [backup_destination_details]
+
+db_backup_config_bd = oci.database.models.db_backup_config.DbBackupConfig(
+    backup_destination_details=backup_destination_list
+)
+
+update_database = oci.database.models.UpdateDatabaseDetails(
+    db_backup_config=db_backup_config_bd
+)
+
+response = db_client.update_database(database_id, update_database)
+
+print(response.data)
+# DB with backup_destination updated

--- a/examples/exacc_vmcluster_example.py
+++ b/examples/exacc_vmcluster_example.py
@@ -1,0 +1,86 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+# This script provides an example of how use database CLI in terms of:
+#   - Creating a Vm Cluster Network at Customer Cloud
+
+# Usage: python exacc_vmcluster_example.py <Compartment OCID> <OCID of the Exadata Infrastructure> <OCID of the Vm Cluster Network> <The path to the public SSH key>
+
+# This script takes the following arguments:
+#
+#   * The compartment in which infrastructure will be created
+#   * OCID of the Exadata Infrastructure
+
+
+import oci
+import os.path
+import sys
+import random
+import string
+
+
+def random_string(elements, num):
+    result = ''
+    for _ in range(num):
+        result += random.choice(elements)
+    return result
+
+
+display_name = 'VmCluster_Network_'.join(random_string(string.ascii_lowercase, 8))
+if len(sys.argv) < 5:
+    print("Missing the required arguments! an OCID of the compartment, OCID of the Exadata Infrastructure, OCID of the Vm Cluster Network  and The path to the public SSH key which can be used for SSHing into the Vm Cluster")
+
+cpuCoreCount = 22
+giVersion = '18.0.0.0'
+displayName = 'vmcluster'
+
+
+compartment_id = sys.argv[1]
+exadata_infrastructure_id = sys.argv[2]
+vm_cluster_network_id = sys.argv[3]
+ssh_public_key_path = os.path.expandvars(os.path.expanduser(sys.argv[4]))
+
+
+config = oci.config.from_file()
+client = oci.database.DatabaseClient(config)
+client_composite_ops = oci.database.DatabaseClientCompositeOperations(client)
+
+with open(ssh_public_key_path, mode='r') as file:
+    ssh_key = file.read()
+
+create_vm_cluster_details = oci.database.models.CreateVmClusterDetails(
+    compartment_id=compartment_id,
+    cpu_core_count=cpuCoreCount,
+    display_name=displayName,
+    exadata_infrastructure_id=exadata_infrastructure_id,
+    gi_version=giVersion,
+    ssh_public_keys=[ssh_key],
+    vm_cluster_network_id=vm_cluster_network_id
+)
+
+
+# Create Vm Cluster
+# We can wait until the Vm Cluster is in AVAILABLE state.
+
+life_cycle_creation_succeed_state = oci.database.models.VmClusterSummary.LIFECYCLE_STATE_AVAILABLE
+vm_cluster = client_composite_ops.create_vm_cluster_and_wait_for_state(create_vm_cluster_details)
+
+
+vm_cluster_ocid = vm_cluster.data.id
+
+new_license_model = oci.database.models.UpdateVmClusterDetailsLICENSE_MODEL_LICENSE_INCLUDED
+
+update_vm_cluster_details = oci.database.models.UpdateVmClusterDetails(
+    license_model=new_license_model
+)
+
+vm_cluster_updated = client_composite_ops.update_vm_cluster_and_wait_for_state(vm_cluster_ocid, update_vm_cluster_details, [life_cycle_creation_succeed_state])
+
+print(vm_cluster_updated.data)
+
+life_cycle_deletion_succeed_state = oci.database.models.VmClusterSummary.LIFECYCLE_STATE_TERMINATED
+vm_cluster_deleted = client_composite_ops.delete_vm_cluster_and_wait_for_state(vm_cluster_ocid, [life_cycle_deletion_succeed_state])
+
+print(vm_cluster_deleted.data)
+
+print('Terminated Vm Cluster')

--- a/examples/exacc_vmclusternetwork_example.py
+++ b/examples/exacc_vmclusternetwork_example.py
@@ -1,0 +1,113 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+# This script provides an example of how use database CLI in terms of:
+#   - Creating a Vm Cluster Network at Customer Cloud
+
+# Usage: python exacc_vmclusternetwork_example.py <Compartment OCID> <OCID of the Exadata Infrastructure>
+
+# This script takes the following arguments:
+#
+#   * The compartment in which infrastructure will be created
+#   * OCID of the Exadata Infrastructure
+
+
+import oci
+import sys
+import random
+import string
+
+
+def random_string(elements, num):
+    result = ''
+    for _ in range(num):
+        result += random.choice(elements)
+    return result
+
+
+display_name = 'VmCluster_Network_'.join(random_string(string.ascii_lowercase, 8))
+if len(sys.argv) < 3:
+    print("Missing the required arguments! an OCID of the compartment and OCID of the Exadata Infrastructure")
+
+cidr = '192.168.10.0/16'
+domain = 'oracleclient.com'
+gateway = '192.168.10.1'
+netmask = '255.255.0.0'
+prefix = 'exacc'
+vlanId = '223'
+cidr2 = '172.168.10.0/16'
+domain2 = 'oraclebkp.com'
+gateway2 = '192.168.10.5'
+netmask2 = '255.255.0.0'
+prefix2 = 'exacc-bkp'
+vlanId2 = '224'
+
+compartment_id = sys.argv[1]
+exadata_infrastructure_id = sys.argv[2]
+
+
+config = oci.config.from_file()
+client = oci.database.DatabaseClient(config)
+client_composite_ops = oci.database.DatabaseClientCompositeOperations(client)
+
+info_for_network_gen_details1 = oci.database.models.InfoForNetworkGenDetails(
+    network_type=oci.database.models.InfoForNetworkGenDetails.NETWORK_TYPE_CLIENT,
+    vlan_id=vlanId,
+    cidr=cidr,
+    gateway=gateway,
+    netmask=netmask,
+    domain=domain,
+    prefix=prefix
+)
+
+info_for_network_gen_details2 = oci.database.models.InfoForNetworkGenDetails(
+    network_type=oci.database.models.InfoForNetworkGenDetails.NETWORK_TYPE_BACKUP,
+    vlan_id=vlanId2,
+    cidr=cidr2,
+    gateway=gateway2,
+    netmask=netmask2,
+    domain=domain2,
+    prefix=prefix2
+)
+
+generate_recommended_network_details = oci.database.models.GenerateRecommendedNetworkDetails(
+    compartment_id=compartment_id,
+    display_name=display_name,
+    networks=[info_for_network_gen_details1, info_for_network_gen_details2]
+)
+
+
+# Create Vm Cluster Network
+# We can wait until the Vm Cluster Network is in REQUIRES_VALIDATION state.
+
+life_cycle_creation_succeed_state = oci.database.models.VmClusterNetworkSummary.LIFECYCLE_STATE_REQUIRES_VALIDATION
+vm_cluster_network = client_composite_ops.create_vm_cluster_network_and_wait_for_state(exadata_infrastructure_id, generate_recommended_network_details)
+
+
+vm_cluster_network_ocid = vm_cluster_network.data.id
+
+
+new_dns = ['210.89.138.33']
+
+update_vm_cluster_network_details = oci.database.models.UpdateVmClusterNetworkDetails(
+    dns=new_dns
+)
+
+vm_cluster_network_updated = client_composite_ops.update_vm_cluster_network_and_wait_for_state(exadata_infrastructure_id, vm_cluster_network_ocid, update_vm_cluster_network_details, [life_cycle_creation_succeed_state])
+
+print(vm_cluster_network_updated.data)
+
+life_cycle_validation_succeed_state = oci.database.models.VmClusterNetworkSummary.LIFECYCLE_STATE_VALIDATED
+vm_cluster_network_validated = client_composite_ops.validate_vm_cluster_network_and_wait_for_state(exadata_infrastructure_id, vm_cluster_network_ocid, [life_cycle_validation_succeed_state])
+
+print(vm_cluster_network_updated.data)
+
+client.delete_vm_cluster_network(exadata_infrastructure_id, vm_cluster_network_ocid)
+oci.wait_until(
+    client,
+    vm_cluster_network_updated,
+    'lifecycle_state',
+    'TERMINATED',
+    succeed_on_not_found=True
+)
+print('Terminated Vm Cluster Network')

--- a/src/oci/database/database_client.py
+++ b/src/oci/database/database_client.py
@@ -82,6 +82,97 @@ class DatabaseClient(object):
         self._config = config
         self._kwargs = kwargs
 
+    def activate_exadata_infrastructure(self, exadata_infrastructure_id, activate_exadata_infrastructure_details, **kwargs):
+        """
+        Activate ExadataInfrastructure
+        Activates the specified Exadata infrastructure.
+
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param ActivateExadataInfrastructureDetails activate_exadata_infrastructure_details: (required)
+            The activation details for the Exadata infrastructure.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExadataInfrastructure`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}/actions/activate"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "activate_exadata_infrastructure got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=activate_exadata_infrastructure_details,
+                response_type="ExadataInfrastructure")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=activate_exadata_infrastructure_details,
+                response_type="ExadataInfrastructure")
+
     def change_autonomous_container_database_compartment(self, change_compartment_details, autonomous_container_database_id, **kwargs):
         """
         ChangeAutonomousContainerDatabaseCompartment
@@ -382,6 +473,106 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=change_compartment_details)
 
+    def change_backup_destination_compartment(self, change_compartment_details, backup_destination_id, **kwargs):
+        """
+        ChangeBackupDestinationCompartment
+        Move the backup destination and its dependent resources to the specified compartment.
+        For more information about moving backup destinations, see
+        `Moving Database Resources to a Different Compartment`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes
+
+
+        :param ChangeCompartmentDetails change_compartment_details: (required)
+            Request to move backup destination to a different compartment
+
+        :param str backup_destination_id: (required)
+            The `OCID`__ of the backup destination.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/backupDestinations/{backupDestinationId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_backup_destination_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "backupDestinationId": backup_destination_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_compartment_details)
+
     def change_db_system_compartment(self, change_compartment_details, db_system_id, **kwargs):
         """
         ChangeDbSystemCompartment
@@ -481,6 +672,200 @@ class DatabaseClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 body=change_compartment_details)
+
+    def change_exadata_infrastructure_compartment(self, change_exadata_infrastructure_compartment_details, exadata_infrastructure_id, **kwargs):
+        """
+        ChangeExadataInfrastructureCompartment
+        To move an Exadata infrastructure and its dependent resources to another compartment, use the
+        :func:`change_exadata_infrastructure_compartment` operation.
+
+
+        :param ChangeExadataInfrastructureCompartmentDetails change_exadata_infrastructure_compartment_details: (required)
+            Request to move Exadata infrastructure to a different compartment
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_exadata_infrastructure_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_exadata_infrastructure_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_exadata_infrastructure_compartment_details)
+
+    def change_vm_cluster_compartment(self, change_vm_cluster_compartment_details, vm_cluster_id, **kwargs):
+        """
+        ChangeVmClusterCompartment
+        To move a VM cluster and its dependent resources to another compartment, use the
+        :func:`change_vm_cluster_compartment` operation.
+
+
+        :param ChangeVmClusterCompartmentDetails change_vm_cluster_compartment_details: (required)
+            Request to move VM cluster to a different compartment
+
+        :param str vm_cluster_id: (required)
+            The VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vmClusters/{vmClusterId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_vm_cluster_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "vmClusterId": vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_vm_cluster_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_vm_cluster_compartment_details)
 
     def complete_external_backup_job(self, backup_id, complete_external_backup_job_details, **kwargs):
         """
@@ -1003,6 +1388,80 @@ class DatabaseClient(object):
                 body=create_backup_details,
                 response_type="Backup")
 
+    def create_backup_destination(self, create_backup_destination_details, **kwargs):
+        """
+        CreateBackupDestination
+        Creates a backup destination.
+
+
+        :param CreateBackupDestinationDetails create_backup_destination_details: (required)
+            Request to create a new backup destination.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.BackupDestination`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/backupDestinations"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_backup_destination got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_backup_destination_details,
+                response_type="BackupDestination")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_backup_destination_details,
+                response_type="BackupDestination")
+
     def create_data_guard_association(self, database_id, create_data_guard_association_details, **kwargs):
         """
         Creates a Data Guard association.
@@ -1105,7 +1564,7 @@ class DatabaseClient(object):
         Creates a new database home in the specified DB system based on the request parameters you provide.
 
 
-        :param CreateDbHomeWithDbSystemIdBase create_db_home_with_db_system_id_details: (required)
+        :param CreateDbHomeBase create_db_home_with_db_system_id_details: (required)
             Request to create a new database home.
 
         :param str opc_retry_token: (optional)
@@ -1167,6 +1626,80 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=create_db_home_with_db_system_id_details,
                 response_type="DbHome")
+
+    def create_exadata_infrastructure(self, create_exadata_infrastructure_details, **kwargs):
+        """
+        CreateExadataInfrastructure
+        Create Exadata infrastructure.
+
+
+        :param CreateExadataInfrastructureDetails create_exadata_infrastructure_details: (required)
+            Request to create Exadata infrastructure.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExadataInfrastructure`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_exadata_infrastructure got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_exadata_infrastructure_details,
+                response_type="ExadataInfrastructure")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_exadata_infrastructure_details,
+                response_type="ExadataInfrastructure")
 
     def create_external_backup_job(self, create_external_backup_job_details, **kwargs):
         """
@@ -1240,6 +1773,171 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=create_external_backup_job_details,
                 response_type="ExternalBackupJob")
+
+    def create_vm_cluster(self, create_vm_cluster_details, **kwargs):
+        """
+        CreateVmCluster
+        Creates a VM cluster.
+
+
+        :param CreateVmClusterDetails create_vm_cluster_details: (required)
+            Request to create a VM cluster.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.VmCluster`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vmClusters"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_vm_cluster got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_vm_cluster_details,
+                response_type="VmCluster")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_vm_cluster_details,
+                response_type="VmCluster")
+
+    def create_vm_cluster_network(self, exadata_infrastructure_id, vm_cluster_network_details, **kwargs):
+        """
+        CreateVmClusterNetwork
+        Creates the VM cluster network.
+
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param VmClusterNetworkDetails vm_cluster_network_details: (required)
+            Request to create the VM cluster network.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.VmClusterNetwork`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_vm_cluster_network got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=vm_cluster_network_details,
+                response_type="VmClusterNetwork")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=vm_cluster_network_details,
+                response_type="VmClusterNetwork")
 
     def db_node_action(self, db_node_id, action, **kwargs):
         """
@@ -1583,6 +2281,86 @@ class DatabaseClient(object):
                 path_params=path_params,
                 header_params=header_params)
 
+    def delete_backup_destination(self, backup_destination_id, **kwargs):
+        """
+        DeleteBackupDestination
+        Deletes a backup destination.
+
+
+        :param str backup_destination_id: (required)
+            The `OCID`__ of the backup destination.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/backupDestinations/{backupDestinationId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_backup_destination got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "backupDestinationId": backup_destination_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
     def delete_db_home(self, db_home_id, **kwargs):
         """
         DeleteDbHome
@@ -1668,6 +2446,430 @@ class DatabaseClient(object):
                 path_params=path_params,
                 query_params=query_params,
                 header_params=header_params)
+
+    def delete_exadata_infrastructure(self, exadata_infrastructure_id, **kwargs):
+        """
+        Deletes the specified Exadata infrastructure.
+        Deletes the Exadata infrastructure.
+
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_exadata_infrastructure got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_vm_cluster(self, vm_cluster_id, **kwargs):
+        """
+        Deletes the specified VM cluster.
+        Deletes the specified VM cluster.
+
+
+        :param str vm_cluster_id: (required)
+            The VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vmClusters/{vmClusterId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_vm_cluster got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "vmClusterId": vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_vm_cluster_network(self, exadata_infrastructure_id, vm_cluster_network_id, **kwargs):
+        """
+        Deletes the specified VM cluster network.
+        Deletes the specified VM cluster network.
+
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str vm_cluster_network_id: (required)
+            The VM cluster network `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks/{vmClusterNetworkId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_vm_cluster_network got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id,
+            "vmClusterNetworkId": vm_cluster_network_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def download_exadata_infrastructure_config_file(self, exadata_infrastructure_id, **kwargs):
+        """
+        Downloads the configuration file for the specified Exadata infrastructure.
+        Downloads the configuration file for the specified Exadata infrastructure.
+
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type stream
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}/actions/downloadConfigFile"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "download_exadata_infrastructure_config_file got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/octet-stream",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
+
+    def download_vm_cluster_network_config_file(self, exadata_infrastructure_id, vm_cluster_network_id, **kwargs):
+        """
+        Downloads the configuration file for the specified VM Cluster Network.
+        Downloads the configuration file for the specified VM Cluster Network.
+
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str vm_cluster_network_id: (required)
+            The VM cluster network `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type stream
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks/{vmClusterNetworkId}/actions/downloadConfigFile"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "download_vm_cluster_network_config_file got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id,
+            "vmClusterNetworkId": vm_cluster_network_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/octet-stream",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
 
     def failover_data_guard_association(self, database_id, data_guard_association_id, failover_data_guard_association_details, **kwargs):
         """
@@ -1942,6 +3144,97 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=generate_autonomous_database_wallet_details,
                 response_type="stream")
+
+    def generate_recommended_vm_cluster_network(self, exadata_infrastructure_id, generate_recommended_network_details, **kwargs):
+        """
+        Generates a recommended VM cluster network configuration.
+        Generates a recommended VM cluster network configuration.
+
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param GenerateRecommendedNetworkDetails generate_recommended_network_details: (required)
+            Request to generate a recommended VM cluster network configuration.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.VmClusterNetworkDetails`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks/actions/generateRecommendedNetwork"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "generate_recommended_vm_cluster_network got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=generate_recommended_network_details,
+                response_type="VmClusterNetworkDetails")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=generate_recommended_network_details,
+                response_type="VmClusterNetworkDetails")
 
     def get_autonomous_container_database(self, autonomous_container_database_id, **kwargs):
         """
@@ -2422,6 +3715,81 @@ class DatabaseClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 response_type="Backup")
+
+    def get_backup_destination(self, backup_destination_id, **kwargs):
+        """
+        GetBackupDestination
+        Gets information about the specified backup destination.
+
+
+        :param str backup_destination_id: (required)
+            The `OCID`__ of the backup destination.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.BackupDestination`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/backupDestinations/{backupDestinationId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_backup_destination got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "backupDestinationId": backup_destination_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="BackupDestination")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="BackupDestination")
 
     def get_data_guard_association(self, database_id, data_guard_association_id, **kwargs):
         """
@@ -3047,6 +4415,81 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="PatchHistoryEntry")
 
+    def get_exadata_infrastructure(self, exadata_infrastructure_id, **kwargs):
+        """
+        GetExadataInfrastructure
+        Gets information about the specified Exadata infrastructure.
+
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExadataInfrastructure`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_exadata_infrastructure got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExadataInfrastructure")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExadataInfrastructure")
+
     def get_exadata_iorm_config(self, db_system_id, **kwargs):
         """
         Gets `IORM` Setting for the requested Exadata DB System.
@@ -3255,6 +4698,162 @@ class DatabaseClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 response_type="MaintenanceRun")
+
+    def get_vm_cluster(self, vm_cluster_id, **kwargs):
+        """
+        GetVmCluster
+        Gets information about the specified VM cluster.
+
+
+        :param str vm_cluster_id: (required)
+            The VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.VmCluster`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vmClusters/{vmClusterId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_vm_cluster got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "vmClusterId": vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="VmCluster")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="VmCluster")
+
+    def get_vm_cluster_network(self, exadata_infrastructure_id, vm_cluster_network_id, **kwargs):
+        """
+        GetVmClusterNetwork
+        Gets information about the specified VM cluster network.
+
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str vm_cluster_network_id: (required)
+            The VM cluster network `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.VmClusterNetwork`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks/{vmClusterNetworkId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_vm_cluster_network got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id,
+            "vmClusterNetworkId": vm_cluster_network_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="VmClusterNetwork")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="VmClusterNetwork")
 
     def launch_autonomous_exadata_infrastructure(self, launch_autonomous_exadata_infrastructure_details, **kwargs):
         """
@@ -4407,6 +6006,91 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="list[AutonomousExadataInfrastructureSummary]")
 
+    def list_backup_destination(self, compartment_id, **kwargs):
+        """
+        ListBackupDestination
+        Gets a list of backup destinations in the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str type: (optional)
+            A filter to return only resources that match the given type of the Backup Destination.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.BackupDestinationSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/backupDestinations"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "opc_request_id",
+            "type"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_backup_destination got unknown kwargs: {!r}".format(extra_kwargs))
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "type": kwargs.get("type", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[BackupDestinationSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[BackupDestinationSummary]")
+
     def list_backups(self, **kwargs):
         """
         ListBackups
@@ -4887,6 +6571,11 @@ class DatabaseClient(object):
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
+        :param str vm_cluster_id: (optional)
+            The `OCID`__ of the VM cluster.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
         :param int limit: (optional)
             The maximum number of items to return per page.
 
@@ -4929,6 +6618,7 @@ class DatabaseClient(object):
         expected_kwargs = [
             "retry_strategy",
             "db_system_id",
+            "vm_cluster_id",
             "limit",
             "page",
             "sort_by",
@@ -4965,6 +6655,7 @@ class DatabaseClient(object):
         query_params = {
             "compartmentId": compartment_id,
             "dbSystemId": kwargs.get("db_system_id", missing),
+            "vmClusterId": kwargs.get("vm_cluster_id", missing),
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing),
             "sortBy": kwargs.get("sort_by", missing),
@@ -5015,6 +6706,11 @@ class DatabaseClient(object):
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
+        :param str vm_cluster_id: (optional)
+            The `OCID`__ of the VM cluster.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
         :param int limit: (optional)
             The maximum number of items to return per page.
 
@@ -5054,6 +6750,7 @@ class DatabaseClient(object):
         expected_kwargs = [
             "retry_strategy",
             "db_system_id",
+            "vm_cluster_id",
             "limit",
             "page",
             "sort_by",
@@ -5089,6 +6786,7 @@ class DatabaseClient(object):
         query_params = {
             "compartmentId": compartment_id,
             "dbSystemId": kwargs.get("db_system_id", missing),
+            "vmClusterId": kwargs.get("vm_cluster_id", missing),
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing),
             "sortBy": kwargs.get("sort_by", missing),
@@ -5292,19 +6990,19 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="list[PatchSummary]")
 
-    def list_db_system_shapes(self, availability_domain, compartment_id, **kwargs):
+    def list_db_system_shapes(self, compartment_id, **kwargs):
         """
         ListDbSystemShapes
         Gets a list of the shapes that can be used to launch a new DB system. The shape determines resources to allocate to the DB system - CPU cores and memory for VM shapes; CPU cores, memory and storage for non-VM (or bare metal) shapes.
 
 
-        :param str availability_domain: (required)
-            The name of the Availability Domain.
-
         :param str compartment_id: (required)
             The compartment `OCID`__.
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str availability_domain: (optional)
+            The name of the Availability Domain.
 
         :param int limit: (optional)
             The maximum number of items to return per page.
@@ -5329,6 +7027,7 @@ class DatabaseClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
+            "availability_domain",
             "limit",
             "page"
         ]
@@ -5338,7 +7037,7 @@ class DatabaseClient(object):
                 "list_db_system_shapes got unknown kwargs: {!r}".format(extra_kwargs))
 
         query_params = {
-            "availabilityDomain": availability_domain,
+            "availabilityDomain": kwargs.get("availability_domain", missing),
             "compartmentId": compartment_id,
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing)
@@ -5591,6 +7290,226 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="list[DbVersionSummary]")
 
+    def list_exadata_infrastructures(self, compartment_id, **kwargs):
+        """
+        ListExadataInfrastructures
+        Gets a list of the Exadata infrastructure in the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str sort_by: (optional)
+            The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the given lifecycle state exactly.
+
+            Allowed values are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE"
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.ExadataInfrastructureSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "opc_request_id",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state",
+            "display_name"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_exadata_infrastructures got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ExadataInfrastructureSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ExadataInfrastructureSummary]")
+
+    def list_gi_versions(self, compartment_id, **kwargs):
+        """
+        ListGiVersions
+        Gets a list of supported GI versions for VM Cluster.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str shape: (optional)
+            If provided, filters the results for the given shape.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.GiVersionSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/giVersions"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "sort_order",
+            "shape"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_gi_versions got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "shape": kwargs.get("shape", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[GiVersionSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[GiVersionSummary]")
+
     def list_maintenance_runs(self, compartment_id, **kwargs):
         """
         ListMaintenanceRuns
@@ -5746,6 +7665,282 @@ class DatabaseClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="list[MaintenanceRunSummary]")
+
+    def list_vm_cluster_networks(self, exadata_infrastructure_id, compartment_id, **kwargs):
+        """
+        ListVmClusterNetworks
+        Gets a list of the VM cluster networks in the specified compartment.
+
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str sort_by: (optional)
+            The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the given lifecycle state exactly.
+
+            Allowed values are: "CREATING", "REQUIRES_VALIDATION", "VALIDATING", "VALIDATED", "VALIDATION_FAILED", "UPDATING", "ALLOCATED", "TERMINATING", "TERMINATED", "FAILED"
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.VmClusterNetworkSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state",
+            "display_name",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_vm_cluster_networks got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "REQUIRES_VALIDATION", "VALIDATING", "VALIDATED", "VALIDATION_FAILED", "UPDATING", "ALLOCATED", "TERMINATING", "TERMINATED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[VmClusterNetworkSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[VmClusterNetworkSummary]")
+
+    def list_vm_clusters(self, compartment_id, **kwargs):
+        """
+        ListVmClusters
+        Gets a list of the VM clusters in the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str exadata_infrastructure_id: (optional)
+            If provided, filters the results for the given Exadata Infrastructure.
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str sort_by: (optional)
+            The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the given lifecycle state exactly.
+
+            Allowed values are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.VmClusterSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vmClusters"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "exadata_infrastructure_id",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state",
+            "display_name",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_vm_clusters got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "exadataInfrastructureId": kwargs.get("exadata_infrastructure_id", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[VmClusterSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[VmClusterSummary]")
 
     def reinstate_data_guard_association(self, database_id, data_guard_association_id, reinstate_data_guard_association_details, **kwargs):
         """
@@ -7125,6 +9320,96 @@ class DatabaseClient(object):
                 body=update_autonomous_exadata_infrastructures_details,
                 response_type="AutonomousExadataInfrastructure")
 
+    def update_backup_destination(self, backup_destination_id, update_backup_destination_details, **kwargs):
+        """
+        Updates the specified backup destination.
+        If no database is associated with the backup destination:
+        - For a RECOVERY_APPLIANCE backup destination, updates the connection string and/or the list of VPC users.
+        - For an NFS backup destination, updates the NFS location.
+
+
+        :param str backup_destination_id: (required)
+            The `OCID`__ of the backup destination.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateBackupDestinationDetails update_backup_destination_details: (required)
+            For a RECOVERY_APPLIANCE backup destination, request to update the connection string and/or the list of VPC users.
+            For an NFS backup destination, request to update the NFS location.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.BackupDestination`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/backupDestinations/{backupDestinationId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_backup_destination got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "backupDestinationId": backup_destination_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_backup_destination_details,
+                response_type="BackupDestination")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_backup_destination_details,
+                response_type="BackupDestination")
+
     def update_database(self, database_id, update_database_details, **kwargs):
         """
         UpdateDatabase
@@ -7371,6 +9656,93 @@ class DatabaseClient(object):
                 body=update_db_system_details,
                 response_type="DbSystem")
 
+    def update_exadata_infrastructure(self, exadata_infrastructure_id, update_exadata_infrastructure_details, **kwargs):
+        """
+        Updates the specified Exadata Infrastructure
+        Updates the Exadata infrastructure.
+
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateExadataInfrastructureDetails update_exadata_infrastructure_details: (required)
+            Request to update the properties of an Exadata infrastructure
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExadataInfrastructure`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_exadata_infrastructure got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_exadata_infrastructure_details,
+                response_type="ExadataInfrastructure")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_exadata_infrastructure_details,
+                response_type="ExadataInfrastructure")
+
     def update_exadata_iorm_config(self, db_system_id, exadata_iorm_config_update_details, **kwargs):
         """
         Update `IORM` Settings for the requested Exadata DB System.
@@ -7536,3 +9908,275 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=update_maintenance_run_details,
                 response_type="MaintenanceRun")
+
+    def update_vm_cluster(self, vm_cluster_id, update_vm_cluster_details, **kwargs):
+        """
+        Updates the specified VM cluster.
+        Updates the specified VM cluster.
+
+
+        :param str vm_cluster_id: (required)
+            The VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateVmClusterDetails update_vm_cluster_details: (required)
+            Request to update the attributes of a VM cluster.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.VmCluster`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vmClusters/{vmClusterId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_vm_cluster got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "vmClusterId": vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_vm_cluster_details,
+                response_type="VmCluster")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_vm_cluster_details,
+                response_type="VmCluster")
+
+    def update_vm_cluster_network(self, exadata_infrastructure_id, vm_cluster_network_id, update_vm_cluster_network_details, **kwargs):
+        """
+        Updates the specified VM cluster network.
+        Updates the specified VM cluster network.
+
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str vm_cluster_network_id: (required)
+            The VM cluster network `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateVmClusterNetworkDetails update_vm_cluster_network_details: (required)
+            Request to update the properties of a VM cluster network.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.VmClusterNetwork`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks/{vmClusterNetworkId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_vm_cluster_network got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id,
+            "vmClusterNetworkId": vm_cluster_network_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_vm_cluster_network_details,
+                response_type="VmClusterNetwork")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_vm_cluster_network_details,
+                response_type="VmClusterNetwork")
+
+    def validate_vm_cluster_network(self, exadata_infrastructure_id, vm_cluster_network_id, **kwargs):
+        """
+        Validates the specified VM cluster network.
+        Validates the specified VM cluster network.
+
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str vm_cluster_network_id: (required)
+            The VM cluster network `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.VmClusterNetwork`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks/{vmClusterNetworkId}/actions/validate"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "validate_vm_cluster_network got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "exadataInfrastructureId": exadata_infrastructure_id,
+            "vmClusterNetworkId": vm_cluster_network_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="VmClusterNetwork")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="VmClusterNetwork")

--- a/src/oci/database/models/__init__.py
+++ b/src/oci/database/models/__init__.py
@@ -3,6 +3,8 @@
 
 from __future__ import absolute_import
 
+from .activate_exadata_infrastructure_details import ActivateExadataInfrastructureDetails
+from .associated_database_details import AssociatedDatabaseDetails
 from .autonomous_container_database import AutonomousContainerDatabase
 from .autonomous_container_database_backup_config import AutonomousContainerDatabaseBackupConfig
 from .autonomous_container_database_summary import AutonomousContainerDatabaseSummary
@@ -25,8 +27,13 @@ from .autonomous_exadata_infrastructure_maintenance_window import AutonomousExad
 from .autonomous_exadata_infrastructure_shape_summary import AutonomousExadataInfrastructureShapeSummary
 from .autonomous_exadata_infrastructure_summary import AutonomousExadataInfrastructureSummary
 from .backup import Backup
+from .backup_destination import BackupDestination
+from .backup_destination_details import BackupDestinationDetails
+from .backup_destination_summary import BackupDestinationSummary
 from .backup_summary import BackupSummary
 from .change_compartment_details import ChangeCompartmentDetails
+from .change_exadata_infrastructure_compartment_details import ChangeExadataInfrastructureCompartmentDetails
+from .change_vm_cluster_compartment_details import ChangeVmClusterCompartmentDetails
 from .complete_external_backup_job_details import CompleteExternalBackupJobDetails
 from .create_autonomous_container_database_details import CreateAutonomousContainerDatabaseDetails
 from .create_autonomous_data_warehouse_backup_details import CreateAutonomousDataWarehouseBackupDetails
@@ -35,18 +42,25 @@ from .create_autonomous_database_backup_details import CreateAutonomousDatabaseB
 from .create_autonomous_database_base import CreateAutonomousDatabaseBase
 from .create_autonomous_database_clone_details import CreateAutonomousDatabaseCloneDetails
 from .create_autonomous_database_details import CreateAutonomousDatabaseDetails
+from .create_backup_destination_details import CreateBackupDestinationDetails
 from .create_backup_details import CreateBackupDetails
 from .create_data_guard_association_details import CreateDataGuardAssociationDetails
 from .create_data_guard_association_to_existing_db_system_details import CreateDataGuardAssociationToExistingDbSystemDetails
 from .create_data_guard_association_with_new_db_system_details import CreateDataGuardAssociationWithNewDbSystemDetails
 from .create_database_details import CreateDatabaseDetails
 from .create_database_from_backup_details import CreateDatabaseFromBackupDetails
+from .create_db_home_base import CreateDbHomeBase
 from .create_db_home_details import CreateDbHomeDetails
 from .create_db_home_from_backup_details import CreateDbHomeFromBackupDetails
-from .create_db_home_with_db_system_id_base import CreateDbHomeWithDbSystemIdBase
 from .create_db_home_with_db_system_id_details import CreateDbHomeWithDbSystemIdDetails
 from .create_db_home_with_db_system_id_from_backup_details import CreateDbHomeWithDbSystemIdFromBackupDetails
+from .create_db_home_with_vm_cluster_id_details import CreateDbHomeWithVmClusterIdDetails
+from .create_db_home_with_vm_cluster_id_from_backup_details import CreateDbHomeWithVmClusterIdFromBackupDetails
+from .create_exadata_infrastructure_details import CreateExadataInfrastructureDetails
 from .create_external_backup_job_details import CreateExternalBackupJobDetails
+from .create_nfs_backup_destination_details import CreateNFSBackupDestinationDetails
+from .create_recovery_appliance_backup_destination_details import CreateRecoveryApplianceBackupDestinationDetails
+from .create_vm_cluster_details import CreateVmClusterDetails
 from .data_guard_association import DataGuardAssociation
 from .data_guard_association_summary import DataGuardAssociationSummary
 from .database import Database
@@ -64,12 +78,17 @@ from .db_system import DbSystem
 from .db_system_shape_summary import DbSystemShapeSummary
 from .db_system_summary import DbSystemSummary
 from .db_version_summary import DbVersionSummary
+from .exadata_infrastructure import ExadataInfrastructure
+from .exadata_infrastructure_summary import ExadataInfrastructureSummary
 from .exadata_iorm_config import ExadataIormConfig
 from .exadata_iorm_config_update_details import ExadataIormConfigUpdateDetails
 from .external_backup_job import ExternalBackupJob
 from .failover_data_guard_association_details import FailoverDataGuardAssociationDetails
 from .generate_autonomous_data_warehouse_wallet_details import GenerateAutonomousDataWarehouseWalletDetails
 from .generate_autonomous_database_wallet_details import GenerateAutonomousDatabaseWalletDetails
+from .generate_recommended_network_details import GenerateRecommendedNetworkDetails
+from .gi_version_summary import GiVersionSummary
+from .info_for_network_gen_details import InfoForNetworkGenDetails
 from .launch_autonomous_exadata_infrastructure_details import LaunchAutonomousExadataInfrastructureDetails
 from .launch_db_system_base import LaunchDbSystemBase
 from .launch_db_system_details import LaunchDbSystemDetails
@@ -78,6 +97,7 @@ from .maintenance_run import MaintenanceRun
 from .maintenance_run_summary import MaintenanceRunSummary
 from .maintenance_window import MaintenanceWindow
 from .month import Month
+from .node_details import NodeDetails
 from .patch import Patch
 from .patch_details import PatchDetails
 from .patch_history_entry import PatchHistoryEntry
@@ -87,18 +107,31 @@ from .reinstate_data_guard_association_details import ReinstateDataGuardAssociat
 from .restore_autonomous_data_warehouse_details import RestoreAutonomousDataWarehouseDetails
 from .restore_autonomous_database_details import RestoreAutonomousDatabaseDetails
 from .restore_database_details import RestoreDatabaseDetails
+from .scan_details import ScanDetails
 from .switchover_data_guard_association_details import SwitchoverDataGuardAssociationDetails
 from .update_autonomous_container_database_details import UpdateAutonomousContainerDatabaseDetails
 from .update_autonomous_data_warehouse_details import UpdateAutonomousDataWarehouseDetails
 from .update_autonomous_database_details import UpdateAutonomousDatabaseDetails
 from .update_autonomous_exadata_infrastructure_details import UpdateAutonomousExadataInfrastructureDetails
+from .update_backup_destination_details import UpdateBackupDestinationDetails
 from .update_database_details import UpdateDatabaseDetails
 from .update_db_home_details import UpdateDbHomeDetails
 from .update_db_system_details import UpdateDbSystemDetails
+from .update_exadata_infrastructure_details import UpdateExadataInfrastructureDetails
 from .update_maintenance_run_details import UpdateMaintenanceRunDetails
+from .update_vm_cluster_details import UpdateVmClusterDetails
+from .update_vm_cluster_network_details import UpdateVmClusterNetworkDetails
+from .vm_cluster import VmCluster
+from .vm_cluster_network import VmClusterNetwork
+from .vm_cluster_network_details import VmClusterNetworkDetails
+from .vm_cluster_network_summary import VmClusterNetworkSummary
+from .vm_cluster_summary import VmClusterSummary
+from .vm_network_details import VmNetworkDetails
 
 # Maps type names to classes for database services.
 database_type_mapping = {
+    "ActivateExadataInfrastructureDetails": ActivateExadataInfrastructureDetails,
+    "AssociatedDatabaseDetails": AssociatedDatabaseDetails,
     "AutonomousContainerDatabase": AutonomousContainerDatabase,
     "AutonomousContainerDatabaseBackupConfig": AutonomousContainerDatabaseBackupConfig,
     "AutonomousContainerDatabaseSummary": AutonomousContainerDatabaseSummary,
@@ -121,8 +154,13 @@ database_type_mapping = {
     "AutonomousExadataInfrastructureShapeSummary": AutonomousExadataInfrastructureShapeSummary,
     "AutonomousExadataInfrastructureSummary": AutonomousExadataInfrastructureSummary,
     "Backup": Backup,
+    "BackupDestination": BackupDestination,
+    "BackupDestinationDetails": BackupDestinationDetails,
+    "BackupDestinationSummary": BackupDestinationSummary,
     "BackupSummary": BackupSummary,
     "ChangeCompartmentDetails": ChangeCompartmentDetails,
+    "ChangeExadataInfrastructureCompartmentDetails": ChangeExadataInfrastructureCompartmentDetails,
+    "ChangeVmClusterCompartmentDetails": ChangeVmClusterCompartmentDetails,
     "CompleteExternalBackupJobDetails": CompleteExternalBackupJobDetails,
     "CreateAutonomousContainerDatabaseDetails": CreateAutonomousContainerDatabaseDetails,
     "CreateAutonomousDataWarehouseBackupDetails": CreateAutonomousDataWarehouseBackupDetails,
@@ -131,18 +169,25 @@ database_type_mapping = {
     "CreateAutonomousDatabaseBase": CreateAutonomousDatabaseBase,
     "CreateAutonomousDatabaseCloneDetails": CreateAutonomousDatabaseCloneDetails,
     "CreateAutonomousDatabaseDetails": CreateAutonomousDatabaseDetails,
+    "CreateBackupDestinationDetails": CreateBackupDestinationDetails,
     "CreateBackupDetails": CreateBackupDetails,
     "CreateDataGuardAssociationDetails": CreateDataGuardAssociationDetails,
     "CreateDataGuardAssociationToExistingDbSystemDetails": CreateDataGuardAssociationToExistingDbSystemDetails,
     "CreateDataGuardAssociationWithNewDbSystemDetails": CreateDataGuardAssociationWithNewDbSystemDetails,
     "CreateDatabaseDetails": CreateDatabaseDetails,
     "CreateDatabaseFromBackupDetails": CreateDatabaseFromBackupDetails,
+    "CreateDbHomeBase": CreateDbHomeBase,
     "CreateDbHomeDetails": CreateDbHomeDetails,
     "CreateDbHomeFromBackupDetails": CreateDbHomeFromBackupDetails,
-    "CreateDbHomeWithDbSystemIdBase": CreateDbHomeWithDbSystemIdBase,
     "CreateDbHomeWithDbSystemIdDetails": CreateDbHomeWithDbSystemIdDetails,
     "CreateDbHomeWithDbSystemIdFromBackupDetails": CreateDbHomeWithDbSystemIdFromBackupDetails,
+    "CreateDbHomeWithVmClusterIdDetails": CreateDbHomeWithVmClusterIdDetails,
+    "CreateDbHomeWithVmClusterIdFromBackupDetails": CreateDbHomeWithVmClusterIdFromBackupDetails,
+    "CreateExadataInfrastructureDetails": CreateExadataInfrastructureDetails,
     "CreateExternalBackupJobDetails": CreateExternalBackupJobDetails,
+    "CreateNFSBackupDestinationDetails": CreateNFSBackupDestinationDetails,
+    "CreateRecoveryApplianceBackupDestinationDetails": CreateRecoveryApplianceBackupDestinationDetails,
+    "CreateVmClusterDetails": CreateVmClusterDetails,
     "DataGuardAssociation": DataGuardAssociation,
     "DataGuardAssociationSummary": DataGuardAssociationSummary,
     "Database": Database,
@@ -160,12 +205,17 @@ database_type_mapping = {
     "DbSystemShapeSummary": DbSystemShapeSummary,
     "DbSystemSummary": DbSystemSummary,
     "DbVersionSummary": DbVersionSummary,
+    "ExadataInfrastructure": ExadataInfrastructure,
+    "ExadataInfrastructureSummary": ExadataInfrastructureSummary,
     "ExadataIormConfig": ExadataIormConfig,
     "ExadataIormConfigUpdateDetails": ExadataIormConfigUpdateDetails,
     "ExternalBackupJob": ExternalBackupJob,
     "FailoverDataGuardAssociationDetails": FailoverDataGuardAssociationDetails,
     "GenerateAutonomousDataWarehouseWalletDetails": GenerateAutonomousDataWarehouseWalletDetails,
     "GenerateAutonomousDatabaseWalletDetails": GenerateAutonomousDatabaseWalletDetails,
+    "GenerateRecommendedNetworkDetails": GenerateRecommendedNetworkDetails,
+    "GiVersionSummary": GiVersionSummary,
+    "InfoForNetworkGenDetails": InfoForNetworkGenDetails,
     "LaunchAutonomousExadataInfrastructureDetails": LaunchAutonomousExadataInfrastructureDetails,
     "LaunchDbSystemBase": LaunchDbSystemBase,
     "LaunchDbSystemDetails": LaunchDbSystemDetails,
@@ -174,6 +224,7 @@ database_type_mapping = {
     "MaintenanceRunSummary": MaintenanceRunSummary,
     "MaintenanceWindow": MaintenanceWindow,
     "Month": Month,
+    "NodeDetails": NodeDetails,
     "Patch": Patch,
     "PatchDetails": PatchDetails,
     "PatchHistoryEntry": PatchHistoryEntry,
@@ -183,13 +234,24 @@ database_type_mapping = {
     "RestoreAutonomousDataWarehouseDetails": RestoreAutonomousDataWarehouseDetails,
     "RestoreAutonomousDatabaseDetails": RestoreAutonomousDatabaseDetails,
     "RestoreDatabaseDetails": RestoreDatabaseDetails,
+    "ScanDetails": ScanDetails,
     "SwitchoverDataGuardAssociationDetails": SwitchoverDataGuardAssociationDetails,
     "UpdateAutonomousContainerDatabaseDetails": UpdateAutonomousContainerDatabaseDetails,
     "UpdateAutonomousDataWarehouseDetails": UpdateAutonomousDataWarehouseDetails,
     "UpdateAutonomousDatabaseDetails": UpdateAutonomousDatabaseDetails,
     "UpdateAutonomousExadataInfrastructureDetails": UpdateAutonomousExadataInfrastructureDetails,
+    "UpdateBackupDestinationDetails": UpdateBackupDestinationDetails,
     "UpdateDatabaseDetails": UpdateDatabaseDetails,
     "UpdateDbHomeDetails": UpdateDbHomeDetails,
     "UpdateDbSystemDetails": UpdateDbSystemDetails,
-    "UpdateMaintenanceRunDetails": UpdateMaintenanceRunDetails
+    "UpdateExadataInfrastructureDetails": UpdateExadataInfrastructureDetails,
+    "UpdateMaintenanceRunDetails": UpdateMaintenanceRunDetails,
+    "UpdateVmClusterDetails": UpdateVmClusterDetails,
+    "UpdateVmClusterNetworkDetails": UpdateVmClusterNetworkDetails,
+    "VmCluster": VmCluster,
+    "VmClusterNetwork": VmClusterNetwork,
+    "VmClusterNetworkDetails": VmClusterNetworkDetails,
+    "VmClusterNetworkSummary": VmClusterNetworkSummary,
+    "VmClusterSummary": VmClusterSummary,
+    "VmNetworkDetails": VmNetworkDetails
 }

--- a/src/oci/database/models/activate_exadata_infrastructure_details.py
+++ b/src/oci/database/models/activate_exadata_infrastructure_details.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ActivateExadataInfrastructureDetails(object):
+    """
+    The activation details for the Exadata infrastructure.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ActivateExadataInfrastructureDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param activation_file:
+            The value to assign to the activation_file property of this ActivateExadataInfrastructureDetails.
+        :type activation_file: str
+
+        """
+        self.swagger_types = {
+            'activation_file': 'str'
+        }
+
+        self.attribute_map = {
+            'activation_file': 'activationFile'
+        }
+
+        self._activation_file = None
+
+    @property
+    def activation_file(self):
+        """
+        **[Required]** Gets the activation_file of this ActivateExadataInfrastructureDetails.
+        The activation zip file.
+
+
+        :return: The activation_file of this ActivateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._activation_file
+
+    @activation_file.setter
+    def activation_file(self, activation_file):
+        """
+        Sets the activation_file of this ActivateExadataInfrastructureDetails.
+        The activation zip file.
+
+
+        :param activation_file: The activation_file of this ActivateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._activation_file = activation_file
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/associated_database_details.py
+++ b/src/oci/database/models/associated_database_details.py
@@ -1,0 +1,104 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AssociatedDatabaseDetails(object):
+    """
+    Databases associated with a backup destination
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AssociatedDatabaseDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this AssociatedDatabaseDetails.
+        :type id: str
+
+        :param db_name:
+            The value to assign to the db_name property of this AssociatedDatabaseDetails.
+        :type db_name: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'db_name': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'db_name': 'dbName'
+        }
+
+        self._id = None
+        self._db_name = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this AssociatedDatabaseDetails.
+        The database `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this AssociatedDatabaseDetails.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this AssociatedDatabaseDetails.
+        The database `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this AssociatedDatabaseDetails.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def db_name(self):
+        """
+        Gets the db_name of this AssociatedDatabaseDetails.
+        The display name of the database that is associated with the backup destination.
+
+
+        :return: The db_name of this AssociatedDatabaseDetails.
+        :rtype: str
+        """
+        return self._db_name
+
+    @db_name.setter
+    def db_name(self, db_name):
+        """
+        Sets the db_name of this AssociatedDatabaseDetails.
+        The display name of the database that is associated with the backup destination.
+
+
+        :param db_name: The db_name of this AssociatedDatabaseDetails.
+        :type: str
+        """
+        self._db_name = db_name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/backup_destination.py
+++ b/src/oci/database/models/backup_destination.py
@@ -1,0 +1,503 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class BackupDestination(object):
+    """
+    Backup destination details.
+    """
+
+    #: A constant which can be used with the type property of a BackupDestination.
+    #: This constant has a value of "NFS"
+    TYPE_NFS = "NFS"
+
+    #: A constant which can be used with the type property of a BackupDestination.
+    #: This constant has a value of "RECOVERY_APPLIANCE"
+    TYPE_RECOVERY_APPLIANCE = "RECOVERY_APPLIANCE"
+
+    #: A constant which can be used with the lifecycle_state property of a BackupDestination.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a BackupDestination.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a BackupDestination.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new BackupDestination object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this BackupDestination.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this BackupDestination.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this BackupDestination.
+        :type compartment_id: str
+
+        :param type:
+            The value to assign to the type property of this BackupDestination.
+            Allowed values for this property are: "NFS", "RECOVERY_APPLIANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type type: str
+
+        :param associated_databases:
+            The value to assign to the associated_databases property of this BackupDestination.
+        :type associated_databases: list[AssociatedDatabaseDetails]
+
+        :param connection_string:
+            The value to assign to the connection_string property of this BackupDestination.
+        :type connection_string: str
+
+        :param vpc_users:
+            The value to assign to the vpc_users property of this BackupDestination.
+        :type vpc_users: list[str]
+
+        :param local_mount_point_path:
+            The value to assign to the local_mount_point_path property of this BackupDestination.
+        :type local_mount_point_path: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this BackupDestination.
+            Allowed values for this property are: "ACTIVE", "FAILED", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param time_created:
+            The value to assign to the time_created property of this BackupDestination.
+        :type time_created: datetime
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this BackupDestination.
+        :type lifecycle_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this BackupDestination.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this BackupDestination.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'type': 'str',
+            'associated_databases': 'list[AssociatedDatabaseDetails]',
+            'connection_string': 'str',
+            'vpc_users': 'list[str]',
+            'local_mount_point_path': 'str',
+            'lifecycle_state': 'str',
+            'time_created': 'datetime',
+            'lifecycle_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'type': 'type',
+            'associated_databases': 'associatedDatabases',
+            'connection_string': 'connectionString',
+            'vpc_users': 'vpcUsers',
+            'local_mount_point_path': 'localMountPointPath',
+            'lifecycle_state': 'lifecycleState',
+            'time_created': 'timeCreated',
+            'lifecycle_details': 'lifecycleDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._type = None
+        self._associated_databases = None
+        self._connection_string = None
+        self._vpc_users = None
+        self._local_mount_point_path = None
+        self._lifecycle_state = None
+        self._time_created = None
+        self._lifecycle_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this BackupDestination.
+        The `OCID`__ of the backup destination.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this BackupDestination.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this BackupDestination.
+        The `OCID`__ of the backup destination.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this BackupDestination.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this BackupDestination.
+        The user-provided name of the backup destination.
+
+
+        :return: The display_name of this BackupDestination.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this BackupDestination.
+        The user-provided name of the backup destination.
+
+
+        :param display_name: The display_name of this BackupDestination.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this BackupDestination.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this BackupDestination.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this BackupDestination.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this BackupDestination.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def type(self):
+        """
+        Gets the type of this BackupDestination.
+        Type of the backup destination.
+
+        Allowed values for this property are: "NFS", "RECOVERY_APPLIANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The type of this BackupDestination.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this BackupDestination.
+        Type of the backup destination.
+
+
+        :param type: The type of this BackupDestination.
+        :type: str
+        """
+        allowed_values = ["NFS", "RECOVERY_APPLIANCE"]
+        if not value_allowed_none_or_none_sentinel(type, allowed_values):
+            type = 'UNKNOWN_ENUM_VALUE'
+        self._type = type
+
+    @property
+    def associated_databases(self):
+        """
+        Gets the associated_databases of this BackupDestination.
+        List of databases associated with the backup destination.
+
+
+        :return: The associated_databases of this BackupDestination.
+        :rtype: list[AssociatedDatabaseDetails]
+        """
+        return self._associated_databases
+
+    @associated_databases.setter
+    def associated_databases(self, associated_databases):
+        """
+        Sets the associated_databases of this BackupDestination.
+        List of databases associated with the backup destination.
+
+
+        :param associated_databases: The associated_databases of this BackupDestination.
+        :type: list[AssociatedDatabaseDetails]
+        """
+        self._associated_databases = associated_databases
+
+    @property
+    def connection_string(self):
+        """
+        Gets the connection_string of this BackupDestination.
+        For a RECOVERY_APPLIANCE backup destination, the connection string for connecting to the Recovery Appliance.
+
+
+        :return: The connection_string of this BackupDestination.
+        :rtype: str
+        """
+        return self._connection_string
+
+    @connection_string.setter
+    def connection_string(self, connection_string):
+        """
+        Sets the connection_string of this BackupDestination.
+        For a RECOVERY_APPLIANCE backup destination, the connection string for connecting to the Recovery Appliance.
+
+
+        :param connection_string: The connection_string of this BackupDestination.
+        :type: str
+        """
+        self._connection_string = connection_string
+
+    @property
+    def vpc_users(self):
+        """
+        Gets the vpc_users of this BackupDestination.
+        For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+
+
+        :return: The vpc_users of this BackupDestination.
+        :rtype: list[str]
+        """
+        return self._vpc_users
+
+    @vpc_users.setter
+    def vpc_users(self, vpc_users):
+        """
+        Sets the vpc_users of this BackupDestination.
+        For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+
+
+        :param vpc_users: The vpc_users of this BackupDestination.
+        :type: list[str]
+        """
+        self._vpc_users = vpc_users
+
+    @property
+    def local_mount_point_path(self):
+        """
+        Gets the local_mount_point_path of this BackupDestination.
+        The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+
+
+        :return: The local_mount_point_path of this BackupDestination.
+        :rtype: str
+        """
+        return self._local_mount_point_path
+
+    @local_mount_point_path.setter
+    def local_mount_point_path(self, local_mount_point_path):
+        """
+        Sets the local_mount_point_path of this BackupDestination.
+        The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+
+
+        :param local_mount_point_path: The local_mount_point_path of this BackupDestination.
+        :type: str
+        """
+        self._local_mount_point_path = local_mount_point_path
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this BackupDestination.
+        The current lifecycle state of the backup destination.
+
+        Allowed values for this property are: "ACTIVE", "FAILED", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this BackupDestination.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this BackupDestination.
+        The current lifecycle state of the backup destination.
+
+
+        :param lifecycle_state: The lifecycle_state of this BackupDestination.
+        :type: str
+        """
+        allowed_values = ["ACTIVE", "FAILED", "DELETED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this BackupDestination.
+        The date and time the backup destination was created.
+
+
+        :return: The time_created of this BackupDestination.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this BackupDestination.
+        The date and time the backup destination was created.
+
+
+        :param time_created: The time_created of this BackupDestination.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this BackupDestination.
+        A descriptive text associated with the lifecycleState.
+        Typically contains additional displayable text
+
+
+        :return: The lifecycle_details of this BackupDestination.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this BackupDestination.
+        A descriptive text associated with the lifecycleState.
+        Typically contains additional displayable text
+
+
+        :param lifecycle_details: The lifecycle_details of this BackupDestination.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this BackupDestination.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this BackupDestination.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this BackupDestination.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this BackupDestination.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this BackupDestination.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this BackupDestination.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this BackupDestination.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this BackupDestination.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/backup_destination_details.py
+++ b/src/oci/database/models/backup_destination_details.py
@@ -1,0 +1,268 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class BackupDestinationDetails(object):
+    """
+    Backup destination details
+    """
+
+    #: A constant which can be used with the type property of a BackupDestinationDetails.
+    #: This constant has a value of "NFS"
+    TYPE_NFS = "NFS"
+
+    #: A constant which can be used with the type property of a BackupDestinationDetails.
+    #: This constant has a value of "RECOVERY_APPLIANCE"
+    TYPE_RECOVERY_APPLIANCE = "RECOVERY_APPLIANCE"
+
+    #: A constant which can be used with the type property of a BackupDestinationDetails.
+    #: This constant has a value of "OBJECT_STORE"
+    TYPE_OBJECT_STORE = "OBJECT_STORE"
+
+    #: A constant which can be used with the type property of a BackupDestinationDetails.
+    #: This constant has a value of "LOCAL"
+    TYPE_LOCAL = "LOCAL"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new BackupDestinationDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param type:
+            The value to assign to the type property of this BackupDestinationDetails.
+            Allowed values for this property are: "NFS", "RECOVERY_APPLIANCE", "OBJECT_STORE", "LOCAL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type type: str
+
+        :param id:
+            The value to assign to the id property of this BackupDestinationDetails.
+        :type id: str
+
+        :param vpc_user:
+            The value to assign to the vpc_user property of this BackupDestinationDetails.
+        :type vpc_user: str
+
+        :param vpc_password:
+            The value to assign to the vpc_password property of this BackupDestinationDetails.
+        :type vpc_password: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this BackupDestinationDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this BackupDestinationDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'type': 'str',
+            'id': 'str',
+            'vpc_user': 'str',
+            'vpc_password': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'type': 'type',
+            'id': 'id',
+            'vpc_user': 'vpcUser',
+            'vpc_password': 'vpcPassword',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._type = None
+        self._id = None
+        self._vpc_user = None
+        self._vpc_password = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def type(self):
+        """
+        **[Required]** Gets the type of this BackupDestinationDetails.
+        Type of the database backup destination.
+
+        Allowed values for this property are: "NFS", "RECOVERY_APPLIANCE", "OBJECT_STORE", "LOCAL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The type of this BackupDestinationDetails.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this BackupDestinationDetails.
+        Type of the database backup destination.
+
+
+        :param type: The type of this BackupDestinationDetails.
+        :type: str
+        """
+        allowed_values = ["NFS", "RECOVERY_APPLIANCE", "OBJECT_STORE", "LOCAL"]
+        if not value_allowed_none_or_none_sentinel(type, allowed_values):
+            type = 'UNKNOWN_ENUM_VALUE'
+        self._type = type
+
+    @property
+    def id(self):
+        """
+        Gets the id of this BackupDestinationDetails.
+        The `OCID`__ of the backup destination.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this BackupDestinationDetails.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this BackupDestinationDetails.
+        The `OCID`__ of the backup destination.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this BackupDestinationDetails.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def vpc_user(self):
+        """
+        Gets the vpc_user of this BackupDestinationDetails.
+        For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) user that is used to access the Recovery Appliance.
+
+
+        :return: The vpc_user of this BackupDestinationDetails.
+        :rtype: str
+        """
+        return self._vpc_user
+
+    @vpc_user.setter
+    def vpc_user(self, vpc_user):
+        """
+        Sets the vpc_user of this BackupDestinationDetails.
+        For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) user that is used to access the Recovery Appliance.
+
+
+        :param vpc_user: The vpc_user of this BackupDestinationDetails.
+        :type: str
+        """
+        self._vpc_user = vpc_user
+
+    @property
+    def vpc_password(self):
+        """
+        Gets the vpc_password of this BackupDestinationDetails.
+        For a RECOVERY_APPLIANCE backup destination, the password for the VPC user that is used to access the Recovery Appliance.
+
+
+        :return: The vpc_password of this BackupDestinationDetails.
+        :rtype: str
+        """
+        return self._vpc_password
+
+    @vpc_password.setter
+    def vpc_password(self, vpc_password):
+        """
+        Sets the vpc_password of this BackupDestinationDetails.
+        For a RECOVERY_APPLIANCE backup destination, the password for the VPC user that is used to access the Recovery Appliance.
+
+
+        :param vpc_password: The vpc_password of this BackupDestinationDetails.
+        :type: str
+        """
+        self._vpc_password = vpc_password
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this BackupDestinationDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this BackupDestinationDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this BackupDestinationDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this BackupDestinationDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this BackupDestinationDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this BackupDestinationDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this BackupDestinationDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this BackupDestinationDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/backup_destination_summary.py
+++ b/src/oci/database/models/backup_destination_summary.py
@@ -1,0 +1,503 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class BackupDestinationSummary(object):
+    """
+    Backup destination details, including the list of databases using the backup destination.
+    """
+
+    #: A constant which can be used with the type property of a BackupDestinationSummary.
+    #: This constant has a value of "NFS"
+    TYPE_NFS = "NFS"
+
+    #: A constant which can be used with the type property of a BackupDestinationSummary.
+    #: This constant has a value of "RECOVERY_APPLIANCE"
+    TYPE_RECOVERY_APPLIANCE = "RECOVERY_APPLIANCE"
+
+    #: A constant which can be used with the lifecycle_state property of a BackupDestinationSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a BackupDestinationSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a BackupDestinationSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new BackupDestinationSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this BackupDestinationSummary.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this BackupDestinationSummary.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this BackupDestinationSummary.
+        :type compartment_id: str
+
+        :param type:
+            The value to assign to the type property of this BackupDestinationSummary.
+            Allowed values for this property are: "NFS", "RECOVERY_APPLIANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type type: str
+
+        :param associated_databases:
+            The value to assign to the associated_databases property of this BackupDestinationSummary.
+        :type associated_databases: list[AssociatedDatabaseDetails]
+
+        :param connection_string:
+            The value to assign to the connection_string property of this BackupDestinationSummary.
+        :type connection_string: str
+
+        :param vpc_users:
+            The value to assign to the vpc_users property of this BackupDestinationSummary.
+        :type vpc_users: list[str]
+
+        :param local_mount_point_path:
+            The value to assign to the local_mount_point_path property of this BackupDestinationSummary.
+        :type local_mount_point_path: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this BackupDestinationSummary.
+            Allowed values for this property are: "ACTIVE", "FAILED", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param time_created:
+            The value to assign to the time_created property of this BackupDestinationSummary.
+        :type time_created: datetime
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this BackupDestinationSummary.
+        :type lifecycle_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this BackupDestinationSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this BackupDestinationSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'type': 'str',
+            'associated_databases': 'list[AssociatedDatabaseDetails]',
+            'connection_string': 'str',
+            'vpc_users': 'list[str]',
+            'local_mount_point_path': 'str',
+            'lifecycle_state': 'str',
+            'time_created': 'datetime',
+            'lifecycle_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'type': 'type',
+            'associated_databases': 'associatedDatabases',
+            'connection_string': 'connectionString',
+            'vpc_users': 'vpcUsers',
+            'local_mount_point_path': 'localMountPointPath',
+            'lifecycle_state': 'lifecycleState',
+            'time_created': 'timeCreated',
+            'lifecycle_details': 'lifecycleDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._type = None
+        self._associated_databases = None
+        self._connection_string = None
+        self._vpc_users = None
+        self._local_mount_point_path = None
+        self._lifecycle_state = None
+        self._time_created = None
+        self._lifecycle_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this BackupDestinationSummary.
+        The `OCID`__ of the backup destination.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this BackupDestinationSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this BackupDestinationSummary.
+        The `OCID`__ of the backup destination.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this BackupDestinationSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this BackupDestinationSummary.
+        The user-provided name of the backup destination.
+
+
+        :return: The display_name of this BackupDestinationSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this BackupDestinationSummary.
+        The user-provided name of the backup destination.
+
+
+        :param display_name: The display_name of this BackupDestinationSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this BackupDestinationSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this BackupDestinationSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this BackupDestinationSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this BackupDestinationSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def type(self):
+        """
+        Gets the type of this BackupDestinationSummary.
+        Type of the backup destination.
+
+        Allowed values for this property are: "NFS", "RECOVERY_APPLIANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The type of this BackupDestinationSummary.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this BackupDestinationSummary.
+        Type of the backup destination.
+
+
+        :param type: The type of this BackupDestinationSummary.
+        :type: str
+        """
+        allowed_values = ["NFS", "RECOVERY_APPLIANCE"]
+        if not value_allowed_none_or_none_sentinel(type, allowed_values):
+            type = 'UNKNOWN_ENUM_VALUE'
+        self._type = type
+
+    @property
+    def associated_databases(self):
+        """
+        Gets the associated_databases of this BackupDestinationSummary.
+        List of databases associated with the backup destination.
+
+
+        :return: The associated_databases of this BackupDestinationSummary.
+        :rtype: list[AssociatedDatabaseDetails]
+        """
+        return self._associated_databases
+
+    @associated_databases.setter
+    def associated_databases(self, associated_databases):
+        """
+        Sets the associated_databases of this BackupDestinationSummary.
+        List of databases associated with the backup destination.
+
+
+        :param associated_databases: The associated_databases of this BackupDestinationSummary.
+        :type: list[AssociatedDatabaseDetails]
+        """
+        self._associated_databases = associated_databases
+
+    @property
+    def connection_string(self):
+        """
+        Gets the connection_string of this BackupDestinationSummary.
+        For a RECOVERY_APPLIANCE backup destination, the connection string for connecting to the Recovery Appliance.
+
+
+        :return: The connection_string of this BackupDestinationSummary.
+        :rtype: str
+        """
+        return self._connection_string
+
+    @connection_string.setter
+    def connection_string(self, connection_string):
+        """
+        Sets the connection_string of this BackupDestinationSummary.
+        For a RECOVERY_APPLIANCE backup destination, the connection string for connecting to the Recovery Appliance.
+
+
+        :param connection_string: The connection_string of this BackupDestinationSummary.
+        :type: str
+        """
+        self._connection_string = connection_string
+
+    @property
+    def vpc_users(self):
+        """
+        Gets the vpc_users of this BackupDestinationSummary.
+        For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+
+
+        :return: The vpc_users of this BackupDestinationSummary.
+        :rtype: list[str]
+        """
+        return self._vpc_users
+
+    @vpc_users.setter
+    def vpc_users(self, vpc_users):
+        """
+        Sets the vpc_users of this BackupDestinationSummary.
+        For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+
+
+        :param vpc_users: The vpc_users of this BackupDestinationSummary.
+        :type: list[str]
+        """
+        self._vpc_users = vpc_users
+
+    @property
+    def local_mount_point_path(self):
+        """
+        Gets the local_mount_point_path of this BackupDestinationSummary.
+        The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+
+
+        :return: The local_mount_point_path of this BackupDestinationSummary.
+        :rtype: str
+        """
+        return self._local_mount_point_path
+
+    @local_mount_point_path.setter
+    def local_mount_point_path(self, local_mount_point_path):
+        """
+        Sets the local_mount_point_path of this BackupDestinationSummary.
+        The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+
+
+        :param local_mount_point_path: The local_mount_point_path of this BackupDestinationSummary.
+        :type: str
+        """
+        self._local_mount_point_path = local_mount_point_path
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this BackupDestinationSummary.
+        The current lifecycle state of the backup destination.
+
+        Allowed values for this property are: "ACTIVE", "FAILED", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this BackupDestinationSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this BackupDestinationSummary.
+        The current lifecycle state of the backup destination.
+
+
+        :param lifecycle_state: The lifecycle_state of this BackupDestinationSummary.
+        :type: str
+        """
+        allowed_values = ["ACTIVE", "FAILED", "DELETED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this BackupDestinationSummary.
+        The date and time the backup destination was created.
+
+
+        :return: The time_created of this BackupDestinationSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this BackupDestinationSummary.
+        The date and time the backup destination was created.
+
+
+        :param time_created: The time_created of this BackupDestinationSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this BackupDestinationSummary.
+        A descriptive text associated with the lifecycleState.
+        Typically contains additional displayable text
+
+
+        :return: The lifecycle_details of this BackupDestinationSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this BackupDestinationSummary.
+        A descriptive text associated with the lifecycleState.
+        Typically contains additional displayable text
+
+
+        :param lifecycle_details: The lifecycle_details of this BackupDestinationSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this BackupDestinationSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this BackupDestinationSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this BackupDestinationSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this BackupDestinationSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this BackupDestinationSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this BackupDestinationSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this BackupDestinationSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this BackupDestinationSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/change_exadata_infrastructure_compartment_details.py
+++ b/src/oci/database/models/change_exadata_infrastructure_compartment_details.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeExadataInfrastructureCompartmentDetails(object):
+    """
+    The configuration details for moving the resource.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeExadataInfrastructureCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeExadataInfrastructureCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeExadataInfrastructureCompartmentDetails.
+        The `OCID`__ of the compartment to move the resource to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeExadataInfrastructureCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeExadataInfrastructureCompartmentDetails.
+        The `OCID`__ of the compartment to move the resource to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeExadataInfrastructureCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/change_vm_cluster_compartment_details.py
+++ b/src/oci/database/models/change_vm_cluster_compartment_details.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeVmClusterCompartmentDetails(object):
+    """
+    The configuration details for moving the VM cluster.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeVmClusterCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeVmClusterCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeVmClusterCompartmentDetails.
+        The `OCID`__ of the compartment to move the VM cluster to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeVmClusterCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeVmClusterCompartmentDetails.
+        The `OCID`__ of the compartment to move the VM cluster to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeVmClusterCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_backup_destination_details.py
+++ b/src/oci/database/models/create_backup_destination_details.py
@@ -1,0 +1,251 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateBackupDestinationDetails(object):
+    """
+    Details for creating a backup destination.
+    """
+
+    #: A constant which can be used with the type property of a CreateBackupDestinationDetails.
+    #: This constant has a value of "NFS"
+    TYPE_NFS = "NFS"
+
+    #: A constant which can be used with the type property of a CreateBackupDestinationDetails.
+    #: This constant has a value of "RECOVERY_APPLIANCE"
+    TYPE_RECOVERY_APPLIANCE = "RECOVERY_APPLIANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateBackupDestinationDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.database.models.CreateNFSBackupDestinationDetails`
+        * :class:`~oci.database.models.CreateRecoveryApplianceBackupDestinationDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateBackupDestinationDetails.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateBackupDestinationDetails.
+        :type compartment_id: str
+
+        :param type:
+            The value to assign to the type property of this CreateBackupDestinationDetails.
+            Allowed values for this property are: "NFS", "RECOVERY_APPLIANCE"
+        :type type: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateBackupDestinationDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateBackupDestinationDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'type': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'type': 'type',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._compartment_id = None
+        self._type = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['type']
+
+        if type == 'NFS':
+            return 'CreateNFSBackupDestinationDetails'
+
+        if type == 'RECOVERY_APPLIANCE':
+            return 'CreateRecoveryApplianceBackupDestinationDetails'
+        else:
+            return 'CreateBackupDestinationDetails'
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateBackupDestinationDetails.
+        The user-provided name of the backup destination.
+
+
+        :return: The display_name of this CreateBackupDestinationDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateBackupDestinationDetails.
+        The user-provided name of the backup destination.
+
+
+        :param display_name: The display_name of this CreateBackupDestinationDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateBackupDestinationDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateBackupDestinationDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateBackupDestinationDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateBackupDestinationDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def type(self):
+        """
+        **[Required]** Gets the type of this CreateBackupDestinationDetails.
+        Type of the backup destination.
+
+        Allowed values for this property are: "NFS", "RECOVERY_APPLIANCE"
+
+
+        :return: The type of this CreateBackupDestinationDetails.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this CreateBackupDestinationDetails.
+        Type of the backup destination.
+
+
+        :param type: The type of this CreateBackupDestinationDetails.
+        :type: str
+        """
+        allowed_values = ["NFS", "RECOVERY_APPLIANCE"]
+        if not value_allowed_none_or_none_sentinel(type, allowed_values):
+            raise ValueError(
+                "Invalid value for `type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._type = type
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateBackupDestinationDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateBackupDestinationDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateBackupDestinationDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateBackupDestinationDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateBackupDestinationDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateBackupDestinationDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateBackupDestinationDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateBackupDestinationDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_database_details.py
+++ b/src/oci/database/models/create_database_details.py
@@ -31,6 +31,10 @@ class CreateDatabaseDetails(object):
             The value to assign to the db_name property of this CreateDatabaseDetails.
         :type db_name: str
 
+        :param db_unique_name:
+            The value to assign to the db_unique_name property of this CreateDatabaseDetails.
+        :type db_unique_name: str
+
         :param pdb_name:
             The value to assign to the pdb_name property of this CreateDatabaseDetails.
         :type pdb_name: str
@@ -67,6 +71,7 @@ class CreateDatabaseDetails(object):
         """
         self.swagger_types = {
             'db_name': 'str',
+            'db_unique_name': 'str',
             'pdb_name': 'str',
             'admin_password': 'str',
             'character_set': 'str',
@@ -79,6 +84,7 @@ class CreateDatabaseDetails(object):
 
         self.attribute_map = {
             'db_name': 'dbName',
+            'db_unique_name': 'dbUniqueName',
             'pdb_name': 'pdbName',
             'admin_password': 'adminPassword',
             'character_set': 'characterSet',
@@ -90,6 +96,7 @@ class CreateDatabaseDetails(object):
         }
 
         self._db_name = None
+        self._db_unique_name = None
         self._pdb_name = None
         self._admin_password = None
         self._character_set = None
@@ -122,6 +129,30 @@ class CreateDatabaseDetails(object):
         :type: str
         """
         self._db_name = db_name
+
+    @property
+    def db_unique_name(self):
+        """
+        Gets the db_unique_name of this CreateDatabaseDetails.
+        The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+
+
+        :return: The db_unique_name of this CreateDatabaseDetails.
+        :rtype: str
+        """
+        return self._db_unique_name
+
+    @db_unique_name.setter
+    def db_unique_name(self, db_unique_name):
+        """
+        Sets the db_unique_name of this CreateDatabaseDetails.
+        The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+
+
+        :param db_unique_name: The db_unique_name of this CreateDatabaseDetails.
+        :type: str
+        """
+        self._db_unique_name = db_unique_name
 
     @property
     def pdb_name(self):

--- a/src/oci/database/models/create_database_from_backup_details.py
+++ b/src/oci/database/models/create_database_from_backup_details.py
@@ -29,6 +29,10 @@ class CreateDatabaseFromBackupDetails(object):
             The value to assign to the admin_password property of this CreateDatabaseFromBackupDetails.
         :type admin_password: str
 
+        :param db_unique_name:
+            The value to assign to the db_unique_name property of this CreateDatabaseFromBackupDetails.
+        :type db_unique_name: str
+
         :param db_name:
             The value to assign to the db_name property of this CreateDatabaseFromBackupDetails.
         :type db_name: str
@@ -38,6 +42,7 @@ class CreateDatabaseFromBackupDetails(object):
             'backup_id': 'str',
             'backup_tde_password': 'str',
             'admin_password': 'str',
+            'db_unique_name': 'str',
             'db_name': 'str'
         }
 
@@ -45,12 +50,14 @@ class CreateDatabaseFromBackupDetails(object):
             'backup_id': 'backupId',
             'backup_tde_password': 'backupTDEPassword',
             'admin_password': 'adminPassword',
+            'db_unique_name': 'dbUniqueName',
             'db_name': 'dbName'
         }
 
         self._backup_id = None
         self._backup_tde_password = None
         self._admin_password = None
+        self._db_unique_name = None
         self._db_name = None
 
     @property
@@ -128,6 +135,30 @@ class CreateDatabaseFromBackupDetails(object):
         :type: str
         """
         self._admin_password = admin_password
+
+    @property
+    def db_unique_name(self):
+        """
+        Gets the db_unique_name of this CreateDatabaseFromBackupDetails.
+        The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+
+
+        :return: The db_unique_name of this CreateDatabaseFromBackupDetails.
+        :rtype: str
+        """
+        return self._db_unique_name
+
+    @db_unique_name.setter
+    def db_unique_name(self, db_unique_name):
+        """
+        Sets the db_unique_name of this CreateDatabaseFromBackupDetails.
+        The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+
+
+        :param db_unique_name: The db_unique_name of this CreateDatabaseFromBackupDetails.
+        :type: str
+        """
+        self._db_unique_name = db_unique_name
 
     @property
     def db_name(self):

--- a/src/oci/database/models/create_db_home_base.py
+++ b/src/oci/database/models/create_db_home_base.py
@@ -7,58 +7,61 @@ from oci.decorators import init_model_state_from_kwargs
 
 
 @init_model_state_from_kwargs
-class CreateDbHomeWithDbSystemIdBase(object):
+class CreateDbHomeBase(object):
     """
     Details for creating a database home.
 
     **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
     """
 
-    #: A constant which can be used with the source property of a CreateDbHomeWithDbSystemIdBase.
+    #: A constant which can be used with the source property of a CreateDbHomeBase.
     #: This constant has a value of "NONE"
     SOURCE_NONE = "NONE"
 
-    #: A constant which can be used with the source property of a CreateDbHomeWithDbSystemIdBase.
+    #: A constant which can be used with the source property of a CreateDbHomeBase.
     #: This constant has a value of "DB_BACKUP"
     SOURCE_DB_BACKUP = "DB_BACKUP"
 
+    #: A constant which can be used with the source property of a CreateDbHomeBase.
+    #: This constant has a value of "VM_CLUSTER_NEW"
+    SOURCE_VM_CLUSTER_NEW = "VM_CLUSTER_NEW"
+
+    #: A constant which can be used with the source property of a CreateDbHomeBase.
+    #: This constant has a value of "VM_CLUSTER_BACKUP"
+    SOURCE_VM_CLUSTER_BACKUP = "VM_CLUSTER_BACKUP"
+
     def __init__(self, **kwargs):
         """
-        Initializes a new CreateDbHomeWithDbSystemIdBase object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        Initializes a new CreateDbHomeBase object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
         * :class:`~oci.database.models.CreateDbHomeWithDbSystemIdFromBackupDetails`
+        * :class:`~oci.database.models.CreateDbHomeWithVmClusterIdFromBackupDetails`
         * :class:`~oci.database.models.CreateDbHomeWithDbSystemIdDetails`
+        * :class:`~oci.database.models.CreateDbHomeWithVmClusterIdDetails`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
-        :param db_system_id:
-            The value to assign to the db_system_id property of this CreateDbHomeWithDbSystemIdBase.
-        :type db_system_id: str
-
         :param display_name:
-            The value to assign to the display_name property of this CreateDbHomeWithDbSystemIdBase.
+            The value to assign to the display_name property of this CreateDbHomeBase.
         :type display_name: str
 
         :param source:
-            The value to assign to the source property of this CreateDbHomeWithDbSystemIdBase.
-            Allowed values for this property are: "NONE", "DB_BACKUP"
+            The value to assign to the source property of this CreateDbHomeBase.
+            Allowed values for this property are: "NONE", "DB_BACKUP", "VM_CLUSTER_NEW", "VM_CLUSTER_BACKUP"
         :type source: str
 
         """
         self.swagger_types = {
-            'db_system_id': 'str',
             'display_name': 'str',
             'source': 'str'
         }
 
         self.attribute_map = {
-            'db_system_id': 'dbSystemId',
             'display_name': 'displayName',
             'source': 'source'
         }
 
-        self._db_system_id = None
         self._display_name = None
         self._source = None
 
@@ -73,47 +76,25 @@ class CreateDbHomeWithDbSystemIdBase(object):
         if type == 'DB_BACKUP':
             return 'CreateDbHomeWithDbSystemIdFromBackupDetails'
 
+        if type == 'VM_CLUSTER_BACKUP':
+            return 'CreateDbHomeWithVmClusterIdFromBackupDetails'
+
         if type == 'NONE':
             return 'CreateDbHomeWithDbSystemIdDetails'
+
+        if type == 'VM_CLUSTER_NEW':
+            return 'CreateDbHomeWithVmClusterIdDetails'
         else:
-            return 'CreateDbHomeWithDbSystemIdBase'
-
-    @property
-    def db_system_id(self):
-        """
-        **[Required]** Gets the db_system_id of this CreateDbHomeWithDbSystemIdBase.
-        The `OCID`__ of the DB system.
-
-        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
-
-
-        :return: The db_system_id of this CreateDbHomeWithDbSystemIdBase.
-        :rtype: str
-        """
-        return self._db_system_id
-
-    @db_system_id.setter
-    def db_system_id(self, db_system_id):
-        """
-        Sets the db_system_id of this CreateDbHomeWithDbSystemIdBase.
-        The `OCID`__ of the DB system.
-
-        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
-
-
-        :param db_system_id: The db_system_id of this CreateDbHomeWithDbSystemIdBase.
-        :type: str
-        """
-        self._db_system_id = db_system_id
+            return 'CreateDbHomeBase'
 
     @property
     def display_name(self):
         """
-        Gets the display_name of this CreateDbHomeWithDbSystemIdBase.
+        Gets the display_name of this CreateDbHomeBase.
         The user-provided name of the database home.
 
 
-        :return: The display_name of this CreateDbHomeWithDbSystemIdBase.
+        :return: The display_name of this CreateDbHomeBase.
         :rtype: str
         """
         return self._display_name
@@ -121,11 +102,11 @@ class CreateDbHomeWithDbSystemIdBase(object):
     @display_name.setter
     def display_name(self, display_name):
         """
-        Sets the display_name of this CreateDbHomeWithDbSystemIdBase.
+        Sets the display_name of this CreateDbHomeBase.
         The user-provided name of the database home.
 
 
-        :param display_name: The display_name of this CreateDbHomeWithDbSystemIdBase.
+        :param display_name: The display_name of this CreateDbHomeBase.
         :type: str
         """
         self._display_name = display_name
@@ -133,13 +114,13 @@ class CreateDbHomeWithDbSystemIdBase(object):
     @property
     def source(self):
         """
-        Gets the source of this CreateDbHomeWithDbSystemIdBase.
+        Gets the source of this CreateDbHomeBase.
         The source of database: NONE for creating a new database. DB_BACKUP for creating a new database by restoring from a database backup.
 
-        Allowed values for this property are: "NONE", "DB_BACKUP"
+        Allowed values for this property are: "NONE", "DB_BACKUP", "VM_CLUSTER_NEW", "VM_CLUSTER_BACKUP"
 
 
-        :return: The source of this CreateDbHomeWithDbSystemIdBase.
+        :return: The source of this CreateDbHomeBase.
         :rtype: str
         """
         return self._source
@@ -147,14 +128,14 @@ class CreateDbHomeWithDbSystemIdBase(object):
     @source.setter
     def source(self, source):
         """
-        Sets the source of this CreateDbHomeWithDbSystemIdBase.
+        Sets the source of this CreateDbHomeBase.
         The source of database: NONE for creating a new database. DB_BACKUP for creating a new database by restoring from a database backup.
 
 
-        :param source: The source of this CreateDbHomeWithDbSystemIdBase.
+        :param source: The source of this CreateDbHomeBase.
         :type: str
         """
-        allowed_values = ["NONE", "DB_BACKUP"]
+        allowed_values = ["NONE", "DB_BACKUP", "VM_CLUSTER_NEW", "VM_CLUSTER_BACKUP"]
         if not value_allowed_none_or_none_sentinel(source, allowed_values):
             raise ValueError(
                 "Invalid value for `source`, must be None or one of {0}"

--- a/src/oci/database/models/create_db_home_with_db_system_id_details.py
+++ b/src/oci/database/models/create_db_home_with_db_system_id_details.py
@@ -1,13 +1,13 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-from .create_db_home_with_db_system_id_base import CreateDbHomeWithDbSystemIdBase
+from .create_db_home_base import CreateDbHomeBase
 from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
 from oci.decorators import init_model_state_from_kwargs
 
 
 @init_model_state_from_kwargs
-class CreateDbHomeWithDbSystemIdDetails(CreateDbHomeWithDbSystemIdBase):
+class CreateDbHomeWithDbSystemIdDetails(CreateDbHomeBase):
     """
     Note that a valid `dbSystemId` value must be supplied for the `CreateDbHomeWithDbSystemId` API operation to successfully complete.
     """
@@ -18,18 +18,18 @@ class CreateDbHomeWithDbSystemIdDetails(CreateDbHomeWithDbSystemIdBase):
         of this class is ``NONE`` and it should not be changed.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
-        :param db_system_id:
-            The value to assign to the db_system_id property of this CreateDbHomeWithDbSystemIdDetails.
-        :type db_system_id: str
-
         :param display_name:
             The value to assign to the display_name property of this CreateDbHomeWithDbSystemIdDetails.
         :type display_name: str
 
         :param source:
             The value to assign to the source property of this CreateDbHomeWithDbSystemIdDetails.
-            Allowed values for this property are: "NONE", "DB_BACKUP"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "VM_CLUSTER_NEW", "VM_CLUSTER_BACKUP"
         :type source: str
+
+        :param db_system_id:
+            The value to assign to the db_system_id property of this CreateDbHomeWithDbSystemIdDetails.
+        :type db_system_id: str
 
         :param db_version:
             The value to assign to the db_version property of this CreateDbHomeWithDbSystemIdDetails.
@@ -41,27 +41,55 @@ class CreateDbHomeWithDbSystemIdDetails(CreateDbHomeWithDbSystemIdBase):
 
         """
         self.swagger_types = {
-            'db_system_id': 'str',
             'display_name': 'str',
             'source': 'str',
+            'db_system_id': 'str',
             'db_version': 'str',
             'database': 'CreateDatabaseDetails'
         }
 
         self.attribute_map = {
-            'db_system_id': 'dbSystemId',
             'display_name': 'displayName',
             'source': 'source',
+            'db_system_id': 'dbSystemId',
             'db_version': 'dbVersion',
             'database': 'database'
         }
 
-        self._db_system_id = None
         self._display_name = None
         self._source = None
+        self._db_system_id = None
         self._db_version = None
         self._database = None
         self._source = 'NONE'
+
+    @property
+    def db_system_id(self):
+        """
+        **[Required]** Gets the db_system_id of this CreateDbHomeWithDbSystemIdDetails.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The db_system_id of this CreateDbHomeWithDbSystemIdDetails.
+        :rtype: str
+        """
+        return self._db_system_id
+
+    @db_system_id.setter
+    def db_system_id(self, db_system_id):
+        """
+        Sets the db_system_id of this CreateDbHomeWithDbSystemIdDetails.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param db_system_id: The db_system_id of this CreateDbHomeWithDbSystemIdDetails.
+        :type: str
+        """
+        self._db_system_id = db_system_id
 
     @property
     def db_version(self):

--- a/src/oci/database/models/create_db_home_with_db_system_id_from_backup_details.py
+++ b/src/oci/database/models/create_db_home_with_db_system_id_from_backup_details.py
@@ -1,13 +1,13 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-from .create_db_home_with_db_system_id_base import CreateDbHomeWithDbSystemIdBase
+from .create_db_home_base import CreateDbHomeBase
 from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
 from oci.decorators import init_model_state_from_kwargs
 
 
 @init_model_state_from_kwargs
-class CreateDbHomeWithDbSystemIdFromBackupDetails(CreateDbHomeWithDbSystemIdBase):
+class CreateDbHomeWithDbSystemIdFromBackupDetails(CreateDbHomeBase):
     """
     Note that a valid `dbSystemId` value must be supplied for the `CreateDbHomeWithDbSystemIdFromBackup` API operation to successfully complete.
     """
@@ -18,18 +18,18 @@ class CreateDbHomeWithDbSystemIdFromBackupDetails(CreateDbHomeWithDbSystemIdBase
         of this class is ``DB_BACKUP`` and it should not be changed.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
-        :param db_system_id:
-            The value to assign to the db_system_id property of this CreateDbHomeWithDbSystemIdFromBackupDetails.
-        :type db_system_id: str
-
         :param display_name:
             The value to assign to the display_name property of this CreateDbHomeWithDbSystemIdFromBackupDetails.
         :type display_name: str
 
         :param source:
             The value to assign to the source property of this CreateDbHomeWithDbSystemIdFromBackupDetails.
-            Allowed values for this property are: "NONE", "DB_BACKUP"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "VM_CLUSTER_NEW", "VM_CLUSTER_BACKUP"
         :type source: str
+
+        :param db_system_id:
+            The value to assign to the db_system_id property of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+        :type db_system_id: str
 
         :param database:
             The value to assign to the database property of this CreateDbHomeWithDbSystemIdFromBackupDetails.
@@ -37,24 +37,52 @@ class CreateDbHomeWithDbSystemIdFromBackupDetails(CreateDbHomeWithDbSystemIdBase
 
         """
         self.swagger_types = {
-            'db_system_id': 'str',
             'display_name': 'str',
             'source': 'str',
+            'db_system_id': 'str',
             'database': 'CreateDatabaseFromBackupDetails'
         }
 
         self.attribute_map = {
-            'db_system_id': 'dbSystemId',
             'display_name': 'displayName',
             'source': 'source',
+            'db_system_id': 'dbSystemId',
             'database': 'database'
         }
 
-        self._db_system_id = None
         self._display_name = None
         self._source = None
+        self._db_system_id = None
         self._database = None
         self._source = 'DB_BACKUP'
+
+    @property
+    def db_system_id(self):
+        """
+        **[Required]** Gets the db_system_id of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The db_system_id of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+        :rtype: str
+        """
+        return self._db_system_id
+
+    @db_system_id.setter
+    def db_system_id(self, db_system_id):
+        """
+        Sets the db_system_id of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param db_system_id: The db_system_id of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+        :type: str
+        """
+        self._db_system_id = db_system_id
 
     @property
     def database(self):

--- a/src/oci/database/models/create_db_home_with_vm_cluster_id_details.py
+++ b/src/oci/database/models/create_db_home_with_vm_cluster_id_details.py
@@ -1,0 +1,148 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .create_db_home_base import CreateDbHomeBase
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDbHomeWithVmClusterIdDetails(CreateDbHomeBase):
+    """
+    Note that a valid `vmClusterId` value must be supplied for the `CreateDbHomeWithVmClusterId` API operation to successfully complete.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDbHomeWithVmClusterIdDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.CreateDbHomeWithVmClusterIdDetails.source` attribute
+        of this class is ``VM_CLUSTER_NEW`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateDbHomeWithVmClusterIdDetails.
+        :type display_name: str
+
+        :param source:
+            The value to assign to the source property of this CreateDbHomeWithVmClusterIdDetails.
+            Allowed values for this property are: "NONE", "DB_BACKUP", "VM_CLUSTER_NEW", "VM_CLUSTER_BACKUP"
+        :type source: str
+
+        :param vm_cluster_id:
+            The value to assign to the vm_cluster_id property of this CreateDbHomeWithVmClusterIdDetails.
+        :type vm_cluster_id: str
+
+        :param db_version:
+            The value to assign to the db_version property of this CreateDbHomeWithVmClusterIdDetails.
+        :type db_version: str
+
+        :param database:
+            The value to assign to the database property of this CreateDbHomeWithVmClusterIdDetails.
+        :type database: CreateDatabaseDetails
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'source': 'str',
+            'vm_cluster_id': 'str',
+            'db_version': 'str',
+            'database': 'CreateDatabaseDetails'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'source': 'source',
+            'vm_cluster_id': 'vmClusterId',
+            'db_version': 'dbVersion',
+            'database': 'database'
+        }
+
+        self._display_name = None
+        self._source = None
+        self._vm_cluster_id = None
+        self._db_version = None
+        self._database = None
+        self._source = 'VM_CLUSTER_NEW'
+
+    @property
+    def vm_cluster_id(self):
+        """
+        **[Required]** Gets the vm_cluster_id of this CreateDbHomeWithVmClusterIdDetails.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vm_cluster_id of this CreateDbHomeWithVmClusterIdDetails.
+        :rtype: str
+        """
+        return self._vm_cluster_id
+
+    @vm_cluster_id.setter
+    def vm_cluster_id(self, vm_cluster_id):
+        """
+        Sets the vm_cluster_id of this CreateDbHomeWithVmClusterIdDetails.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vm_cluster_id: The vm_cluster_id of this CreateDbHomeWithVmClusterIdDetails.
+        :type: str
+        """
+        self._vm_cluster_id = vm_cluster_id
+
+    @property
+    def db_version(self):
+        """
+        **[Required]** Gets the db_version of this CreateDbHomeWithVmClusterIdDetails.
+        A valid Oracle Database version. To get a list of supported versions, use the :func:`list_db_versions` operation.
+
+
+        :return: The db_version of this CreateDbHomeWithVmClusterIdDetails.
+        :rtype: str
+        """
+        return self._db_version
+
+    @db_version.setter
+    def db_version(self, db_version):
+        """
+        Sets the db_version of this CreateDbHomeWithVmClusterIdDetails.
+        A valid Oracle Database version. To get a list of supported versions, use the :func:`list_db_versions` operation.
+
+
+        :param db_version: The db_version of this CreateDbHomeWithVmClusterIdDetails.
+        :type: str
+        """
+        self._db_version = db_version
+
+    @property
+    def database(self):
+        """
+        **[Required]** Gets the database of this CreateDbHomeWithVmClusterIdDetails.
+
+        :return: The database of this CreateDbHomeWithVmClusterIdDetails.
+        :rtype: CreateDatabaseDetails
+        """
+        return self._database
+
+    @database.setter
+    def database(self, database):
+        """
+        Sets the database of this CreateDbHomeWithVmClusterIdDetails.
+
+        :param database: The database of this CreateDbHomeWithVmClusterIdDetails.
+        :type: CreateDatabaseDetails
+        """
+        self._database = database
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_db_home_with_vm_cluster_id_from_backup_details.py
+++ b/src/oci/database/models/create_db_home_with_vm_cluster_id_from_backup_details.py
@@ -1,0 +1,117 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .create_db_home_base import CreateDbHomeBase
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDbHomeWithVmClusterIdFromBackupDetails(CreateDbHomeBase):
+    """
+    Note that a valid `vmClusterId` value must be supplied for the `CreateDbHomeWithVmClusterIdFromBackup` API operation to successfully complete.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDbHomeWithVmClusterIdFromBackupDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.CreateDbHomeWithVmClusterIdFromBackupDetails.source` attribute
+        of this class is ``VM_CLUSTER_BACKUP`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type display_name: str
+
+        :param source:
+            The value to assign to the source property of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+            Allowed values for this property are: "NONE", "DB_BACKUP", "VM_CLUSTER_NEW", "VM_CLUSTER_BACKUP"
+        :type source: str
+
+        :param vm_cluster_id:
+            The value to assign to the vm_cluster_id property of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type vm_cluster_id: str
+
+        :param database:
+            The value to assign to the database property of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type database: CreateDatabaseFromBackupDetails
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'source': 'str',
+            'vm_cluster_id': 'str',
+            'database': 'CreateDatabaseFromBackupDetails'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'source': 'source',
+            'vm_cluster_id': 'vmClusterId',
+            'database': 'database'
+        }
+
+        self._display_name = None
+        self._source = None
+        self._vm_cluster_id = None
+        self._database = None
+        self._source = 'VM_CLUSTER_BACKUP'
+
+    @property
+    def vm_cluster_id(self):
+        """
+        **[Required]** Gets the vm_cluster_id of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vm_cluster_id of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :rtype: str
+        """
+        return self._vm_cluster_id
+
+    @vm_cluster_id.setter
+    def vm_cluster_id(self, vm_cluster_id):
+        """
+        Sets the vm_cluster_id of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vm_cluster_id: The vm_cluster_id of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type: str
+        """
+        self._vm_cluster_id = vm_cluster_id
+
+    @property
+    def database(self):
+        """
+        **[Required]** Gets the database of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+
+        :return: The database of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :rtype: CreateDatabaseFromBackupDetails
+        """
+        return self._database
+
+    @database.setter
+    def database(self, database):
+        """
+        Sets the database of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+
+        :param database: The database of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type: CreateDatabaseFromBackupDetails
+        """
+        self._database = database
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_exadata_infrastructure_details.py
+++ b/src/oci/database/models/create_exadata_infrastructure_details.py
@@ -1,0 +1,527 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateExadataInfrastructureDetails(object):
+    """
+    Request to create Exadata infrastructure.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateExadataInfrastructureDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateExadataInfrastructureDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateExadataInfrastructureDetails.
+        :type display_name: str
+
+        :param shape:
+            The value to assign to the shape property of this CreateExadataInfrastructureDetails.
+        :type shape: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this CreateExadataInfrastructureDetails.
+        :type time_zone: str
+
+        :param cloud_control_plane_server1:
+            The value to assign to the cloud_control_plane_server1 property of this CreateExadataInfrastructureDetails.
+        :type cloud_control_plane_server1: str
+
+        :param cloud_control_plane_server2:
+            The value to assign to the cloud_control_plane_server2 property of this CreateExadataInfrastructureDetails.
+        :type cloud_control_plane_server2: str
+
+        :param netmask:
+            The value to assign to the netmask property of this CreateExadataInfrastructureDetails.
+        :type netmask: str
+
+        :param gateway:
+            The value to assign to the gateway property of this CreateExadataInfrastructureDetails.
+        :type gateway: str
+
+        :param admin_network_cidr:
+            The value to assign to the admin_network_cidr property of this CreateExadataInfrastructureDetails.
+        :type admin_network_cidr: str
+
+        :param infini_band_network_cidr:
+            The value to assign to the infini_band_network_cidr property of this CreateExadataInfrastructureDetails.
+        :type infini_band_network_cidr: str
+
+        :param corporate_proxy:
+            The value to assign to the corporate_proxy property of this CreateExadataInfrastructureDetails.
+        :type corporate_proxy: str
+
+        :param dns_server:
+            The value to assign to the dns_server property of this CreateExadataInfrastructureDetails.
+        :type dns_server: list[str]
+
+        :param ntp_server:
+            The value to assign to the ntp_server property of this CreateExadataInfrastructureDetails.
+        :type ntp_server: list[str]
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateExadataInfrastructureDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateExadataInfrastructureDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'shape': 'str',
+            'time_zone': 'str',
+            'cloud_control_plane_server1': 'str',
+            'cloud_control_plane_server2': 'str',
+            'netmask': 'str',
+            'gateway': 'str',
+            'admin_network_cidr': 'str',
+            'infini_band_network_cidr': 'str',
+            'corporate_proxy': 'str',
+            'dns_server': 'list[str]',
+            'ntp_server': 'list[str]',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'shape': 'shape',
+            'time_zone': 'timeZone',
+            'cloud_control_plane_server1': 'cloudControlPlaneServer1',
+            'cloud_control_plane_server2': 'cloudControlPlaneServer2',
+            'netmask': 'netmask',
+            'gateway': 'gateway',
+            'admin_network_cidr': 'adminNetworkCIDR',
+            'infini_band_network_cidr': 'infiniBandNetworkCIDR',
+            'corporate_proxy': 'corporateProxy',
+            'dns_server': 'dnsServer',
+            'ntp_server': 'ntpServer',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._display_name = None
+        self._shape = None
+        self._time_zone = None
+        self._cloud_control_plane_server1 = None
+        self._cloud_control_plane_server2 = None
+        self._netmask = None
+        self._gateway = None
+        self._admin_network_cidr = None
+        self._infini_band_network_cidr = None
+        self._corporate_proxy = None
+        self._dns_server = None
+        self._ntp_server = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateExadataInfrastructureDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateExadataInfrastructureDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateExadataInfrastructureDetails.
+        The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+
+
+        :return: The display_name of this CreateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateExadataInfrastructureDetails.
+        The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this CreateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def shape(self):
+        """
+        **[Required]** Gets the shape of this CreateExadataInfrastructureDetails.
+        The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+
+
+        :return: The shape of this CreateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this CreateExadataInfrastructureDetails.
+        The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+
+
+        :param shape: The shape of this CreateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def time_zone(self):
+        """
+        **[Required]** Gets the time_zone of this CreateExadataInfrastructureDetails.
+        The time zone of the Exadata infrastructure. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :return: The time_zone of this CreateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this CreateExadataInfrastructureDetails.
+        The time zone of the Exadata infrastructure. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :param time_zone: The time_zone of this CreateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def cloud_control_plane_server1(self):
+        """
+        **[Required]** Gets the cloud_control_plane_server1 of this CreateExadataInfrastructureDetails.
+        The IP address for the first control plane server.
+
+
+        :return: The cloud_control_plane_server1 of this CreateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._cloud_control_plane_server1
+
+    @cloud_control_plane_server1.setter
+    def cloud_control_plane_server1(self, cloud_control_plane_server1):
+        """
+        Sets the cloud_control_plane_server1 of this CreateExadataInfrastructureDetails.
+        The IP address for the first control plane server.
+
+
+        :param cloud_control_plane_server1: The cloud_control_plane_server1 of this CreateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._cloud_control_plane_server1 = cloud_control_plane_server1
+
+    @property
+    def cloud_control_plane_server2(self):
+        """
+        **[Required]** Gets the cloud_control_plane_server2 of this CreateExadataInfrastructureDetails.
+        The IP address for the second control plane server.
+
+
+        :return: The cloud_control_plane_server2 of this CreateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._cloud_control_plane_server2
+
+    @cloud_control_plane_server2.setter
+    def cloud_control_plane_server2(self, cloud_control_plane_server2):
+        """
+        Sets the cloud_control_plane_server2 of this CreateExadataInfrastructureDetails.
+        The IP address for the second control plane server.
+
+
+        :param cloud_control_plane_server2: The cloud_control_plane_server2 of this CreateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._cloud_control_plane_server2 = cloud_control_plane_server2
+
+    @property
+    def netmask(self):
+        """
+        **[Required]** Gets the netmask of this CreateExadataInfrastructureDetails.
+        The netmask for the control plane network.
+
+
+        :return: The netmask of this CreateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._netmask
+
+    @netmask.setter
+    def netmask(self, netmask):
+        """
+        Sets the netmask of this CreateExadataInfrastructureDetails.
+        The netmask for the control plane network.
+
+
+        :param netmask: The netmask of this CreateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._netmask = netmask
+
+    @property
+    def gateway(self):
+        """
+        **[Required]** Gets the gateway of this CreateExadataInfrastructureDetails.
+        The gateway for the control plane network.
+
+
+        :return: The gateway of this CreateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._gateway
+
+    @gateway.setter
+    def gateway(self, gateway):
+        """
+        Sets the gateway of this CreateExadataInfrastructureDetails.
+        The gateway for the control plane network.
+
+
+        :param gateway: The gateway of this CreateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._gateway = gateway
+
+    @property
+    def admin_network_cidr(self):
+        """
+        **[Required]** Gets the admin_network_cidr of this CreateExadataInfrastructureDetails.
+        The CIDR block for the Exadata administration network.
+
+
+        :return: The admin_network_cidr of this CreateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._admin_network_cidr
+
+    @admin_network_cidr.setter
+    def admin_network_cidr(self, admin_network_cidr):
+        """
+        Sets the admin_network_cidr of this CreateExadataInfrastructureDetails.
+        The CIDR block for the Exadata administration network.
+
+
+        :param admin_network_cidr: The admin_network_cidr of this CreateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._admin_network_cidr = admin_network_cidr
+
+    @property
+    def infini_band_network_cidr(self):
+        """
+        **[Required]** Gets the infini_band_network_cidr of this CreateExadataInfrastructureDetails.
+        The CIDR block for the Exadata InfiniBand interconnect.
+
+
+        :return: The infini_band_network_cidr of this CreateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._infini_band_network_cidr
+
+    @infini_band_network_cidr.setter
+    def infini_band_network_cidr(self, infini_band_network_cidr):
+        """
+        Sets the infini_band_network_cidr of this CreateExadataInfrastructureDetails.
+        The CIDR block for the Exadata InfiniBand interconnect.
+
+
+        :param infini_band_network_cidr: The infini_band_network_cidr of this CreateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._infini_band_network_cidr = infini_band_network_cidr
+
+    @property
+    def corporate_proxy(self):
+        """
+        **[Required]** Gets the corporate_proxy of this CreateExadataInfrastructureDetails.
+        The corporate network proxy for access to the control plane network.
+
+
+        :return: The corporate_proxy of this CreateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._corporate_proxy
+
+    @corporate_proxy.setter
+    def corporate_proxy(self, corporate_proxy):
+        """
+        Sets the corporate_proxy of this CreateExadataInfrastructureDetails.
+        The corporate network proxy for access to the control plane network.
+
+
+        :param corporate_proxy: The corporate_proxy of this CreateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._corporate_proxy = corporate_proxy
+
+    @property
+    def dns_server(self):
+        """
+        **[Required]** Gets the dns_server of this CreateExadataInfrastructureDetails.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The dns_server of this CreateExadataInfrastructureDetails.
+        :rtype: list[str]
+        """
+        return self._dns_server
+
+    @dns_server.setter
+    def dns_server(self, dns_server):
+        """
+        Sets the dns_server of this CreateExadataInfrastructureDetails.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :param dns_server: The dns_server of this CreateExadataInfrastructureDetails.
+        :type: list[str]
+        """
+        self._dns_server = dns_server
+
+    @property
+    def ntp_server(self):
+        """
+        **[Required]** Gets the ntp_server of this CreateExadataInfrastructureDetails.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The ntp_server of this CreateExadataInfrastructureDetails.
+        :rtype: list[str]
+        """
+        return self._ntp_server
+
+    @ntp_server.setter
+    def ntp_server(self, ntp_server):
+        """
+        Sets the ntp_server of this CreateExadataInfrastructureDetails.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :param ntp_server: The ntp_server of this CreateExadataInfrastructureDetails.
+        :type: list[str]
+        """
+        self._ntp_server = ntp_server
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateExadataInfrastructureDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateExadataInfrastructureDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateExadataInfrastructureDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateExadataInfrastructureDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateExadataInfrastructureDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateExadataInfrastructureDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateExadataInfrastructureDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateExadataInfrastructureDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_nfs_backup_destination_details.py
+++ b/src/oci/database/models/create_nfs_backup_destination_details.py
@@ -1,0 +1,107 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .create_backup_destination_details import CreateBackupDestinationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateNFSBackupDestinationDetails(CreateBackupDestinationDetails):
+    """
+    Used for creating NFS backup destinations.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateNFSBackupDestinationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.CreateNFSBackupDestinationDetails.type` attribute
+        of this class is ``NFS`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateNFSBackupDestinationDetails.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateNFSBackupDestinationDetails.
+        :type compartment_id: str
+
+        :param type:
+            The value to assign to the type property of this CreateNFSBackupDestinationDetails.
+            Allowed values for this property are: "NFS", "RECOVERY_APPLIANCE"
+        :type type: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateNFSBackupDestinationDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateNFSBackupDestinationDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param local_mount_point_path:
+            The value to assign to the local_mount_point_path property of this CreateNFSBackupDestinationDetails.
+        :type local_mount_point_path: str
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'type': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'local_mount_point_path': 'str'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'type': 'type',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'local_mount_point_path': 'localMountPointPath'
+        }
+
+        self._display_name = None
+        self._compartment_id = None
+        self._type = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._local_mount_point_path = None
+        self._type = 'NFS'
+
+    @property
+    def local_mount_point_path(self):
+        """
+        **[Required]** Gets the local_mount_point_path of this CreateNFSBackupDestinationDetails.
+        The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+
+
+        :return: The local_mount_point_path of this CreateNFSBackupDestinationDetails.
+        :rtype: str
+        """
+        return self._local_mount_point_path
+
+    @local_mount_point_path.setter
+    def local_mount_point_path(self, local_mount_point_path):
+        """
+        Sets the local_mount_point_path of this CreateNFSBackupDestinationDetails.
+        The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+
+
+        :param local_mount_point_path: The local_mount_point_path of this CreateNFSBackupDestinationDetails.
+        :type: str
+        """
+        self._local_mount_point_path = local_mount_point_path
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_recovery_appliance_backup_destination_details.py
+++ b/src/oci/database/models/create_recovery_appliance_backup_destination_details.py
@@ -1,0 +1,138 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .create_backup_destination_details import CreateBackupDestinationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateRecoveryApplianceBackupDestinationDetails(CreateBackupDestinationDetails):
+    """
+    Used for creating Recovery Appliance backup destinations.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateRecoveryApplianceBackupDestinationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.CreateRecoveryApplianceBackupDestinationDetails.type` attribute
+        of this class is ``RECOVERY_APPLIANCE`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateRecoveryApplianceBackupDestinationDetails.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateRecoveryApplianceBackupDestinationDetails.
+        :type compartment_id: str
+
+        :param type:
+            The value to assign to the type property of this CreateRecoveryApplianceBackupDestinationDetails.
+            Allowed values for this property are: "NFS", "RECOVERY_APPLIANCE"
+        :type type: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateRecoveryApplianceBackupDestinationDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateRecoveryApplianceBackupDestinationDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param connection_string:
+            The value to assign to the connection_string property of this CreateRecoveryApplianceBackupDestinationDetails.
+        :type connection_string: str
+
+        :param vpc_users:
+            The value to assign to the vpc_users property of this CreateRecoveryApplianceBackupDestinationDetails.
+        :type vpc_users: list[str]
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'type': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'connection_string': 'str',
+            'vpc_users': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'type': 'type',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'connection_string': 'connectionString',
+            'vpc_users': 'vpcUsers'
+        }
+
+        self._display_name = None
+        self._compartment_id = None
+        self._type = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._connection_string = None
+        self._vpc_users = None
+        self._type = 'RECOVERY_APPLIANCE'
+
+    @property
+    def connection_string(self):
+        """
+        **[Required]** Gets the connection_string of this CreateRecoveryApplianceBackupDestinationDetails.
+        The connection string for connecting to the Recovery Appliance.
+
+
+        :return: The connection_string of this CreateRecoveryApplianceBackupDestinationDetails.
+        :rtype: str
+        """
+        return self._connection_string
+
+    @connection_string.setter
+    def connection_string(self, connection_string):
+        """
+        Sets the connection_string of this CreateRecoveryApplianceBackupDestinationDetails.
+        The connection string for connecting to the Recovery Appliance.
+
+
+        :param connection_string: The connection_string of this CreateRecoveryApplianceBackupDestinationDetails.
+        :type: str
+        """
+        self._connection_string = connection_string
+
+    @property
+    def vpc_users(self):
+        """
+        **[Required]** Gets the vpc_users of this CreateRecoveryApplianceBackupDestinationDetails.
+        The Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+
+
+        :return: The vpc_users of this CreateRecoveryApplianceBackupDestinationDetails.
+        :rtype: list[str]
+        """
+        return self._vpc_users
+
+    @vpc_users.setter
+    def vpc_users(self, vpc_users):
+        """
+        Sets the vpc_users of this CreateRecoveryApplianceBackupDestinationDetails.
+        The Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+
+
+        :param vpc_users: The vpc_users of this CreateRecoveryApplianceBackupDestinationDetails.
+        :type: list[str]
+        """
+        self._vpc_users = vpc_users
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_vm_cluster_details.py
+++ b/src/oci/database/models/create_vm_cluster_details.py
@@ -1,0 +1,490 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateVmClusterDetails(object):
+    """
+    Details for the create VM cluster operation.
+    """
+
+    #: A constant which can be used with the license_model property of a CreateVmClusterDetails.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a CreateVmClusterDetails.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateVmClusterDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateVmClusterDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateVmClusterDetails.
+        :type display_name: str
+
+        :param exadata_infrastructure_id:
+            The value to assign to the exadata_infrastructure_id property of this CreateVmClusterDetails.
+        :type exadata_infrastructure_id: str
+
+        :param cpu_core_count:
+            The value to assign to the cpu_core_count property of this CreateVmClusterDetails.
+        :type cpu_core_count: int
+
+        :param ssh_public_keys:
+            The value to assign to the ssh_public_keys property of this CreateVmClusterDetails.
+        :type ssh_public_keys: list[str]
+
+        :param vm_cluster_network_id:
+            The value to assign to the vm_cluster_network_id property of this CreateVmClusterDetails.
+        :type vm_cluster_network_id: str
+
+        :param license_model:
+            The value to assign to the license_model property of this CreateVmClusterDetails.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+        :type license_model: str
+
+        :param is_sparse_diskgroup_enabled:
+            The value to assign to the is_sparse_diskgroup_enabled property of this CreateVmClusterDetails.
+        :type is_sparse_diskgroup_enabled: bool
+
+        :param is_local_backup_enabled:
+            The value to assign to the is_local_backup_enabled property of this CreateVmClusterDetails.
+        :type is_local_backup_enabled: bool
+
+        :param time_zone:
+            The value to assign to the time_zone property of this CreateVmClusterDetails.
+        :type time_zone: str
+
+        :param gi_version:
+            The value to assign to the gi_version property of this CreateVmClusterDetails.
+        :type gi_version: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateVmClusterDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateVmClusterDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'exadata_infrastructure_id': 'str',
+            'cpu_core_count': 'int',
+            'ssh_public_keys': 'list[str]',
+            'vm_cluster_network_id': 'str',
+            'license_model': 'str',
+            'is_sparse_diskgroup_enabled': 'bool',
+            'is_local_backup_enabled': 'bool',
+            'time_zone': 'str',
+            'gi_version': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'exadata_infrastructure_id': 'exadataInfrastructureId',
+            'cpu_core_count': 'cpuCoreCount',
+            'ssh_public_keys': 'sshPublicKeys',
+            'vm_cluster_network_id': 'vmClusterNetworkId',
+            'license_model': 'licenseModel',
+            'is_sparse_diskgroup_enabled': 'isSparseDiskgroupEnabled',
+            'is_local_backup_enabled': 'isLocalBackupEnabled',
+            'time_zone': 'timeZone',
+            'gi_version': 'giVersion',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._display_name = None
+        self._exadata_infrastructure_id = None
+        self._cpu_core_count = None
+        self._ssh_public_keys = None
+        self._vm_cluster_network_id = None
+        self._license_model = None
+        self._is_sparse_diskgroup_enabled = None
+        self._is_local_backup_enabled = None
+        self._time_zone = None
+        self._gi_version = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateVmClusterDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateVmClusterDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateVmClusterDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateVmClusterDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateVmClusterDetails.
+        The user-friendly name for the VM cluster. The name does not need to be unique.
+
+
+        :return: The display_name of this CreateVmClusterDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateVmClusterDetails.
+        The user-friendly name for the VM cluster. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this CreateVmClusterDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def exadata_infrastructure_id(self):
+        """
+        **[Required]** Gets the exadata_infrastructure_id of this CreateVmClusterDetails.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The exadata_infrastructure_id of this CreateVmClusterDetails.
+        :rtype: str
+        """
+        return self._exadata_infrastructure_id
+
+    @exadata_infrastructure_id.setter
+    def exadata_infrastructure_id(self, exadata_infrastructure_id):
+        """
+        Sets the exadata_infrastructure_id of this CreateVmClusterDetails.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param exadata_infrastructure_id: The exadata_infrastructure_id of this CreateVmClusterDetails.
+        :type: str
+        """
+        self._exadata_infrastructure_id = exadata_infrastructure_id
+
+    @property
+    def cpu_core_count(self):
+        """
+        **[Required]** Gets the cpu_core_count of this CreateVmClusterDetails.
+        The number of CPU cores to enable for the VM cluster.
+
+
+        :return: The cpu_core_count of this CreateVmClusterDetails.
+        :rtype: int
+        """
+        return self._cpu_core_count
+
+    @cpu_core_count.setter
+    def cpu_core_count(self, cpu_core_count):
+        """
+        Sets the cpu_core_count of this CreateVmClusterDetails.
+        The number of CPU cores to enable for the VM cluster.
+
+
+        :param cpu_core_count: The cpu_core_count of this CreateVmClusterDetails.
+        :type: int
+        """
+        self._cpu_core_count = cpu_core_count
+
+    @property
+    def ssh_public_keys(self):
+        """
+        **[Required]** Gets the ssh_public_keys of this CreateVmClusterDetails.
+        The public key portion of one or more key pairs used for SSH access to the VM cluster.
+
+
+        :return: The ssh_public_keys of this CreateVmClusterDetails.
+        :rtype: list[str]
+        """
+        return self._ssh_public_keys
+
+    @ssh_public_keys.setter
+    def ssh_public_keys(self, ssh_public_keys):
+        """
+        Sets the ssh_public_keys of this CreateVmClusterDetails.
+        The public key portion of one or more key pairs used for SSH access to the VM cluster.
+
+
+        :param ssh_public_keys: The ssh_public_keys of this CreateVmClusterDetails.
+        :type: list[str]
+        """
+        self._ssh_public_keys = ssh_public_keys
+
+    @property
+    def vm_cluster_network_id(self):
+        """
+        **[Required]** Gets the vm_cluster_network_id of this CreateVmClusterDetails.
+        The `OCID`__ of the VM cluster network.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vm_cluster_network_id of this CreateVmClusterDetails.
+        :rtype: str
+        """
+        return self._vm_cluster_network_id
+
+    @vm_cluster_network_id.setter
+    def vm_cluster_network_id(self, vm_cluster_network_id):
+        """
+        Sets the vm_cluster_network_id of this CreateVmClusterDetails.
+        The `OCID`__ of the VM cluster network.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vm_cluster_network_id: The vm_cluster_network_id of this CreateVmClusterDetails.
+        :type: str
+        """
+        self._vm_cluster_network_id = vm_cluster_network_id
+
+    @property
+    def license_model(self):
+        """
+        Gets the license_model of this CreateVmClusterDetails.
+        The Oracle license model that applies to the VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+
+
+        :return: The license_model of this CreateVmClusterDetails.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this CreateVmClusterDetails.
+        The Oracle license model that applies to the VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+
+
+        :param license_model: The license_model of this CreateVmClusterDetails.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            raise ValueError(
+                "Invalid value for `license_model`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._license_model = license_model
+
+    @property
+    def is_sparse_diskgroup_enabled(self):
+        """
+        Gets the is_sparse_diskgroup_enabled of this CreateVmClusterDetails.
+        If true, the sparse disk group is configured for the VM cluster. If false, the sparse disk group is not created.
+
+
+        :return: The is_sparse_diskgroup_enabled of this CreateVmClusterDetails.
+        :rtype: bool
+        """
+        return self._is_sparse_diskgroup_enabled
+
+    @is_sparse_diskgroup_enabled.setter
+    def is_sparse_diskgroup_enabled(self, is_sparse_diskgroup_enabled):
+        """
+        Sets the is_sparse_diskgroup_enabled of this CreateVmClusterDetails.
+        If true, the sparse disk group is configured for the VM cluster. If false, the sparse disk group is not created.
+
+
+        :param is_sparse_diskgroup_enabled: The is_sparse_diskgroup_enabled of this CreateVmClusterDetails.
+        :type: bool
+        """
+        self._is_sparse_diskgroup_enabled = is_sparse_diskgroup_enabled
+
+    @property
+    def is_local_backup_enabled(self):
+        """
+        Gets the is_local_backup_enabled of this CreateVmClusterDetails.
+        If true, database backup on local Exadata storage is configured for the VM cluster. If false, database backup on local Exadata storage is not available in the VM cluster.
+
+
+        :return: The is_local_backup_enabled of this CreateVmClusterDetails.
+        :rtype: bool
+        """
+        return self._is_local_backup_enabled
+
+    @is_local_backup_enabled.setter
+    def is_local_backup_enabled(self, is_local_backup_enabled):
+        """
+        Sets the is_local_backup_enabled of this CreateVmClusterDetails.
+        If true, database backup on local Exadata storage is configured for the VM cluster. If false, database backup on local Exadata storage is not available in the VM cluster.
+
+
+        :param is_local_backup_enabled: The is_local_backup_enabled of this CreateVmClusterDetails.
+        :type: bool
+        """
+        self._is_local_backup_enabled = is_local_backup_enabled
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this CreateVmClusterDetails.
+        The time zone to use for the VM cluster. For details, see `DB System Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :return: The time_zone of this CreateVmClusterDetails.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this CreateVmClusterDetails.
+        The time zone to use for the VM cluster. For details, see `DB System Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :param time_zone: The time_zone of this CreateVmClusterDetails.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def gi_version(self):
+        """
+        **[Required]** Gets the gi_version of this CreateVmClusterDetails.
+        The Oracle Grid Infrastructure software version for the VM cluster.
+
+
+        :return: The gi_version of this CreateVmClusterDetails.
+        :rtype: str
+        """
+        return self._gi_version
+
+    @gi_version.setter
+    def gi_version(self, gi_version):
+        """
+        Sets the gi_version of this CreateVmClusterDetails.
+        The Oracle Grid Infrastructure software version for the VM cluster.
+
+
+        :param gi_version: The gi_version of this CreateVmClusterDetails.
+        :type: str
+        """
+        self._gi_version = gi_version
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateVmClusterDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateVmClusterDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateVmClusterDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateVmClusterDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateVmClusterDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateVmClusterDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateVmClusterDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateVmClusterDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/db_backup_config.py
+++ b/src/oci/database/models/db_backup_config.py
@@ -82,22 +82,29 @@ class DbBackupConfig(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type auto_backup_window: str
 
+        :param backup_destination_details:
+            The value to assign to the backup_destination_details property of this DbBackupConfig.
+        :type backup_destination_details: list[BackupDestinationDetails]
+
         """
         self.swagger_types = {
             'auto_backup_enabled': 'bool',
             'recovery_window_in_days': 'int',
-            'auto_backup_window': 'str'
+            'auto_backup_window': 'str',
+            'backup_destination_details': 'list[BackupDestinationDetails]'
         }
 
         self.attribute_map = {
             'auto_backup_enabled': 'autoBackupEnabled',
             'recovery_window_in_days': 'recoveryWindowInDays',
-            'auto_backup_window': 'autoBackupWindow'
+            'auto_backup_window': 'autoBackupWindow',
+            'backup_destination_details': 'backupDestinationDetails'
         }
 
         self._auto_backup_enabled = None
         self._recovery_window_in_days = None
         self._auto_backup_window = None
+        self._backup_destination_details = None
 
     @property
     def auto_backup_enabled(self):
@@ -184,6 +191,30 @@ class DbBackupConfig(object):
         if not value_allowed_none_or_none_sentinel(auto_backup_window, allowed_values):
             auto_backup_window = 'UNKNOWN_ENUM_VALUE'
         self._auto_backup_window = auto_backup_window
+
+    @property
+    def backup_destination_details(self):
+        """
+        Gets the backup_destination_details of this DbBackupConfig.
+        Backup destination details.
+
+
+        :return: The backup_destination_details of this DbBackupConfig.
+        :rtype: list[BackupDestinationDetails]
+        """
+        return self._backup_destination_details
+
+    @backup_destination_details.setter
+    def backup_destination_details(self, backup_destination_details):
+        """
+        Sets the backup_destination_details of this DbBackupConfig.
+        Backup destination details.
+
+
+        :param backup_destination_details: The backup_destination_details of this DbBackupConfig.
+        :type: list[BackupDestinationDetails]
+        """
+        self._backup_destination_details = backup_destination_details
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/db_home.py
+++ b/src/oci/database/models/db_home.py
@@ -67,6 +67,10 @@ class DbHome(object):
             The value to assign to the db_system_id property of this DbHome.
         :type db_system_id: str
 
+        :param vm_cluster_id:
+            The value to assign to the vm_cluster_id property of this DbHome.
+        :type vm_cluster_id: str
+
         :param db_version:
             The value to assign to the db_version property of this DbHome.
         :type db_version: str
@@ -83,6 +87,7 @@ class DbHome(object):
             'last_patch_history_entry_id': 'str',
             'lifecycle_state': 'str',
             'db_system_id': 'str',
+            'vm_cluster_id': 'str',
             'db_version': 'str',
             'time_created': 'datetime'
         }
@@ -94,6 +99,7 @@ class DbHome(object):
             'last_patch_history_entry_id': 'lastPatchHistoryEntryId',
             'lifecycle_state': 'lifecycleState',
             'db_system_id': 'dbSystemId',
+            'vm_cluster_id': 'vmClusterId',
             'db_version': 'dbVersion',
             'time_created': 'timeCreated'
         }
@@ -104,6 +110,7 @@ class DbHome(object):
         self._last_patch_history_entry_id = None
         self._lifecycle_state = None
         self._db_system_id = None
+        self._vm_cluster_id = None
         self._db_version = None
         self._time_created = None
 
@@ -272,6 +279,34 @@ class DbHome(object):
         :type: str
         """
         self._db_system_id = db_system_id
+
+    @property
+    def vm_cluster_id(self):
+        """
+        Gets the vm_cluster_id of this DbHome.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vm_cluster_id of this DbHome.
+        :rtype: str
+        """
+        return self._vm_cluster_id
+
+    @vm_cluster_id.setter
+    def vm_cluster_id(self, vm_cluster_id):
+        """
+        Sets the vm_cluster_id of this DbHome.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vm_cluster_id: The vm_cluster_id of this DbHome.
+        :type: str
+        """
+        self._vm_cluster_id = vm_cluster_id
 
     @property
     def db_version(self):

--- a/src/oci/database/models/db_home_summary.py
+++ b/src/oci/database/models/db_home_summary.py
@@ -78,6 +78,10 @@ class DbHomeSummary(object):
             The value to assign to the db_system_id property of this DbHomeSummary.
         :type db_system_id: str
 
+        :param vm_cluster_id:
+            The value to assign to the vm_cluster_id property of this DbHomeSummary.
+        :type vm_cluster_id: str
+
         :param db_version:
             The value to assign to the db_version property of this DbHomeSummary.
         :type db_version: str
@@ -94,6 +98,7 @@ class DbHomeSummary(object):
             'last_patch_history_entry_id': 'str',
             'lifecycle_state': 'str',
             'db_system_id': 'str',
+            'vm_cluster_id': 'str',
             'db_version': 'str',
             'time_created': 'datetime'
         }
@@ -105,6 +110,7 @@ class DbHomeSummary(object):
             'last_patch_history_entry_id': 'lastPatchHistoryEntryId',
             'lifecycle_state': 'lifecycleState',
             'db_system_id': 'dbSystemId',
+            'vm_cluster_id': 'vmClusterId',
             'db_version': 'dbVersion',
             'time_created': 'timeCreated'
         }
@@ -115,6 +121,7 @@ class DbHomeSummary(object):
         self._last_patch_history_entry_id = None
         self._lifecycle_state = None
         self._db_system_id = None
+        self._vm_cluster_id = None
         self._db_version = None
         self._time_created = None
 
@@ -283,6 +290,34 @@ class DbHomeSummary(object):
         :type: str
         """
         self._db_system_id = db_system_id
+
+    @property
+    def vm_cluster_id(self):
+        """
+        Gets the vm_cluster_id of this DbHomeSummary.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vm_cluster_id of this DbHomeSummary.
+        :rtype: str
+        """
+        return self._vm_cluster_id
+
+    @vm_cluster_id.setter
+    def vm_cluster_id(self, vm_cluster_id):
+        """
+        Sets the vm_cluster_id of this DbHomeSummary.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vm_cluster_id: The vm_cluster_id of this DbHomeSummary.
+        :type: str
+        """
+        self._vm_cluster_id = vm_cluster_id
 
     @property
     def db_version(self):

--- a/src/oci/database/models/db_system_shape_summary.py
+++ b/src/oci/database/models/db_system_shape_summary.py
@@ -28,6 +28,10 @@ class DbSystemShapeSummary(object):
             The value to assign to the name property of this DbSystemShapeSummary.
         :type name: str
 
+        :param shape_family:
+            The value to assign to the shape_family property of this DbSystemShapeSummary.
+        :type shape_family: str
+
         :param shape:
             The value to assign to the shape property of this DbSystemShapeSummary.
         :type shape: str
@@ -55,6 +59,7 @@ class DbSystemShapeSummary(object):
         """
         self.swagger_types = {
             'name': 'str',
+            'shape_family': 'str',
             'shape': 'str',
             'available_core_count': 'int',
             'minimum_core_count': 'int',
@@ -65,6 +70,7 @@ class DbSystemShapeSummary(object):
 
         self.attribute_map = {
             'name': 'name',
+            'shape_family': 'shapeFamily',
             'shape': 'shape',
             'available_core_count': 'availableCoreCount',
             'minimum_core_count': 'minimumCoreCount',
@@ -74,6 +80,7 @@ class DbSystemShapeSummary(object):
         }
 
         self._name = None
+        self._shape_family = None
         self._shape = None
         self._available_core_count = None
         self._minimum_core_count = None
@@ -104,6 +111,30 @@ class DbSystemShapeSummary(object):
         :type: str
         """
         self._name = name
+
+    @property
+    def shape_family(self):
+        """
+        Gets the shape_family of this DbSystemShapeSummary.
+        The family of the shape used for the DB system.
+
+
+        :return: The shape_family of this DbSystemShapeSummary.
+        :rtype: str
+        """
+        return self._shape_family
+
+    @shape_family.setter
+    def shape_family(self, shape_family):
+        """
+        Sets the shape_family of this DbSystemShapeSummary.
+        The family of the shape used for the DB system.
+
+
+        :param shape_family: The shape_family of this DbSystemShapeSummary.
+        :type: str
+        """
+        self._shape_family = shape_family
 
     @property
     def shape(self):

--- a/src/oci/database/models/exadata_infrastructure.py
+++ b/src/oci/database/models/exadata_infrastructure.py
@@ -1,0 +1,765 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExadataInfrastructure(object):
+    """
+    ExadataInfrastructure
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructure.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructure.
+    #: This constant has a value of "REQUIRES_ACTIVATION"
+    LIFECYCLE_STATE_REQUIRES_ACTIVATION = "REQUIRES_ACTIVATION"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructure.
+    #: This constant has a value of "ACTIVATING"
+    LIFECYCLE_STATE_ACTIVATING = "ACTIVATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructure.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructure.
+    #: This constant has a value of "ACTIVATION_FAILED"
+    LIFECYCLE_STATE_ACTIVATION_FAILED = "ACTIVATION_FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructure.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructure.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructure.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructure.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructure.
+    #: This constant has a value of "OFFLINE"
+    LIFECYCLE_STATE_OFFLINE = "OFFLINE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExadataInfrastructure object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this ExadataInfrastructure.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ExadataInfrastructure.
+        :type compartment_id: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ExadataInfrastructure.
+            Allowed values for this property are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param display_name:
+            The value to assign to the display_name property of this ExadataInfrastructure.
+        :type display_name: str
+
+        :param shape:
+            The value to assign to the shape property of this ExadataInfrastructure.
+        :type shape: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this ExadataInfrastructure.
+        :type time_zone: str
+
+        :param cpus_enabled:
+            The value to assign to the cpus_enabled property of this ExadataInfrastructure.
+        :type cpus_enabled: int
+
+        :param data_storage_size_in_tbs:
+            The value to assign to the data_storage_size_in_tbs property of this ExadataInfrastructure.
+        :type data_storage_size_in_tbs: int
+
+        :param cloud_control_plane_server1:
+            The value to assign to the cloud_control_plane_server1 property of this ExadataInfrastructure.
+        :type cloud_control_plane_server1: str
+
+        :param cloud_control_plane_server2:
+            The value to assign to the cloud_control_plane_server2 property of this ExadataInfrastructure.
+        :type cloud_control_plane_server2: str
+
+        :param netmask:
+            The value to assign to the netmask property of this ExadataInfrastructure.
+        :type netmask: str
+
+        :param gateway:
+            The value to assign to the gateway property of this ExadataInfrastructure.
+        :type gateway: str
+
+        :param admin_network_cidr:
+            The value to assign to the admin_network_cidr property of this ExadataInfrastructure.
+        :type admin_network_cidr: str
+
+        :param infini_band_network_cidr:
+            The value to assign to the infini_band_network_cidr property of this ExadataInfrastructure.
+        :type infini_band_network_cidr: str
+
+        :param corporate_proxy:
+            The value to assign to the corporate_proxy property of this ExadataInfrastructure.
+        :type corporate_proxy: str
+
+        :param dns_server:
+            The value to assign to the dns_server property of this ExadataInfrastructure.
+        :type dns_server: list[str]
+
+        :param ntp_server:
+            The value to assign to the ntp_server property of this ExadataInfrastructure.
+        :type ntp_server: list[str]
+
+        :param time_created:
+            The value to assign to the time_created property of this ExadataInfrastructure.
+        :type time_created: datetime
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ExadataInfrastructure.
+        :type lifecycle_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ExadataInfrastructure.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ExadataInfrastructure.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'lifecycle_state': 'str',
+            'display_name': 'str',
+            'shape': 'str',
+            'time_zone': 'str',
+            'cpus_enabled': 'int',
+            'data_storage_size_in_tbs': 'int',
+            'cloud_control_plane_server1': 'str',
+            'cloud_control_plane_server2': 'str',
+            'netmask': 'str',
+            'gateway': 'str',
+            'admin_network_cidr': 'str',
+            'infini_band_network_cidr': 'str',
+            'corporate_proxy': 'str',
+            'dns_server': 'list[str]',
+            'ntp_server': 'list[str]',
+            'time_created': 'datetime',
+            'lifecycle_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'lifecycle_state': 'lifecycleState',
+            'display_name': 'displayName',
+            'shape': 'shape',
+            'time_zone': 'timeZone',
+            'cpus_enabled': 'cpusEnabled',
+            'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
+            'cloud_control_plane_server1': 'cloudControlPlaneServer1',
+            'cloud_control_plane_server2': 'cloudControlPlaneServer2',
+            'netmask': 'netmask',
+            'gateway': 'gateway',
+            'admin_network_cidr': 'adminNetworkCIDR',
+            'infini_band_network_cidr': 'infiniBandNetworkCIDR',
+            'corporate_proxy': 'corporateProxy',
+            'dns_server': 'dnsServer',
+            'ntp_server': 'ntpServer',
+            'time_created': 'timeCreated',
+            'lifecycle_details': 'lifecycleDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._lifecycle_state = None
+        self._display_name = None
+        self._shape = None
+        self._time_zone = None
+        self._cpus_enabled = None
+        self._data_storage_size_in_tbs = None
+        self._cloud_control_plane_server1 = None
+        self._cloud_control_plane_server2 = None
+        self._netmask = None
+        self._gateway = None
+        self._admin_network_cidr = None
+        self._infini_band_network_cidr = None
+        self._corporate_proxy = None
+        self._dns_server = None
+        self._ntp_server = None
+        self._time_created = None
+        self._lifecycle_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ExadataInfrastructure.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ExadataInfrastructure.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ExadataInfrastructure.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ExadataInfrastructure.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ExadataInfrastructure.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ExadataInfrastructure.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ExadataInfrastructure.
+        The current lifecycle state of the Exadata infrastructure.
+
+        Allowed values for this property are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ExadataInfrastructure.
+        The current lifecycle state of the Exadata infrastructure.
+
+
+        :param lifecycle_state: The lifecycle_state of this ExadataInfrastructure.
+        :type: str
+        """
+        allowed_values = ["CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ExadataInfrastructure.
+        The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+
+
+        :return: The display_name of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ExadataInfrastructure.
+        The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this ExadataInfrastructure.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def shape(self):
+        """
+        **[Required]** Gets the shape of this ExadataInfrastructure.
+        The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+
+
+        :return: The shape of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this ExadataInfrastructure.
+        The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+
+
+        :param shape: The shape of this ExadataInfrastructure.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this ExadataInfrastructure.
+        The time zone of the Exadata infrastructure. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :return: The time_zone of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this ExadataInfrastructure.
+        The time zone of the Exadata infrastructure. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :param time_zone: The time_zone of this ExadataInfrastructure.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def cpus_enabled(self):
+        """
+        Gets the cpus_enabled of this ExadataInfrastructure.
+        The number of enabled CPU cores.
+
+
+        :return: The cpus_enabled of this ExadataInfrastructure.
+        :rtype: int
+        """
+        return self._cpus_enabled
+
+    @cpus_enabled.setter
+    def cpus_enabled(self, cpus_enabled):
+        """
+        Sets the cpus_enabled of this ExadataInfrastructure.
+        The number of enabled CPU cores.
+
+
+        :param cpus_enabled: The cpus_enabled of this ExadataInfrastructure.
+        :type: int
+        """
+        self._cpus_enabled = cpus_enabled
+
+    @property
+    def data_storage_size_in_tbs(self):
+        """
+        Gets the data_storage_size_in_tbs of this ExadataInfrastructure.
+        Size, in terabytes, of the DATA disk group.
+
+
+        :return: The data_storage_size_in_tbs of this ExadataInfrastructure.
+        :rtype: int
+        """
+        return self._data_storage_size_in_tbs
+
+    @data_storage_size_in_tbs.setter
+    def data_storage_size_in_tbs(self, data_storage_size_in_tbs):
+        """
+        Sets the data_storage_size_in_tbs of this ExadataInfrastructure.
+        Size, in terabytes, of the DATA disk group.
+
+
+        :param data_storage_size_in_tbs: The data_storage_size_in_tbs of this ExadataInfrastructure.
+        :type: int
+        """
+        self._data_storage_size_in_tbs = data_storage_size_in_tbs
+
+    @property
+    def cloud_control_plane_server1(self):
+        """
+        Gets the cloud_control_plane_server1 of this ExadataInfrastructure.
+        The IP address for the first control plane server.
+
+
+        :return: The cloud_control_plane_server1 of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._cloud_control_plane_server1
+
+    @cloud_control_plane_server1.setter
+    def cloud_control_plane_server1(self, cloud_control_plane_server1):
+        """
+        Sets the cloud_control_plane_server1 of this ExadataInfrastructure.
+        The IP address for the first control plane server.
+
+
+        :param cloud_control_plane_server1: The cloud_control_plane_server1 of this ExadataInfrastructure.
+        :type: str
+        """
+        self._cloud_control_plane_server1 = cloud_control_plane_server1
+
+    @property
+    def cloud_control_plane_server2(self):
+        """
+        Gets the cloud_control_plane_server2 of this ExadataInfrastructure.
+        The IP address for the second control plane server.
+
+
+        :return: The cloud_control_plane_server2 of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._cloud_control_plane_server2
+
+    @cloud_control_plane_server2.setter
+    def cloud_control_plane_server2(self, cloud_control_plane_server2):
+        """
+        Sets the cloud_control_plane_server2 of this ExadataInfrastructure.
+        The IP address for the second control plane server.
+
+
+        :param cloud_control_plane_server2: The cloud_control_plane_server2 of this ExadataInfrastructure.
+        :type: str
+        """
+        self._cloud_control_plane_server2 = cloud_control_plane_server2
+
+    @property
+    def netmask(self):
+        """
+        Gets the netmask of this ExadataInfrastructure.
+        The netmask for the control plane network.
+
+
+        :return: The netmask of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._netmask
+
+    @netmask.setter
+    def netmask(self, netmask):
+        """
+        Sets the netmask of this ExadataInfrastructure.
+        The netmask for the control plane network.
+
+
+        :param netmask: The netmask of this ExadataInfrastructure.
+        :type: str
+        """
+        self._netmask = netmask
+
+    @property
+    def gateway(self):
+        """
+        Gets the gateway of this ExadataInfrastructure.
+        The gateway for the control plane network.
+
+
+        :return: The gateway of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._gateway
+
+    @gateway.setter
+    def gateway(self, gateway):
+        """
+        Sets the gateway of this ExadataInfrastructure.
+        The gateway for the control plane network.
+
+
+        :param gateway: The gateway of this ExadataInfrastructure.
+        :type: str
+        """
+        self._gateway = gateway
+
+    @property
+    def admin_network_cidr(self):
+        """
+        Gets the admin_network_cidr of this ExadataInfrastructure.
+        The CIDR block for the Exadata administration network.
+
+
+        :return: The admin_network_cidr of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._admin_network_cidr
+
+    @admin_network_cidr.setter
+    def admin_network_cidr(self, admin_network_cidr):
+        """
+        Sets the admin_network_cidr of this ExadataInfrastructure.
+        The CIDR block for the Exadata administration network.
+
+
+        :param admin_network_cidr: The admin_network_cidr of this ExadataInfrastructure.
+        :type: str
+        """
+        self._admin_network_cidr = admin_network_cidr
+
+    @property
+    def infini_band_network_cidr(self):
+        """
+        Gets the infini_band_network_cidr of this ExadataInfrastructure.
+        The CIDR block for the Exadata InfiniBand interconnect.
+
+
+        :return: The infini_band_network_cidr of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._infini_band_network_cidr
+
+    @infini_band_network_cidr.setter
+    def infini_band_network_cidr(self, infini_band_network_cidr):
+        """
+        Sets the infini_band_network_cidr of this ExadataInfrastructure.
+        The CIDR block for the Exadata InfiniBand interconnect.
+
+
+        :param infini_band_network_cidr: The infini_band_network_cidr of this ExadataInfrastructure.
+        :type: str
+        """
+        self._infini_band_network_cidr = infini_band_network_cidr
+
+    @property
+    def corporate_proxy(self):
+        """
+        Gets the corporate_proxy of this ExadataInfrastructure.
+        The corporate network proxy for access to the control plane network.
+
+
+        :return: The corporate_proxy of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._corporate_proxy
+
+    @corporate_proxy.setter
+    def corporate_proxy(self, corporate_proxy):
+        """
+        Sets the corporate_proxy of this ExadataInfrastructure.
+        The corporate network proxy for access to the control plane network.
+
+
+        :param corporate_proxy: The corporate_proxy of this ExadataInfrastructure.
+        :type: str
+        """
+        self._corporate_proxy = corporate_proxy
+
+    @property
+    def dns_server(self):
+        """
+        Gets the dns_server of this ExadataInfrastructure.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The dns_server of this ExadataInfrastructure.
+        :rtype: list[str]
+        """
+        return self._dns_server
+
+    @dns_server.setter
+    def dns_server(self, dns_server):
+        """
+        Sets the dns_server of this ExadataInfrastructure.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :param dns_server: The dns_server of this ExadataInfrastructure.
+        :type: list[str]
+        """
+        self._dns_server = dns_server
+
+    @property
+    def ntp_server(self):
+        """
+        Gets the ntp_server of this ExadataInfrastructure.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The ntp_server of this ExadataInfrastructure.
+        :rtype: list[str]
+        """
+        return self._ntp_server
+
+    @ntp_server.setter
+    def ntp_server(self, ntp_server):
+        """
+        Sets the ntp_server of this ExadataInfrastructure.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :param ntp_server: The ntp_server of this ExadataInfrastructure.
+        :type: list[str]
+        """
+        self._ntp_server = ntp_server
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this ExadataInfrastructure.
+        The date and time the Exadata infrastructure was created.
+
+
+        :return: The time_created of this ExadataInfrastructure.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ExadataInfrastructure.
+        The date and time the Exadata infrastructure was created.
+
+
+        :param time_created: The time_created of this ExadataInfrastructure.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this ExadataInfrastructure.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this ExadataInfrastructure.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this ExadataInfrastructure.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ExadataInfrastructure.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ExadataInfrastructure.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ExadataInfrastructure.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ExadataInfrastructure.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ExadataInfrastructure.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ExadataInfrastructure.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ExadataInfrastructure.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ExadataInfrastructure.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/exadata_infrastructure_summary.py
+++ b/src/oci/database/models/exadata_infrastructure_summary.py
@@ -1,0 +1,765 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExadataInfrastructureSummary(object):
+    """
+    Details of the Exadata infrastructure.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructureSummary.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructureSummary.
+    #: This constant has a value of "REQUIRES_ACTIVATION"
+    LIFECYCLE_STATE_REQUIRES_ACTIVATION = "REQUIRES_ACTIVATION"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructureSummary.
+    #: This constant has a value of "ACTIVATING"
+    LIFECYCLE_STATE_ACTIVATING = "ACTIVATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructureSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructureSummary.
+    #: This constant has a value of "ACTIVATION_FAILED"
+    LIFECYCLE_STATE_ACTIVATION_FAILED = "ACTIVATION_FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructureSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructureSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructureSummary.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructureSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructureSummary.
+    #: This constant has a value of "OFFLINE"
+    LIFECYCLE_STATE_OFFLINE = "OFFLINE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExadataInfrastructureSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this ExadataInfrastructureSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ExadataInfrastructureSummary.
+        :type compartment_id: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ExadataInfrastructureSummary.
+            Allowed values for this property are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param display_name:
+            The value to assign to the display_name property of this ExadataInfrastructureSummary.
+        :type display_name: str
+
+        :param shape:
+            The value to assign to the shape property of this ExadataInfrastructureSummary.
+        :type shape: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this ExadataInfrastructureSummary.
+        :type time_zone: str
+
+        :param cpus_enabled:
+            The value to assign to the cpus_enabled property of this ExadataInfrastructureSummary.
+        :type cpus_enabled: int
+
+        :param data_storage_size_in_tbs:
+            The value to assign to the data_storage_size_in_tbs property of this ExadataInfrastructureSummary.
+        :type data_storage_size_in_tbs: int
+
+        :param cloud_control_plane_server1:
+            The value to assign to the cloud_control_plane_server1 property of this ExadataInfrastructureSummary.
+        :type cloud_control_plane_server1: str
+
+        :param cloud_control_plane_server2:
+            The value to assign to the cloud_control_plane_server2 property of this ExadataInfrastructureSummary.
+        :type cloud_control_plane_server2: str
+
+        :param netmask:
+            The value to assign to the netmask property of this ExadataInfrastructureSummary.
+        :type netmask: str
+
+        :param gateway:
+            The value to assign to the gateway property of this ExadataInfrastructureSummary.
+        :type gateway: str
+
+        :param admin_network_cidr:
+            The value to assign to the admin_network_cidr property of this ExadataInfrastructureSummary.
+        :type admin_network_cidr: str
+
+        :param infini_band_network_cidr:
+            The value to assign to the infini_band_network_cidr property of this ExadataInfrastructureSummary.
+        :type infini_band_network_cidr: str
+
+        :param corporate_proxy:
+            The value to assign to the corporate_proxy property of this ExadataInfrastructureSummary.
+        :type corporate_proxy: str
+
+        :param dns_server:
+            The value to assign to the dns_server property of this ExadataInfrastructureSummary.
+        :type dns_server: list[str]
+
+        :param ntp_server:
+            The value to assign to the ntp_server property of this ExadataInfrastructureSummary.
+        :type ntp_server: list[str]
+
+        :param time_created:
+            The value to assign to the time_created property of this ExadataInfrastructureSummary.
+        :type time_created: datetime
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ExadataInfrastructureSummary.
+        :type lifecycle_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ExadataInfrastructureSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ExadataInfrastructureSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'lifecycle_state': 'str',
+            'display_name': 'str',
+            'shape': 'str',
+            'time_zone': 'str',
+            'cpus_enabled': 'int',
+            'data_storage_size_in_tbs': 'int',
+            'cloud_control_plane_server1': 'str',
+            'cloud_control_plane_server2': 'str',
+            'netmask': 'str',
+            'gateway': 'str',
+            'admin_network_cidr': 'str',
+            'infini_band_network_cidr': 'str',
+            'corporate_proxy': 'str',
+            'dns_server': 'list[str]',
+            'ntp_server': 'list[str]',
+            'time_created': 'datetime',
+            'lifecycle_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'lifecycle_state': 'lifecycleState',
+            'display_name': 'displayName',
+            'shape': 'shape',
+            'time_zone': 'timeZone',
+            'cpus_enabled': 'cpusEnabled',
+            'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
+            'cloud_control_plane_server1': 'cloudControlPlaneServer1',
+            'cloud_control_plane_server2': 'cloudControlPlaneServer2',
+            'netmask': 'netmask',
+            'gateway': 'gateway',
+            'admin_network_cidr': 'adminNetworkCIDR',
+            'infini_band_network_cidr': 'infiniBandNetworkCIDR',
+            'corporate_proxy': 'corporateProxy',
+            'dns_server': 'dnsServer',
+            'ntp_server': 'ntpServer',
+            'time_created': 'timeCreated',
+            'lifecycle_details': 'lifecycleDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._lifecycle_state = None
+        self._display_name = None
+        self._shape = None
+        self._time_zone = None
+        self._cpus_enabled = None
+        self._data_storage_size_in_tbs = None
+        self._cloud_control_plane_server1 = None
+        self._cloud_control_plane_server2 = None
+        self._netmask = None
+        self._gateway = None
+        self._admin_network_cidr = None
+        self._infini_band_network_cidr = None
+        self._corporate_proxy = None
+        self._dns_server = None
+        self._ntp_server = None
+        self._time_created = None
+        self._lifecycle_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ExadataInfrastructureSummary.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ExadataInfrastructureSummary.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ExadataInfrastructureSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ExadataInfrastructureSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ExadataInfrastructureSummary.
+        The current lifecycle state of the Exadata infrastructure.
+
+        Allowed values for this property are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ExadataInfrastructureSummary.
+        The current lifecycle state of the Exadata infrastructure.
+
+
+        :param lifecycle_state: The lifecycle_state of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        allowed_values = ["CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ExadataInfrastructureSummary.
+        The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+
+
+        :return: The display_name of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ExadataInfrastructureSummary.
+        The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def shape(self):
+        """
+        **[Required]** Gets the shape of this ExadataInfrastructureSummary.
+        The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+
+
+        :return: The shape of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this ExadataInfrastructureSummary.
+        The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+
+
+        :param shape: The shape of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this ExadataInfrastructureSummary.
+        The time zone of the Exadata infrastructure. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :return: The time_zone of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this ExadataInfrastructureSummary.
+        The time zone of the Exadata infrastructure. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :param time_zone: The time_zone of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def cpus_enabled(self):
+        """
+        Gets the cpus_enabled of this ExadataInfrastructureSummary.
+        The number of enabled CPU cores.
+
+
+        :return: The cpus_enabled of this ExadataInfrastructureSummary.
+        :rtype: int
+        """
+        return self._cpus_enabled
+
+    @cpus_enabled.setter
+    def cpus_enabled(self, cpus_enabled):
+        """
+        Sets the cpus_enabled of this ExadataInfrastructureSummary.
+        The number of enabled CPU cores.
+
+
+        :param cpus_enabled: The cpus_enabled of this ExadataInfrastructureSummary.
+        :type: int
+        """
+        self._cpus_enabled = cpus_enabled
+
+    @property
+    def data_storage_size_in_tbs(self):
+        """
+        Gets the data_storage_size_in_tbs of this ExadataInfrastructureSummary.
+        Size, in terabytes, of the DATA disk group.
+
+
+        :return: The data_storage_size_in_tbs of this ExadataInfrastructureSummary.
+        :rtype: int
+        """
+        return self._data_storage_size_in_tbs
+
+    @data_storage_size_in_tbs.setter
+    def data_storage_size_in_tbs(self, data_storage_size_in_tbs):
+        """
+        Sets the data_storage_size_in_tbs of this ExadataInfrastructureSummary.
+        Size, in terabytes, of the DATA disk group.
+
+
+        :param data_storage_size_in_tbs: The data_storage_size_in_tbs of this ExadataInfrastructureSummary.
+        :type: int
+        """
+        self._data_storage_size_in_tbs = data_storage_size_in_tbs
+
+    @property
+    def cloud_control_plane_server1(self):
+        """
+        Gets the cloud_control_plane_server1 of this ExadataInfrastructureSummary.
+        The IP address for the first control plane server.
+
+
+        :return: The cloud_control_plane_server1 of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._cloud_control_plane_server1
+
+    @cloud_control_plane_server1.setter
+    def cloud_control_plane_server1(self, cloud_control_plane_server1):
+        """
+        Sets the cloud_control_plane_server1 of this ExadataInfrastructureSummary.
+        The IP address for the first control plane server.
+
+
+        :param cloud_control_plane_server1: The cloud_control_plane_server1 of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        self._cloud_control_plane_server1 = cloud_control_plane_server1
+
+    @property
+    def cloud_control_plane_server2(self):
+        """
+        Gets the cloud_control_plane_server2 of this ExadataInfrastructureSummary.
+        The IP address for the second control plane server.
+
+
+        :return: The cloud_control_plane_server2 of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._cloud_control_plane_server2
+
+    @cloud_control_plane_server2.setter
+    def cloud_control_plane_server2(self, cloud_control_plane_server2):
+        """
+        Sets the cloud_control_plane_server2 of this ExadataInfrastructureSummary.
+        The IP address for the second control plane server.
+
+
+        :param cloud_control_plane_server2: The cloud_control_plane_server2 of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        self._cloud_control_plane_server2 = cloud_control_plane_server2
+
+    @property
+    def netmask(self):
+        """
+        Gets the netmask of this ExadataInfrastructureSummary.
+        The netmask for the control plane network.
+
+
+        :return: The netmask of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._netmask
+
+    @netmask.setter
+    def netmask(self, netmask):
+        """
+        Sets the netmask of this ExadataInfrastructureSummary.
+        The netmask for the control plane network.
+
+
+        :param netmask: The netmask of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        self._netmask = netmask
+
+    @property
+    def gateway(self):
+        """
+        Gets the gateway of this ExadataInfrastructureSummary.
+        The gateway for the control plane network.
+
+
+        :return: The gateway of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._gateway
+
+    @gateway.setter
+    def gateway(self, gateway):
+        """
+        Sets the gateway of this ExadataInfrastructureSummary.
+        The gateway for the control plane network.
+
+
+        :param gateway: The gateway of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        self._gateway = gateway
+
+    @property
+    def admin_network_cidr(self):
+        """
+        Gets the admin_network_cidr of this ExadataInfrastructureSummary.
+        The CIDR block for the Exadata administration network.
+
+
+        :return: The admin_network_cidr of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._admin_network_cidr
+
+    @admin_network_cidr.setter
+    def admin_network_cidr(self, admin_network_cidr):
+        """
+        Sets the admin_network_cidr of this ExadataInfrastructureSummary.
+        The CIDR block for the Exadata administration network.
+
+
+        :param admin_network_cidr: The admin_network_cidr of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        self._admin_network_cidr = admin_network_cidr
+
+    @property
+    def infini_band_network_cidr(self):
+        """
+        Gets the infini_band_network_cidr of this ExadataInfrastructureSummary.
+        The CIDR block for the Exadata InfiniBand interconnect.
+
+
+        :return: The infini_band_network_cidr of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._infini_band_network_cidr
+
+    @infini_band_network_cidr.setter
+    def infini_band_network_cidr(self, infini_band_network_cidr):
+        """
+        Sets the infini_band_network_cidr of this ExadataInfrastructureSummary.
+        The CIDR block for the Exadata InfiniBand interconnect.
+
+
+        :param infini_band_network_cidr: The infini_band_network_cidr of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        self._infini_band_network_cidr = infini_band_network_cidr
+
+    @property
+    def corporate_proxy(self):
+        """
+        Gets the corporate_proxy of this ExadataInfrastructureSummary.
+        The corporate network proxy for access to the control plane network.
+
+
+        :return: The corporate_proxy of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._corporate_proxy
+
+    @corporate_proxy.setter
+    def corporate_proxy(self, corporate_proxy):
+        """
+        Sets the corporate_proxy of this ExadataInfrastructureSummary.
+        The corporate network proxy for access to the control plane network.
+
+
+        :param corporate_proxy: The corporate_proxy of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        self._corporate_proxy = corporate_proxy
+
+    @property
+    def dns_server(self):
+        """
+        Gets the dns_server of this ExadataInfrastructureSummary.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The dns_server of this ExadataInfrastructureSummary.
+        :rtype: list[str]
+        """
+        return self._dns_server
+
+    @dns_server.setter
+    def dns_server(self, dns_server):
+        """
+        Sets the dns_server of this ExadataInfrastructureSummary.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :param dns_server: The dns_server of this ExadataInfrastructureSummary.
+        :type: list[str]
+        """
+        self._dns_server = dns_server
+
+    @property
+    def ntp_server(self):
+        """
+        Gets the ntp_server of this ExadataInfrastructureSummary.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The ntp_server of this ExadataInfrastructureSummary.
+        :rtype: list[str]
+        """
+        return self._ntp_server
+
+    @ntp_server.setter
+    def ntp_server(self, ntp_server):
+        """
+        Sets the ntp_server of this ExadataInfrastructureSummary.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :param ntp_server: The ntp_server of this ExadataInfrastructureSummary.
+        :type: list[str]
+        """
+        self._ntp_server = ntp_server
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this ExadataInfrastructureSummary.
+        The date and time the Exadata infrastructure was created.
+
+
+        :return: The time_created of this ExadataInfrastructureSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ExadataInfrastructureSummary.
+        The date and time the Exadata infrastructure was created.
+
+
+        :param time_created: The time_created of this ExadataInfrastructureSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this ExadataInfrastructureSummary.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this ExadataInfrastructureSummary.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ExadataInfrastructureSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ExadataInfrastructureSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ExadataInfrastructureSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ExadataInfrastructureSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ExadataInfrastructureSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ExadataInfrastructureSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ExadataInfrastructureSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ExadataInfrastructureSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/generate_recommended_network_details.py
+++ b/src/oci/database/models/generate_recommended_network_details.py
@@ -1,0 +1,275 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class GenerateRecommendedNetworkDetails(object):
+    """
+    Generates a recommended VM cluster network configuration.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new GenerateRecommendedNetworkDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this GenerateRecommendedNetworkDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this GenerateRecommendedNetworkDetails.
+        :type display_name: str
+
+        :param networks:
+            The value to assign to the networks property of this GenerateRecommendedNetworkDetails.
+        :type networks: list[InfoForNetworkGenDetails]
+
+        :param dns:
+            The value to assign to the dns property of this GenerateRecommendedNetworkDetails.
+        :type dns: list[str]
+
+        :param ntp:
+            The value to assign to the ntp property of this GenerateRecommendedNetworkDetails.
+        :type ntp: list[str]
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this GenerateRecommendedNetworkDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this GenerateRecommendedNetworkDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'networks': 'list[InfoForNetworkGenDetails]',
+            'dns': 'list[str]',
+            'ntp': 'list[str]',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'networks': 'networks',
+            'dns': 'dns',
+            'ntp': 'ntp',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._display_name = None
+        self._networks = None
+        self._dns = None
+        self._ntp = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this GenerateRecommendedNetworkDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this GenerateRecommendedNetworkDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this GenerateRecommendedNetworkDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this GenerateRecommendedNetworkDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this GenerateRecommendedNetworkDetails.
+        The user-friendly name for the VM cluster network. The name does not need to be unique.
+
+
+        :return: The display_name of this GenerateRecommendedNetworkDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this GenerateRecommendedNetworkDetails.
+        The user-friendly name for the VM cluster network. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this GenerateRecommendedNetworkDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def networks(self):
+        """
+        **[Required]** Gets the networks of this GenerateRecommendedNetworkDetails.
+        List of parameters for generation of the client and backup networks.
+
+
+        :return: The networks of this GenerateRecommendedNetworkDetails.
+        :rtype: list[InfoForNetworkGenDetails]
+        """
+        return self._networks
+
+    @networks.setter
+    def networks(self, networks):
+        """
+        Sets the networks of this GenerateRecommendedNetworkDetails.
+        List of parameters for generation of the client and backup networks.
+
+
+        :param networks: The networks of this GenerateRecommendedNetworkDetails.
+        :type: list[InfoForNetworkGenDetails]
+        """
+        self._networks = networks
+
+    @property
+    def dns(self):
+        """
+        Gets the dns of this GenerateRecommendedNetworkDetails.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The dns of this GenerateRecommendedNetworkDetails.
+        :rtype: list[str]
+        """
+        return self._dns
+
+    @dns.setter
+    def dns(self, dns):
+        """
+        Sets the dns of this GenerateRecommendedNetworkDetails.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :param dns: The dns of this GenerateRecommendedNetworkDetails.
+        :type: list[str]
+        """
+        self._dns = dns
+
+    @property
+    def ntp(self):
+        """
+        Gets the ntp of this GenerateRecommendedNetworkDetails.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The ntp of this GenerateRecommendedNetworkDetails.
+        :rtype: list[str]
+        """
+        return self._ntp
+
+    @ntp.setter
+    def ntp(self, ntp):
+        """
+        Sets the ntp of this GenerateRecommendedNetworkDetails.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :param ntp: The ntp of this GenerateRecommendedNetworkDetails.
+        :type: list[str]
+        """
+        self._ntp = ntp
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this GenerateRecommendedNetworkDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this GenerateRecommendedNetworkDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this GenerateRecommendedNetworkDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this GenerateRecommendedNetworkDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this GenerateRecommendedNetworkDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this GenerateRecommendedNetworkDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this GenerateRecommendedNetworkDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this GenerateRecommendedNetworkDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/gi_version_summary.py
+++ b/src/oci/database/models/gi_version_summary.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class GiVersionSummary(object):
+    """
+    The Oracle Grid Infrastructure (GI) version.
+
+    To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized, talk to an administrator. If you're an administrator who needs to write policies to give users access, see `Getting Started with Policies`__.
+
+    __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new GiVersionSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param version:
+            The value to assign to the version property of this GiVersionSummary.
+        :type version: str
+
+        """
+        self.swagger_types = {
+            'version': 'str'
+        }
+
+        self.attribute_map = {
+            'version': 'version'
+        }
+
+        self._version = None
+
+    @property
+    def version(self):
+        """
+        **[Required]** Gets the version of this GiVersionSummary.
+        A valid Oracle Grid Infrastructure (GI) software version.
+
+
+        :return: The version of this GiVersionSummary.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this GiVersionSummary.
+        A valid Oracle Grid Infrastructure (GI) software version.
+
+
+        :param version: The version of this GiVersionSummary.
+        :type: str
+        """
+        self._version = version
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/info_for_network_gen_details.py
+++ b/src/oci/database/models/info_for_network_gen_details.py
@@ -1,0 +1,272 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class InfoForNetworkGenDetails(object):
+    """
+    Parameters for generation of the client or backup network in a VM cluster network.
+    """
+
+    #: A constant which can be used with the network_type property of a InfoForNetworkGenDetails.
+    #: This constant has a value of "CLIENT"
+    NETWORK_TYPE_CLIENT = "CLIENT"
+
+    #: A constant which can be used with the network_type property of a InfoForNetworkGenDetails.
+    #: This constant has a value of "BACKUP"
+    NETWORK_TYPE_BACKUP = "BACKUP"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new InfoForNetworkGenDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param network_type:
+            The value to assign to the network_type property of this InfoForNetworkGenDetails.
+            Allowed values for this property are: "CLIENT", "BACKUP"
+        :type network_type: str
+
+        :param vlan_id:
+            The value to assign to the vlan_id property of this InfoForNetworkGenDetails.
+        :type vlan_id: str
+
+        :param cidr:
+            The value to assign to the cidr property of this InfoForNetworkGenDetails.
+        :type cidr: str
+
+        :param gateway:
+            The value to assign to the gateway property of this InfoForNetworkGenDetails.
+        :type gateway: str
+
+        :param netmask:
+            The value to assign to the netmask property of this InfoForNetworkGenDetails.
+        :type netmask: str
+
+        :param domain:
+            The value to assign to the domain property of this InfoForNetworkGenDetails.
+        :type domain: str
+
+        :param prefix:
+            The value to assign to the prefix property of this InfoForNetworkGenDetails.
+        :type prefix: str
+
+        """
+        self.swagger_types = {
+            'network_type': 'str',
+            'vlan_id': 'str',
+            'cidr': 'str',
+            'gateway': 'str',
+            'netmask': 'str',
+            'domain': 'str',
+            'prefix': 'str'
+        }
+
+        self.attribute_map = {
+            'network_type': 'networkType',
+            'vlan_id': 'vlanId',
+            'cidr': 'cidr',
+            'gateway': 'gateway',
+            'netmask': 'netmask',
+            'domain': 'domain',
+            'prefix': 'prefix'
+        }
+
+        self._network_type = None
+        self._vlan_id = None
+        self._cidr = None
+        self._gateway = None
+        self._netmask = None
+        self._domain = None
+        self._prefix = None
+
+    @property
+    def network_type(self):
+        """
+        **[Required]** Gets the network_type of this InfoForNetworkGenDetails.
+        The network type.
+
+        Allowed values for this property are: "CLIENT", "BACKUP"
+
+
+        :return: The network_type of this InfoForNetworkGenDetails.
+        :rtype: str
+        """
+        return self._network_type
+
+    @network_type.setter
+    def network_type(self, network_type):
+        """
+        Sets the network_type of this InfoForNetworkGenDetails.
+        The network type.
+
+
+        :param network_type: The network_type of this InfoForNetworkGenDetails.
+        :type: str
+        """
+        allowed_values = ["CLIENT", "BACKUP"]
+        if not value_allowed_none_or_none_sentinel(network_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `network_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._network_type = network_type
+
+    @property
+    def vlan_id(self):
+        """
+        **[Required]** Gets the vlan_id of this InfoForNetworkGenDetails.
+        The network VLAN ID.
+
+
+        :return: The vlan_id of this InfoForNetworkGenDetails.
+        :rtype: str
+        """
+        return self._vlan_id
+
+    @vlan_id.setter
+    def vlan_id(self, vlan_id):
+        """
+        Sets the vlan_id of this InfoForNetworkGenDetails.
+        The network VLAN ID.
+
+
+        :param vlan_id: The vlan_id of this InfoForNetworkGenDetails.
+        :type: str
+        """
+        self._vlan_id = vlan_id
+
+    @property
+    def cidr(self):
+        """
+        **[Required]** Gets the cidr of this InfoForNetworkGenDetails.
+        The cidr for the network.
+
+
+        :return: The cidr of this InfoForNetworkGenDetails.
+        :rtype: str
+        """
+        return self._cidr
+
+    @cidr.setter
+    def cidr(self, cidr):
+        """
+        Sets the cidr of this InfoForNetworkGenDetails.
+        The cidr for the network.
+
+
+        :param cidr: The cidr of this InfoForNetworkGenDetails.
+        :type: str
+        """
+        self._cidr = cidr
+
+    @property
+    def gateway(self):
+        """
+        **[Required]** Gets the gateway of this InfoForNetworkGenDetails.
+        The network gateway.
+
+
+        :return: The gateway of this InfoForNetworkGenDetails.
+        :rtype: str
+        """
+        return self._gateway
+
+    @gateway.setter
+    def gateway(self, gateway):
+        """
+        Sets the gateway of this InfoForNetworkGenDetails.
+        The network gateway.
+
+
+        :param gateway: The gateway of this InfoForNetworkGenDetails.
+        :type: str
+        """
+        self._gateway = gateway
+
+    @property
+    def netmask(self):
+        """
+        **[Required]** Gets the netmask of this InfoForNetworkGenDetails.
+        The network netmask.
+
+
+        :return: The netmask of this InfoForNetworkGenDetails.
+        :rtype: str
+        """
+        return self._netmask
+
+    @netmask.setter
+    def netmask(self, netmask):
+        """
+        Sets the netmask of this InfoForNetworkGenDetails.
+        The network netmask.
+
+
+        :param netmask: The netmask of this InfoForNetworkGenDetails.
+        :type: str
+        """
+        self._netmask = netmask
+
+    @property
+    def domain(self):
+        """
+        **[Required]** Gets the domain of this InfoForNetworkGenDetails.
+        The network domain name.
+
+
+        :return: The domain of this InfoForNetworkGenDetails.
+        :rtype: str
+        """
+        return self._domain
+
+    @domain.setter
+    def domain(self, domain):
+        """
+        Sets the domain of this InfoForNetworkGenDetails.
+        The network domain name.
+
+
+        :param domain: The domain of this InfoForNetworkGenDetails.
+        :type: str
+        """
+        self._domain = domain
+
+    @property
+    def prefix(self):
+        """
+        **[Required]** Gets the prefix of this InfoForNetworkGenDetails.
+        The network domain name.
+
+
+        :return: The prefix of this InfoForNetworkGenDetails.
+        :rtype: str
+        """
+        return self._prefix
+
+    @prefix.setter
+    def prefix(self, prefix):
+        """
+        Sets the prefix of this InfoForNetworkGenDetails.
+        The network domain name.
+
+
+        :param prefix: The prefix of this InfoForNetworkGenDetails.
+        :type: str
+        """
+        self._prefix = prefix
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/node_details.py
+++ b/src/oci/database/models/node_details.py
@@ -1,0 +1,162 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class NodeDetails(object):
+    """
+    Node details associated with a network.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new NodeDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param hostname:
+            The value to assign to the hostname property of this NodeDetails.
+        :type hostname: str
+
+        :param ip:
+            The value to assign to the ip property of this NodeDetails.
+        :type ip: str
+
+        :param vip_hostname:
+            The value to assign to the vip_hostname property of this NodeDetails.
+        :type vip_hostname: str
+
+        :param vip:
+            The value to assign to the vip property of this NodeDetails.
+        :type vip: str
+
+        """
+        self.swagger_types = {
+            'hostname': 'str',
+            'ip': 'str',
+            'vip_hostname': 'str',
+            'vip': 'str'
+        }
+
+        self.attribute_map = {
+            'hostname': 'hostname',
+            'ip': 'ip',
+            'vip_hostname': 'vipHostname',
+            'vip': 'vip'
+        }
+
+        self._hostname = None
+        self._ip = None
+        self._vip_hostname = None
+        self._vip = None
+
+    @property
+    def hostname(self):
+        """
+        Gets the hostname of this NodeDetails.
+        The node host name.
+
+
+        :return: The hostname of this NodeDetails.
+        :rtype: str
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, hostname):
+        """
+        Sets the hostname of this NodeDetails.
+        The node host name.
+
+
+        :param hostname: The hostname of this NodeDetails.
+        :type: str
+        """
+        self._hostname = hostname
+
+    @property
+    def ip(self):
+        """
+        **[Required]** Gets the ip of this NodeDetails.
+        The node IP address.
+
+
+        :return: The ip of this NodeDetails.
+        :rtype: str
+        """
+        return self._ip
+
+    @ip.setter
+    def ip(self, ip):
+        """
+        Sets the ip of this NodeDetails.
+        The node IP address.
+
+
+        :param ip: The ip of this NodeDetails.
+        :type: str
+        """
+        self._ip = ip
+
+    @property
+    def vip_hostname(self):
+        """
+        Gets the vip_hostname of this NodeDetails.
+        The node virtual IP (VIP) host name.
+
+
+        :return: The vip_hostname of this NodeDetails.
+        :rtype: str
+        """
+        return self._vip_hostname
+
+    @vip_hostname.setter
+    def vip_hostname(self, vip_hostname):
+        """
+        Sets the vip_hostname of this NodeDetails.
+        The node virtual IP (VIP) host name.
+
+
+        :param vip_hostname: The vip_hostname of this NodeDetails.
+        :type: str
+        """
+        self._vip_hostname = vip_hostname
+
+    @property
+    def vip(self):
+        """
+        Gets the vip of this NodeDetails.
+        The node virtual IP (VIP) address.
+
+
+        :return: The vip of this NodeDetails.
+        :rtype: str
+        """
+        return self._vip
+
+    @vip.setter
+    def vip(self, vip):
+        """
+        Sets the vip of this NodeDetails.
+        The node virtual IP (VIP) address.
+
+
+        :param vip: The vip of this NodeDetails.
+        :type: str
+        """
+        self._vip = vip
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/scan_details.py
+++ b/src/oci/database/models/scan_details.py
@@ -1,0 +1,131 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ScanDetails(object):
+    """
+    The Single Client Access Name (SCAN) details.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ScanDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param hostname:
+            The value to assign to the hostname property of this ScanDetails.
+        :type hostname: str
+
+        :param port:
+            The value to assign to the port property of this ScanDetails.
+        :type port: int
+
+        :param ips:
+            The value to assign to the ips property of this ScanDetails.
+        :type ips: list[str]
+
+        """
+        self.swagger_types = {
+            'hostname': 'str',
+            'port': 'int',
+            'ips': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'hostname': 'hostname',
+            'port': 'port',
+            'ips': 'ips'
+        }
+
+        self._hostname = None
+        self._port = None
+        self._ips = None
+
+    @property
+    def hostname(self):
+        """
+        **[Required]** Gets the hostname of this ScanDetails.
+        The SCAN hostname.
+
+
+        :return: The hostname of this ScanDetails.
+        :rtype: str
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, hostname):
+        """
+        Sets the hostname of this ScanDetails.
+        The SCAN hostname.
+
+
+        :param hostname: The hostname of this ScanDetails.
+        :type: str
+        """
+        self._hostname = hostname
+
+    @property
+    def port(self):
+        """
+        **[Required]** Gets the port of this ScanDetails.
+        The SCAN port. Default is 1521.
+
+
+        :return: The port of this ScanDetails.
+        :rtype: int
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this ScanDetails.
+        The SCAN port. Default is 1521.
+
+
+        :param port: The port of this ScanDetails.
+        :type: int
+        """
+        self._port = port
+
+    @property
+    def ips(self):
+        """
+        **[Required]** Gets the ips of this ScanDetails.
+        The list of SCAN IP addresses. Three addresses should be provided.
+
+
+        :return: The ips of this ScanDetails.
+        :rtype: list[str]
+        """
+        return self._ips
+
+    @ips.setter
+    def ips(self, ips):
+        """
+        Sets the ips of this ScanDetails.
+        The list of SCAN IP addresses. Three addresses should be provided.
+
+
+        :param ips: The ips of this ScanDetails.
+        :type: list[str]
+        """
+        self._ips = ips
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_backup_destination_details.py
+++ b/src/oci/database/models/update_backup_destination_details.py
@@ -1,0 +1,210 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateBackupDestinationDetails(object):
+    """
+    For a RECOVERY_APPLIANCE backup destination, used to update the connection string and/or the list of VPC users.
+    For an NFS backup destination, used to update the NFS location.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateBackupDestinationDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param vpc_users:
+            The value to assign to the vpc_users property of this UpdateBackupDestinationDetails.
+        :type vpc_users: list[str]
+
+        :param connection_string:
+            The value to assign to the connection_string property of this UpdateBackupDestinationDetails.
+        :type connection_string: str
+
+        :param local_mount_point_path:
+            The value to assign to the local_mount_point_path property of this UpdateBackupDestinationDetails.
+        :type local_mount_point_path: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateBackupDestinationDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateBackupDestinationDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'vpc_users': 'list[str]',
+            'connection_string': 'str',
+            'local_mount_point_path': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'vpc_users': 'vpcUsers',
+            'connection_string': 'connectionString',
+            'local_mount_point_path': 'localMountPointPath',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._vpc_users = None
+        self._connection_string = None
+        self._local_mount_point_path = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def vpc_users(self):
+        """
+        Gets the vpc_users of this UpdateBackupDestinationDetails.
+        For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+
+
+        :return: The vpc_users of this UpdateBackupDestinationDetails.
+        :rtype: list[str]
+        """
+        return self._vpc_users
+
+    @vpc_users.setter
+    def vpc_users(self, vpc_users):
+        """
+        Sets the vpc_users of this UpdateBackupDestinationDetails.
+        For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+
+
+        :param vpc_users: The vpc_users of this UpdateBackupDestinationDetails.
+        :type: list[str]
+        """
+        self._vpc_users = vpc_users
+
+    @property
+    def connection_string(self):
+        """
+        Gets the connection_string of this UpdateBackupDestinationDetails.
+        For a RECOVERY_APPLIANCE backup destination, the connection string for connecting to the Recovery Appliance.
+
+
+        :return: The connection_string of this UpdateBackupDestinationDetails.
+        :rtype: str
+        """
+        return self._connection_string
+
+    @connection_string.setter
+    def connection_string(self, connection_string):
+        """
+        Sets the connection_string of this UpdateBackupDestinationDetails.
+        For a RECOVERY_APPLIANCE backup destination, the connection string for connecting to the Recovery Appliance.
+
+
+        :param connection_string: The connection_string of this UpdateBackupDestinationDetails.
+        :type: str
+        """
+        self._connection_string = connection_string
+
+    @property
+    def local_mount_point_path(self):
+        """
+        Gets the local_mount_point_path of this UpdateBackupDestinationDetails.
+        The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+
+
+        :return: The local_mount_point_path of this UpdateBackupDestinationDetails.
+        :rtype: str
+        """
+        return self._local_mount_point_path
+
+    @local_mount_point_path.setter
+    def local_mount_point_path(self, local_mount_point_path):
+        """
+        Sets the local_mount_point_path of this UpdateBackupDestinationDetails.
+        The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+
+
+        :param local_mount_point_path: The local_mount_point_path of this UpdateBackupDestinationDetails.
+        :type: str
+        """
+        self._local_mount_point_path = local_mount_point_path
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateBackupDestinationDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateBackupDestinationDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateBackupDestinationDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateBackupDestinationDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateBackupDestinationDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateBackupDestinationDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateBackupDestinationDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateBackupDestinationDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_exadata_infrastructure_details.py
+++ b/src/oci/database/models/update_exadata_infrastructure_details.py
@@ -1,0 +1,430 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateExadataInfrastructureDetails(object):
+    """
+    Updates the Exadata infrastructure.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateExadataInfrastructureDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param cloud_control_plane_server1:
+            The value to assign to the cloud_control_plane_server1 property of this UpdateExadataInfrastructureDetails.
+        :type cloud_control_plane_server1: str
+
+        :param cloud_control_plane_server2:
+            The value to assign to the cloud_control_plane_server2 property of this UpdateExadataInfrastructureDetails.
+        :type cloud_control_plane_server2: str
+
+        :param netmask:
+            The value to assign to the netmask property of this UpdateExadataInfrastructureDetails.
+        :type netmask: str
+
+        :param gateway:
+            The value to assign to the gateway property of this UpdateExadataInfrastructureDetails.
+        :type gateway: str
+
+        :param admin_network_cidr:
+            The value to assign to the admin_network_cidr property of this UpdateExadataInfrastructureDetails.
+        :type admin_network_cidr: str
+
+        :param infini_band_network_cidr:
+            The value to assign to the infini_band_network_cidr property of this UpdateExadataInfrastructureDetails.
+        :type infini_band_network_cidr: str
+
+        :param corporate_proxy:
+            The value to assign to the corporate_proxy property of this UpdateExadataInfrastructureDetails.
+        :type corporate_proxy: str
+
+        :param dns_server:
+            The value to assign to the dns_server property of this UpdateExadataInfrastructureDetails.
+        :type dns_server: list[str]
+
+        :param ntp_server:
+            The value to assign to the ntp_server property of this UpdateExadataInfrastructureDetails.
+        :type ntp_server: list[str]
+
+        :param time_zone:
+            The value to assign to the time_zone property of this UpdateExadataInfrastructureDetails.
+        :type time_zone: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateExadataInfrastructureDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateExadataInfrastructureDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'cloud_control_plane_server1': 'str',
+            'cloud_control_plane_server2': 'str',
+            'netmask': 'str',
+            'gateway': 'str',
+            'admin_network_cidr': 'str',
+            'infini_band_network_cidr': 'str',
+            'corporate_proxy': 'str',
+            'dns_server': 'list[str]',
+            'ntp_server': 'list[str]',
+            'time_zone': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'cloud_control_plane_server1': 'cloudControlPlaneServer1',
+            'cloud_control_plane_server2': 'cloudControlPlaneServer2',
+            'netmask': 'netmask',
+            'gateway': 'gateway',
+            'admin_network_cidr': 'adminNetworkCIDR',
+            'infini_band_network_cidr': 'infiniBandNetworkCIDR',
+            'corporate_proxy': 'corporateProxy',
+            'dns_server': 'dnsServer',
+            'ntp_server': 'ntpServer',
+            'time_zone': 'timeZone',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._cloud_control_plane_server1 = None
+        self._cloud_control_plane_server2 = None
+        self._netmask = None
+        self._gateway = None
+        self._admin_network_cidr = None
+        self._infini_band_network_cidr = None
+        self._corporate_proxy = None
+        self._dns_server = None
+        self._ntp_server = None
+        self._time_zone = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def cloud_control_plane_server1(self):
+        """
+        Gets the cloud_control_plane_server1 of this UpdateExadataInfrastructureDetails.
+        The IP address for the first control plane server.
+
+
+        :return: The cloud_control_plane_server1 of this UpdateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._cloud_control_plane_server1
+
+    @cloud_control_plane_server1.setter
+    def cloud_control_plane_server1(self, cloud_control_plane_server1):
+        """
+        Sets the cloud_control_plane_server1 of this UpdateExadataInfrastructureDetails.
+        The IP address for the first control plane server.
+
+
+        :param cloud_control_plane_server1: The cloud_control_plane_server1 of this UpdateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._cloud_control_plane_server1 = cloud_control_plane_server1
+
+    @property
+    def cloud_control_plane_server2(self):
+        """
+        Gets the cloud_control_plane_server2 of this UpdateExadataInfrastructureDetails.
+        The IP address for the second control plane server.
+
+
+        :return: The cloud_control_plane_server2 of this UpdateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._cloud_control_plane_server2
+
+    @cloud_control_plane_server2.setter
+    def cloud_control_plane_server2(self, cloud_control_plane_server2):
+        """
+        Sets the cloud_control_plane_server2 of this UpdateExadataInfrastructureDetails.
+        The IP address for the second control plane server.
+
+
+        :param cloud_control_plane_server2: The cloud_control_plane_server2 of this UpdateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._cloud_control_plane_server2 = cloud_control_plane_server2
+
+    @property
+    def netmask(self):
+        """
+        Gets the netmask of this UpdateExadataInfrastructureDetails.
+        The netmask for the control plane network.
+
+
+        :return: The netmask of this UpdateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._netmask
+
+    @netmask.setter
+    def netmask(self, netmask):
+        """
+        Sets the netmask of this UpdateExadataInfrastructureDetails.
+        The netmask for the control plane network.
+
+
+        :param netmask: The netmask of this UpdateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._netmask = netmask
+
+    @property
+    def gateway(self):
+        """
+        Gets the gateway of this UpdateExadataInfrastructureDetails.
+        The gateway for the control plane network.
+
+
+        :return: The gateway of this UpdateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._gateway
+
+    @gateway.setter
+    def gateway(self, gateway):
+        """
+        Sets the gateway of this UpdateExadataInfrastructureDetails.
+        The gateway for the control plane network.
+
+
+        :param gateway: The gateway of this UpdateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._gateway = gateway
+
+    @property
+    def admin_network_cidr(self):
+        """
+        Gets the admin_network_cidr of this UpdateExadataInfrastructureDetails.
+        The CIDR block for the Exadata administration network.
+
+
+        :return: The admin_network_cidr of this UpdateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._admin_network_cidr
+
+    @admin_network_cidr.setter
+    def admin_network_cidr(self, admin_network_cidr):
+        """
+        Sets the admin_network_cidr of this UpdateExadataInfrastructureDetails.
+        The CIDR block for the Exadata administration network.
+
+
+        :param admin_network_cidr: The admin_network_cidr of this UpdateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._admin_network_cidr = admin_network_cidr
+
+    @property
+    def infini_band_network_cidr(self):
+        """
+        Gets the infini_band_network_cidr of this UpdateExadataInfrastructureDetails.
+        The CIDR block for the Exadata InfiniBand interconnect.
+
+
+        :return: The infini_band_network_cidr of this UpdateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._infini_band_network_cidr
+
+    @infini_band_network_cidr.setter
+    def infini_band_network_cidr(self, infini_band_network_cidr):
+        """
+        Sets the infini_band_network_cidr of this UpdateExadataInfrastructureDetails.
+        The CIDR block for the Exadata InfiniBand interconnect.
+
+
+        :param infini_band_network_cidr: The infini_band_network_cidr of this UpdateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._infini_band_network_cidr = infini_band_network_cidr
+
+    @property
+    def corporate_proxy(self):
+        """
+        Gets the corporate_proxy of this UpdateExadataInfrastructureDetails.
+        The corporate network proxy for access to the control plane network.
+
+
+        :return: The corporate_proxy of this UpdateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._corporate_proxy
+
+    @corporate_proxy.setter
+    def corporate_proxy(self, corporate_proxy):
+        """
+        Sets the corporate_proxy of this UpdateExadataInfrastructureDetails.
+        The corporate network proxy for access to the control plane network.
+
+
+        :param corporate_proxy: The corporate_proxy of this UpdateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._corporate_proxy = corporate_proxy
+
+    @property
+    def dns_server(self):
+        """
+        Gets the dns_server of this UpdateExadataInfrastructureDetails.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The dns_server of this UpdateExadataInfrastructureDetails.
+        :rtype: list[str]
+        """
+        return self._dns_server
+
+    @dns_server.setter
+    def dns_server(self, dns_server):
+        """
+        Sets the dns_server of this UpdateExadataInfrastructureDetails.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :param dns_server: The dns_server of this UpdateExadataInfrastructureDetails.
+        :type: list[str]
+        """
+        self._dns_server = dns_server
+
+    @property
+    def ntp_server(self):
+        """
+        Gets the ntp_server of this UpdateExadataInfrastructureDetails.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The ntp_server of this UpdateExadataInfrastructureDetails.
+        :rtype: list[str]
+        """
+        return self._ntp_server
+
+    @ntp_server.setter
+    def ntp_server(self, ntp_server):
+        """
+        Sets the ntp_server of this UpdateExadataInfrastructureDetails.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :param ntp_server: The ntp_server of this UpdateExadataInfrastructureDetails.
+        :type: list[str]
+        """
+        self._ntp_server = ntp_server
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this UpdateExadataInfrastructureDetails.
+        The time zone of the Exadata infrastructure. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :return: The time_zone of this UpdateExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this UpdateExadataInfrastructureDetails.
+        The time zone of the Exadata infrastructure. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :param time_zone: The time_zone of this UpdateExadataInfrastructureDetails.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateExadataInfrastructureDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateExadataInfrastructureDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateExadataInfrastructureDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateExadataInfrastructureDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateExadataInfrastructureDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateExadataInfrastructureDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateExadataInfrastructureDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateExadataInfrastructureDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_vm_cluster_details.py
+++ b/src/oci/database/models/update_vm_cluster_details.py
@@ -1,0 +1,226 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateVmClusterDetails(object):
+    """
+    Details for updating the VM cluster.
+    """
+
+    #: A constant which can be used with the license_model property of a UpdateVmClusterDetails.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a UpdateVmClusterDetails.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateVmClusterDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param cpu_core_count:
+            The value to assign to the cpu_core_count property of this UpdateVmClusterDetails.
+        :type cpu_core_count: int
+
+        :param license_model:
+            The value to assign to the license_model property of this UpdateVmClusterDetails.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+        :type license_model: str
+
+        :param ssh_public_keys:
+            The value to assign to the ssh_public_keys property of this UpdateVmClusterDetails.
+        :type ssh_public_keys: list[str]
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateVmClusterDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateVmClusterDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'cpu_core_count': 'int',
+            'license_model': 'str',
+            'ssh_public_keys': 'list[str]',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'cpu_core_count': 'cpuCoreCount',
+            'license_model': 'licenseModel',
+            'ssh_public_keys': 'sshPublicKeys',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._cpu_core_count = None
+        self._license_model = None
+        self._ssh_public_keys = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def cpu_core_count(self):
+        """
+        Gets the cpu_core_count of this UpdateVmClusterDetails.
+        The number of CPU cores to enable for the VM cluster.
+
+
+        :return: The cpu_core_count of this UpdateVmClusterDetails.
+        :rtype: int
+        """
+        return self._cpu_core_count
+
+    @cpu_core_count.setter
+    def cpu_core_count(self, cpu_core_count):
+        """
+        Sets the cpu_core_count of this UpdateVmClusterDetails.
+        The number of CPU cores to enable for the VM cluster.
+
+
+        :param cpu_core_count: The cpu_core_count of this UpdateVmClusterDetails.
+        :type: int
+        """
+        self._cpu_core_count = cpu_core_count
+
+    @property
+    def license_model(self):
+        """
+        Gets the license_model of this UpdateVmClusterDetails.
+        The Oracle license model that applies to the VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+
+
+        :return: The license_model of this UpdateVmClusterDetails.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this UpdateVmClusterDetails.
+        The Oracle license model that applies to the VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+
+
+        :param license_model: The license_model of this UpdateVmClusterDetails.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            raise ValueError(
+                "Invalid value for `license_model`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._license_model = license_model
+
+    @property
+    def ssh_public_keys(self):
+        """
+        Gets the ssh_public_keys of this UpdateVmClusterDetails.
+        The public key portion of one or more key pairs used for SSH access to the VM cluster.
+
+
+        :return: The ssh_public_keys of this UpdateVmClusterDetails.
+        :rtype: list[str]
+        """
+        return self._ssh_public_keys
+
+    @ssh_public_keys.setter
+    def ssh_public_keys(self, ssh_public_keys):
+        """
+        Sets the ssh_public_keys of this UpdateVmClusterDetails.
+        The public key portion of one or more key pairs used for SSH access to the VM cluster.
+
+
+        :param ssh_public_keys: The ssh_public_keys of this UpdateVmClusterDetails.
+        :type: list[str]
+        """
+        self._ssh_public_keys = ssh_public_keys
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateVmClusterDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateVmClusterDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateVmClusterDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateVmClusterDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateVmClusterDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateVmClusterDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateVmClusterDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateVmClusterDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_vm_cluster_network_details.py
+++ b/src/oci/database/models/update_vm_cluster_network_details.py
@@ -1,0 +1,240 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateVmClusterNetworkDetails(object):
+    """
+    Details for a VM cluster network.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateVmClusterNetworkDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param scans:
+            The value to assign to the scans property of this UpdateVmClusterNetworkDetails.
+        :type scans: list[ScanDetails]
+
+        :param dns:
+            The value to assign to the dns property of this UpdateVmClusterNetworkDetails.
+        :type dns: list[str]
+
+        :param ntp:
+            The value to assign to the ntp property of this UpdateVmClusterNetworkDetails.
+        :type ntp: list[str]
+
+        :param vm_networks:
+            The value to assign to the vm_networks property of this UpdateVmClusterNetworkDetails.
+        :type vm_networks: list[VmNetworkDetails]
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateVmClusterNetworkDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateVmClusterNetworkDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'scans': 'list[ScanDetails]',
+            'dns': 'list[str]',
+            'ntp': 'list[str]',
+            'vm_networks': 'list[VmNetworkDetails]',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'scans': 'scans',
+            'dns': 'dns',
+            'ntp': 'ntp',
+            'vm_networks': 'vmNetworks',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._scans = None
+        self._dns = None
+        self._ntp = None
+        self._vm_networks = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def scans(self):
+        """
+        Gets the scans of this UpdateVmClusterNetworkDetails.
+        The SCAN details.
+
+
+        :return: The scans of this UpdateVmClusterNetworkDetails.
+        :rtype: list[ScanDetails]
+        """
+        return self._scans
+
+    @scans.setter
+    def scans(self, scans):
+        """
+        Sets the scans of this UpdateVmClusterNetworkDetails.
+        The SCAN details.
+
+
+        :param scans: The scans of this UpdateVmClusterNetworkDetails.
+        :type: list[ScanDetails]
+        """
+        self._scans = scans
+
+    @property
+    def dns(self):
+        """
+        Gets the dns of this UpdateVmClusterNetworkDetails.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The dns of this UpdateVmClusterNetworkDetails.
+        :rtype: list[str]
+        """
+        return self._dns
+
+    @dns.setter
+    def dns(self, dns):
+        """
+        Sets the dns of this UpdateVmClusterNetworkDetails.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :param dns: The dns of this UpdateVmClusterNetworkDetails.
+        :type: list[str]
+        """
+        self._dns = dns
+
+    @property
+    def ntp(self):
+        """
+        Gets the ntp of this UpdateVmClusterNetworkDetails.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The ntp of this UpdateVmClusterNetworkDetails.
+        :rtype: list[str]
+        """
+        return self._ntp
+
+    @ntp.setter
+    def ntp(self, ntp):
+        """
+        Sets the ntp of this UpdateVmClusterNetworkDetails.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :param ntp: The ntp of this UpdateVmClusterNetworkDetails.
+        :type: list[str]
+        """
+        self._ntp = ntp
+
+    @property
+    def vm_networks(self):
+        """
+        Gets the vm_networks of this UpdateVmClusterNetworkDetails.
+        Details of the client and backup networks.
+
+
+        :return: The vm_networks of this UpdateVmClusterNetworkDetails.
+        :rtype: list[VmNetworkDetails]
+        """
+        return self._vm_networks
+
+    @vm_networks.setter
+    def vm_networks(self, vm_networks):
+        """
+        Sets the vm_networks of this UpdateVmClusterNetworkDetails.
+        Details of the client and backup networks.
+
+
+        :param vm_networks: The vm_networks of this UpdateVmClusterNetworkDetails.
+        :type: list[VmNetworkDetails]
+        """
+        self._vm_networks = vm_networks
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateVmClusterNetworkDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateVmClusterNetworkDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateVmClusterNetworkDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateVmClusterNetworkDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateVmClusterNetworkDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateVmClusterNetworkDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateVmClusterNetworkDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateVmClusterNetworkDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/vm_cluster.py
+++ b/src/oci/database/models/vm_cluster.py
@@ -1,0 +1,711 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class VmCluster(object):
+    """
+    Details of the VM cluster.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a VmCluster.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmCluster.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a VmCluster.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmCluster.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmCluster.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a VmCluster.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the license_model property of a VmCluster.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a VmCluster.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new VmCluster object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this VmCluster.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this VmCluster.
+        :type compartment_id: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this VmCluster.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param display_name:
+            The value to assign to the display_name property of this VmCluster.
+        :type display_name: str
+
+        :param time_created:
+            The value to assign to the time_created property of this VmCluster.
+        :type time_created: datetime
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this VmCluster.
+        :type lifecycle_details: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this VmCluster.
+        :type time_zone: str
+
+        :param is_local_backup_enabled:
+            The value to assign to the is_local_backup_enabled property of this VmCluster.
+        :type is_local_backup_enabled: bool
+
+        :param exadata_infrastructure_id:
+            The value to assign to the exadata_infrastructure_id property of this VmCluster.
+        :type exadata_infrastructure_id: str
+
+        :param is_sparse_diskgroup_enabled:
+            The value to assign to the is_sparse_diskgroup_enabled property of this VmCluster.
+        :type is_sparse_diskgroup_enabled: bool
+
+        :param vm_cluster_network_id:
+            The value to assign to the vm_cluster_network_id property of this VmCluster.
+        :type vm_cluster_network_id: str
+
+        :param cpus_enabled:
+            The value to assign to the cpus_enabled property of this VmCluster.
+        :type cpus_enabled: int
+
+        :param data_storage_size_in_tbs:
+            The value to assign to the data_storage_size_in_tbs property of this VmCluster.
+        :type data_storage_size_in_tbs: int
+
+        :param shape:
+            The value to assign to the shape property of this VmCluster.
+        :type shape: str
+
+        :param gi_version:
+            The value to assign to the gi_version property of this VmCluster.
+        :type gi_version: str
+
+        :param ssh_public_keys:
+            The value to assign to the ssh_public_keys property of this VmCluster.
+        :type ssh_public_keys: list[str]
+
+        :param license_model:
+            The value to assign to the license_model property of this VmCluster.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type license_model: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this VmCluster.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this VmCluster.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'lifecycle_state': 'str',
+            'display_name': 'str',
+            'time_created': 'datetime',
+            'lifecycle_details': 'str',
+            'time_zone': 'str',
+            'is_local_backup_enabled': 'bool',
+            'exadata_infrastructure_id': 'str',
+            'is_sparse_diskgroup_enabled': 'bool',
+            'vm_cluster_network_id': 'str',
+            'cpus_enabled': 'int',
+            'data_storage_size_in_tbs': 'int',
+            'shape': 'str',
+            'gi_version': 'str',
+            'ssh_public_keys': 'list[str]',
+            'license_model': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'lifecycle_state': 'lifecycleState',
+            'display_name': 'displayName',
+            'time_created': 'timeCreated',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_zone': 'timeZone',
+            'is_local_backup_enabled': 'isLocalBackupEnabled',
+            'exadata_infrastructure_id': 'exadataInfrastructureId',
+            'is_sparse_diskgroup_enabled': 'isSparseDiskgroupEnabled',
+            'vm_cluster_network_id': 'vmClusterNetworkId',
+            'cpus_enabled': 'cpusEnabled',
+            'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
+            'shape': 'shape',
+            'gi_version': 'giVersion',
+            'ssh_public_keys': 'sshPublicKeys',
+            'license_model': 'licenseModel',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._lifecycle_state = None
+        self._display_name = None
+        self._time_created = None
+        self._lifecycle_details = None
+        self._time_zone = None
+        self._is_local_backup_enabled = None
+        self._exadata_infrastructure_id = None
+        self._is_sparse_diskgroup_enabled = None
+        self._vm_cluster_network_id = None
+        self._cpus_enabled = None
+        self._data_storage_size_in_tbs = None
+        self._shape = None
+        self._gi_version = None
+        self._ssh_public_keys = None
+        self._license_model = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this VmCluster.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this VmCluster.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this VmCluster.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this VmCluster.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this VmCluster.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this VmCluster.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this VmCluster.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this VmCluster.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this VmCluster.
+        The current state of the VM cluster.
+
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this VmCluster.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this VmCluster.
+        The current state of the VM cluster.
+
+
+        :param lifecycle_state: The lifecycle_state of this VmCluster.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this VmCluster.
+        The user-friendly name for the VM cluster. The name does not need to be unique.
+
+
+        :return: The display_name of this VmCluster.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this VmCluster.
+        The user-friendly name for the VM cluster. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this VmCluster.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this VmCluster.
+        The date and time that the VM cluster was created.
+
+
+        :return: The time_created of this VmCluster.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this VmCluster.
+        The date and time that the VM cluster was created.
+
+
+        :param time_created: The time_created of this VmCluster.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this VmCluster.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this VmCluster.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this VmCluster.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this VmCluster.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this VmCluster.
+        The time zone of the Exadata infrastructure. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :return: The time_zone of this VmCluster.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this VmCluster.
+        The time zone of the Exadata infrastructure. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :param time_zone: The time_zone of this VmCluster.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def is_local_backup_enabled(self):
+        """
+        Gets the is_local_backup_enabled of this VmCluster.
+        If true, database backup on local Exadata storage is configured for the VM cluster. If false, database backup on local Exadata storage is not available in the VM cluster.
+
+
+        :return: The is_local_backup_enabled of this VmCluster.
+        :rtype: bool
+        """
+        return self._is_local_backup_enabled
+
+    @is_local_backup_enabled.setter
+    def is_local_backup_enabled(self, is_local_backup_enabled):
+        """
+        Sets the is_local_backup_enabled of this VmCluster.
+        If true, database backup on local Exadata storage is configured for the VM cluster. If false, database backup on local Exadata storage is not available in the VM cluster.
+
+
+        :param is_local_backup_enabled: The is_local_backup_enabled of this VmCluster.
+        :type: bool
+        """
+        self._is_local_backup_enabled = is_local_backup_enabled
+
+    @property
+    def exadata_infrastructure_id(self):
+        """
+        Gets the exadata_infrastructure_id of this VmCluster.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The exadata_infrastructure_id of this VmCluster.
+        :rtype: str
+        """
+        return self._exadata_infrastructure_id
+
+    @exadata_infrastructure_id.setter
+    def exadata_infrastructure_id(self, exadata_infrastructure_id):
+        """
+        Sets the exadata_infrastructure_id of this VmCluster.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param exadata_infrastructure_id: The exadata_infrastructure_id of this VmCluster.
+        :type: str
+        """
+        self._exadata_infrastructure_id = exadata_infrastructure_id
+
+    @property
+    def is_sparse_diskgroup_enabled(self):
+        """
+        Gets the is_sparse_diskgroup_enabled of this VmCluster.
+        If true, sparse disk group is configured for the VM cluster. If false, sparse disk group is not created.
+
+
+        :return: The is_sparse_diskgroup_enabled of this VmCluster.
+        :rtype: bool
+        """
+        return self._is_sparse_diskgroup_enabled
+
+    @is_sparse_diskgroup_enabled.setter
+    def is_sparse_diskgroup_enabled(self, is_sparse_diskgroup_enabled):
+        """
+        Sets the is_sparse_diskgroup_enabled of this VmCluster.
+        If true, sparse disk group is configured for the VM cluster. If false, sparse disk group is not created.
+
+
+        :param is_sparse_diskgroup_enabled: The is_sparse_diskgroup_enabled of this VmCluster.
+        :type: bool
+        """
+        self._is_sparse_diskgroup_enabled = is_sparse_diskgroup_enabled
+
+    @property
+    def vm_cluster_network_id(self):
+        """
+        Gets the vm_cluster_network_id of this VmCluster.
+        The `OCID`__ of the VM cluster network.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vm_cluster_network_id of this VmCluster.
+        :rtype: str
+        """
+        return self._vm_cluster_network_id
+
+    @vm_cluster_network_id.setter
+    def vm_cluster_network_id(self, vm_cluster_network_id):
+        """
+        Sets the vm_cluster_network_id of this VmCluster.
+        The `OCID`__ of the VM cluster network.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vm_cluster_network_id: The vm_cluster_network_id of this VmCluster.
+        :type: str
+        """
+        self._vm_cluster_network_id = vm_cluster_network_id
+
+    @property
+    def cpus_enabled(self):
+        """
+        Gets the cpus_enabled of this VmCluster.
+        The number of enabled CPU cores.
+
+
+        :return: The cpus_enabled of this VmCluster.
+        :rtype: int
+        """
+        return self._cpus_enabled
+
+    @cpus_enabled.setter
+    def cpus_enabled(self, cpus_enabled):
+        """
+        Sets the cpus_enabled of this VmCluster.
+        The number of enabled CPU cores.
+
+
+        :param cpus_enabled: The cpus_enabled of this VmCluster.
+        :type: int
+        """
+        self._cpus_enabled = cpus_enabled
+
+    @property
+    def data_storage_size_in_tbs(self):
+        """
+        Gets the data_storage_size_in_tbs of this VmCluster.
+        Size, in terabytes, of the DATA disk group.
+
+
+        :return: The data_storage_size_in_tbs of this VmCluster.
+        :rtype: int
+        """
+        return self._data_storage_size_in_tbs
+
+    @data_storage_size_in_tbs.setter
+    def data_storage_size_in_tbs(self, data_storage_size_in_tbs):
+        """
+        Sets the data_storage_size_in_tbs of this VmCluster.
+        Size, in terabytes, of the DATA disk group.
+
+
+        :param data_storage_size_in_tbs: The data_storage_size_in_tbs of this VmCluster.
+        :type: int
+        """
+        self._data_storage_size_in_tbs = data_storage_size_in_tbs
+
+    @property
+    def shape(self):
+        """
+        Gets the shape of this VmCluster.
+        The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+
+
+        :return: The shape of this VmCluster.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this VmCluster.
+        The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+
+
+        :param shape: The shape of this VmCluster.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def gi_version(self):
+        """
+        Gets the gi_version of this VmCluster.
+        The Oracle Grid Infrastructure software version for the VM cluster.
+
+
+        :return: The gi_version of this VmCluster.
+        :rtype: str
+        """
+        return self._gi_version
+
+    @gi_version.setter
+    def gi_version(self, gi_version):
+        """
+        Sets the gi_version of this VmCluster.
+        The Oracle Grid Infrastructure software version for the VM cluster.
+
+
+        :param gi_version: The gi_version of this VmCluster.
+        :type: str
+        """
+        self._gi_version = gi_version
+
+    @property
+    def ssh_public_keys(self):
+        """
+        Gets the ssh_public_keys of this VmCluster.
+        The public key portion of one or more key pairs used for SSH access to the VM cluster.
+
+
+        :return: The ssh_public_keys of this VmCluster.
+        :rtype: list[str]
+        """
+        return self._ssh_public_keys
+
+    @ssh_public_keys.setter
+    def ssh_public_keys(self, ssh_public_keys):
+        """
+        Sets the ssh_public_keys of this VmCluster.
+        The public key portion of one or more key pairs used for SSH access to the VM cluster.
+
+
+        :param ssh_public_keys: The ssh_public_keys of this VmCluster.
+        :type: list[str]
+        """
+        self._ssh_public_keys = ssh_public_keys
+
+    @property
+    def license_model(self):
+        """
+        Gets the license_model of this VmCluster.
+        The Oracle license model that applies to the VM cluster. The default is LICENSE_INCLUDED.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The license_model of this VmCluster.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this VmCluster.
+        The Oracle license model that applies to the VM cluster. The default is LICENSE_INCLUDED.
+
+
+        :param license_model: The license_model of this VmCluster.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            license_model = 'UNKNOWN_ENUM_VALUE'
+        self._license_model = license_model
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this VmCluster.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this VmCluster.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this VmCluster.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this VmCluster.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this VmCluster.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this VmCluster.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this VmCluster.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this VmCluster.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/vm_cluster_network.py
+++ b/src/oci/database/models/vm_cluster_network.py
@@ -1,0 +1,552 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class VmClusterNetwork(object):
+    """
+    The VM cluster network.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetwork.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetwork.
+    #: This constant has a value of "REQUIRES_VALIDATION"
+    LIFECYCLE_STATE_REQUIRES_VALIDATION = "REQUIRES_VALIDATION"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetwork.
+    #: This constant has a value of "VALIDATING"
+    LIFECYCLE_STATE_VALIDATING = "VALIDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetwork.
+    #: This constant has a value of "VALIDATED"
+    LIFECYCLE_STATE_VALIDATED = "VALIDATED"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetwork.
+    #: This constant has a value of "VALIDATION_FAILED"
+    LIFECYCLE_STATE_VALIDATION_FAILED = "VALIDATION_FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetwork.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetwork.
+    #: This constant has a value of "ALLOCATED"
+    LIFECYCLE_STATE_ALLOCATED = "ALLOCATED"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetwork.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetwork.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetwork.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new VmClusterNetwork object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this VmClusterNetwork.
+        :type id: str
+
+        :param exadata_infrastructure_id:
+            The value to assign to the exadata_infrastructure_id property of this VmClusterNetwork.
+        :type exadata_infrastructure_id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this VmClusterNetwork.
+        :type compartment_id: str
+
+        :param vm_cluster_id:
+            The value to assign to the vm_cluster_id property of this VmClusterNetwork.
+        :type vm_cluster_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this VmClusterNetwork.
+        :type display_name: str
+
+        :param scans:
+            The value to assign to the scans property of this VmClusterNetwork.
+        :type scans: list[ScanDetails]
+
+        :param dns:
+            The value to assign to the dns property of this VmClusterNetwork.
+        :type dns: list[str]
+
+        :param ntp:
+            The value to assign to the ntp property of this VmClusterNetwork.
+        :type ntp: list[str]
+
+        :param vm_networks:
+            The value to assign to the vm_networks property of this VmClusterNetwork.
+        :type vm_networks: list[VmNetworkDetails]
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this VmClusterNetwork.
+            Allowed values for this property are: "CREATING", "REQUIRES_VALIDATION", "VALIDATING", "VALIDATED", "VALIDATION_FAILED", "UPDATING", "ALLOCATED", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param time_created:
+            The value to assign to the time_created property of this VmClusterNetwork.
+        :type time_created: datetime
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this VmClusterNetwork.
+        :type lifecycle_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this VmClusterNetwork.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this VmClusterNetwork.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'exadata_infrastructure_id': 'str',
+            'compartment_id': 'str',
+            'vm_cluster_id': 'str',
+            'display_name': 'str',
+            'scans': 'list[ScanDetails]',
+            'dns': 'list[str]',
+            'ntp': 'list[str]',
+            'vm_networks': 'list[VmNetworkDetails]',
+            'lifecycle_state': 'str',
+            'time_created': 'datetime',
+            'lifecycle_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'exadata_infrastructure_id': 'exadataInfrastructureId',
+            'compartment_id': 'compartmentId',
+            'vm_cluster_id': 'vmClusterId',
+            'display_name': 'displayName',
+            'scans': 'scans',
+            'dns': 'dns',
+            'ntp': 'ntp',
+            'vm_networks': 'vmNetworks',
+            'lifecycle_state': 'lifecycleState',
+            'time_created': 'timeCreated',
+            'lifecycle_details': 'lifecycleDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._exadata_infrastructure_id = None
+        self._compartment_id = None
+        self._vm_cluster_id = None
+        self._display_name = None
+        self._scans = None
+        self._dns = None
+        self._ntp = None
+        self._vm_networks = None
+        self._lifecycle_state = None
+        self._time_created = None
+        self._lifecycle_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this VmClusterNetwork.
+        The `OCID`__ of the VM cluster network.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this VmClusterNetwork.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this VmClusterNetwork.
+        The `OCID`__ of the VM cluster network.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this VmClusterNetwork.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def exadata_infrastructure_id(self):
+        """
+        Gets the exadata_infrastructure_id of this VmClusterNetwork.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The exadata_infrastructure_id of this VmClusterNetwork.
+        :rtype: str
+        """
+        return self._exadata_infrastructure_id
+
+    @exadata_infrastructure_id.setter
+    def exadata_infrastructure_id(self, exadata_infrastructure_id):
+        """
+        Sets the exadata_infrastructure_id of this VmClusterNetwork.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param exadata_infrastructure_id: The exadata_infrastructure_id of this VmClusterNetwork.
+        :type: str
+        """
+        self._exadata_infrastructure_id = exadata_infrastructure_id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this VmClusterNetwork.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this VmClusterNetwork.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this VmClusterNetwork.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this VmClusterNetwork.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def vm_cluster_id(self):
+        """
+        Gets the vm_cluster_id of this VmClusterNetwork.
+        The `OCID`__ of the associated VM Cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vm_cluster_id of this VmClusterNetwork.
+        :rtype: str
+        """
+        return self._vm_cluster_id
+
+    @vm_cluster_id.setter
+    def vm_cluster_id(self, vm_cluster_id):
+        """
+        Sets the vm_cluster_id of this VmClusterNetwork.
+        The `OCID`__ of the associated VM Cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vm_cluster_id: The vm_cluster_id of this VmClusterNetwork.
+        :type: str
+        """
+        self._vm_cluster_id = vm_cluster_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this VmClusterNetwork.
+        The user-friendly name for the VM cluster network. The name does not need to be unique.
+
+
+        :return: The display_name of this VmClusterNetwork.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this VmClusterNetwork.
+        The user-friendly name for the VM cluster network. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this VmClusterNetwork.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def scans(self):
+        """
+        Gets the scans of this VmClusterNetwork.
+        The SCAN details.
+
+
+        :return: The scans of this VmClusterNetwork.
+        :rtype: list[ScanDetails]
+        """
+        return self._scans
+
+    @scans.setter
+    def scans(self, scans):
+        """
+        Sets the scans of this VmClusterNetwork.
+        The SCAN details.
+
+
+        :param scans: The scans of this VmClusterNetwork.
+        :type: list[ScanDetails]
+        """
+        self._scans = scans
+
+    @property
+    def dns(self):
+        """
+        Gets the dns of this VmClusterNetwork.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The dns of this VmClusterNetwork.
+        :rtype: list[str]
+        """
+        return self._dns
+
+    @dns.setter
+    def dns(self, dns):
+        """
+        Sets the dns of this VmClusterNetwork.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :param dns: The dns of this VmClusterNetwork.
+        :type: list[str]
+        """
+        self._dns = dns
+
+    @property
+    def ntp(self):
+        """
+        Gets the ntp of this VmClusterNetwork.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The ntp of this VmClusterNetwork.
+        :rtype: list[str]
+        """
+        return self._ntp
+
+    @ntp.setter
+    def ntp(self, ntp):
+        """
+        Sets the ntp of this VmClusterNetwork.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :param ntp: The ntp of this VmClusterNetwork.
+        :type: list[str]
+        """
+        self._ntp = ntp
+
+    @property
+    def vm_networks(self):
+        """
+        Gets the vm_networks of this VmClusterNetwork.
+        Details of the client and backup networks.
+
+
+        :return: The vm_networks of this VmClusterNetwork.
+        :rtype: list[VmNetworkDetails]
+        """
+        return self._vm_networks
+
+    @vm_networks.setter
+    def vm_networks(self, vm_networks):
+        """
+        Sets the vm_networks of this VmClusterNetwork.
+        Details of the client and backup networks.
+
+
+        :param vm_networks: The vm_networks of this VmClusterNetwork.
+        :type: list[VmNetworkDetails]
+        """
+        self._vm_networks = vm_networks
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this VmClusterNetwork.
+        The current state of the VM cluster network.
+
+        Allowed values for this property are: "CREATING", "REQUIRES_VALIDATION", "VALIDATING", "VALIDATED", "VALIDATION_FAILED", "UPDATING", "ALLOCATED", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this VmClusterNetwork.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this VmClusterNetwork.
+        The current state of the VM cluster network.
+
+
+        :param lifecycle_state: The lifecycle_state of this VmClusterNetwork.
+        :type: str
+        """
+        allowed_values = ["CREATING", "REQUIRES_VALIDATION", "VALIDATING", "VALIDATED", "VALIDATION_FAILED", "UPDATING", "ALLOCATED", "TERMINATING", "TERMINATED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this VmClusterNetwork.
+        The date and time when the VM cluster network was created.
+
+
+        :return: The time_created of this VmClusterNetwork.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this VmClusterNetwork.
+        The date and time when the VM cluster network was created.
+
+
+        :param time_created: The time_created of this VmClusterNetwork.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this VmClusterNetwork.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this VmClusterNetwork.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this VmClusterNetwork.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this VmClusterNetwork.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this VmClusterNetwork.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this VmClusterNetwork.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this VmClusterNetwork.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this VmClusterNetwork.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this VmClusterNetwork.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this VmClusterNetwork.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this VmClusterNetwork.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this VmClusterNetwork.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/vm_cluster_network_details.py
+++ b/src/oci/database/models/vm_cluster_network_details.py
@@ -1,0 +1,306 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class VmClusterNetworkDetails(object):
+    """
+    Details for a VM cluster network.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new VmClusterNetworkDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this VmClusterNetworkDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this VmClusterNetworkDetails.
+        :type display_name: str
+
+        :param scans:
+            The value to assign to the scans property of this VmClusterNetworkDetails.
+        :type scans: list[ScanDetails]
+
+        :param dns:
+            The value to assign to the dns property of this VmClusterNetworkDetails.
+        :type dns: list[str]
+
+        :param ntp:
+            The value to assign to the ntp property of this VmClusterNetworkDetails.
+        :type ntp: list[str]
+
+        :param vm_networks:
+            The value to assign to the vm_networks property of this VmClusterNetworkDetails.
+        :type vm_networks: list[VmNetworkDetails]
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this VmClusterNetworkDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this VmClusterNetworkDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'scans': 'list[ScanDetails]',
+            'dns': 'list[str]',
+            'ntp': 'list[str]',
+            'vm_networks': 'list[VmNetworkDetails]',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'scans': 'scans',
+            'dns': 'dns',
+            'ntp': 'ntp',
+            'vm_networks': 'vmNetworks',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._display_name = None
+        self._scans = None
+        self._dns = None
+        self._ntp = None
+        self._vm_networks = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this VmClusterNetworkDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this VmClusterNetworkDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this VmClusterNetworkDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this VmClusterNetworkDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this VmClusterNetworkDetails.
+        The user-friendly name for the VM cluster network. The name does not need to be unique.
+
+
+        :return: The display_name of this VmClusterNetworkDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this VmClusterNetworkDetails.
+        The user-friendly name for the VM cluster network. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this VmClusterNetworkDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def scans(self):
+        """
+        **[Required]** Gets the scans of this VmClusterNetworkDetails.
+        The SCAN details.
+
+
+        :return: The scans of this VmClusterNetworkDetails.
+        :rtype: list[ScanDetails]
+        """
+        return self._scans
+
+    @scans.setter
+    def scans(self, scans):
+        """
+        Sets the scans of this VmClusterNetworkDetails.
+        The SCAN details.
+
+
+        :param scans: The scans of this VmClusterNetworkDetails.
+        :type: list[ScanDetails]
+        """
+        self._scans = scans
+
+    @property
+    def dns(self):
+        """
+        Gets the dns of this VmClusterNetworkDetails.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The dns of this VmClusterNetworkDetails.
+        :rtype: list[str]
+        """
+        return self._dns
+
+    @dns.setter
+    def dns(self, dns):
+        """
+        Sets the dns of this VmClusterNetworkDetails.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :param dns: The dns of this VmClusterNetworkDetails.
+        :type: list[str]
+        """
+        self._dns = dns
+
+    @property
+    def ntp(self):
+        """
+        Gets the ntp of this VmClusterNetworkDetails.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The ntp of this VmClusterNetworkDetails.
+        :rtype: list[str]
+        """
+        return self._ntp
+
+    @ntp.setter
+    def ntp(self, ntp):
+        """
+        Sets the ntp of this VmClusterNetworkDetails.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :param ntp: The ntp of this VmClusterNetworkDetails.
+        :type: list[str]
+        """
+        self._ntp = ntp
+
+    @property
+    def vm_networks(self):
+        """
+        **[Required]** Gets the vm_networks of this VmClusterNetworkDetails.
+        Details of the client and backup networks.
+
+
+        :return: The vm_networks of this VmClusterNetworkDetails.
+        :rtype: list[VmNetworkDetails]
+        """
+        return self._vm_networks
+
+    @vm_networks.setter
+    def vm_networks(self, vm_networks):
+        """
+        Sets the vm_networks of this VmClusterNetworkDetails.
+        Details of the client and backup networks.
+
+
+        :param vm_networks: The vm_networks of this VmClusterNetworkDetails.
+        :type: list[VmNetworkDetails]
+        """
+        self._vm_networks = vm_networks
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this VmClusterNetworkDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this VmClusterNetworkDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this VmClusterNetworkDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this VmClusterNetworkDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this VmClusterNetworkDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this VmClusterNetworkDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this VmClusterNetworkDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this VmClusterNetworkDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/vm_cluster_network_summary.py
+++ b/src/oci/database/models/vm_cluster_network_summary.py
@@ -1,0 +1,552 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class VmClusterNetworkSummary(object):
+    """
+    Details of the VM cluster network.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetworkSummary.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetworkSummary.
+    #: This constant has a value of "REQUIRES_VALIDATION"
+    LIFECYCLE_STATE_REQUIRES_VALIDATION = "REQUIRES_VALIDATION"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetworkSummary.
+    #: This constant has a value of "VALIDATING"
+    LIFECYCLE_STATE_VALIDATING = "VALIDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetworkSummary.
+    #: This constant has a value of "VALIDATED"
+    LIFECYCLE_STATE_VALIDATED = "VALIDATED"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetworkSummary.
+    #: This constant has a value of "VALIDATION_FAILED"
+    LIFECYCLE_STATE_VALIDATION_FAILED = "VALIDATION_FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetworkSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetworkSummary.
+    #: This constant has a value of "ALLOCATED"
+    LIFECYCLE_STATE_ALLOCATED = "ALLOCATED"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetworkSummary.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetworkSummary.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterNetworkSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new VmClusterNetworkSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this VmClusterNetworkSummary.
+        :type id: str
+
+        :param exadata_infrastructure_id:
+            The value to assign to the exadata_infrastructure_id property of this VmClusterNetworkSummary.
+        :type exadata_infrastructure_id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this VmClusterNetworkSummary.
+        :type compartment_id: str
+
+        :param vm_cluster_id:
+            The value to assign to the vm_cluster_id property of this VmClusterNetworkSummary.
+        :type vm_cluster_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this VmClusterNetworkSummary.
+        :type display_name: str
+
+        :param scans:
+            The value to assign to the scans property of this VmClusterNetworkSummary.
+        :type scans: list[ScanDetails]
+
+        :param dns:
+            The value to assign to the dns property of this VmClusterNetworkSummary.
+        :type dns: list[str]
+
+        :param ntp:
+            The value to assign to the ntp property of this VmClusterNetworkSummary.
+        :type ntp: list[str]
+
+        :param vm_networks:
+            The value to assign to the vm_networks property of this VmClusterNetworkSummary.
+        :type vm_networks: list[VmNetworkDetails]
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this VmClusterNetworkSummary.
+            Allowed values for this property are: "CREATING", "REQUIRES_VALIDATION", "VALIDATING", "VALIDATED", "VALIDATION_FAILED", "UPDATING", "ALLOCATED", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param time_created:
+            The value to assign to the time_created property of this VmClusterNetworkSummary.
+        :type time_created: datetime
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this VmClusterNetworkSummary.
+        :type lifecycle_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this VmClusterNetworkSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this VmClusterNetworkSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'exadata_infrastructure_id': 'str',
+            'compartment_id': 'str',
+            'vm_cluster_id': 'str',
+            'display_name': 'str',
+            'scans': 'list[ScanDetails]',
+            'dns': 'list[str]',
+            'ntp': 'list[str]',
+            'vm_networks': 'list[VmNetworkDetails]',
+            'lifecycle_state': 'str',
+            'time_created': 'datetime',
+            'lifecycle_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'exadata_infrastructure_id': 'exadataInfrastructureId',
+            'compartment_id': 'compartmentId',
+            'vm_cluster_id': 'vmClusterId',
+            'display_name': 'displayName',
+            'scans': 'scans',
+            'dns': 'dns',
+            'ntp': 'ntp',
+            'vm_networks': 'vmNetworks',
+            'lifecycle_state': 'lifecycleState',
+            'time_created': 'timeCreated',
+            'lifecycle_details': 'lifecycleDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._exadata_infrastructure_id = None
+        self._compartment_id = None
+        self._vm_cluster_id = None
+        self._display_name = None
+        self._scans = None
+        self._dns = None
+        self._ntp = None
+        self._vm_networks = None
+        self._lifecycle_state = None
+        self._time_created = None
+        self._lifecycle_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this VmClusterNetworkSummary.
+        The `OCID`__ of the VM cluster network.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this VmClusterNetworkSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this VmClusterNetworkSummary.
+        The `OCID`__ of the VM cluster network.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this VmClusterNetworkSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def exadata_infrastructure_id(self):
+        """
+        Gets the exadata_infrastructure_id of this VmClusterNetworkSummary.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The exadata_infrastructure_id of this VmClusterNetworkSummary.
+        :rtype: str
+        """
+        return self._exadata_infrastructure_id
+
+    @exadata_infrastructure_id.setter
+    def exadata_infrastructure_id(self, exadata_infrastructure_id):
+        """
+        Sets the exadata_infrastructure_id of this VmClusterNetworkSummary.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param exadata_infrastructure_id: The exadata_infrastructure_id of this VmClusterNetworkSummary.
+        :type: str
+        """
+        self._exadata_infrastructure_id = exadata_infrastructure_id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this VmClusterNetworkSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this VmClusterNetworkSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this VmClusterNetworkSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this VmClusterNetworkSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def vm_cluster_id(self):
+        """
+        Gets the vm_cluster_id of this VmClusterNetworkSummary.
+        The `OCID`__ of the associated VM Cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vm_cluster_id of this VmClusterNetworkSummary.
+        :rtype: str
+        """
+        return self._vm_cluster_id
+
+    @vm_cluster_id.setter
+    def vm_cluster_id(self, vm_cluster_id):
+        """
+        Sets the vm_cluster_id of this VmClusterNetworkSummary.
+        The `OCID`__ of the associated VM Cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vm_cluster_id: The vm_cluster_id of this VmClusterNetworkSummary.
+        :type: str
+        """
+        self._vm_cluster_id = vm_cluster_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this VmClusterNetworkSummary.
+        The user-friendly name for the VM cluster network. The name does not need to be unique.
+
+
+        :return: The display_name of this VmClusterNetworkSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this VmClusterNetworkSummary.
+        The user-friendly name for the VM cluster network. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this VmClusterNetworkSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def scans(self):
+        """
+        Gets the scans of this VmClusterNetworkSummary.
+        The SCAN details.
+
+
+        :return: The scans of this VmClusterNetworkSummary.
+        :rtype: list[ScanDetails]
+        """
+        return self._scans
+
+    @scans.setter
+    def scans(self, scans):
+        """
+        Sets the scans of this VmClusterNetworkSummary.
+        The SCAN details.
+
+
+        :param scans: The scans of this VmClusterNetworkSummary.
+        :type: list[ScanDetails]
+        """
+        self._scans = scans
+
+    @property
+    def dns(self):
+        """
+        Gets the dns of this VmClusterNetworkSummary.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The dns of this VmClusterNetworkSummary.
+        :rtype: list[str]
+        """
+        return self._dns
+
+    @dns.setter
+    def dns(self, dns):
+        """
+        Sets the dns of this VmClusterNetworkSummary.
+        The list of DNS server IP addresses. Maximum of 3 allowed.
+
+
+        :param dns: The dns of this VmClusterNetworkSummary.
+        :type: list[str]
+        """
+        self._dns = dns
+
+    @property
+    def ntp(self):
+        """
+        Gets the ntp of this VmClusterNetworkSummary.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :return: The ntp of this VmClusterNetworkSummary.
+        :rtype: list[str]
+        """
+        return self._ntp
+
+    @ntp.setter
+    def ntp(self, ntp):
+        """
+        Sets the ntp of this VmClusterNetworkSummary.
+        The list of NTP server IP addresses. Maximum of 3 allowed.
+
+
+        :param ntp: The ntp of this VmClusterNetworkSummary.
+        :type: list[str]
+        """
+        self._ntp = ntp
+
+    @property
+    def vm_networks(self):
+        """
+        Gets the vm_networks of this VmClusterNetworkSummary.
+        Details of the client and backup networks.
+
+
+        :return: The vm_networks of this VmClusterNetworkSummary.
+        :rtype: list[VmNetworkDetails]
+        """
+        return self._vm_networks
+
+    @vm_networks.setter
+    def vm_networks(self, vm_networks):
+        """
+        Sets the vm_networks of this VmClusterNetworkSummary.
+        Details of the client and backup networks.
+
+
+        :param vm_networks: The vm_networks of this VmClusterNetworkSummary.
+        :type: list[VmNetworkDetails]
+        """
+        self._vm_networks = vm_networks
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this VmClusterNetworkSummary.
+        The current state of the VM cluster network.
+
+        Allowed values for this property are: "CREATING", "REQUIRES_VALIDATION", "VALIDATING", "VALIDATED", "VALIDATION_FAILED", "UPDATING", "ALLOCATED", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this VmClusterNetworkSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this VmClusterNetworkSummary.
+        The current state of the VM cluster network.
+
+
+        :param lifecycle_state: The lifecycle_state of this VmClusterNetworkSummary.
+        :type: str
+        """
+        allowed_values = ["CREATING", "REQUIRES_VALIDATION", "VALIDATING", "VALIDATED", "VALIDATION_FAILED", "UPDATING", "ALLOCATED", "TERMINATING", "TERMINATED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this VmClusterNetworkSummary.
+        The date and time when the VM cluster network was created.
+
+
+        :return: The time_created of this VmClusterNetworkSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this VmClusterNetworkSummary.
+        The date and time when the VM cluster network was created.
+
+
+        :param time_created: The time_created of this VmClusterNetworkSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this VmClusterNetworkSummary.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this VmClusterNetworkSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this VmClusterNetworkSummary.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this VmClusterNetworkSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this VmClusterNetworkSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this VmClusterNetworkSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this VmClusterNetworkSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this VmClusterNetworkSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this VmClusterNetworkSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this VmClusterNetworkSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this VmClusterNetworkSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this VmClusterNetworkSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/vm_cluster_summary.py
+++ b/src/oci/database/models/vm_cluster_summary.py
@@ -1,0 +1,711 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class VmClusterSummary(object):
+    """
+    Details of the VM cluster.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterSummary.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterSummary.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterSummary.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterSummary.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a VmClusterSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the license_model property of a VmClusterSummary.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a VmClusterSummary.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new VmClusterSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this VmClusterSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this VmClusterSummary.
+        :type compartment_id: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this VmClusterSummary.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param display_name:
+            The value to assign to the display_name property of this VmClusterSummary.
+        :type display_name: str
+
+        :param time_created:
+            The value to assign to the time_created property of this VmClusterSummary.
+        :type time_created: datetime
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this VmClusterSummary.
+        :type lifecycle_details: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this VmClusterSummary.
+        :type time_zone: str
+
+        :param is_local_backup_enabled:
+            The value to assign to the is_local_backup_enabled property of this VmClusterSummary.
+        :type is_local_backup_enabled: bool
+
+        :param exadata_infrastructure_id:
+            The value to assign to the exadata_infrastructure_id property of this VmClusterSummary.
+        :type exadata_infrastructure_id: str
+
+        :param is_sparse_diskgroup_enabled:
+            The value to assign to the is_sparse_diskgroup_enabled property of this VmClusterSummary.
+        :type is_sparse_diskgroup_enabled: bool
+
+        :param vm_cluster_network_id:
+            The value to assign to the vm_cluster_network_id property of this VmClusterSummary.
+        :type vm_cluster_network_id: str
+
+        :param cpus_enabled:
+            The value to assign to the cpus_enabled property of this VmClusterSummary.
+        :type cpus_enabled: int
+
+        :param data_storage_size_in_tbs:
+            The value to assign to the data_storage_size_in_tbs property of this VmClusterSummary.
+        :type data_storage_size_in_tbs: int
+
+        :param shape:
+            The value to assign to the shape property of this VmClusterSummary.
+        :type shape: str
+
+        :param gi_version:
+            The value to assign to the gi_version property of this VmClusterSummary.
+        :type gi_version: str
+
+        :param ssh_public_keys:
+            The value to assign to the ssh_public_keys property of this VmClusterSummary.
+        :type ssh_public_keys: list[str]
+
+        :param license_model:
+            The value to assign to the license_model property of this VmClusterSummary.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type license_model: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this VmClusterSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this VmClusterSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'lifecycle_state': 'str',
+            'display_name': 'str',
+            'time_created': 'datetime',
+            'lifecycle_details': 'str',
+            'time_zone': 'str',
+            'is_local_backup_enabled': 'bool',
+            'exadata_infrastructure_id': 'str',
+            'is_sparse_diskgroup_enabled': 'bool',
+            'vm_cluster_network_id': 'str',
+            'cpus_enabled': 'int',
+            'data_storage_size_in_tbs': 'int',
+            'shape': 'str',
+            'gi_version': 'str',
+            'ssh_public_keys': 'list[str]',
+            'license_model': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'lifecycle_state': 'lifecycleState',
+            'display_name': 'displayName',
+            'time_created': 'timeCreated',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_zone': 'timeZone',
+            'is_local_backup_enabled': 'isLocalBackupEnabled',
+            'exadata_infrastructure_id': 'exadataInfrastructureId',
+            'is_sparse_diskgroup_enabled': 'isSparseDiskgroupEnabled',
+            'vm_cluster_network_id': 'vmClusterNetworkId',
+            'cpus_enabled': 'cpusEnabled',
+            'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
+            'shape': 'shape',
+            'gi_version': 'giVersion',
+            'ssh_public_keys': 'sshPublicKeys',
+            'license_model': 'licenseModel',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._lifecycle_state = None
+        self._display_name = None
+        self._time_created = None
+        self._lifecycle_details = None
+        self._time_zone = None
+        self._is_local_backup_enabled = None
+        self._exadata_infrastructure_id = None
+        self._is_sparse_diskgroup_enabled = None
+        self._vm_cluster_network_id = None
+        self._cpus_enabled = None
+        self._data_storage_size_in_tbs = None
+        self._shape = None
+        self._gi_version = None
+        self._ssh_public_keys = None
+        self._license_model = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this VmClusterSummary.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this VmClusterSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this VmClusterSummary.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this VmClusterSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this VmClusterSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this VmClusterSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this VmClusterSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this VmClusterSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this VmClusterSummary.
+        The current state of the VM cluster.
+
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this VmClusterSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this VmClusterSummary.
+        The current state of the VM cluster.
+
+
+        :param lifecycle_state: The lifecycle_state of this VmClusterSummary.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this VmClusterSummary.
+        The user-friendly name for the VM cluster. The name does not need to be unique.
+
+
+        :return: The display_name of this VmClusterSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this VmClusterSummary.
+        The user-friendly name for the VM cluster. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this VmClusterSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this VmClusterSummary.
+        The date and time that the VM cluster was created.
+
+
+        :return: The time_created of this VmClusterSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this VmClusterSummary.
+        The date and time that the VM cluster was created.
+
+
+        :param time_created: The time_created of this VmClusterSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this VmClusterSummary.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this VmClusterSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this VmClusterSummary.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this VmClusterSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this VmClusterSummary.
+        The time zone of the Exadata infrastructure. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :return: The time_zone of this VmClusterSummary.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this VmClusterSummary.
+        The time zone of the Exadata infrastructure. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :param time_zone: The time_zone of this VmClusterSummary.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def is_local_backup_enabled(self):
+        """
+        Gets the is_local_backup_enabled of this VmClusterSummary.
+        If true, database backup on local Exadata storage is configured for the VM cluster. If false, database backup on local Exadata storage is not available in the VM cluster.
+
+
+        :return: The is_local_backup_enabled of this VmClusterSummary.
+        :rtype: bool
+        """
+        return self._is_local_backup_enabled
+
+    @is_local_backup_enabled.setter
+    def is_local_backup_enabled(self, is_local_backup_enabled):
+        """
+        Sets the is_local_backup_enabled of this VmClusterSummary.
+        If true, database backup on local Exadata storage is configured for the VM cluster. If false, database backup on local Exadata storage is not available in the VM cluster.
+
+
+        :param is_local_backup_enabled: The is_local_backup_enabled of this VmClusterSummary.
+        :type: bool
+        """
+        self._is_local_backup_enabled = is_local_backup_enabled
+
+    @property
+    def exadata_infrastructure_id(self):
+        """
+        Gets the exadata_infrastructure_id of this VmClusterSummary.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The exadata_infrastructure_id of this VmClusterSummary.
+        :rtype: str
+        """
+        return self._exadata_infrastructure_id
+
+    @exadata_infrastructure_id.setter
+    def exadata_infrastructure_id(self, exadata_infrastructure_id):
+        """
+        Sets the exadata_infrastructure_id of this VmClusterSummary.
+        The `OCID`__ of the Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param exadata_infrastructure_id: The exadata_infrastructure_id of this VmClusterSummary.
+        :type: str
+        """
+        self._exadata_infrastructure_id = exadata_infrastructure_id
+
+    @property
+    def is_sparse_diskgroup_enabled(self):
+        """
+        Gets the is_sparse_diskgroup_enabled of this VmClusterSummary.
+        If true, sparse disk group is configured for the VM cluster. If false, sparse disk group is not created.
+
+
+        :return: The is_sparse_diskgroup_enabled of this VmClusterSummary.
+        :rtype: bool
+        """
+        return self._is_sparse_diskgroup_enabled
+
+    @is_sparse_diskgroup_enabled.setter
+    def is_sparse_diskgroup_enabled(self, is_sparse_diskgroup_enabled):
+        """
+        Sets the is_sparse_diskgroup_enabled of this VmClusterSummary.
+        If true, sparse disk group is configured for the VM cluster. If false, sparse disk group is not created.
+
+
+        :param is_sparse_diskgroup_enabled: The is_sparse_diskgroup_enabled of this VmClusterSummary.
+        :type: bool
+        """
+        self._is_sparse_diskgroup_enabled = is_sparse_diskgroup_enabled
+
+    @property
+    def vm_cluster_network_id(self):
+        """
+        Gets the vm_cluster_network_id of this VmClusterSummary.
+        The `OCID`__ of the VM cluster network.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vm_cluster_network_id of this VmClusterSummary.
+        :rtype: str
+        """
+        return self._vm_cluster_network_id
+
+    @vm_cluster_network_id.setter
+    def vm_cluster_network_id(self, vm_cluster_network_id):
+        """
+        Sets the vm_cluster_network_id of this VmClusterSummary.
+        The `OCID`__ of the VM cluster network.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vm_cluster_network_id: The vm_cluster_network_id of this VmClusterSummary.
+        :type: str
+        """
+        self._vm_cluster_network_id = vm_cluster_network_id
+
+    @property
+    def cpus_enabled(self):
+        """
+        Gets the cpus_enabled of this VmClusterSummary.
+        The number of enabled CPU cores.
+
+
+        :return: The cpus_enabled of this VmClusterSummary.
+        :rtype: int
+        """
+        return self._cpus_enabled
+
+    @cpus_enabled.setter
+    def cpus_enabled(self, cpus_enabled):
+        """
+        Sets the cpus_enabled of this VmClusterSummary.
+        The number of enabled CPU cores.
+
+
+        :param cpus_enabled: The cpus_enabled of this VmClusterSummary.
+        :type: int
+        """
+        self._cpus_enabled = cpus_enabled
+
+    @property
+    def data_storage_size_in_tbs(self):
+        """
+        Gets the data_storage_size_in_tbs of this VmClusterSummary.
+        Size, in terabytes, of the DATA disk group.
+
+
+        :return: The data_storage_size_in_tbs of this VmClusterSummary.
+        :rtype: int
+        """
+        return self._data_storage_size_in_tbs
+
+    @data_storage_size_in_tbs.setter
+    def data_storage_size_in_tbs(self, data_storage_size_in_tbs):
+        """
+        Sets the data_storage_size_in_tbs of this VmClusterSummary.
+        Size, in terabytes, of the DATA disk group.
+
+
+        :param data_storage_size_in_tbs: The data_storage_size_in_tbs of this VmClusterSummary.
+        :type: int
+        """
+        self._data_storage_size_in_tbs = data_storage_size_in_tbs
+
+    @property
+    def shape(self):
+        """
+        Gets the shape of this VmClusterSummary.
+        The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+
+
+        :return: The shape of this VmClusterSummary.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this VmClusterSummary.
+        The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+
+
+        :param shape: The shape of this VmClusterSummary.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def gi_version(self):
+        """
+        Gets the gi_version of this VmClusterSummary.
+        The Oracle Grid Infrastructure software version for the VM cluster.
+
+
+        :return: The gi_version of this VmClusterSummary.
+        :rtype: str
+        """
+        return self._gi_version
+
+    @gi_version.setter
+    def gi_version(self, gi_version):
+        """
+        Sets the gi_version of this VmClusterSummary.
+        The Oracle Grid Infrastructure software version for the VM cluster.
+
+
+        :param gi_version: The gi_version of this VmClusterSummary.
+        :type: str
+        """
+        self._gi_version = gi_version
+
+    @property
+    def ssh_public_keys(self):
+        """
+        Gets the ssh_public_keys of this VmClusterSummary.
+        The public key portion of one or more key pairs used for SSH access to the VM cluster.
+
+
+        :return: The ssh_public_keys of this VmClusterSummary.
+        :rtype: list[str]
+        """
+        return self._ssh_public_keys
+
+    @ssh_public_keys.setter
+    def ssh_public_keys(self, ssh_public_keys):
+        """
+        Sets the ssh_public_keys of this VmClusterSummary.
+        The public key portion of one or more key pairs used for SSH access to the VM cluster.
+
+
+        :param ssh_public_keys: The ssh_public_keys of this VmClusterSummary.
+        :type: list[str]
+        """
+        self._ssh_public_keys = ssh_public_keys
+
+    @property
+    def license_model(self):
+        """
+        Gets the license_model of this VmClusterSummary.
+        The Oracle license model that applies to the VM cluster. The default is LICENSE_INCLUDED.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The license_model of this VmClusterSummary.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this VmClusterSummary.
+        The Oracle license model that applies to the VM cluster. The default is LICENSE_INCLUDED.
+
+
+        :param license_model: The license_model of this VmClusterSummary.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            license_model = 'UNKNOWN_ENUM_VALUE'
+        self._license_model = license_model
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this VmClusterSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this VmClusterSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this VmClusterSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this VmClusterSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this VmClusterSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this VmClusterSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this VmClusterSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this VmClusterSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/vm_network_details.py
+++ b/src/oci/database/models/vm_network_details.py
@@ -1,0 +1,240 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class VmNetworkDetails(object):
+    """
+    Details of the client or backup networks in a VM cluster network.
+    """
+
+    #: A constant which can be used with the network_type property of a VmNetworkDetails.
+    #: This constant has a value of "CLIENT"
+    NETWORK_TYPE_CLIENT = "CLIENT"
+
+    #: A constant which can be used with the network_type property of a VmNetworkDetails.
+    #: This constant has a value of "BACKUP"
+    NETWORK_TYPE_BACKUP = "BACKUP"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new VmNetworkDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param vlan_id:
+            The value to assign to the vlan_id property of this VmNetworkDetails.
+        :type vlan_id: str
+
+        :param network_type:
+            The value to assign to the network_type property of this VmNetworkDetails.
+            Allowed values for this property are: "CLIENT", "BACKUP", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type network_type: str
+
+        :param netmask:
+            The value to assign to the netmask property of this VmNetworkDetails.
+        :type netmask: str
+
+        :param gateway:
+            The value to assign to the gateway property of this VmNetworkDetails.
+        :type gateway: str
+
+        :param domain_name:
+            The value to assign to the domain_name property of this VmNetworkDetails.
+        :type domain_name: str
+
+        :param nodes:
+            The value to assign to the nodes property of this VmNetworkDetails.
+        :type nodes: list[NodeDetails]
+
+        """
+        self.swagger_types = {
+            'vlan_id': 'str',
+            'network_type': 'str',
+            'netmask': 'str',
+            'gateway': 'str',
+            'domain_name': 'str',
+            'nodes': 'list[NodeDetails]'
+        }
+
+        self.attribute_map = {
+            'vlan_id': 'vlanId',
+            'network_type': 'networkType',
+            'netmask': 'netmask',
+            'gateway': 'gateway',
+            'domain_name': 'domainName',
+            'nodes': 'nodes'
+        }
+
+        self._vlan_id = None
+        self._network_type = None
+        self._netmask = None
+        self._gateway = None
+        self._domain_name = None
+        self._nodes = None
+
+    @property
+    def vlan_id(self):
+        """
+        **[Required]** Gets the vlan_id of this VmNetworkDetails.
+        The network VLAN ID.
+
+
+        :return: The vlan_id of this VmNetworkDetails.
+        :rtype: str
+        """
+        return self._vlan_id
+
+    @vlan_id.setter
+    def vlan_id(self, vlan_id):
+        """
+        Sets the vlan_id of this VmNetworkDetails.
+        The network VLAN ID.
+
+
+        :param vlan_id: The vlan_id of this VmNetworkDetails.
+        :type: str
+        """
+        self._vlan_id = vlan_id
+
+    @property
+    def network_type(self):
+        """
+        **[Required]** Gets the network_type of this VmNetworkDetails.
+        The network type.
+
+        Allowed values for this property are: "CLIENT", "BACKUP", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The network_type of this VmNetworkDetails.
+        :rtype: str
+        """
+        return self._network_type
+
+    @network_type.setter
+    def network_type(self, network_type):
+        """
+        Sets the network_type of this VmNetworkDetails.
+        The network type.
+
+
+        :param network_type: The network_type of this VmNetworkDetails.
+        :type: str
+        """
+        allowed_values = ["CLIENT", "BACKUP"]
+        if not value_allowed_none_or_none_sentinel(network_type, allowed_values):
+            network_type = 'UNKNOWN_ENUM_VALUE'
+        self._network_type = network_type
+
+    @property
+    def netmask(self):
+        """
+        **[Required]** Gets the netmask of this VmNetworkDetails.
+        The network netmask.
+
+
+        :return: The netmask of this VmNetworkDetails.
+        :rtype: str
+        """
+        return self._netmask
+
+    @netmask.setter
+    def netmask(self, netmask):
+        """
+        Sets the netmask of this VmNetworkDetails.
+        The network netmask.
+
+
+        :param netmask: The netmask of this VmNetworkDetails.
+        :type: str
+        """
+        self._netmask = netmask
+
+    @property
+    def gateway(self):
+        """
+        **[Required]** Gets the gateway of this VmNetworkDetails.
+        The network gateway.
+
+
+        :return: The gateway of this VmNetworkDetails.
+        :rtype: str
+        """
+        return self._gateway
+
+    @gateway.setter
+    def gateway(self, gateway):
+        """
+        Sets the gateway of this VmNetworkDetails.
+        The network gateway.
+
+
+        :param gateway: The gateway of this VmNetworkDetails.
+        :type: str
+        """
+        self._gateway = gateway
+
+    @property
+    def domain_name(self):
+        """
+        **[Required]** Gets the domain_name of this VmNetworkDetails.
+        The network domain name.
+
+
+        :return: The domain_name of this VmNetworkDetails.
+        :rtype: str
+        """
+        return self._domain_name
+
+    @domain_name.setter
+    def domain_name(self, domain_name):
+        """
+        Sets the domain_name of this VmNetworkDetails.
+        The network domain name.
+
+
+        :param domain_name: The domain_name of this VmNetworkDetails.
+        :type: str
+        """
+        self._domain_name = domain_name
+
+    @property
+    def nodes(self):
+        """
+        **[Required]** Gets the nodes of this VmNetworkDetails.
+        The list of node details.
+
+
+        :return: The nodes of this VmNetworkDetails.
+        :rtype: list[NodeDetails]
+        """
+        return self._nodes
+
+    @nodes.setter
+    def nodes(self, nodes):
+        """
+        Sets the nodes of this VmNetworkDetails.
+        The list of node details.
+
+
+        :param nodes: The nodes of this VmNetworkDetails.
+        :type: list[NodeDetails]
+        """
+        self._nodes = nodes
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/__init__.py
+++ b/src/oci/resource_manager/models/__init__.py
@@ -3,17 +3,32 @@
 
 from __future__ import absolute_import
 
+from .apply_job_operation_details import ApplyJobOperationDetails
+from .apply_job_operation_details_summary import ApplyJobOperationDetailsSummary
 from .apply_job_plan_resolution import ApplyJobPlanResolution
 from .change_stack_compartment_details import ChangeStackCompartmentDetails
 from .config_source import ConfigSource
+from .create_apply_job_operation_details import CreateApplyJobOperationDetails
 from .create_config_source_details import CreateConfigSourceDetails
+from .create_destroy_job_operation_details import CreateDestroyJobOperationDetails
+from .create_import_tf_state_job_operation_details import CreateImportTfStateJobOperationDetails
 from .create_job_details import CreateJobDetails
+from .create_job_operation_details import CreateJobOperationDetails
+from .create_plan_job_operation_details import CreatePlanJobOperationDetails
 from .create_stack_details import CreateStackDetails
 from .create_zip_upload_config_source_details import CreateZipUploadConfigSourceDetails
+from .destroy_job_operation_details import DestroyJobOperationDetails
+from .destroy_job_operation_details_summary import DestroyJobOperationDetailsSummary
 from .failure_details import FailureDetails
+from .import_tf_state_job_operation_details import ImportTfStateJobOperationDetails
+from .import_tf_state_job_operation_details_summary import ImportTfStateJobOperationDetailsSummary
 from .job import Job
+from .job_operation_details import JobOperationDetails
+from .job_operation_details_summary import JobOperationDetailsSummary
 from .job_summary import JobSummary
 from .log_entry import LogEntry
+from .plan_job_operation_details import PlanJobOperationDetails
+from .plan_job_operation_details_summary import PlanJobOperationDetailsSummary
 from .stack import Stack
 from .stack_summary import StackSummary
 from .update_config_source_details import UpdateConfigSourceDetails
@@ -29,17 +44,32 @@ from .zip_upload_config_source import ZipUploadConfigSource
 
 # Maps type names to classes for resource_manager services.
 resource_manager_type_mapping = {
+    "ApplyJobOperationDetails": ApplyJobOperationDetails,
+    "ApplyJobOperationDetailsSummary": ApplyJobOperationDetailsSummary,
     "ApplyJobPlanResolution": ApplyJobPlanResolution,
     "ChangeStackCompartmentDetails": ChangeStackCompartmentDetails,
     "ConfigSource": ConfigSource,
+    "CreateApplyJobOperationDetails": CreateApplyJobOperationDetails,
     "CreateConfigSourceDetails": CreateConfigSourceDetails,
+    "CreateDestroyJobOperationDetails": CreateDestroyJobOperationDetails,
+    "CreateImportTfStateJobOperationDetails": CreateImportTfStateJobOperationDetails,
     "CreateJobDetails": CreateJobDetails,
+    "CreateJobOperationDetails": CreateJobOperationDetails,
+    "CreatePlanJobOperationDetails": CreatePlanJobOperationDetails,
     "CreateStackDetails": CreateStackDetails,
     "CreateZipUploadConfigSourceDetails": CreateZipUploadConfigSourceDetails,
+    "DestroyJobOperationDetails": DestroyJobOperationDetails,
+    "DestroyJobOperationDetailsSummary": DestroyJobOperationDetailsSummary,
     "FailureDetails": FailureDetails,
+    "ImportTfStateJobOperationDetails": ImportTfStateJobOperationDetails,
+    "ImportTfStateJobOperationDetailsSummary": ImportTfStateJobOperationDetailsSummary,
     "Job": Job,
+    "JobOperationDetails": JobOperationDetails,
+    "JobOperationDetailsSummary": JobOperationDetailsSummary,
     "JobSummary": JobSummary,
     "LogEntry": LogEntry,
+    "PlanJobOperationDetails": PlanJobOperationDetails,
+    "PlanJobOperationDetailsSummary": PlanJobOperationDetailsSummary,
     "Stack": Stack,
     "StackSummary": StackSummary,
     "UpdateConfigSourceDetails": UpdateConfigSourceDetails,

--- a/src/oci/resource_manager/models/apply_job_operation_details.py
+++ b/src/oci/resource_manager/models/apply_job_operation_details.py
@@ -1,0 +1,133 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .job_operation_details import JobOperationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ApplyJobOperationDetails(JobOperationDetails):
+    """
+    Job details that are specific to apply operations.
+    """
+
+    #: A constant which can be used with the execution_plan_strategy property of a ApplyJobOperationDetails.
+    #: This constant has a value of "FROM_PLAN_JOB_ID"
+    EXECUTION_PLAN_STRATEGY_FROM_PLAN_JOB_ID = "FROM_PLAN_JOB_ID"
+
+    #: A constant which can be used with the execution_plan_strategy property of a ApplyJobOperationDetails.
+    #: This constant has a value of "FROM_LATEST_PLAN_JOB"
+    EXECUTION_PLAN_STRATEGY_FROM_LATEST_PLAN_JOB = "FROM_LATEST_PLAN_JOB"
+
+    #: A constant which can be used with the execution_plan_strategy property of a ApplyJobOperationDetails.
+    #: This constant has a value of "AUTO_APPROVED"
+    EXECUTION_PLAN_STRATEGY_AUTO_APPROVED = "AUTO_APPROVED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ApplyJobOperationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.ApplyJobOperationDetails.operation` attribute
+        of this class is ``APPLY`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this ApplyJobOperationDetails.
+        :type operation: str
+
+        :param execution_plan_strategy:
+            The value to assign to the execution_plan_strategy property of this ApplyJobOperationDetails.
+            Allowed values for this property are: "FROM_PLAN_JOB_ID", "FROM_LATEST_PLAN_JOB", "AUTO_APPROVED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type execution_plan_strategy: str
+
+        :param execution_plan_job_id:
+            The value to assign to the execution_plan_job_id property of this ApplyJobOperationDetails.
+        :type execution_plan_job_id: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str',
+            'execution_plan_strategy': 'str',
+            'execution_plan_job_id': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation',
+            'execution_plan_strategy': 'executionPlanStrategy',
+            'execution_plan_job_id': 'executionPlanJobId'
+        }
+
+        self._operation = None
+        self._execution_plan_strategy = None
+        self._execution_plan_job_id = None
+        self._operation = 'APPLY'
+
+    @property
+    def execution_plan_strategy(self):
+        """
+        **[Required]** Gets the execution_plan_strategy of this ApplyJobOperationDetails.
+        Specifies the source of the execution plan to apply.
+        Use `AUTO_APPROVED` to run the job without an execution plan.
+
+        Allowed values for this property are: "FROM_PLAN_JOB_ID", "FROM_LATEST_PLAN_JOB", "AUTO_APPROVED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The execution_plan_strategy of this ApplyJobOperationDetails.
+        :rtype: str
+        """
+        return self._execution_plan_strategy
+
+    @execution_plan_strategy.setter
+    def execution_plan_strategy(self, execution_plan_strategy):
+        """
+        Sets the execution_plan_strategy of this ApplyJobOperationDetails.
+        Specifies the source of the execution plan to apply.
+        Use `AUTO_APPROVED` to run the job without an execution plan.
+
+
+        :param execution_plan_strategy: The execution_plan_strategy of this ApplyJobOperationDetails.
+        :type: str
+        """
+        allowed_values = ["FROM_PLAN_JOB_ID", "FROM_LATEST_PLAN_JOB", "AUTO_APPROVED"]
+        if not value_allowed_none_or_none_sentinel(execution_plan_strategy, allowed_values):
+            execution_plan_strategy = 'UNKNOWN_ENUM_VALUE'
+        self._execution_plan_strategy = execution_plan_strategy
+
+    @property
+    def execution_plan_job_id(self):
+        """
+        Gets the execution_plan_job_id of this ApplyJobOperationDetails.
+        The OCID of the plan job that contains the execution plan used for this job,
+        or `null` if no execution plan was used.
+
+
+        :return: The execution_plan_job_id of this ApplyJobOperationDetails.
+        :rtype: str
+        """
+        return self._execution_plan_job_id
+
+    @execution_plan_job_id.setter
+    def execution_plan_job_id(self, execution_plan_job_id):
+        """
+        Sets the execution_plan_job_id of this ApplyJobOperationDetails.
+        The OCID of the plan job that contains the execution plan used for this job,
+        or `null` if no execution plan was used.
+
+
+        :param execution_plan_job_id: The execution_plan_job_id of this ApplyJobOperationDetails.
+        :type: str
+        """
+        self._execution_plan_job_id = execution_plan_job_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/apply_job_operation_details_summary.py
+++ b/src/oci/resource_manager/models/apply_job_operation_details_summary.py
@@ -1,0 +1,113 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .job_operation_details_summary import JobOperationDetailsSummary
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ApplyJobOperationDetailsSummary(JobOperationDetailsSummary):
+    """
+    Job details that are specific to apply operations.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ApplyJobOperationDetailsSummary object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.ApplyJobOperationDetailsSummary.operation` attribute
+        of this class is ``APPLY`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this ApplyJobOperationDetailsSummary.
+        :type operation: str
+
+        :param execution_plan_strategy:
+            The value to assign to the execution_plan_strategy property of this ApplyJobOperationDetailsSummary.
+        :type execution_plan_strategy: str
+
+        :param execution_plan_job_id:
+            The value to assign to the execution_plan_job_id property of this ApplyJobOperationDetailsSummary.
+        :type execution_plan_job_id: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str',
+            'execution_plan_strategy': 'str',
+            'execution_plan_job_id': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation',
+            'execution_plan_strategy': 'executionPlanStrategy',
+            'execution_plan_job_id': 'executionPlanJobId'
+        }
+
+        self._operation = None
+        self._execution_plan_strategy = None
+        self._execution_plan_job_id = None
+        self._operation = 'APPLY'
+
+    @property
+    def execution_plan_strategy(self):
+        """
+        **[Required]** Gets the execution_plan_strategy of this ApplyJobOperationDetailsSummary.
+        Specifies the source of the execution plan to apply.
+        Use `AUTO_APPROVED` to run the job without an execution plan.
+
+
+        :return: The execution_plan_strategy of this ApplyJobOperationDetailsSummary.
+        :rtype: str
+        """
+        return self._execution_plan_strategy
+
+    @execution_plan_strategy.setter
+    def execution_plan_strategy(self, execution_plan_strategy):
+        """
+        Sets the execution_plan_strategy of this ApplyJobOperationDetailsSummary.
+        Specifies the source of the execution plan to apply.
+        Use `AUTO_APPROVED` to run the job without an execution plan.
+
+
+        :param execution_plan_strategy: The execution_plan_strategy of this ApplyJobOperationDetailsSummary.
+        :type: str
+        """
+        self._execution_plan_strategy = execution_plan_strategy
+
+    @property
+    def execution_plan_job_id(self):
+        """
+        Gets the execution_plan_job_id of this ApplyJobOperationDetailsSummary.
+        The OCID of the plan job that contains the execution plan used for this job,
+        or `null` if no execution plan was used.
+
+
+        :return: The execution_plan_job_id of this ApplyJobOperationDetailsSummary.
+        :rtype: str
+        """
+        return self._execution_plan_job_id
+
+    @execution_plan_job_id.setter
+    def execution_plan_job_id(self, execution_plan_job_id):
+        """
+        Sets the execution_plan_job_id of this ApplyJobOperationDetailsSummary.
+        The OCID of the plan job that contains the execution plan used for this job,
+        or `null` if no execution plan was used.
+
+
+        :param execution_plan_job_id: The execution_plan_job_id of this ApplyJobOperationDetailsSummary.
+        :type: str
+        """
+        self._execution_plan_job_id = execution_plan_job_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/create_apply_job_operation_details.py
+++ b/src/oci/resource_manager/models/create_apply_job_operation_details.py
@@ -1,0 +1,111 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .create_job_operation_details import CreateJobOperationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateApplyJobOperationDetails(CreateJobOperationDetails):
+    """
+    Job details that are specific to apply operations.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateApplyJobOperationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.CreateApplyJobOperationDetails.operation` attribute
+        of this class is ``APPLY`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this CreateApplyJobOperationDetails.
+        :type operation: str
+
+        :param execution_plan_strategy:
+            The value to assign to the execution_plan_strategy property of this CreateApplyJobOperationDetails.
+        :type execution_plan_strategy: str
+
+        :param execution_plan_job_id:
+            The value to assign to the execution_plan_job_id property of this CreateApplyJobOperationDetails.
+        :type execution_plan_job_id: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str',
+            'execution_plan_strategy': 'str',
+            'execution_plan_job_id': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation',
+            'execution_plan_strategy': 'executionPlanStrategy',
+            'execution_plan_job_id': 'executionPlanJobId'
+        }
+
+        self._operation = None
+        self._execution_plan_strategy = None
+        self._execution_plan_job_id = None
+        self._operation = 'APPLY'
+
+    @property
+    def execution_plan_strategy(self):
+        """
+        Gets the execution_plan_strategy of this CreateApplyJobOperationDetails.
+        Specifies the source of the execution plan to apply.
+        Use `AUTO_APPROVED` to run the job without an execution plan.
+
+
+        :return: The execution_plan_strategy of this CreateApplyJobOperationDetails.
+        :rtype: str
+        """
+        return self._execution_plan_strategy
+
+    @execution_plan_strategy.setter
+    def execution_plan_strategy(self, execution_plan_strategy):
+        """
+        Sets the execution_plan_strategy of this CreateApplyJobOperationDetails.
+        Specifies the source of the execution plan to apply.
+        Use `AUTO_APPROVED` to run the job without an execution plan.
+
+
+        :param execution_plan_strategy: The execution_plan_strategy of this CreateApplyJobOperationDetails.
+        :type: str
+        """
+        self._execution_plan_strategy = execution_plan_strategy
+
+    @property
+    def execution_plan_job_id(self):
+        """
+        Gets the execution_plan_job_id of this CreateApplyJobOperationDetails.
+        The OCID of a plan job, for use when specifying `FROM_PLAN_JOB_ID` as the `executionPlanStrategy`.
+
+
+        :return: The execution_plan_job_id of this CreateApplyJobOperationDetails.
+        :rtype: str
+        """
+        return self._execution_plan_job_id
+
+    @execution_plan_job_id.setter
+    def execution_plan_job_id(self, execution_plan_job_id):
+        """
+        Sets the execution_plan_job_id of this CreateApplyJobOperationDetails.
+        The OCID of a plan job, for use when specifying `FROM_PLAN_JOB_ID` as the `executionPlanStrategy`.
+
+
+        :param execution_plan_job_id: The execution_plan_job_id of this CreateApplyJobOperationDetails.
+        :type: str
+        """
+        self._execution_plan_job_id = execution_plan_job_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/create_destroy_job_operation_details.py
+++ b/src/oci/resource_manager/models/create_destroy_job_operation_details.py
@@ -1,0 +1,82 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .create_job_operation_details import CreateJobOperationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDestroyJobOperationDetails(CreateJobOperationDetails):
+    """
+    Job details that are specific to destroy operations.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDestroyJobOperationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.CreateDestroyJobOperationDetails.operation` attribute
+        of this class is ``DESTROY`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this CreateDestroyJobOperationDetails.
+        :type operation: str
+
+        :param execution_plan_strategy:
+            The value to assign to the execution_plan_strategy property of this CreateDestroyJobOperationDetails.
+        :type execution_plan_strategy: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str',
+            'execution_plan_strategy': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation',
+            'execution_plan_strategy': 'executionPlanStrategy'
+        }
+
+        self._operation = None
+        self._execution_plan_strategy = None
+        self._operation = 'DESTROY'
+
+    @property
+    def execution_plan_strategy(self):
+        """
+        **[Required]** Gets the execution_plan_strategy of this CreateDestroyJobOperationDetails.
+        Specifies the source of the execution plan to apply.
+        Currently, only `AUTO_APPROVED` is allowed, which indicates that the job
+        will be run without an execution plan.
+
+
+        :return: The execution_plan_strategy of this CreateDestroyJobOperationDetails.
+        :rtype: str
+        """
+        return self._execution_plan_strategy
+
+    @execution_plan_strategy.setter
+    def execution_plan_strategy(self, execution_plan_strategy):
+        """
+        Sets the execution_plan_strategy of this CreateDestroyJobOperationDetails.
+        Specifies the source of the execution plan to apply.
+        Currently, only `AUTO_APPROVED` is allowed, which indicates that the job
+        will be run without an execution plan.
+
+
+        :param execution_plan_strategy: The execution_plan_strategy of this CreateDestroyJobOperationDetails.
+        :type: str
+        """
+        self._execution_plan_strategy = execution_plan_strategy
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/create_import_tf_state_job_operation_details.py
+++ b/src/oci/resource_manager/models/create_import_tf_state_job_operation_details.py
@@ -1,0 +1,78 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .create_job_operation_details import CreateJobOperationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateImportTfStateJobOperationDetails(CreateJobOperationDetails):
+    """
+    Job details that are specific to import Terraform state operations.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateImportTfStateJobOperationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.CreateImportTfStateJobOperationDetails.operation` attribute
+        of this class is ``IMPORT_TF_STATE`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this CreateImportTfStateJobOperationDetails.
+        :type operation: str
+
+        :param tf_state_base64_encoded:
+            The value to assign to the tf_state_base64_encoded property of this CreateImportTfStateJobOperationDetails.
+        :type tf_state_base64_encoded: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str',
+            'tf_state_base64_encoded': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation',
+            'tf_state_base64_encoded': 'tfStateBase64Encoded'
+        }
+
+        self._operation = None
+        self._tf_state_base64_encoded = None
+        self._operation = 'IMPORT_TF_STATE'
+
+    @property
+    def tf_state_base64_encoded(self):
+        """
+        **[Required]** Gets the tf_state_base64_encoded of this CreateImportTfStateJobOperationDetails.
+        Base64-encoded state file
+
+
+        :return: The tf_state_base64_encoded of this CreateImportTfStateJobOperationDetails.
+        :rtype: str
+        """
+        return self._tf_state_base64_encoded
+
+    @tf_state_base64_encoded.setter
+    def tf_state_base64_encoded(self, tf_state_base64_encoded):
+        """
+        Sets the tf_state_base64_encoded of this CreateImportTfStateJobOperationDetails.
+        Base64-encoded state file
+
+
+        :param tf_state_base64_encoded: The tf_state_base64_encoded of this CreateImportTfStateJobOperationDetails.
+        :type: str
+        """
+        self._tf_state_base64_encoded = tf_state_base64_encoded
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/create_job_details.py
+++ b/src/oci/resource_manager/models/create_job_details.py
@@ -29,6 +29,10 @@ class CreateJobDetails(object):
             The value to assign to the operation property of this CreateJobDetails.
         :type operation: str
 
+        :param job_operation_details:
+            The value to assign to the job_operation_details property of this CreateJobDetails.
+        :type job_operation_details: CreateJobOperationDetails
+
         :param apply_job_plan_resolution:
             The value to assign to the apply_job_plan_resolution property of this CreateJobDetails.
         :type apply_job_plan_resolution: ApplyJobPlanResolution
@@ -46,6 +50,7 @@ class CreateJobDetails(object):
             'stack_id': 'str',
             'display_name': 'str',
             'operation': 'str',
+            'job_operation_details': 'CreateJobOperationDetails',
             'apply_job_plan_resolution': 'ApplyJobPlanResolution',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
@@ -55,6 +60,7 @@ class CreateJobDetails(object):
             'stack_id': 'stackId',
             'display_name': 'displayName',
             'operation': 'operation',
+            'job_operation_details': 'jobOperationDetails',
             'apply_job_plan_resolution': 'applyJobPlanResolution',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
@@ -63,6 +69,7 @@ class CreateJobDetails(object):
         self._stack_id = None
         self._display_name = None
         self._operation = None
+        self._job_operation_details = None
         self._apply_job_plan_resolution = None
         self._freeform_tags = None
         self._defined_tags = None
@@ -118,7 +125,7 @@ class CreateJobDetails(object):
     @property
     def operation(self):
         """
-        **[Required]** Gets the operation of this CreateJobDetails.
+        Gets the operation of this CreateJobDetails.
         Terraform-specific operation to execute.
 
 
@@ -140,9 +147,35 @@ class CreateJobDetails(object):
         self._operation = operation
 
     @property
+    def job_operation_details(self):
+        """
+        Gets the job_operation_details of this CreateJobDetails.
+        Job details that are specific to the operation type.
+
+
+        :return: The job_operation_details of this CreateJobDetails.
+        :rtype: CreateJobOperationDetails
+        """
+        return self._job_operation_details
+
+    @job_operation_details.setter
+    def job_operation_details(self, job_operation_details):
+        """
+        Sets the job_operation_details of this CreateJobDetails.
+        Job details that are specific to the operation type.
+
+
+        :param job_operation_details: The job_operation_details of this CreateJobDetails.
+        :type: CreateJobOperationDetails
+        """
+        self._job_operation_details = job_operation_details
+
+    @property
     def apply_job_plan_resolution(self):
         """
         Gets the apply_job_plan_resolution of this CreateJobDetails.
+        Deprecated. Use the property `executionPlanStrategy` in `jobOperationDetails` instead.
+
 
         :return: The apply_job_plan_resolution of this CreateJobDetails.
         :rtype: ApplyJobPlanResolution
@@ -153,6 +186,8 @@ class CreateJobDetails(object):
     def apply_job_plan_resolution(self, apply_job_plan_resolution):
         """
         Sets the apply_job_plan_resolution of this CreateJobDetails.
+        Deprecated. Use the property `executionPlanStrategy` in `jobOperationDetails` instead.
+
 
         :param apply_job_plan_resolution: The apply_job_plan_resolution of this CreateJobDetails.
         :type: ApplyJobPlanResolution

--- a/src/oci/resource_manager/models/create_job_operation_details.py
+++ b/src/oci/resource_manager/models/create_job_operation_details.py
@@ -1,0 +1,98 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateJobOperationDetails(object):
+    """
+    Job details that are specific to the operation type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateJobOperationDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.resource_manager.models.CreateImportTfStateJobOperationDetails`
+        * :class:`~oci.resource_manager.models.CreateApplyJobOperationDetails`
+        * :class:`~oci.resource_manager.models.CreatePlanJobOperationDetails`
+        * :class:`~oci.resource_manager.models.CreateDestroyJobOperationDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this CreateJobOperationDetails.
+        :type operation: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation'
+        }
+
+        self._operation = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['operation']
+
+        if type == 'IMPORT_TF_STATE':
+            return 'CreateImportTfStateJobOperationDetails'
+
+        if type == 'APPLY':
+            return 'CreateApplyJobOperationDetails'
+
+        if type == 'PLAN':
+            return 'CreatePlanJobOperationDetails'
+
+        if type == 'DESTROY':
+            return 'CreateDestroyJobOperationDetails'
+        else:
+            return 'CreateJobOperationDetails'
+
+    @property
+    def operation(self):
+        """
+        **[Required]** Gets the operation of this CreateJobOperationDetails.
+        Terraform-specific operation to execute.
+
+
+        :return: The operation of this CreateJobOperationDetails.
+        :rtype: str
+        """
+        return self._operation
+
+    @operation.setter
+    def operation(self, operation):
+        """
+        Sets the operation of this CreateJobOperationDetails.
+        Terraform-specific operation to execute.
+
+
+        :param operation: The operation of this CreateJobOperationDetails.
+        :type: str
+        """
+        self._operation = operation
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/create_plan_job_operation_details.py
+++ b/src/oci/resource_manager/models/create_plan_job_operation_details.py
@@ -1,0 +1,47 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .create_job_operation_details import CreateJobOperationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreatePlanJobOperationDetails(CreateJobOperationDetails):
+    """
+    Job details that are specific to plan operations.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreatePlanJobOperationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.CreatePlanJobOperationDetails.operation` attribute
+        of this class is ``PLAN`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this CreatePlanJobOperationDetails.
+        :type operation: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation'
+        }
+
+        self._operation = None
+        self._operation = 'PLAN'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/destroy_job_operation_details.py
+++ b/src/oci/resource_manager/models/destroy_job_operation_details.py
@@ -1,0 +1,94 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .job_operation_details import JobOperationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DestroyJobOperationDetails(JobOperationDetails):
+    """
+    Job details that are specific to destroy operations.
+    """
+
+    #: A constant which can be used with the execution_plan_strategy property of a DestroyJobOperationDetails.
+    #: This constant has a value of "AUTO_APPROVED"
+    EXECUTION_PLAN_STRATEGY_AUTO_APPROVED = "AUTO_APPROVED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DestroyJobOperationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.DestroyJobOperationDetails.operation` attribute
+        of this class is ``DESTROY`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this DestroyJobOperationDetails.
+        :type operation: str
+
+        :param execution_plan_strategy:
+            The value to assign to the execution_plan_strategy property of this DestroyJobOperationDetails.
+            Allowed values for this property are: "AUTO_APPROVED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type execution_plan_strategy: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str',
+            'execution_plan_strategy': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation',
+            'execution_plan_strategy': 'executionPlanStrategy'
+        }
+
+        self._operation = None
+        self._execution_plan_strategy = None
+        self._operation = 'DESTROY'
+
+    @property
+    def execution_plan_strategy(self):
+        """
+        **[Required]** Gets the execution_plan_strategy of this DestroyJobOperationDetails.
+        Specifies the source of the execution plan to apply.
+        Currently, only `AUTO_APPROVED` is allowed, which indicates that the job
+        will be run without an execution plan.
+
+        Allowed values for this property are: "AUTO_APPROVED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The execution_plan_strategy of this DestroyJobOperationDetails.
+        :rtype: str
+        """
+        return self._execution_plan_strategy
+
+    @execution_plan_strategy.setter
+    def execution_plan_strategy(self, execution_plan_strategy):
+        """
+        Sets the execution_plan_strategy of this DestroyJobOperationDetails.
+        Specifies the source of the execution plan to apply.
+        Currently, only `AUTO_APPROVED` is allowed, which indicates that the job
+        will be run without an execution plan.
+
+
+        :param execution_plan_strategy: The execution_plan_strategy of this DestroyJobOperationDetails.
+        :type: str
+        """
+        allowed_values = ["AUTO_APPROVED"]
+        if not value_allowed_none_or_none_sentinel(execution_plan_strategy, allowed_values):
+            execution_plan_strategy = 'UNKNOWN_ENUM_VALUE'
+        self._execution_plan_strategy = execution_plan_strategy
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/destroy_job_operation_details_summary.py
+++ b/src/oci/resource_manager/models/destroy_job_operation_details_summary.py
@@ -1,0 +1,82 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .job_operation_details_summary import JobOperationDetailsSummary
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DestroyJobOperationDetailsSummary(JobOperationDetailsSummary):
+    """
+    Job details that are specific to destroy operations.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DestroyJobOperationDetailsSummary object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.DestroyJobOperationDetailsSummary.operation` attribute
+        of this class is ``DESTROY`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this DestroyJobOperationDetailsSummary.
+        :type operation: str
+
+        :param execution_plan_strategy:
+            The value to assign to the execution_plan_strategy property of this DestroyJobOperationDetailsSummary.
+        :type execution_plan_strategy: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str',
+            'execution_plan_strategy': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation',
+            'execution_plan_strategy': 'executionPlanStrategy'
+        }
+
+        self._operation = None
+        self._execution_plan_strategy = None
+        self._operation = 'DESTROY'
+
+    @property
+    def execution_plan_strategy(self):
+        """
+        **[Required]** Gets the execution_plan_strategy of this DestroyJobOperationDetailsSummary.
+        Specifies the source of the execution plan to apply.
+        Currently, only `AUTO_APPROVED` is allowed, which indicates that the job
+        will be run without an execution plan.
+
+
+        :return: The execution_plan_strategy of this DestroyJobOperationDetailsSummary.
+        :rtype: str
+        """
+        return self._execution_plan_strategy
+
+    @execution_plan_strategy.setter
+    def execution_plan_strategy(self, execution_plan_strategy):
+        """
+        Sets the execution_plan_strategy of this DestroyJobOperationDetailsSummary.
+        Specifies the source of the execution plan to apply.
+        Currently, only `AUTO_APPROVED` is allowed, which indicates that the job
+        will be run without an execution plan.
+
+
+        :param execution_plan_strategy: The execution_plan_strategy of this DestroyJobOperationDetailsSummary.
+        :type: str
+        """
+        self._execution_plan_strategy = execution_plan_strategy
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/import_tf_state_job_operation_details.py
+++ b/src/oci/resource_manager/models/import_tf_state_job_operation_details.py
@@ -1,0 +1,47 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .job_operation_details import JobOperationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ImportTfStateJobOperationDetails(JobOperationDetails):
+    """
+    Job details that are specific to import Terraform state operations.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ImportTfStateJobOperationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.ImportTfStateJobOperationDetails.operation` attribute
+        of this class is ``IMPORT_TF_STATE`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this ImportTfStateJobOperationDetails.
+        :type operation: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation'
+        }
+
+        self._operation = None
+        self._operation = 'IMPORT_TF_STATE'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/import_tf_state_job_operation_details_summary.py
+++ b/src/oci/resource_manager/models/import_tf_state_job_operation_details_summary.py
@@ -1,0 +1,47 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .job_operation_details_summary import JobOperationDetailsSummary
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ImportTfStateJobOperationDetailsSummary(JobOperationDetailsSummary):
+    """
+    Job details that are specific to import Terraform state operations.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ImportTfStateJobOperationDetailsSummary object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.ImportTfStateJobOperationDetailsSummary.operation` attribute
+        of this class is ``IMPORT_TF_STATE`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this ImportTfStateJobOperationDetailsSummary.
+        :type operation: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation'
+        }
+
+        self._operation = None
+        self._operation = 'IMPORT_TF_STATE'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/job.py
+++ b/src/oci/resource_manager/models/job.py
@@ -16,6 +16,8 @@ class Job(object):
     - **Destroy job**. To clean up the infrastructure controlled by the stack, you run a destroy job.
     A destroy job does not delete the stack or associated job resources,
     but instead releases the resources managed by the stack.
+    - **Import_TF_State job**. An import Terraform state job takes a Terraform state file and sets it as the current
+    state of the stack. This is used to migrate local Terraform environments to Resource Manager.
     """
 
     #: A constant which can be used with the operation property of a Job.
@@ -29,6 +31,10 @@ class Job(object):
     #: A constant which can be used with the operation property of a Job.
     #: This constant has a value of "DESTROY"
     OPERATION_DESTROY = "DESTROY"
+
+    #: A constant which can be used with the operation property of a Job.
+    #: This constant has a value of "IMPORT_TF_STATE"
+    OPERATION_IMPORT_TF_STATE = "IMPORT_TF_STATE"
 
     #: A constant which can be used with the lifecycle_state property of a Job.
     #: This constant has a value of "ACCEPTED"
@@ -77,9 +83,13 @@ class Job(object):
 
         :param operation:
             The value to assign to the operation property of this Job.
-            Allowed values for this property are: "PLAN", "APPLY", "DESTROY", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PLAN", "APPLY", "DESTROY", "IMPORT_TF_STATE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type operation: str
+
+        :param job_operation_details:
+            The value to assign to the job_operation_details property of this Job.
+        :type job_operation_details: JobOperationDetails
 
         :param apply_job_plan_resolution:
             The value to assign to the apply_job_plan_resolution property of this Job.
@@ -130,6 +140,7 @@ class Job(object):
             'compartment_id': 'str',
             'display_name': 'str',
             'operation': 'str',
+            'job_operation_details': 'JobOperationDetails',
             'apply_job_plan_resolution': 'ApplyJobPlanResolution',
             'resolved_plan_job_id': 'str',
             'time_created': 'datetime',
@@ -148,6 +159,7 @@ class Job(object):
             'compartment_id': 'compartmentId',
             'display_name': 'displayName',
             'operation': 'operation',
+            'job_operation_details': 'jobOperationDetails',
             'apply_job_plan_resolution': 'applyJobPlanResolution',
             'resolved_plan_job_id': 'resolvedPlanJobId',
             'time_created': 'timeCreated',
@@ -165,6 +177,7 @@ class Job(object):
         self._compartment_id = None
         self._display_name = None
         self._operation = None
+        self._job_operation_details = None
         self._apply_job_plan_resolution = None
         self._resolved_plan_job_id = None
         self._time_created = None
@@ -278,7 +291,7 @@ class Job(object):
         Gets the operation of this Job.
         The type of job executing.
 
-        Allowed values for this property are: "PLAN", "APPLY", "DESTROY", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PLAN", "APPLY", "DESTROY", "IMPORT_TF_STATE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -297,15 +310,41 @@ class Job(object):
         :param operation: The operation of this Job.
         :type: str
         """
-        allowed_values = ["PLAN", "APPLY", "DESTROY"]
+        allowed_values = ["PLAN", "APPLY", "DESTROY", "IMPORT_TF_STATE"]
         if not value_allowed_none_or_none_sentinel(operation, allowed_values):
             operation = 'UNKNOWN_ENUM_VALUE'
         self._operation = operation
 
     @property
+    def job_operation_details(self):
+        """
+        Gets the job_operation_details of this Job.
+        Job details that are specific to the operation type.
+
+
+        :return: The job_operation_details of this Job.
+        :rtype: JobOperationDetails
+        """
+        return self._job_operation_details
+
+    @job_operation_details.setter
+    def job_operation_details(self, job_operation_details):
+        """
+        Sets the job_operation_details of this Job.
+        Job details that are specific to the operation type.
+
+
+        :param job_operation_details: The job_operation_details of this Job.
+        :type: JobOperationDetails
+        """
+        self._job_operation_details = job_operation_details
+
+    @property
     def apply_job_plan_resolution(self):
         """
         Gets the apply_job_plan_resolution of this Job.
+        Deprecated. Use the property `executionPlanStrategy` in `jobOperationDetails` instead.
+
 
         :return: The apply_job_plan_resolution of this Job.
         :rtype: ApplyJobPlanResolution
@@ -316,6 +355,8 @@ class Job(object):
     def apply_job_plan_resolution(self, apply_job_plan_resolution):
         """
         Sets the apply_job_plan_resolution of this Job.
+        Deprecated. Use the property `executionPlanStrategy` in `jobOperationDetails` instead.
+
 
         :param apply_job_plan_resolution: The apply_job_plan_resolution of this Job.
         :type: ApplyJobPlanResolution
@@ -326,6 +367,7 @@ class Job(object):
     def resolved_plan_job_id(self):
         """
         Gets the resolved_plan_job_id of this Job.
+        Deprecated. Use the property `executionPlanJobId` in `jobOperationDetails` instead.
         The plan job OCID that was used (if this was an apply job and was not auto-approved).
 
 
@@ -338,6 +380,7 @@ class Job(object):
     def resolved_plan_job_id(self, resolved_plan_job_id):
         """
         Sets the resolved_plan_job_id of this Job.
+        Deprecated. Use the property `executionPlanJobId` in `jobOperationDetails` instead.
         The plan job OCID that was used (if this was an apply job and was not auto-approved).
 
 

--- a/src/oci/resource_manager/models/job_operation_details.py
+++ b/src/oci/resource_manager/models/job_operation_details.py
@@ -1,0 +1,98 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class JobOperationDetails(object):
+    """
+    Job details that are specific to the operation type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new JobOperationDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.resource_manager.models.ImportTfStateJobOperationDetails`
+        * :class:`~oci.resource_manager.models.PlanJobOperationDetails`
+        * :class:`~oci.resource_manager.models.ApplyJobOperationDetails`
+        * :class:`~oci.resource_manager.models.DestroyJobOperationDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this JobOperationDetails.
+        :type operation: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation'
+        }
+
+        self._operation = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['operation']
+
+        if type == 'IMPORT_TF_STATE':
+            return 'ImportTfStateJobOperationDetails'
+
+        if type == 'PLAN':
+            return 'PlanJobOperationDetails'
+
+        if type == 'APPLY':
+            return 'ApplyJobOperationDetails'
+
+        if type == 'DESTROY':
+            return 'DestroyJobOperationDetails'
+        else:
+            return 'JobOperationDetails'
+
+    @property
+    def operation(self):
+        """
+        **[Required]** Gets the operation of this JobOperationDetails.
+        Terraform-specific operation to execute.
+
+
+        :return: The operation of this JobOperationDetails.
+        :rtype: str
+        """
+        return self._operation
+
+    @operation.setter
+    def operation(self, operation):
+        """
+        Sets the operation of this JobOperationDetails.
+        Terraform-specific operation to execute.
+
+
+        :param operation: The operation of this JobOperationDetails.
+        :type: str
+        """
+        self._operation = operation
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/job_operation_details_summary.py
+++ b/src/oci/resource_manager/models/job_operation_details_summary.py
@@ -1,0 +1,98 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class JobOperationDetailsSummary(object):
+    """
+    Job details that are specific to the operation type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new JobOperationDetailsSummary object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.resource_manager.models.ImportTfStateJobOperationDetailsSummary`
+        * :class:`~oci.resource_manager.models.PlanJobOperationDetailsSummary`
+        * :class:`~oci.resource_manager.models.DestroyJobOperationDetailsSummary`
+        * :class:`~oci.resource_manager.models.ApplyJobOperationDetailsSummary`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this JobOperationDetailsSummary.
+        :type operation: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation'
+        }
+
+        self._operation = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['operation']
+
+        if type == 'IMPORT_TF_STATE':
+            return 'ImportTfStateJobOperationDetailsSummary'
+
+        if type == 'PLAN':
+            return 'PlanJobOperationDetailsSummary'
+
+        if type == 'DESTROY':
+            return 'DestroyJobOperationDetailsSummary'
+
+        if type == 'APPLY':
+            return 'ApplyJobOperationDetailsSummary'
+        else:
+            return 'JobOperationDetailsSummary'
+
+    @property
+    def operation(self):
+        """
+        **[Required]** Gets the operation of this JobOperationDetailsSummary.
+        Terraform-specific operation to execute.
+
+
+        :return: The operation of this JobOperationDetailsSummary.
+        :rtype: str
+        """
+        return self._operation
+
+    @operation.setter
+    def operation(self, operation):
+        """
+        Sets the operation of this JobOperationDetailsSummary.
+        Terraform-specific operation to execute.
+
+
+        :param operation: The operation of this JobOperationDetailsSummary.
+        :type: str
+        """
+        self._operation = operation
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/job_summary.py
+++ b/src/oci/resource_manager/models/job_summary.py
@@ -37,6 +37,10 @@ class JobSummary(object):
             The value to assign to the operation property of this JobSummary.
         :type operation: str
 
+        :param job_operation_details:
+            The value to assign to the job_operation_details property of this JobSummary.
+        :type job_operation_details: JobOperationDetailsSummary
+
         :param apply_job_plan_resolution:
             The value to assign to the apply_job_plan_resolution property of this JobSummary.
         :type apply_job_plan_resolution: ApplyJobPlanResolution
@@ -72,6 +76,7 @@ class JobSummary(object):
             'compartment_id': 'str',
             'display_name': 'str',
             'operation': 'str',
+            'job_operation_details': 'JobOperationDetailsSummary',
             'apply_job_plan_resolution': 'ApplyJobPlanResolution',
             'resolved_plan_job_id': 'str',
             'time_created': 'datetime',
@@ -87,6 +92,7 @@ class JobSummary(object):
             'compartment_id': 'compartmentId',
             'display_name': 'displayName',
             'operation': 'operation',
+            'job_operation_details': 'jobOperationDetails',
             'apply_job_plan_resolution': 'applyJobPlanResolution',
             'resolved_plan_job_id': 'resolvedPlanJobId',
             'time_created': 'timeCreated',
@@ -101,6 +107,7 @@ class JobSummary(object):
         self._compartment_id = None
         self._display_name = None
         self._operation = None
+        self._job_operation_details = None
         self._apply_job_plan_resolution = None
         self._resolved_plan_job_id = None
         self._time_created = None
@@ -230,9 +237,35 @@ class JobSummary(object):
         self._operation = operation
 
     @property
+    def job_operation_details(self):
+        """
+        Gets the job_operation_details of this JobSummary.
+        Job details that are specific to the operation type.
+
+
+        :return: The job_operation_details of this JobSummary.
+        :rtype: JobOperationDetailsSummary
+        """
+        return self._job_operation_details
+
+    @job_operation_details.setter
+    def job_operation_details(self, job_operation_details):
+        """
+        Sets the job_operation_details of this JobSummary.
+        Job details that are specific to the operation type.
+
+
+        :param job_operation_details: The job_operation_details of this JobSummary.
+        :type: JobOperationDetailsSummary
+        """
+        self._job_operation_details = job_operation_details
+
+    @property
     def apply_job_plan_resolution(self):
         """
         Gets the apply_job_plan_resolution of this JobSummary.
+        Deprecated. Use the property `executionPlanStrategy` in `jobOperationDetails` instead.
+
 
         :return: The apply_job_plan_resolution of this JobSummary.
         :rtype: ApplyJobPlanResolution
@@ -243,6 +276,8 @@ class JobSummary(object):
     def apply_job_plan_resolution(self, apply_job_plan_resolution):
         """
         Sets the apply_job_plan_resolution of this JobSummary.
+        Deprecated. Use the property `executionPlanStrategy` in `jobOperationDetails` instead.
+
 
         :param apply_job_plan_resolution: The apply_job_plan_resolution of this JobSummary.
         :type: ApplyJobPlanResolution
@@ -253,7 +288,8 @@ class JobSummary(object):
     def resolved_plan_job_id(self):
         """
         Gets the resolved_plan_job_id of this JobSummary.
-        The plan job OCID that was used (if this was an APPLY job and not auto approved).
+        Deprecated. Use the property `executionPlanJobId` in `jobOperationDetails` instead.
+        The plan job OCID that was used (if this was an apply job and was not auto-approved).
 
 
         :return: The resolved_plan_job_id of this JobSummary.
@@ -265,7 +301,8 @@ class JobSummary(object):
     def resolved_plan_job_id(self, resolved_plan_job_id):
         """
         Sets the resolved_plan_job_id of this JobSummary.
-        The plan job OCID that was used (if this was an APPLY job and not auto approved).
+        Deprecated. Use the property `executionPlanJobId` in `jobOperationDetails` instead.
+        The plan job OCID that was used (if this was an apply job and was not auto-approved).
 
 
         :param resolved_plan_job_id: The resolved_plan_job_id of this JobSummary.

--- a/src/oci/resource_manager/models/plan_job_operation_details.py
+++ b/src/oci/resource_manager/models/plan_job_operation_details.py
@@ -1,0 +1,47 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .job_operation_details import JobOperationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PlanJobOperationDetails(JobOperationDetails):
+    """
+    Job details that are specific to plan operations.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PlanJobOperationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.PlanJobOperationDetails.operation` attribute
+        of this class is ``PLAN`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this PlanJobOperationDetails.
+        :type operation: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation'
+        }
+
+        self._operation = None
+        self._operation = 'PLAN'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/plan_job_operation_details_summary.py
+++ b/src/oci/resource_manager/models/plan_job_operation_details_summary.py
@@ -1,0 +1,47 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .job_operation_details_summary import JobOperationDetailsSummary
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PlanJobOperationDetailsSummary(JobOperationDetailsSummary):
+    """
+    Job details that are specific to plan operations.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PlanJobOperationDetailsSummary object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.PlanJobOperationDetailsSummary.operation` attribute
+        of this class is ``PLAN`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation:
+            The value to assign to the operation property of this PlanJobOperationDetailsSummary.
+        :type operation: str
+
+        """
+        self.swagger_types = {
+            'operation': 'str'
+        }
+
+        self.attribute_map = {
+            'operation': 'operation'
+        }
+
+        self._operation = None
+        self._operation = 'PLAN'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "2.4.0"
+__version__ = "2.5.0"


### PR DESCRIPTION
## Added

- Support for importing state files in the Resource Manager service

- Support for Exadata Cloud at Customer in the Database service

- Support for free tier resources and system tags in the Load Balancing service

- Support for free tier resources and system tags in the Compute service

- Support for free tier resources and system tags in the Block Storage service

- Support for free tier and system tags on autonomous databases in the Database service



## Breaking

- The availability_domain parameter is now a kwarg for list_db_system_shapes in DatabaseClient

- The model CreateDbHomeWithDbSystemIdBase was renamed CreateDbHomeBase and the parameter db_system_id was removed

- The parameter create_db_home_with_db_system_id_details for create_db_home in DatabaseClient changed from CreateDbHomeWithDbSystemIdBase to CreateDbHomeBase
