### PR TITLE
Releasing version 2.6.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 ====================
+2.6.0 - 2019-10-08
+====================
+
+Added
+-----
+* Support for the new schema for events in the Audit service
+* Support for entitlements in the Data Transfer service
+* Support for custom scheduled backup policies on volumes in the Block Storage service
+* Support for specifying the network type when launching virtual machine instances in the Compute service
+* Support for Monitoring service integration in the Health Checks service
+
+Breaking
+--------
+* The tenant_id parameter is now id (Id of the Transfer Application Entitlement) for get_transfer_appliance_entitlement in TransferApplianceEntitlementClient
+* The topic_attributes_details parameter is now required for update_topic in NotificationControlPlaneClient
+* The Audit service version was bumped to 20190901, use older version of Python SDK for Audit service version 20160918
+
+====================
 2.5.2 - 2019-10-01
 ====================
 

--- a/docs/api/audit.rst
+++ b/docs/api/audit.rst
@@ -20,4 +20,9 @@ Audit
 
     oci.audit.models.AuditEvent
     oci.audit.models.Configuration
+    oci.audit.models.Data
+    oci.audit.models.Identity
+    oci.audit.models.Request
+    oci.audit.models.Response
+    oci.audit.models.StateChange
     oci.audit.models.UpdateConfigurationDetails

--- a/docs/api/audit/models/oci.audit.models.Data.rst
+++ b/docs/api/audit/models/oci.audit.models.Data.rst
@@ -1,0 +1,11 @@
+Data
+====
+
+.. currentmodule:: oci.audit.models
+
+.. autoclass:: Data
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/audit/models/oci.audit.models.Identity.rst
+++ b/docs/api/audit/models/oci.audit.models.Identity.rst
@@ -1,0 +1,11 @@
+Identity
+========
+
+.. currentmodule:: oci.audit.models
+
+.. autoclass:: Identity
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/audit/models/oci.audit.models.Request.rst
+++ b/docs/api/audit/models/oci.audit.models.Request.rst
@@ -1,0 +1,11 @@
+Request
+=======
+
+.. currentmodule:: oci.audit.models
+
+.. autoclass:: Request
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/audit/models/oci.audit.models.Response.rst
+++ b/docs/api/audit/models/oci.audit.models.Response.rst
@@ -1,0 +1,11 @@
+Response
+========
+
+.. currentmodule:: oci.audit.models
+
+.. autoclass:: Response
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/audit/models/oci.audit.models.StateChange.rst
+++ b/docs/api/audit/models/oci.audit.models.StateChange.rst
@@ -1,0 +1,11 @@
+StateChange
+===========
+
+.. currentmodule:: oci.audit.models
+
+.. autoclass:: StateChange
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -132,6 +132,7 @@ Core Services
     oci.core.models.CreateVnicDetails
     oci.core.models.CreateVolumeBackupDetails
     oci.core.models.CreateVolumeBackupPolicyAssignmentDetails
+    oci.core.models.CreateVolumeBackupPolicyDetails
     oci.core.models.CreateVolumeDetails
     oci.core.models.CreateVolumeGroupBackupDetails
     oci.core.models.CreateVolumeGroupDetails
@@ -279,6 +280,7 @@ Core Services
     oci.core.models.UpdateVirtualCircuitDetails
     oci.core.models.UpdateVnicDetails
     oci.core.models.UpdateVolumeBackupDetails
+    oci.core.models.UpdateVolumeBackupPolicyDetails
     oci.core.models.UpdateVolumeDetails
     oci.core.models.UpdateVolumeGroupBackupDetails
     oci.core.models.UpdateVolumeGroupDetails

--- a/docs/api/core/models/oci.core.models.CreateVolumeBackupPolicyDetails.rst
+++ b/docs/api/core/models/oci.core.models.CreateVolumeBackupPolicyDetails.rst
@@ -1,0 +1,11 @@
+CreateVolumeBackupPolicyDetails
+===============================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: CreateVolumeBackupPolicyDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.UpdateVolumeBackupPolicyDetails.rst
+++ b/docs/api/core/models/oci.core.models.UpdateVolumeBackupPolicyDetails.rst
@@ -1,0 +1,11 @@
+UpdateVolumeBackupPolicyDetails
+===============================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: UpdateVolumeBackupPolicyDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/dts.rst
+++ b/docs/api/dts.rst
@@ -46,6 +46,7 @@ Dts
     oci.dts.models.TransferApplianceCertificate
     oci.dts.models.TransferApplianceEncryptionPassphrase
     oci.dts.models.TransferApplianceEntitlement
+    oci.dts.models.TransferApplianceEntitlementSummary
     oci.dts.models.TransferAppliancePublicKey
     oci.dts.models.TransferApplianceSummary
     oci.dts.models.TransferDevice

--- a/docs/api/dts/models/oci.dts.models.TransferApplianceEntitlementSummary.rst
+++ b/docs/api/dts/models/oci.dts.models.TransferApplianceEntitlementSummary.rst
@@ -1,0 +1,11 @@
+TransferApplianceEntitlementSummary
+===================================
+
+.. currentmodule:: oci.dts.models
+
+.. autoclass:: TransferApplianceEntitlementSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ mock==2.0.0
 pyOpenSSL==18.0.0
 pytest==4.1.0
 pytest-cov==2.6.1
+attrs==19.1.0
 python-dateutil>=2.5.3,<=2.7.3
 pytz>=2016.10
 sphinx-rtd-theme==0.4.2

--- a/src/oci/audit/audit_client.py
+++ b/src/oci/audit/audit_client.py
@@ -17,7 +17,10 @@ missing = Sentinel("Missing")
 
 class AuditClient(object):
     """
-    API for the Audit Service. You can use this API for queries, but not bulk-export operations.
+    API for the Audit Service. Use this API for compliance monitoring in your tenancy.
+    For more information, see [Overview of Audit](/iaas/Content/Audit/Concepts/auditoverview.htm).
+
+    **Tip**: This API is good for queries, but not bulk-export operations.
     """
 
     def __init__(self, config, **kwargs):
@@ -73,7 +76,8 @@ class AuditClient(object):
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
-            'base_path': '/20160918',
+            'base_path': '/20190901',
+            'service_endpoint_template': 'https://audit.{region}.oraclecloud.com',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("audit", config, signer, audit_type_mapping, **base_client_init_kwargs)
@@ -141,32 +145,47 @@ class AuditClient(object):
     def list_events(self, compartment_id, start_time, end_time, **kwargs):
         """
         ListEvents
-        Returns all audit events for the specified compartment that were processed within the specified time range.
+        Returns all the audit events processed for the specified compartment within the specified
+        time range.
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param datetime start_time: (required)
-            Returns events that were processed at or after this start date and time, expressed in `RFC 3339`__ timestamp format.
-            For example, a start value of `2017-01-15T11:30:00Z` will retrieve a list of all events processed since 30 minutes after the 11th hour of January 15, 2017, in Coordinated Universal Time (UTC).
-            You can specify a value with granularity to the minute. Seconds (and milliseconds, if included) must be set to `0`.
+            Returns events that were processed at or after this start date and time, expressed in
+            `RFC 3339`__ timestamp format.
+
+            For example, a start value of `2017-01-15T11:30:00Z` will retrieve a list of all events processed
+            since 30 minutes after the 11th hour of January 15, 2017, in Coordinated Universal Time (UTC).
+            You can specify a value with granularity to the minute. Seconds (and milliseconds, if included) must
+            be set to `0`.
 
             __ https://tools.ietf.org/html/rfc3339
 
         :param datetime end_time: (required)
-            Returns events that were processed before this end date and time, expressed in `RFC 3339`__ timestamp format. For example, a start value of `2017-01-01T00:00:00Z` and an end value of `2017-01-02T00:00:00Z` will retrieve a list of all events processed on January 1, 2017.
-            Similarly, a start value of `2017-01-01T00:00:00Z` and an end value of `2017-02-01T00:00:00Z` will result in a list of all events processed between January 1, 2017 and January 31, 2017.
-            You can specify a value with granularity to the minute. Seconds (and milliseconds, if included) must be set to `0`.
+            Returns events that were processed before this end date and time, expressed in
+            `RFC 3339`__ timestamp format.
+
+            For example, a start value of `2017-01-01T00:00:00Z` and an end value of `2017-01-02T00:00:00Z`
+            will retrieve a list of all events processed on January 1, 2017. Similarly, a start value of
+            `2017-01-01T00:00:00Z` and an end value of `2017-02-01T00:00:00Z` will result in a list of all
+            events processed between January 1, 2017 and January 31, 2017. You can specify a value with
+            granularity to the minute. Seconds (and milliseconds, if included) must be set to `0`.
 
             __ https://tools.ietf.org/html/rfc3339
 
         :param str page: (optional)
-            The value of the `opc-next-page` response header from the previous list query.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call.
+            For important details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request.
-            If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.

--- a/src/oci/audit/models/__init__.py
+++ b/src/oci/audit/models/__init__.py
@@ -5,11 +5,21 @@ from __future__ import absolute_import
 
 from .audit_event import AuditEvent
 from .configuration import Configuration
+from .data import Data
+from .identity import Identity
+from .request import Request
+from .response import Response
+from .state_change import StateChange
 from .update_configuration_details import UpdateConfigurationDetails
 
 # Maps type names to classes for audit services.
 audit_type_mapping = {
     "AuditEvent": AuditEvent,
     "Configuration": Configuration,
+    "Data": Data,
+    "Identity": Identity,
+    "Request": Request,
+    "Response": Response,
+    "StateChange": StateChange,
     "UpdateConfigurationDetails": UpdateConfigurationDetails
 }

--- a/src/oci/audit/models/audit_event.py
+++ b/src/oci/audit/models/audit_event.py
@@ -9,7 +9,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class AuditEvent(object):
     """
-    AuditEvent model.
+    All the attributes of an audit event. For more information, see `Viewing Audit Log Events`__.
+
+    __ https://docs.cloud.oracle.com/iaas/Content/Audit/Tasks/viewinglogevents.htm
     """
 
     def __init__(self, **kwargs):
@@ -17,241 +19,205 @@ class AuditEvent(object):
         Initializes a new AuditEvent object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
-        :param tenant_id:
-            The value to assign to the tenant_id property of this AuditEvent.
-        :type tenant_id: str
+        :param event_type:
+            The value to assign to the event_type property of this AuditEvent.
+        :type event_type: str
 
-        :param compartment_id:
-            The value to assign to the compartment_id property of this AuditEvent.
-        :type compartment_id: str
+        :param cloud_events_version:
+            The value to assign to the cloud_events_version property of this AuditEvent.
+        :type cloud_events_version: str
 
-        :param compartment_name:
-            The value to assign to the compartment_name property of this AuditEvent.
-        :type compartment_name: str
+        :param event_type_version:
+            The value to assign to the event_type_version property of this AuditEvent.
+        :type event_type_version: str
+
+        :param source:
+            The value to assign to the source property of this AuditEvent.
+        :type source: str
 
         :param event_id:
             The value to assign to the event_id property of this AuditEvent.
         :type event_id: str
 
-        :param event_name:
-            The value to assign to the event_name property of this AuditEvent.
-        :type event_name: str
-
-        :param event_source:
-            The value to assign to the event_source property of this AuditEvent.
-        :type event_source: str
-
-        :param event_type:
-            The value to assign to the event_type property of this AuditEvent.
-        :type event_type: str
-
         :param event_time:
             The value to assign to the event_time property of this AuditEvent.
         :type event_time: datetime
 
-        :param principal_id:
-            The value to assign to the principal_id property of this AuditEvent.
-        :type principal_id: str
+        :param content_type:
+            The value to assign to the content_type property of this AuditEvent.
+        :type content_type: str
 
-        :param credential_id:
-            The value to assign to the credential_id property of this AuditEvent.
-        :type credential_id: str
-
-        :param request_action:
-            The value to assign to the request_action property of this AuditEvent.
-        :type request_action: str
-
-        :param request_id:
-            The value to assign to the request_id property of this AuditEvent.
-        :type request_id: str
-
-        :param request_agent:
-            The value to assign to the request_agent property of this AuditEvent.
-        :type request_agent: str
-
-        :param request_headers:
-            The value to assign to the request_headers property of this AuditEvent.
-        :type request_headers: dict(str, list[str])
-
-        :param request_origin:
-            The value to assign to the request_origin property of this AuditEvent.
-        :type request_origin: str
-
-        :param request_parameters:
-            The value to assign to the request_parameters property of this AuditEvent.
-        :type request_parameters: dict(str, list[str])
-
-        :param request_resource:
-            The value to assign to the request_resource property of this AuditEvent.
-        :type request_resource: str
-
-        :param response_headers:
-            The value to assign to the response_headers property of this AuditEvent.
-        :type response_headers: dict(str, list[str])
-
-        :param response_status:
-            The value to assign to the response_status property of this AuditEvent.
-        :type response_status: str
-
-        :param response_time:
-            The value to assign to the response_time property of this AuditEvent.
-        :type response_time: datetime
-
-        :param response_payload:
-            The value to assign to the response_payload property of this AuditEvent.
-        :type response_payload: dict(str, object)
-
-        :param user_name:
-            The value to assign to the user_name property of this AuditEvent.
-        :type user_name: str
+        :param data:
+            The value to assign to the data property of this AuditEvent.
+        :type data: Data
 
         """
         self.swagger_types = {
-            'tenant_id': 'str',
-            'compartment_id': 'str',
-            'compartment_name': 'str',
-            'event_id': 'str',
-            'event_name': 'str',
-            'event_source': 'str',
             'event_type': 'str',
+            'cloud_events_version': 'str',
+            'event_type_version': 'str',
+            'source': 'str',
+            'event_id': 'str',
             'event_time': 'datetime',
-            'principal_id': 'str',
-            'credential_id': 'str',
-            'request_action': 'str',
-            'request_id': 'str',
-            'request_agent': 'str',
-            'request_headers': 'dict(str, list[str])',
-            'request_origin': 'str',
-            'request_parameters': 'dict(str, list[str])',
-            'request_resource': 'str',
-            'response_headers': 'dict(str, list[str])',
-            'response_status': 'str',
-            'response_time': 'datetime',
-            'response_payload': 'dict(str, object)',
-            'user_name': 'str'
+            'content_type': 'str',
+            'data': 'Data'
         }
 
         self.attribute_map = {
-            'tenant_id': 'tenantId',
-            'compartment_id': 'compartmentId',
-            'compartment_name': 'compartmentName',
-            'event_id': 'eventId',
-            'event_name': 'eventName',
-            'event_source': 'eventSource',
             'event_type': 'eventType',
+            'cloud_events_version': 'cloudEventsVersion',
+            'event_type_version': 'eventTypeVersion',
+            'source': 'source',
+            'event_id': 'eventId',
             'event_time': 'eventTime',
-            'principal_id': 'principalId',
-            'credential_id': 'credentialId',
-            'request_action': 'requestAction',
-            'request_id': 'requestId',
-            'request_agent': 'requestAgent',
-            'request_headers': 'requestHeaders',
-            'request_origin': 'requestOrigin',
-            'request_parameters': 'requestParameters',
-            'request_resource': 'requestResource',
-            'response_headers': 'responseHeaders',
-            'response_status': 'responseStatus',
-            'response_time': 'responseTime',
-            'response_payload': 'responsePayload',
-            'user_name': 'userName'
+            'content_type': 'contentType',
+            'data': 'data'
         }
 
-        self._tenant_id = None
-        self._compartment_id = None
-        self._compartment_name = None
-        self._event_id = None
-        self._event_name = None
-        self._event_source = None
         self._event_type = None
+        self._cloud_events_version = None
+        self._event_type_version = None
+        self._source = None
+        self._event_id = None
         self._event_time = None
-        self._principal_id = None
-        self._credential_id = None
-        self._request_action = None
-        self._request_id = None
-        self._request_agent = None
-        self._request_headers = None
-        self._request_origin = None
-        self._request_parameters = None
-        self._request_resource = None
-        self._response_headers = None
-        self._response_status = None
-        self._response_time = None
-        self._response_payload = None
-        self._user_name = None
+        self._content_type = None
+        self._data = None
 
     @property
-    def tenant_id(self):
+    def event_type(self):
         """
-        Gets the tenant_id of this AuditEvent.
-        The OCID of the tenant.
+        Gets the event_type of this AuditEvent.
+        The type of event that happened.
+
+        The service that produces the event can also add, remove, or change the meaning of a field.
+        A service implementing these type changes would publish a new version of an `eventType` and
+        revise the `eventTypeVersion` field.
+
+        Example: `com.oraclecloud.ComputeApi.GetInstance`
 
 
-        :return: The tenant_id of this AuditEvent.
+        :return: The event_type of this AuditEvent.
         :rtype: str
         """
-        return self._tenant_id
+        return self._event_type
 
-    @tenant_id.setter
-    def tenant_id(self, tenant_id):
+    @event_type.setter
+    def event_type(self, event_type):
         """
-        Sets the tenant_id of this AuditEvent.
-        The OCID of the tenant.
+        Sets the event_type of this AuditEvent.
+        The type of event that happened.
+
+        The service that produces the event can also add, remove, or change the meaning of a field.
+        A service implementing these type changes would publish a new version of an `eventType` and
+        revise the `eventTypeVersion` field.
+
+        Example: `com.oraclecloud.ComputeApi.GetInstance`
 
 
-        :param tenant_id: The tenant_id of this AuditEvent.
+        :param event_type: The event_type of this AuditEvent.
         :type: str
         """
-        self._tenant_id = tenant_id
+        self._event_type = event_type
 
     @property
-    def compartment_id(self):
+    def cloud_events_version(self):
         """
-        Gets the compartment_id of this AuditEvent.
-        The OCID of the compartment.
+        Gets the cloud_events_version of this AuditEvent.
+        The version of the CloudEvents specification. The structure of the envelope follows the
+        `CloudEvents`__ industry standard format hosted by the
+        `Cloud Native Computing Foundation ( CNCF)`__.
+
+        Audit uses version 0.1 specification of the CloudEvents event envelope.
+
+        Example: `0.1`
+
+        __ https://github.com/cloudevents/spec
+        __ https://www.cncf.io/
 
 
-        :return: The compartment_id of this AuditEvent.
+        :return: The cloud_events_version of this AuditEvent.
         :rtype: str
         """
-        return self._compartment_id
+        return self._cloud_events_version
 
-    @compartment_id.setter
-    def compartment_id(self, compartment_id):
+    @cloud_events_version.setter
+    def cloud_events_version(self, cloud_events_version):
         """
-        Sets the compartment_id of this AuditEvent.
-        The OCID of the compartment.
+        Sets the cloud_events_version of this AuditEvent.
+        The version of the CloudEvents specification. The structure of the envelope follows the
+        `CloudEvents`__ industry standard format hosted by the
+        `Cloud Native Computing Foundation ( CNCF)`__.
+
+        Audit uses version 0.1 specification of the CloudEvents event envelope.
+
+        Example: `0.1`
+
+        __ https://github.com/cloudevents/spec
+        __ https://www.cncf.io/
 
 
-        :param compartment_id: The compartment_id of this AuditEvent.
+        :param cloud_events_version: The cloud_events_version of this AuditEvent.
         :type: str
         """
-        self._compartment_id = compartment_id
+        self._cloud_events_version = cloud_events_version
 
     @property
-    def compartment_name(self):
+    def event_type_version(self):
         """
-        Gets the compartment_name of this AuditEvent.
-        The name of the compartment. This value is the friendly name associated with compartmentId.
-        This value can change, but the service logs the value that appeared at the time of the audit event.
+        Gets the event_type_version of this AuditEvent.
+        The version of the event type. This version applies to the payload of the event, not the envelope.
+        Use `cloudEventsVersion` to determine the version of the envelope.
+
+        Example: `2.0`
 
 
-        :return: The compartment_name of this AuditEvent.
+        :return: The event_type_version of this AuditEvent.
         :rtype: str
         """
-        return self._compartment_name
+        return self._event_type_version
 
-    @compartment_name.setter
-    def compartment_name(self, compartment_name):
+    @event_type_version.setter
+    def event_type_version(self, event_type_version):
         """
-        Sets the compartment_name of this AuditEvent.
-        The name of the compartment. This value is the friendly name associated with compartmentId.
-        This value can change, but the service logs the value that appeared at the time of the audit event.
+        Sets the event_type_version of this AuditEvent.
+        The version of the event type. This version applies to the payload of the event, not the envelope.
+        Use `cloudEventsVersion` to determine the version of the envelope.
+
+        Example: `2.0`
 
 
-        :param compartment_name: The compartment_name of this AuditEvent.
+        :param event_type_version: The event_type_version of this AuditEvent.
         :type: str
         """
-        self._compartment_name = compartment_name
+        self._event_type_version = event_type_version
+
+    @property
+    def source(self):
+        """
+        Gets the source of this AuditEvent.
+        The source of the event.
+
+        Example: `ComputeApi`
+
+
+        :return: The source of this AuditEvent.
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """
+        Sets the source of this AuditEvent.
+        The source of the event.
+
+        Example: `ComputeApi`
+
+
+        :param source: The source of this AuditEvent.
+        :type: str
+        """
+        self._source = source
 
     @property
     def event_id(self):
@@ -278,84 +244,12 @@ class AuditEvent(object):
         self._event_id = event_id
 
     @property
-    def event_name(self):
-        """
-        Gets the event_name of this AuditEvent.
-        The name of the event.
-        Example: `LaunchInstance`
-
-
-        :return: The event_name of this AuditEvent.
-        :rtype: str
-        """
-        return self._event_name
-
-    @event_name.setter
-    def event_name(self, event_name):
-        """
-        Sets the event_name of this AuditEvent.
-        The name of the event.
-        Example: `LaunchInstance`
-
-
-        :param event_name: The event_name of this AuditEvent.
-        :type: str
-        """
-        self._event_name = event_name
-
-    @property
-    def event_source(self):
-        """
-        Gets the event_source of this AuditEvent.
-        The source of the event.
-
-
-        :return: The event_source of this AuditEvent.
-        :rtype: str
-        """
-        return self._event_source
-
-    @event_source.setter
-    def event_source(self, event_source):
-        """
-        Sets the event_source of this AuditEvent.
-        The source of the event.
-
-
-        :param event_source: The event_source of this AuditEvent.
-        :type: str
-        """
-        self._event_source = event_source
-
-    @property
-    def event_type(self):
-        """
-        Gets the event_type of this AuditEvent.
-        The type of the event.
-
-
-        :return: The event_type of this AuditEvent.
-        :rtype: str
-        """
-        return self._event_type
-
-    @event_type.setter
-    def event_type(self, event_type):
-        """
-        Sets the event_type of this AuditEvent.
-        The type of the event.
-
-
-        :param event_type: The event_type of this AuditEvent.
-        :type: str
-        """
-        self._event_type = event_type
-
-    @property
     def event_time(self):
         """
         Gets the event_time of this AuditEvent.
         The time the event occurred, expressed in `RFC 3339`__ timestamp format.
+
+        Example: `2019-09-18T00:10:59.252Z`
 
         __ https://tools.ietf.org/html/rfc3339
 
@@ -371,6 +265,8 @@ class AuditEvent(object):
         Sets the event_time of this AuditEvent.
         The time the event occurred, expressed in `RFC 3339`__ timestamp format.
 
+        Example: `2019-09-18T00:10:59.252Z`
+
         __ https://tools.ietf.org/html/rfc3339
 
 
@@ -380,344 +276,52 @@ class AuditEvent(object):
         self._event_time = event_time
 
     @property
-    def principal_id(self):
+    def content_type(self):
         """
-        Gets the principal_id of this AuditEvent.
-        The OCID of the user whose action triggered the event.
+        Gets the content_type of this AuditEvent.
+        The content type of the data contained in `data`.
+
+        Example: `application/json`
 
 
-        :return: The principal_id of this AuditEvent.
+        :return: The content_type of this AuditEvent.
         :rtype: str
         """
-        return self._principal_id
+        return self._content_type
 
-    @principal_id.setter
-    def principal_id(self, principal_id):
+    @content_type.setter
+    def content_type(self, content_type):
         """
-        Sets the principal_id of this AuditEvent.
-        The OCID of the user whose action triggered the event.
+        Sets the content_type of this AuditEvent.
+        The content type of the data contained in `data`.
+
+        Example: `application/json`
 
 
-        :param principal_id: The principal_id of this AuditEvent.
+        :param content_type: The content_type of this AuditEvent.
         :type: str
         """
-        self._principal_id = principal_id
+        self._content_type = content_type
 
     @property
-    def credential_id(self):
+    def data(self):
         """
-        Gets the credential_id of this AuditEvent.
-        The credential ID of the user. This value is extracted from the HTTP 'Authorization' request header. It consists of the tenantId, userId, and user fingerprint, all delimited by a slash (/).
+        Gets the data of this AuditEvent.
 
-
-        :return: The credential_id of this AuditEvent.
-        :rtype: str
+        :return: The data of this AuditEvent.
+        :rtype: Data
         """
-        return self._credential_id
+        return self._data
 
-    @credential_id.setter
-    def credential_id(self, credential_id):
+    @data.setter
+    def data(self, data):
         """
-        Sets the credential_id of this AuditEvent.
-        The credential ID of the user. This value is extracted from the HTTP 'Authorization' request header. It consists of the tenantId, userId, and user fingerprint, all delimited by a slash (/).
+        Sets the data of this AuditEvent.
 
-
-        :param credential_id: The credential_id of this AuditEvent.
-        :type: str
+        :param data: The data of this AuditEvent.
+        :type: Data
         """
-        self._credential_id = credential_id
-
-    @property
-    def request_action(self):
-        """
-        Gets the request_action of this AuditEvent.
-        The HTTP method of the request.
-
-
-        :return: The request_action of this AuditEvent.
-        :rtype: str
-        """
-        return self._request_action
-
-    @request_action.setter
-    def request_action(self, request_action):
-        """
-        Sets the request_action of this AuditEvent.
-        The HTTP method of the request.
-
-
-        :param request_action: The request_action of this AuditEvent.
-        :type: str
-        """
-        self._request_action = request_action
-
-    @property
-    def request_id(self):
-        """
-        Gets the request_id of this AuditEvent.
-        The opc-request-id of the request.
-
-
-        :return: The request_id of this AuditEvent.
-        :rtype: str
-        """
-        return self._request_id
-
-    @request_id.setter
-    def request_id(self, request_id):
-        """
-        Sets the request_id of this AuditEvent.
-        The opc-request-id of the request.
-
-
-        :param request_id: The request_id of this AuditEvent.
-        :type: str
-        """
-        self._request_id = request_id
-
-    @property
-    def request_agent(self):
-        """
-        Gets the request_agent of this AuditEvent.
-        The user agent of the client that made the request.
-
-
-        :return: The request_agent of this AuditEvent.
-        :rtype: str
-        """
-        return self._request_agent
-
-    @request_agent.setter
-    def request_agent(self, request_agent):
-        """
-        Sets the request_agent of this AuditEvent.
-        The user agent of the client that made the request.
-
-
-        :param request_agent: The request_agent of this AuditEvent.
-        :type: str
-        """
-        self._request_agent = request_agent
-
-    @property
-    def request_headers(self):
-        """
-        Gets the request_headers of this AuditEvent.
-        The HTTP header fields and values in the request.
-
-
-        :return: The request_headers of this AuditEvent.
-        :rtype: dict(str, list[str])
-        """
-        return self._request_headers
-
-    @request_headers.setter
-    def request_headers(self, request_headers):
-        """
-        Sets the request_headers of this AuditEvent.
-        The HTTP header fields and values in the request.
-
-
-        :param request_headers: The request_headers of this AuditEvent.
-        :type: dict(str, list[str])
-        """
-        self._request_headers = request_headers
-
-    @property
-    def request_origin(self):
-        """
-        Gets the request_origin of this AuditEvent.
-        The IP address of the source of the request.
-
-
-        :return: The request_origin of this AuditEvent.
-        :rtype: str
-        """
-        return self._request_origin
-
-    @request_origin.setter
-    def request_origin(self, request_origin):
-        """
-        Sets the request_origin of this AuditEvent.
-        The IP address of the source of the request.
-
-
-        :param request_origin: The request_origin of this AuditEvent.
-        :type: str
-        """
-        self._request_origin = request_origin
-
-    @property
-    def request_parameters(self):
-        """
-        Gets the request_parameters of this AuditEvent.
-        The query parameter fields and values for the request.
-
-
-        :return: The request_parameters of this AuditEvent.
-        :rtype: dict(str, list[str])
-        """
-        return self._request_parameters
-
-    @request_parameters.setter
-    def request_parameters(self, request_parameters):
-        """
-        Sets the request_parameters of this AuditEvent.
-        The query parameter fields and values for the request.
-
-
-        :param request_parameters: The request_parameters of this AuditEvent.
-        :type: dict(str, list[str])
-        """
-        self._request_parameters = request_parameters
-
-    @property
-    def request_resource(self):
-        """
-        Gets the request_resource of this AuditEvent.
-        The resource targeted by the request.
-
-
-        :return: The request_resource of this AuditEvent.
-        :rtype: str
-        """
-        return self._request_resource
-
-    @request_resource.setter
-    def request_resource(self, request_resource):
-        """
-        Sets the request_resource of this AuditEvent.
-        The resource targeted by the request.
-
-
-        :param request_resource: The request_resource of this AuditEvent.
-        :type: str
-        """
-        self._request_resource = request_resource
-
-    @property
-    def response_headers(self):
-        """
-        Gets the response_headers of this AuditEvent.
-        The headers of the response.
-
-
-        :return: The response_headers of this AuditEvent.
-        :rtype: dict(str, list[str])
-        """
-        return self._response_headers
-
-    @response_headers.setter
-    def response_headers(self, response_headers):
-        """
-        Sets the response_headers of this AuditEvent.
-        The headers of the response.
-
-
-        :param response_headers: The response_headers of this AuditEvent.
-        :type: dict(str, list[str])
-        """
-        self._response_headers = response_headers
-
-    @property
-    def response_status(self):
-        """
-        Gets the response_status of this AuditEvent.
-        The status code of the response.
-
-
-        :return: The response_status of this AuditEvent.
-        :rtype: str
-        """
-        return self._response_status
-
-    @response_status.setter
-    def response_status(self, response_status):
-        """
-        Sets the response_status of this AuditEvent.
-        The status code of the response.
-
-
-        :param response_status: The response_status of this AuditEvent.
-        :type: str
-        """
-        self._response_status = response_status
-
-    @property
-    def response_time(self):
-        """
-        Gets the response_time of this AuditEvent.
-        The time of the response to the audited request, expressed in `RFC 3339`__ timestamp format.
-
-        __ https://tools.ietf.org/html/rfc3339
-
-
-        :return: The response_time of this AuditEvent.
-        :rtype: datetime
-        """
-        return self._response_time
-
-    @response_time.setter
-    def response_time(self, response_time):
-        """
-        Sets the response_time of this AuditEvent.
-        The time of the response to the audited request, expressed in `RFC 3339`__ timestamp format.
-
-        __ https://tools.ietf.org/html/rfc3339
-
-
-        :param response_time: The response_time of this AuditEvent.
-        :type: datetime
-        """
-        self._response_time = response_time
-
-    @property
-    def response_payload(self):
-        """
-        Gets the response_payload of this AuditEvent.
-        Metadata of interest from the response payload. For example, the OCID of a resource.
-
-
-        :return: The response_payload of this AuditEvent.
-        :rtype: dict(str, object)
-        """
-        return self._response_payload
-
-    @response_payload.setter
-    def response_payload(self, response_payload):
-        """
-        Sets the response_payload of this AuditEvent.
-        Metadata of interest from the response payload. For example, the OCID of a resource.
-
-
-        :param response_payload: The response_payload of this AuditEvent.
-        :type: dict(str, object)
-        """
-        self._response_payload = response_payload
-
-    @property
-    def user_name(self):
-        """
-        Gets the user_name of this AuditEvent.
-        The name of the user or service. This value is the friendly name associated with principalId.
-
-
-        :return: The user_name of this AuditEvent.
-        :rtype: str
-        """
-        return self._user_name
-
-    @user_name.setter
-    def user_name(self, user_name):
-        """
-        Sets the user_name of this AuditEvent.
-        The name of the user or service. This value is the friendly name associated with principalId.
-
-
-        :param user_name: The user_name of this AuditEvent.
-        :type: str
-        """
-        self._user_name = user_name
+        self._data = data
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/audit/models/configuration.py
+++ b/src/oci/audit/models/configuration.py
@@ -9,7 +9,10 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Configuration(object):
     """
-    Configuration model.
+    The retention period setting, specified in days. For more information, see `Setting Audit
+    Log Retention Period`__.
+
+    __ https://docs.cloud.oracle.com/iaas/Content/Audit/Tasks/settingretentionperiod.htm
     """
 
     def __init__(self, **kwargs):
@@ -36,7 +39,9 @@ class Configuration(object):
     def retention_period_days(self):
         """
         Gets the retention_period_days of this Configuration.
-        The retention period days
+        The retention period setting, specified in days. The minimum is 90, the maximum 365.
+
+        Example: `90`
 
 
         :return: The retention_period_days of this Configuration.
@@ -48,7 +53,9 @@ class Configuration(object):
     def retention_period_days(self, retention_period_days):
         """
         Sets the retention_period_days of this Configuration.
-        The retention period days
+        The retention period setting, specified in days. The minimum is 90, the maximum 365.
+
+        Example: `90`
 
 
         :param retention_period_days: The retention_period_days of this Configuration.

--- a/src/oci/audit/models/data.py
+++ b/src/oci/audit/models/data.py
@@ -1,0 +1,633 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Data(object):
+    """
+    The payload of the event. Information within `data` comes from the resource emitting the event.
+
+    Example:
+
+    -----
+    {
+    \"eventGroupingId\": null,
+    \"eventName\": \"GetInstance\",
+    \"compartmentId\": \"ocid1.tenancy.oc1..<unique_ID>\",
+    \"compartmentName\": \"compartmentA\",
+    \"resourceName\": \"my_instance\",
+    \"resourceId\": \"ocid1.instance.oc1.phx.<unique_ID>\",
+    \"availabilityDomain\": \"<availability_domain>\",
+    \"freeformTags\": null,
+    \"definedTags\": null,
+    \"identity\": {
+    \"principalName\": \"ExampleName\",
+    \"principalId\": \"ocid1.user.oc1..<unique_ID>\",
+    \"authType\": \"natv\",
+    \"callerName\": null,
+    \"callerId\": null,
+    \"tenantId\": \"ocid1.tenancy.oc1..<unique_ID>\",
+    \"ipAddress\": \"172.24.80.88\",
+    \"credentials\": null,
+    \"userAgent\": \"Jersey/2.23 (HttpUrlConnection 1.8.0_212)\",
+    \"consoleSessionId\": null
+    },
+    \"request\": {
+    \"id\": \"<unique_ID>\",
+    \"path\": \"/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\",
+    \"action\": \"GET\",
+    \"parameters\": {},
+    \"headers\": {
+    \"opc-principal\": [
+    \"{\\\"tenantId\\\":\\\"ocid1.tenancy.oc1..<unique_ID>\\\",\\\"subjectId\\\":\\\"ocid1.user.oc1..<unique_ID>\\\",\\\"claims\\\":[{\\\"key\\\":\\\"pstype\\\",\\\"value\\\":\\\"natv\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_host\\\",\\\"value\\\":\\\"iaas.r2.oracleiaas.com\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_opc-request-id\\\",\\\"value\\\":\\\"<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"ptype\\\",\\\"value\\\":\\\"user\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_date\\\",\\\"value\\\":\\\"Wed, 18 Sep 2019 00:10:58 UTC\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_accept\\\",\\\"value\\\":\\\"application/json\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"authorization\\\",\\\"value\\\":\\\"Signature headers=\\\\\\\"date (request-target) host accept opc-request-id\\\\\\\",keyId=\\\\\\\"ocid1.tenancy.oc1..<unique_ID>/ocid1.user.oc1..<unique_ID>/8c:b4:5f:18:e7:ec:db:08:b8:fa:d2:2a:7d:11:76:ac\\\\\\\",algorithm=\\\\\\\"rsa-pss-sha256\\\\\\\",signature=\\\\\\\"<unique_ID>\\\\\\\",version=\\\\\\\"1\\\\\\\"\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_(request-target)\\\",\\\"value\\\":\\\"get /20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"}]}\"
+    ],
+    \"Accept\": [
+    \"application/json\"
+    ],
+    \"X-Oracle-Auth-Client-CN\": [
+    \"splat-proxy-se-02302.node.ad2.r2\"
+    ],
+    \"X-Forwarded-Host\": [
+    \"compute-api.svc.ad1.r2\"
+    ],
+    \"Connection\": [
+    \"close\"
+    ],
+    \"User-Agent\": [
+    \"Jersey/2.23 (HttpUrlConnection 1.8.0_212)\"
+    ],
+    \"X-Forwarded-For\": [
+    \"172.24.80.88\"
+    ],
+    \"X-Real-IP\": [
+    \"172.24.80.88\"
+    ],
+    \"oci-original-url\": [
+    \"https://iaas.r2.oracleiaas.com/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\"
+    ],
+    \"opc-request-id\": [
+    \"<unique_ID>\"
+    ],
+    \"Date\": [
+    \"Wed, 18 Sep 2019 00:10:58 UTC\"
+    ]
+    }
+    },
+    \"response\": {
+    \"status\": \"200\",
+    \"responseTime\": \"2019-09-18T00:10:59.278Z\",
+    \"headers\": {
+    \"ETag\": [
+    \"<unique_ID>\"
+    ],
+    \"Connection\": [
+    \"close\"
+    ],
+    \"Content-Length\": [
+    \"1828\"
+    ],
+    \"opc-request-id\": [
+    \"<unique_ID>\"
+    ],
+    \"Date\": [
+    \"Wed, 18 Sep 2019 00:10:59 GMT\"
+    ],
+    \"Content-Type\": [
+    \"application/json\"
+    ]
+    },
+    \"payload\": {
+    \"resourceName\": \"my_instance\",
+    \"id\": \"ocid1.instance.oc1.phx.<unique_ID>\"
+    },
+    \"message\": null
+    },
+    \"stateChange\": {
+    \"previous\": null,
+    \"current\": null
+    },
+    \"additionalDetails\": {
+    \"imageId\": \"ocid1.image.oc1.phx.<unique_ID>\",
+    \"shape\": \"VM.Standard1.1\",
+    \"type\": \"CustomerVmi\"
+    }
+    }
+    -----
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Data object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param event_grouping_id:
+            The value to assign to the event_grouping_id property of this Data.
+        :type event_grouping_id: str
+
+        :param event_name:
+            The value to assign to the event_name property of this Data.
+        :type event_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this Data.
+        :type compartment_id: str
+
+        :param compartment_name:
+            The value to assign to the compartment_name property of this Data.
+        :type compartment_name: str
+
+        :param resource_name:
+            The value to assign to the resource_name property of this Data.
+        :type resource_name: str
+
+        :param resource_id:
+            The value to assign to the resource_id property of this Data.
+        :type resource_id: str
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this Data.
+        :type availability_domain: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this Data.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this Data.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param identity:
+            The value to assign to the identity property of this Data.
+        :type identity: Identity
+
+        :param request:
+            The value to assign to the request property of this Data.
+        :type request: Request
+
+        :param response:
+            The value to assign to the response property of this Data.
+        :type response: Response
+
+        :param state_change:
+            The value to assign to the state_change property of this Data.
+        :type state_change: StateChange
+
+        :param additional_details:
+            The value to assign to the additional_details property of this Data.
+        :type additional_details: dict(str, object)
+
+        """
+        self.swagger_types = {
+            'event_grouping_id': 'str',
+            'event_name': 'str',
+            'compartment_id': 'str',
+            'compartment_name': 'str',
+            'resource_name': 'str',
+            'resource_id': 'str',
+            'availability_domain': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'identity': 'Identity',
+            'request': 'Request',
+            'response': 'Response',
+            'state_change': 'StateChange',
+            'additional_details': 'dict(str, object)'
+        }
+
+        self.attribute_map = {
+            'event_grouping_id': 'eventGroupingId',
+            'event_name': 'eventName',
+            'compartment_id': 'compartmentId',
+            'compartment_name': 'compartmentName',
+            'resource_name': 'resourceName',
+            'resource_id': 'resourceId',
+            'availability_domain': 'availabilityDomain',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'identity': 'identity',
+            'request': 'request',
+            'response': 'response',
+            'state_change': 'stateChange',
+            'additional_details': 'additionalDetails'
+        }
+
+        self._event_grouping_id = None
+        self._event_name = None
+        self._compartment_id = None
+        self._compartment_name = None
+        self._resource_name = None
+        self._resource_id = None
+        self._availability_domain = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._identity = None
+        self._request = None
+        self._response = None
+        self._state_change = None
+        self._additional_details = None
+
+    @property
+    def event_grouping_id(self):
+        """
+        Gets the event_grouping_id of this Data.
+        This value links multiple audit events that are part of the same API operation. For example,
+        a long running API operations that emit an event at the start and the end of an operation
+        would use the same value in this field for both events.
+
+
+        :return: The event_grouping_id of this Data.
+        :rtype: str
+        """
+        return self._event_grouping_id
+
+    @event_grouping_id.setter
+    def event_grouping_id(self, event_grouping_id):
+        """
+        Sets the event_grouping_id of this Data.
+        This value links multiple audit events that are part of the same API operation. For example,
+        a long running API operations that emit an event at the start and the end of an operation
+        would use the same value in this field for both events.
+
+
+        :param event_grouping_id: The event_grouping_id of this Data.
+        :type: str
+        """
+        self._event_grouping_id = event_grouping_id
+
+    @property
+    def event_name(self):
+        """
+        Gets the event_name of this Data.
+        Name of the API operation that generated this event.
+
+        Example: `GetInstance`
+
+
+        :return: The event_name of this Data.
+        :rtype: str
+        """
+        return self._event_name
+
+    @event_name.setter
+    def event_name(self, event_name):
+        """
+        Sets the event_name of this Data.
+        Name of the API operation that generated this event.
+
+        Example: `GetInstance`
+
+
+        :param event_name: The event_name of this Data.
+        :type: str
+        """
+        self._event_name = event_name
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this Data.
+        The `OCID`__ of the compartment of the resource
+        emitting the event.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this Data.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this Data.
+        The `OCID`__ of the compartment of the resource
+        emitting the event.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this Data.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def compartment_name(self):
+        """
+        Gets the compartment_name of this Data.
+        The name of the compartment. This value is the friendly name associated with compartmentId.
+        This value can change, but the service logs the value that appeared at the time of the audit
+        event.
+
+        Example: `CompartmentA`
+
+
+        :return: The compartment_name of this Data.
+        :rtype: str
+        """
+        return self._compartment_name
+
+    @compartment_name.setter
+    def compartment_name(self, compartment_name):
+        """
+        Sets the compartment_name of this Data.
+        The name of the compartment. This value is the friendly name associated with compartmentId.
+        This value can change, but the service logs the value that appeared at the time of the audit
+        event.
+
+        Example: `CompartmentA`
+
+
+        :param compartment_name: The compartment_name of this Data.
+        :type: str
+        """
+        self._compartment_name = compartment_name
+
+    @property
+    def resource_name(self):
+        """
+        Gets the resource_name of this Data.
+        The name of the resource emitting the event.
+
+
+        :return: The resource_name of this Data.
+        :rtype: str
+        """
+        return self._resource_name
+
+    @resource_name.setter
+    def resource_name(self, resource_name):
+        """
+        Sets the resource_name of this Data.
+        The name of the resource emitting the event.
+
+
+        :param resource_name: The resource_name of this Data.
+        :type: str
+        """
+        self._resource_name = resource_name
+
+    @property
+    def resource_id(self):
+        """
+        Gets the resource_id of this Data.
+        An `OCID`__ or some other ID for the resource
+        emitting the event.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The resource_id of this Data.
+        :rtype: str
+        """
+        return self._resource_id
+
+    @resource_id.setter
+    def resource_id(self, resource_id):
+        """
+        Sets the resource_id of this Data.
+        An `OCID`__ or some other ID for the resource
+        emitting the event.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param resource_id: The resource_id of this Data.
+        :type: str
+        """
+        self._resource_id = resource_id
+
+    @property
+    def availability_domain(self):
+        """
+        Gets the availability_domain of this Data.
+        The availability domain where the resource resides.
+
+
+        :return: The availability_domain of this Data.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this Data.
+        The availability domain where the resource resides.
+
+
+        :param availability_domain: The availability_domain of this Data.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this Data.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name,
+        type, or namespace. Exists for cross-compatibility only. For more information,
+        see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this Data.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this Data.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name,
+        type, or namespace. Exists for cross-compatibility only. For more information,
+        see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this Data.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this Data.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more
+        information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this Data.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this Data.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more
+        information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this Data.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def identity(self):
+        """
+        Gets the identity of this Data.
+
+        :return: The identity of this Data.
+        :rtype: Identity
+        """
+        return self._identity
+
+    @identity.setter
+    def identity(self, identity):
+        """
+        Sets the identity of this Data.
+
+        :param identity: The identity of this Data.
+        :type: Identity
+        """
+        self._identity = identity
+
+    @property
+    def request(self):
+        """
+        Gets the request of this Data.
+
+        :return: The request of this Data.
+        :rtype: Request
+        """
+        return self._request
+
+    @request.setter
+    def request(self, request):
+        """
+        Sets the request of this Data.
+
+        :param request: The request of this Data.
+        :type: Request
+        """
+        self._request = request
+
+    @property
+    def response(self):
+        """
+        Gets the response of this Data.
+
+        :return: The response of this Data.
+        :rtype: Response
+        """
+        return self._response
+
+    @response.setter
+    def response(self, response):
+        """
+        Sets the response of this Data.
+
+        :param response: The response of this Data.
+        :type: Response
+        """
+        self._response = response
+
+    @property
+    def state_change(self):
+        """
+        Gets the state_change of this Data.
+
+        :return: The state_change of this Data.
+        :rtype: StateChange
+        """
+        return self._state_change
+
+    @state_change.setter
+    def state_change(self, state_change):
+        """
+        Sets the state_change of this Data.
+
+        :param state_change: The state_change of this Data.
+        :type: StateChange
+        """
+        self._state_change = state_change
+
+    @property
+    def additional_details(self):
+        """
+        Gets the additional_details of this Data.
+        A container object for attribues unique to the resource emitting the event.
+
+        Example:
+
+          -----
+            {
+              \"imageId\": \"ocid1.image.oc1.phx.<unique_ID>\",
+              \"shape\": \"VM.Standard1.1\",
+              \"type\": \"CustomerVmi\"
+            }
+          -----
+
+
+        :return: The additional_details of this Data.
+        :rtype: dict(str, object)
+        """
+        return self._additional_details
+
+    @additional_details.setter
+    def additional_details(self, additional_details):
+        """
+        Sets the additional_details of this Data.
+        A container object for attribues unique to the resource emitting the event.
+
+        Example:
+
+          -----
+            {
+              \"imageId\": \"ocid1.image.oc1.phx.<unique_ID>\",
+              \"shape\": \"VM.Standard1.1\",
+              \"type\": \"CustomerVmi\"
+            }
+          -----
+
+
+        :param additional_details: The additional_details of this Data.
+        :type: dict(str, object)
+        """
+        self._additional_details = additional_details
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/audit/models/identity.py
+++ b/src/oci/audit/models/identity.py
@@ -1,0 +1,397 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Identity(object):
+    """
+    A container object for identity attributes.
+
+    Example:
+
+    -----
+    {
+    \"principalName\": \"ExampleName\",
+    \"principalId\": \"ocid1.user.oc1..<unique_ID>\",
+    \"authType\": \"natv\",
+    \"callerName\": null,
+    \"callerId\": null,
+    \"tenantId\": \"ocid1.tenancy.oc1..<unique_ID>\",
+    \"ipAddress\": \"172.24.80.88\",
+    \"credentials\": null,
+    \"userAgent\": \"Jersey/2.23 (HttpUrlConnection 1.8.0_212)\",
+    \"consoleSessionId\": null
+    }
+    -----
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Identity object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param principal_name:
+            The value to assign to the principal_name property of this Identity.
+        :type principal_name: str
+
+        :param principal_id:
+            The value to assign to the principal_id property of this Identity.
+        :type principal_id: str
+
+        :param auth_type:
+            The value to assign to the auth_type property of this Identity.
+        :type auth_type: str
+
+        :param caller_name:
+            The value to assign to the caller_name property of this Identity.
+        :type caller_name: str
+
+        :param caller_id:
+            The value to assign to the caller_id property of this Identity.
+        :type caller_id: str
+
+        :param tenant_id:
+            The value to assign to the tenant_id property of this Identity.
+        :type tenant_id: str
+
+        :param ip_address:
+            The value to assign to the ip_address property of this Identity.
+        :type ip_address: str
+
+        :param credentials:
+            The value to assign to the credentials property of this Identity.
+        :type credentials: str
+
+        :param user_agent:
+            The value to assign to the user_agent property of this Identity.
+        :type user_agent: str
+
+        :param console_session_id:
+            The value to assign to the console_session_id property of this Identity.
+        :type console_session_id: str
+
+        """
+        self.swagger_types = {
+            'principal_name': 'str',
+            'principal_id': 'str',
+            'auth_type': 'str',
+            'caller_name': 'str',
+            'caller_id': 'str',
+            'tenant_id': 'str',
+            'ip_address': 'str',
+            'credentials': 'str',
+            'user_agent': 'str',
+            'console_session_id': 'str'
+        }
+
+        self.attribute_map = {
+            'principal_name': 'principalName',
+            'principal_id': 'principalId',
+            'auth_type': 'authType',
+            'caller_name': 'callerName',
+            'caller_id': 'callerId',
+            'tenant_id': 'tenantId',
+            'ip_address': 'ipAddress',
+            'credentials': 'credentials',
+            'user_agent': 'userAgent',
+            'console_session_id': 'consoleSessionId'
+        }
+
+        self._principal_name = None
+        self._principal_id = None
+        self._auth_type = None
+        self._caller_name = None
+        self._caller_id = None
+        self._tenant_id = None
+        self._ip_address = None
+        self._credentials = None
+        self._user_agent = None
+        self._console_session_id = None
+
+    @property
+    def principal_name(self):
+        """
+        Gets the principal_name of this Identity.
+        The name of the user or service. This value is the friendly name associated with `principalId`.
+
+        Example: `ExampleName`
+
+
+        :return: The principal_name of this Identity.
+        :rtype: str
+        """
+        return self._principal_name
+
+    @principal_name.setter
+    def principal_name(self, principal_name):
+        """
+        Sets the principal_name of this Identity.
+        The name of the user or service. This value is the friendly name associated with `principalId`.
+
+        Example: `ExampleName`
+
+
+        :param principal_name: The principal_name of this Identity.
+        :type: str
+        """
+        self._principal_name = principal_name
+
+    @property
+    def principal_id(self):
+        """
+        Gets the principal_id of this Identity.
+        The `OCID`__ of the principal.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The principal_id of this Identity.
+        :rtype: str
+        """
+        return self._principal_id
+
+    @principal_id.setter
+    def principal_id(self, principal_id):
+        """
+        Sets the principal_id of this Identity.
+        The `OCID`__ of the principal.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param principal_id: The principal_id of this Identity.
+        :type: str
+        """
+        self._principal_id = principal_id
+
+    @property
+    def auth_type(self):
+        """
+        Gets the auth_type of this Identity.
+        The type of authentication used.
+
+        Example: `natv`
+
+
+        :return: The auth_type of this Identity.
+        :rtype: str
+        """
+        return self._auth_type
+
+    @auth_type.setter
+    def auth_type(self, auth_type):
+        """
+        Sets the auth_type of this Identity.
+        The type of authentication used.
+
+        Example: `natv`
+
+
+        :param auth_type: The auth_type of this Identity.
+        :type: str
+        """
+        self._auth_type = auth_type
+
+    @property
+    def caller_name(self):
+        """
+        Gets the caller_name of this Identity.
+        The name of the user or service. This value is the friendly name associated with `callerId`.
+
+
+        :return: The caller_name of this Identity.
+        :rtype: str
+        """
+        return self._caller_name
+
+    @caller_name.setter
+    def caller_name(self, caller_name):
+        """
+        Sets the caller_name of this Identity.
+        The name of the user or service. This value is the friendly name associated with `callerId`.
+
+
+        :param caller_name: The caller_name of this Identity.
+        :type: str
+        """
+        self._caller_name = caller_name
+
+    @property
+    def caller_id(self):
+        """
+        Gets the caller_id of this Identity.
+        The `OCID`__ of the caller. The caller that made a
+        request on behalf of the prinicpal.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The caller_id of this Identity.
+        :rtype: str
+        """
+        return self._caller_id
+
+    @caller_id.setter
+    def caller_id(self, caller_id):
+        """
+        Sets the caller_id of this Identity.
+        The `OCID`__ of the caller. The caller that made a
+        request on behalf of the prinicpal.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param caller_id: The caller_id of this Identity.
+        :type: str
+        """
+        self._caller_id = caller_id
+
+    @property
+    def tenant_id(self):
+        """
+        Gets the tenant_id of this Identity.
+        The `OCID`__ of the tenant.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The tenant_id of this Identity.
+        :rtype: str
+        """
+        return self._tenant_id
+
+    @tenant_id.setter
+    def tenant_id(self, tenant_id):
+        """
+        Sets the tenant_id of this Identity.
+        The `OCID`__ of the tenant.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param tenant_id: The tenant_id of this Identity.
+        :type: str
+        """
+        self._tenant_id = tenant_id
+
+    @property
+    def ip_address(self):
+        """
+        Gets the ip_address of this Identity.
+        The IP address of the source of the request.
+
+        Example: `172.24.80.88`
+
+
+        :return: The ip_address of this Identity.
+        :rtype: str
+        """
+        return self._ip_address
+
+    @ip_address.setter
+    def ip_address(self, ip_address):
+        """
+        Sets the ip_address of this Identity.
+        The IP address of the source of the request.
+
+        Example: `172.24.80.88`
+
+
+        :param ip_address: The ip_address of this Identity.
+        :type: str
+        """
+        self._ip_address = ip_address
+
+    @property
+    def credentials(self):
+        """
+        Gets the credentials of this Identity.
+        The credential ID of the user. This value is extracted from the HTTP 'Authorization' request
+        header. It consists of the tenantId, userId, and user fingerprint, all delimited by a slash (/).
+
+
+        :return: The credentials of this Identity.
+        :rtype: str
+        """
+        return self._credentials
+
+    @credentials.setter
+    def credentials(self, credentials):
+        """
+        Sets the credentials of this Identity.
+        The credential ID of the user. This value is extracted from the HTTP 'Authorization' request
+        header. It consists of the tenantId, userId, and user fingerprint, all delimited by a slash (/).
+
+
+        :param credentials: The credentials of this Identity.
+        :type: str
+        """
+        self._credentials = credentials
+
+    @property
+    def user_agent(self):
+        """
+        Gets the user_agent of this Identity.
+        The user agent of the client that made the request.
+
+        Example: `Jersey/2.23 (HttpUrlConnection 1.8.0_212)`
+
+
+        :return: The user_agent of this Identity.
+        :rtype: str
+        """
+        return self._user_agent
+
+    @user_agent.setter
+    def user_agent(self, user_agent):
+        """
+        Sets the user_agent of this Identity.
+        The user agent of the client that made the request.
+
+        Example: `Jersey/2.23 (HttpUrlConnection 1.8.0_212)`
+
+
+        :param user_agent: The user_agent of this Identity.
+        :type: str
+        """
+        self._user_agent = user_agent
+
+    @property
+    def console_session_id(self):
+        """
+        Gets the console_session_id of this Identity.
+        This value identifies any Console session associated with this request.
+
+
+        :return: The console_session_id of this Identity.
+        :rtype: str
+        """
+        return self._console_session_id
+
+    @console_session_id.setter
+    def console_session_id(self, console_session_id):
+        """
+        Sets the console_session_id of this Identity.
+        This value identifies any Console session associated with this request.
+
+
+        :param console_session_id: The console_session_id of this Identity.
+        :type: str
+        """
+        self._console_session_id = console_session_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/audit/models/request.py
+++ b/src/oci/audit/models/request.py
@@ -1,0 +1,327 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Request(object):
+    """
+    A container object for request attributes.
+
+    Example:
+
+    -----
+    {
+    \"id\": \"<unique_ID>\",
+    \"path\": \"/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\",
+    \"action\": \"GET\",
+    \"parameters\": {},
+    \"headers\": {
+    \"opc-principal\": [
+    \"{\\\"tenantId\\\":\\\"ocid1.tenancy.oc1..<unique_ID>\\\",\\\"subjectId\\\":\\\"ocid1.user.oc1..<unique_ID>\\\",\\\"claims\\\":[{\\\"key\\\":\\\"pstype\\\",\\\"value\\\":\\\"natv\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_host\\\",\\\"value\\\":\\\"iaas.r2.oracleiaas.com\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_opc-request-id\\\",\\\"value\\\":\\\"<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"ptype\\\",\\\"value\\\":\\\"user\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_date\\\",\\\"value\\\":\\\"Wed, 18 Sep 2019 00:10:58 UTC\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_accept\\\",\\\"value\\\":\\\"application/json\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"authorization\\\",\\\"value\\\":\\\"Signature headers=\\\\\\\"date (request-target) host accept opc-request-id\\\\\\\",keyId=\\\\\\\"ocid1.tenancy.oc1..<unique_ID>/ocid1.user.oc1..<unique_ID>/8c:b4:5f:18:e7:ec:db:08:b8:fa:d2:2a:7d:11:76:ac\\\\\\\",algorithm=\\\\\\\"rsa-pss-sha256\\\\\\\",signature=\\\\\\\"<unique_ID>\\\\\\\",version=\\\\\\\"1\\\\\\\"\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_(request-target)\\\",\\\"value\\\":\\\"get /20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"}]}\"
+    ],
+    \"Accept\": [
+    \"application/json\"
+    ],
+    \"X-Oracle-Auth-Client-CN\": [
+    \"splat-proxy-se-02302.node.ad2.r2\"
+    ],
+    \"X-Forwarded-Host\": [
+    \"compute-api.svc.ad1.r2\"
+    ],
+    \"Connection\": [
+    \"close\"
+    ],
+    \"User-Agent\": [
+    \"Jersey/2.23 (HttpUrlConnection 1.8.0_212)\"
+    ],
+    \"X-Forwarded-For\": [
+    \"172.24.80.88\"
+    ],
+    \"X-Real-IP\": [
+    \"172.24.80.88\"
+    ],
+    \"oci-original-url\": [
+    \"https://iaas.r2.oracleiaas.com/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\"
+    ],
+    \"opc-request-id\": [
+    \"<unique_ID>\"
+    ],
+    \"Date\": [
+    \"Wed, 18 Sep 2019 00:10:58 UTC\"
+    ]
+    }
+    }
+    -----
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Request object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this Request.
+        :type id: str
+
+        :param path:
+            The value to assign to the path property of this Request.
+        :type path: str
+
+        :param action:
+            The value to assign to the action property of this Request.
+        :type action: str
+
+        :param parameters:
+            The value to assign to the parameters property of this Request.
+        :type parameters: dict(str, list[str])
+
+        :param headers:
+            The value to assign to the headers property of this Request.
+        :type headers: dict(str, list[str])
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'path': 'str',
+            'action': 'str',
+            'parameters': 'dict(str, list[str])',
+            'headers': 'dict(str, list[str])'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'path': 'path',
+            'action': 'action',
+            'parameters': 'parameters',
+            'headers': 'headers'
+        }
+
+        self._id = None
+        self._path = None
+        self._action = None
+        self._parameters = None
+        self._headers = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this Request.
+        The opc-request-id of the request.
+
+
+        :return: The id of this Request.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this Request.
+        The opc-request-id of the request.
+
+
+        :param id: The id of this Request.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def path(self):
+        """
+        Gets the path of this Request.
+        The full path of the API request.
+
+        Example: `/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>`
+
+
+        :return: The path of this Request.
+        :rtype: str
+        """
+        return self._path
+
+    @path.setter
+    def path(self, path):
+        """
+        Sets the path of this Request.
+        The full path of the API request.
+
+        Example: `/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>`
+
+
+        :param path: The path of this Request.
+        :type: str
+        """
+        self._path = path
+
+    @property
+    def action(self):
+        """
+        Gets the action of this Request.
+        The HTTP method of the request.
+
+        Example: `GET`
+
+
+        :return: The action of this Request.
+        :rtype: str
+        """
+        return self._action
+
+    @action.setter
+    def action(self, action):
+        """
+        Sets the action of this Request.
+        The HTTP method of the request.
+
+        Example: `GET`
+
+
+        :param action: The action of this Request.
+        :type: str
+        """
+        self._action = action
+
+    @property
+    def parameters(self):
+        """
+        Gets the parameters of this Request.
+        The parameters supplied by the caller during this operation.
+
+
+        :return: The parameters of this Request.
+        :rtype: dict(str, list[str])
+        """
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        """
+        Sets the parameters of this Request.
+        The parameters supplied by the caller during this operation.
+
+
+        :param parameters: The parameters of this Request.
+        :type: dict(str, list[str])
+        """
+        self._parameters = parameters
+
+    @property
+    def headers(self):
+        """
+        Gets the headers of this Request.
+        The HTTP header fields and values in the request.
+
+        Example:
+
+          -----
+            {
+              \"opc-principal\": [
+                \"{\\\"tenantId\\\":\\\"ocid1.tenancy.oc1..<unique_ID>\\\",\\\"subjectId\\\":\\\"ocid1.user.oc1..<unique_ID>\\\",\\\"claims\\\":[{\\\"key\\\":\\\"pstype\\\",\\\"value\\\":\\\"natv\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_host\\\",\\\"value\\\":\\\"iaas.r2.oracleiaas.com\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_opc-request-id\\\",\\\"value\\\":\\\"<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"ptype\\\",\\\"value\\\":\\\"user\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_date\\\",\\\"value\\\":\\\"Wed, 18 Sep 2019 00:10:58 UTC\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_accept\\\",\\\"value\\\":\\\"application/json\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"authorization\\\",\\\"value\\\":\\\"Signature headers=\\\\\\\"date (request-target) host accept opc-request-id\\\\\\\",keyId=\\\\\\\"ocid1.tenancy.oc1..<unique_ID>/ocid1.user.oc1..<unique_ID>/8c:b4:5f:18:e7:ec:db:08:b8:fa:d2:2a:7d:11:76:ac\\\\\\\",algorithm=\\\\\\\"rsa-pss-sha256\\\\\\\",signature=\\\\\\\"<unique_ID>\\\\\\\",version=\\\\\\\"1\\\\\\\"\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_(request-target)\\\",\\\"value\\\":\\\"get /20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"}]}\"
+              ],
+              \"Accept\": [
+                \"application/json\"
+              ],
+              \"X-Oracle-Auth-Client-CN\": [
+                \"splat-proxy-se-02302.node.ad2.r2\"
+              ],
+              \"X-Forwarded-Host\": [
+                \"compute-api.svc.ad1.r2\"
+              ],
+              \"Connection\": [
+                \"close\"
+              ],
+              \"User-Agent\": [
+                \"Jersey/2.23 (HttpUrlConnection 1.8.0_212)\"
+              ],
+              \"X-Forwarded-For\": [
+                \"172.24.80.88\"
+              ],
+              \"X-Real-IP\": [
+                \"172.24.80.88\"
+              ],
+              \"oci-original-url\": [
+                \"https://iaas.r2.oracleiaas.com/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\"
+              ],
+              \"opc-request-id\": [
+                \"<unique_ID>\"
+              ],
+              \"Date\": [
+                \"Wed, 18 Sep 2019 00:10:58 UTC\"
+              ]
+            }
+          -----
+
+
+        :return: The headers of this Request.
+        :rtype: dict(str, list[str])
+        """
+        return self._headers
+
+    @headers.setter
+    def headers(self, headers):
+        """
+        Sets the headers of this Request.
+        The HTTP header fields and values in the request.
+
+        Example:
+
+          -----
+            {
+              \"opc-principal\": [
+                \"{\\\"tenantId\\\":\\\"ocid1.tenancy.oc1..<unique_ID>\\\",\\\"subjectId\\\":\\\"ocid1.user.oc1..<unique_ID>\\\",\\\"claims\\\":[{\\\"key\\\":\\\"pstype\\\",\\\"value\\\":\\\"natv\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_host\\\",\\\"value\\\":\\\"iaas.r2.oracleiaas.com\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_opc-request-id\\\",\\\"value\\\":\\\"<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"ptype\\\",\\\"value\\\":\\\"user\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_date\\\",\\\"value\\\":\\\"Wed, 18 Sep 2019 00:10:58 UTC\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_accept\\\",\\\"value\\\":\\\"application/json\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"authorization\\\",\\\"value\\\":\\\"Signature headers=\\\\\\\"date (request-target) host accept opc-request-id\\\\\\\",keyId=\\\\\\\"ocid1.tenancy.oc1..<unique_ID>/ocid1.user.oc1..<unique_ID>/8c:b4:5f:18:e7:ec:db:08:b8:fa:d2:2a:7d:11:76:ac\\\\\\\",algorithm=\\\\\\\"rsa-pss-sha256\\\\\\\",signature=\\\\\\\"<unique_ID>\\\\\\\",version=\\\\\\\"1\\\\\\\"\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_(request-target)\\\",\\\"value\\\":\\\"get /20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"}]}\"
+              ],
+              \"Accept\": [
+                \"application/json\"
+              ],
+              \"X-Oracle-Auth-Client-CN\": [
+                \"splat-proxy-se-02302.node.ad2.r2\"
+              ],
+              \"X-Forwarded-Host\": [
+                \"compute-api.svc.ad1.r2\"
+              ],
+              \"Connection\": [
+                \"close\"
+              ],
+              \"User-Agent\": [
+                \"Jersey/2.23 (HttpUrlConnection 1.8.0_212)\"
+              ],
+              \"X-Forwarded-For\": [
+                \"172.24.80.88\"
+              ],
+              \"X-Real-IP\": [
+                \"172.24.80.88\"
+              ],
+              \"oci-original-url\": [
+                \"https://iaas.r2.oracleiaas.com/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\"
+              ],
+              \"opc-request-id\": [
+                \"<unique_ID>\"
+              ],
+              \"Date\": [
+                \"Wed, 18 Sep 2019 00:10:58 UTC\"
+              ]
+            }
+          -----
+
+
+        :param headers: The headers of this Request.
+        :type: dict(str, list[str])
+        """
+        self._headers = headers
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/audit/models/response.py
+++ b/src/oci/audit/models/response.py
@@ -1,0 +1,311 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Response(object):
+    """
+    A container object for response attributes.
+
+    Example:
+
+    -----
+    {
+    \"status\": \"200\",
+    \"responseTime\": \"2019-09-18T00:10:59.278Z\",
+    \"headers\": {
+    \"ETag\": [
+    \"<unique_ID>\"
+    ],
+    \"Connection\": [
+    \"close\"
+    ],
+    \"Content-Length\": [
+    \"1828\"
+    ],
+    \"opc-request-id\": [
+    \"<unique_ID>\"
+    ],
+    \"Date\": [
+    \"Wed, 18 Sep 2019 00:10:59 GMT\"
+    ],
+    \"Content-Type\": [
+    \"application/json\"
+    ]
+    },
+    \"payload\": {
+    \"resourceName\": \"my_instance\",
+    \"id\": \"ocid1.instance.oc1.phx.<unique_ID>\"
+    },
+    \"message\": null
+    }
+    -----
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Response object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param status:
+            The value to assign to the status property of this Response.
+        :type status: str
+
+        :param response_time:
+            The value to assign to the response_time property of this Response.
+        :type response_time: datetime
+
+        :param headers:
+            The value to assign to the headers property of this Response.
+        :type headers: dict(str, list[str])
+
+        :param payload:
+            The value to assign to the payload property of this Response.
+        :type payload: dict(str, object)
+
+        :param message:
+            The value to assign to the message property of this Response.
+        :type message: str
+
+        """
+        self.swagger_types = {
+            'status': 'str',
+            'response_time': 'datetime',
+            'headers': 'dict(str, list[str])',
+            'payload': 'dict(str, object)',
+            'message': 'str'
+        }
+
+        self.attribute_map = {
+            'status': 'status',
+            'response_time': 'responseTime',
+            'headers': 'headers',
+            'payload': 'payload',
+            'message': 'message'
+        }
+
+        self._status = None
+        self._response_time = None
+        self._headers = None
+        self._payload = None
+        self._message = None
+
+    @property
+    def status(self):
+        """
+        Gets the status of this Response.
+        The status code of the response.
+
+        Example: `200`
+
+
+        :return: The status of this Response.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this Response.
+        The status code of the response.
+
+        Example: `200`
+
+
+        :param status: The status of this Response.
+        :type: str
+        """
+        self._status = status
+
+    @property
+    def response_time(self):
+        """
+        Gets the response_time of this Response.
+        The time of the response to the audited request, expressed in
+        `RFC 3339`__ timestamp format.
+
+        Example: `2019-09-18T00:10:59.278Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The response_time of this Response.
+        :rtype: datetime
+        """
+        return self._response_time
+
+    @response_time.setter
+    def response_time(self, response_time):
+        """
+        Sets the response_time of this Response.
+        The time of the response to the audited request, expressed in
+        `RFC 3339`__ timestamp format.
+
+        Example: `2019-09-18T00:10:59.278Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param response_time: The response_time of this Response.
+        :type: datetime
+        """
+        self._response_time = response_time
+
+    @property
+    def headers(self):
+        """
+        Gets the headers of this Response.
+        The headers of the response.
+
+        Example:
+
+          -----
+            {
+              \"ETag\": [
+                \"<unique_ID>\"
+              ],
+              \"Connection\": [
+                \"close\"
+              ],
+              \"Content-Length\": [
+                \"1828\"
+              ],
+              \"opc-request-id\": [
+                \"<unique_ID>\"
+              ],
+              \"Date\": [
+                \"Wed, 18 Sep 2019 00:10:59 GMT\"
+              ],
+              \"Content-Type\": [
+                \"application/json\"
+              ]
+            }
+          -----
+
+
+        :return: The headers of this Response.
+        :rtype: dict(str, list[str])
+        """
+        return self._headers
+
+    @headers.setter
+    def headers(self, headers):
+        """
+        Sets the headers of this Response.
+        The headers of the response.
+
+        Example:
+
+          -----
+            {
+              \"ETag\": [
+                \"<unique_ID>\"
+              ],
+              \"Connection\": [
+                \"close\"
+              ],
+              \"Content-Length\": [
+                \"1828\"
+              ],
+              \"opc-request-id\": [
+                \"<unique_ID>\"
+              ],
+              \"Date\": [
+                \"Wed, 18 Sep 2019 00:10:59 GMT\"
+              ],
+              \"Content-Type\": [
+                \"application/json\"
+              ]
+            }
+          -----
+
+
+        :param headers: The headers of this Response.
+        :type: dict(str, list[str])
+        """
+        self._headers = headers
+
+    @property
+    def payload(self):
+        """
+        Gets the payload of this Response.
+        This value is included for backward compatibility with the Audit version 1 schema, where
+        it contained metadata of interest from the response payload.
+
+        Example:
+
+          -----
+            {
+              \"resourceName\": \"my_instance\",
+              \"id\": \"ocid1.instance.oc1.phx.<unique_ID>\"
+            }
+          -----
+
+
+        :return: The payload of this Response.
+        :rtype: dict(str, object)
+        """
+        return self._payload
+
+    @payload.setter
+    def payload(self, payload):
+        """
+        Sets the payload of this Response.
+        This value is included for backward compatibility with the Audit version 1 schema, where
+        it contained metadata of interest from the response payload.
+
+        Example:
+
+          -----
+            {
+              \"resourceName\": \"my_instance\",
+              \"id\": \"ocid1.instance.oc1.phx.<unique_ID>\"
+            }
+          -----
+
+
+        :param payload: The payload of this Response.
+        :type: dict(str, object)
+        """
+        self._payload = payload
+
+    @property
+    def message(self):
+        """
+        Gets the message of this Response.
+        A friendly description of what happened during the operation. Use this for troubleshooting.
+
+
+        :return: The message of this Response.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this Response.
+        A friendly description of what happened during the operation. Use this for troubleshooting.
+
+
+        :param message: The message of this Response.
+        :type: str
+        """
+        self._message = message
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/audit/models/state_change.py
+++ b/src/oci/audit/models/state_change.py
@@ -1,0 +1,117 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class StateChange(object):
+    """
+    A container object for state change attributes.
+
+    Example:
+
+    -----
+    {
+    \"previous\": null,
+    \"current\": null
+    }
+    -----
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new StateChange object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param previous:
+            The value to assign to the previous property of this StateChange.
+        :type previous: dict(str, object)
+
+        :param current:
+            The value to assign to the current property of this StateChange.
+        :type current: dict(str, object)
+
+        """
+        self.swagger_types = {
+            'previous': 'dict(str, object)',
+            'current': 'dict(str, object)'
+        }
+
+        self.attribute_map = {
+            'previous': 'previous',
+            'current': 'current'
+        }
+
+        self._previous = None
+        self._current = None
+
+    @property
+    def previous(self):
+        """
+        Gets the previous of this StateChange.
+        Provides the previous state of fields that may have changed during an operation. To determine
+        how the current operation changed a resource, compare the information in this attribute to
+        `current`.
+
+
+        :return: The previous of this StateChange.
+        :rtype: dict(str, object)
+        """
+        return self._previous
+
+    @previous.setter
+    def previous(self, previous):
+        """
+        Sets the previous of this StateChange.
+        Provides the previous state of fields that may have changed during an operation. To determine
+        how the current operation changed a resource, compare the information in this attribute to
+        `current`.
+
+
+        :param previous: The previous of this StateChange.
+        :type: dict(str, object)
+        """
+        self._previous = previous
+
+    @property
+    def current(self):
+        """
+        Gets the current of this StateChange.
+        Provides the current state of fields that may have changed during an operation. To determine
+        how the current operation changed a resource, compare the information in this attribute to
+        `previous`.
+
+
+        :return: The current of this StateChange.
+        :rtype: dict(str, object)
+        """
+        return self._current
+
+    @current.setter
+    def current(self, current):
+        """
+        Sets the current of this StateChange.
+        Provides the current state of fields that may have changed during an operation. To determine
+        how the current operation changed a resource, compare the information in this attribute to
+        `previous`.
+
+
+        :param current: The current of this StateChange.
+        :type: dict(str, object)
+        """
+        self._current = current
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/audit/models/update_configuration_details.py
+++ b/src/oci/audit/models/update_configuration_details.py
@@ -9,7 +9,10 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateConfigurationDetails(object):
     """
-    UpdateConfigurationDetails model.
+    The configuration details for the retention period setting, specified in days. For more
+    information, see `Setting Audit Log Retention Period`__.
+
+    __ https://docs.cloud.oracle.com/iaas/Content/Audit/Tasks/settingretentionperiod.htm
     """
 
     def __init__(self, **kwargs):
@@ -35,8 +38,10 @@ class UpdateConfigurationDetails(object):
     @property
     def retention_period_days(self):
         """
-        Gets the retention_period_days of this UpdateConfigurationDetails.
-        The retention period days
+        **[Required]** Gets the retention_period_days of this UpdateConfigurationDetails.
+        The retention period setting, specified in days. The minimum is 90, the maximum 365.
+
+        Example: `90`
 
 
         :return: The retention_period_days of this UpdateConfigurationDetails.
@@ -48,7 +53,9 @@ class UpdateConfigurationDetails(object):
     def retention_period_days(self, retention_period_days):
         """
         Sets the retention_period_days of this UpdateConfigurationDetails.
-        The retention period days
+        The retention period setting, specified in days. The minimum is 90, the maximum 365.
+
+        Example: `90`
 
 
         :param retention_period_days: The retention_period_days of this UpdateConfigurationDetails.

--- a/src/oci/base_client.py
+++ b/src/oci/base_client.py
@@ -7,6 +7,7 @@ import logging
 import platform
 import pytz
 import random
+import os
 import re
 import string
 import uuid
@@ -197,6 +198,11 @@ class BaseClient(object):
 
         if header_params.get(constants.HEADER_REQUEST_ID, missing) is missing:
             header_params[constants.HEADER_REQUEST_ID] = self.build_request_id()
+
+        # This allows for testing with "fake" database resources.
+        opc_host_serial = os.environ.get('OCI_DB_OPC_HOST_SERIAL')
+        if opc_host_serial:
+            header_params['opc-host-serial'] = opc_host_serial
 
         if path_params:
             path_params = self.sanitize_for_serialization(path_params)

--- a/src/oci/core/blockstorage_client.py
+++ b/src/oci/core/blockstorage_client.py
@@ -977,6 +977,81 @@ class BlockstorageClient(object):
                 body=create_volume_backup_details,
                 response_type="VolumeBackup")
 
+    def create_volume_backup_policy(self, create_volume_backup_policy_details, **kwargs):
+        """
+        CreateVolumeBackupPolicy
+        Creates a new backup policy for the caller.
+
+
+        :param CreateVolumeBackupPolicyDetails create_volume_backup_policy_details: (required)
+            Request to create a new scheduled backup policy.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.VolumeBackupPolicy`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/volumeBackupPolicies"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_volume_backup_policy got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_volume_backup_policy_details,
+                response_type="VolumeBackupPolicy")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_volume_backup_policy_details,
+                response_type="VolumeBackupPolicy")
+
     def create_volume_backup_policy_assignment(self, create_volume_backup_policy_assignment_details, **kwargs):
         """
         CreateVolumeBackupPolicyAssignment
@@ -1535,6 +1610,85 @@ class BlockstorageClient(object):
         header_params = {
             "accept": "application/json",
             "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_volume_backup_policy(self, policy_id, **kwargs):
+        """
+        DeleteVolumeBackupPolicy
+        Deletes the specified scheduled backup policy.
+
+
+        :param str policy_id: (required)
+            The OCID of the volume backup policy.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/volumeBackupPolicies/{policyId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_volume_backup_policy got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "policyId": policy_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
             "if-match": kwargs.get("if_match", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
@@ -2865,6 +3019,10 @@ class BlockstorageClient(object):
 
             __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
+        :param str compartment_id: (optional)
+            The OCID of the compartment to list.
+            If no compartment is specified, list the predefined (Gold, Silver, Bronze) backup policies.
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -2883,7 +3041,8 @@ class BlockstorageClient(object):
         expected_kwargs = [
             "retry_strategy",
             "limit",
-            "page"
+            "page",
+            "compartment_id"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -2892,7 +3051,8 @@ class BlockstorageClient(object):
 
         query_params = {
             "limit": kwargs.get("limit", missing),
-            "page": kwargs.get("page", missing)
+            "page": kwargs.get("page", missing),
+            "compartmentId": kwargs.get("compartment_id", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -3905,6 +4065,104 @@ class BlockstorageClient(object):
                 header_params=header_params,
                 body=update_volume_backup_details,
                 response_type="VolumeBackup")
+
+    def update_volume_backup_policy(self, policy_id, update_volume_backup_policy_details, **kwargs):
+        """
+        UpdateVolumeBackupPolicy
+        Updates a volume backup policy.
+        Avoid entering confidential information.
+
+
+        :param str policy_id: (required)
+            The OCID of the volume backup policy.
+
+        :param UpdateVolumeBackupPolicyDetails update_volume_backup_policy_details: (required)
+            Update volume backup policy fields
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.VolumeBackupPolicy`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/volumeBackupPolicies/{policyId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_volume_backup_policy got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "policyId": policy_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_volume_backup_policy_details,
+                response_type="VolumeBackupPolicy")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_volume_backup_policy_details,
+                response_type="VolumeBackupPolicy")
 
     def update_volume_group(self, volume_group_id, update_volume_group_details, **kwargs):
         """

--- a/src/oci/core/models/__init__.py
+++ b/src/oci/core/models/__init__.py
@@ -111,6 +111,7 @@ from .create_virtual_circuit_public_prefix_details import CreateVirtualCircuitPu
 from .create_vnic_details import CreateVnicDetails
 from .create_volume_backup_details import CreateVolumeBackupDetails
 from .create_volume_backup_policy_assignment_details import CreateVolumeBackupPolicyAssignmentDetails
+from .create_volume_backup_policy_details import CreateVolumeBackupPolicyDetails
 from .create_volume_details import CreateVolumeDetails
 from .create_volume_group_backup_details import CreateVolumeGroupBackupDetails
 from .create_volume_group_details import CreateVolumeGroupDetails
@@ -258,6 +259,7 @@ from .update_vcn_details import UpdateVcnDetails
 from .update_virtual_circuit_details import UpdateVirtualCircuitDetails
 from .update_vnic_details import UpdateVnicDetails
 from .update_volume_backup_details import UpdateVolumeBackupDetails
+from .update_volume_backup_policy_details import UpdateVolumeBackupPolicyDetails
 from .update_volume_details import UpdateVolumeDetails
 from .update_volume_group_backup_details import UpdateVolumeGroupBackupDetails
 from .update_volume_group_details import UpdateVolumeGroupDetails
@@ -396,6 +398,7 @@ core_type_mapping = {
     "CreateVnicDetails": CreateVnicDetails,
     "CreateVolumeBackupDetails": CreateVolumeBackupDetails,
     "CreateVolumeBackupPolicyAssignmentDetails": CreateVolumeBackupPolicyAssignmentDetails,
+    "CreateVolumeBackupPolicyDetails": CreateVolumeBackupPolicyDetails,
     "CreateVolumeDetails": CreateVolumeDetails,
     "CreateVolumeGroupBackupDetails": CreateVolumeGroupBackupDetails,
     "CreateVolumeGroupDetails": CreateVolumeGroupDetails,
@@ -543,6 +546,7 @@ core_type_mapping = {
     "UpdateVirtualCircuitDetails": UpdateVirtualCircuitDetails,
     "UpdateVnicDetails": UpdateVnicDetails,
     "UpdateVolumeBackupDetails": UpdateVolumeBackupDetails,
+    "UpdateVolumeBackupPolicyDetails": UpdateVolumeBackupPolicyDetails,
     "UpdateVolumeDetails": UpdateVolumeDetails,
     "UpdateVolumeGroupBackupDetails": UpdateVolumeGroupBackupDetails,
     "UpdateVolumeGroupDetails": UpdateVolumeGroupDetails,

--- a/src/oci/core/models/create_volume_backup_policy_details.py
+++ b/src/oci/core/models/create_volume_backup_policy_details.py
@@ -1,0 +1,215 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateVolumeBackupPolicyDetails(object):
+    """
+    Contains properties for a scheduled backup policy.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateVolumeBackupPolicyDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateVolumeBackupPolicyDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateVolumeBackupPolicyDetails.
+        :type display_name: str
+
+        :param schedules:
+            The value to assign to the schedules property of this CreateVolumeBackupPolicyDetails.
+        :type schedules: list[VolumeBackupSchedule]
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateVolumeBackupPolicyDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateVolumeBackupPolicyDetails.
+        :type freeform_tags: dict(str, str)
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'schedules': 'list[VolumeBackupSchedule]',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'freeform_tags': 'dict(str, str)'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'schedules': 'schedules',
+            'defined_tags': 'definedTags',
+            'freeform_tags': 'freeformTags'
+        }
+
+        self._compartment_id = None
+        self._display_name = None
+        self._schedules = None
+        self._defined_tags = None
+        self._freeform_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateVolumeBackupPolicyDetails.
+        The OCID of the compartment that contains the backup policy.
+
+
+        :return: The compartment_id of this CreateVolumeBackupPolicyDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateVolumeBackupPolicyDetails.
+        The OCID of the compartment that contains the backup policy.
+
+
+        :param compartment_id: The compartment_id of this CreateVolumeBackupPolicyDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateVolumeBackupPolicyDetails.
+        A user-friendly name for the volume backup policy. Does not have to be unique and it's changeable.
+        Avoid entering confidential information.
+
+
+        :return: The display_name of this CreateVolumeBackupPolicyDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateVolumeBackupPolicyDetails.
+        A user-friendly name for the volume backup policy. Does not have to be unique and it's changeable.
+        Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this CreateVolumeBackupPolicyDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def schedules(self):
+        """
+        Gets the schedules of this CreateVolumeBackupPolicyDetails.
+        The collection of schedules that this policy will apply.
+
+
+        :return: The schedules of this CreateVolumeBackupPolicyDetails.
+        :rtype: list[VolumeBackupSchedule]
+        """
+        return self._schedules
+
+    @schedules.setter
+    def schedules(self, schedules):
+        """
+        Sets the schedules of this CreateVolumeBackupPolicyDetails.
+        The collection of schedules that this policy will apply.
+
+
+        :param schedules: The schedules of this CreateVolumeBackupPolicyDetails.
+        :type: list[VolumeBackupSchedule]
+        """
+        self._schedules = schedules
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateVolumeBackupPolicyDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateVolumeBackupPolicyDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateVolumeBackupPolicyDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateVolumeBackupPolicyDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateVolumeBackupPolicyDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateVolumeBackupPolicyDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateVolumeBackupPolicyDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateVolumeBackupPolicyDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/launch_instance_details.py
+++ b/src/oci/core/models/launch_instance_details.py
@@ -66,6 +66,10 @@ class LaunchInstanceDetails(object):
             The value to assign to the ipxe_script property of this LaunchInstanceDetails.
         :type ipxe_script: str
 
+        :param launch_options:
+            The value to assign to the launch_options property of this LaunchInstanceDetails.
+        :type launch_options: LaunchOptions
+
         :param metadata:
             The value to assign to the metadata property of this LaunchInstanceDetails.
         :type metadata: dict(str, str)
@@ -104,6 +108,7 @@ class LaunchInstanceDetails(object):
             'hostname_label': 'str',
             'image_id': 'str',
             'ipxe_script': 'str',
+            'launch_options': 'LaunchOptions',
             'metadata': 'dict(str, str)',
             'agent_config': 'LaunchInstanceAgentConfigDetails',
             'shape': 'str',
@@ -125,6 +130,7 @@ class LaunchInstanceDetails(object):
             'hostname_label': 'hostnameLabel',
             'image_id': 'imageId',
             'ipxe_script': 'ipxeScript',
+            'launch_options': 'launchOptions',
             'metadata': 'metadata',
             'agent_config': 'agentConfig',
             'shape': 'shape',
@@ -145,6 +151,7 @@ class LaunchInstanceDetails(object):
         self._hostname_label = None
         self._image_id = None
         self._ipxe_script = None
+        self._launch_options = None
         self._metadata = None
         self._agent_config = None
         self._shape = None
@@ -557,6 +564,26 @@ class LaunchInstanceDetails(object):
         :type: str
         """
         self._ipxe_script = ipxe_script
+
+    @property
+    def launch_options(self):
+        """
+        Gets the launch_options of this LaunchInstanceDetails.
+
+        :return: The launch_options of this LaunchInstanceDetails.
+        :rtype: LaunchOptions
+        """
+        return self._launch_options
+
+    @launch_options.setter
+    def launch_options(self, launch_options):
+        """
+        Sets the launch_options of this LaunchInstanceDetails.
+
+        :param launch_options: The launch_options of this LaunchInstanceDetails.
+        :type: LaunchOptions
+        """
+        self._launch_options = launch_options
 
     @property
     def metadata(self):

--- a/src/oci/core/models/launch_options.py
+++ b/src/oci/core/models/launch_options.py
@@ -138,7 +138,7 @@ class LaunchOptions(object):
     @property
     def boot_volume_type(self):
         """
-        **[Required]** Gets the boot_volume_type of this LaunchOptions.
+        Gets the boot_volume_type of this LaunchOptions.
         Emulation type for volume.
         * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
         Storage volumes on Oracle provided images.
@@ -182,7 +182,7 @@ class LaunchOptions(object):
     @property
     def firmware(self):
         """
-        **[Required]** Gets the firmware of this LaunchOptions.
+        Gets the firmware of this LaunchOptions.
         Firmware used to boot VM.  Select the option that matches your operating system.
         * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
         systems that boot using MBR style bootloaders.
@@ -220,7 +220,7 @@ class LaunchOptions(object):
     @property
     def network_type(self):
         """
-        **[Required]** Gets the network_type of this LaunchOptions.
+        Gets the network_type of this LaunchOptions.
         Emulation type for the physical network interface card (NIC).
         * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
         * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
@@ -258,7 +258,7 @@ class LaunchOptions(object):
     @property
     def remote_data_volume_type(self):
         """
-        **[Required]** Gets the remote_data_volume_type of this LaunchOptions.
+        Gets the remote_data_volume_type of this LaunchOptions.
         Emulation type for volume.
         * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
         Storage volumes on Oracle provided images.

--- a/src/oci/core/models/update_volume_backup_policy_details.py
+++ b/src/oci/core/models/update_volume_backup_policy_details.py
@@ -1,0 +1,184 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateVolumeBackupPolicyDetails(object):
+    """
+    Contains properties for updating a scheduled backup policy.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateVolumeBackupPolicyDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateVolumeBackupPolicyDetails.
+        :type display_name: str
+
+        :param schedules:
+            The value to assign to the schedules property of this UpdateVolumeBackupPolicyDetails.
+        :type schedules: list[VolumeBackupSchedule]
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateVolumeBackupPolicyDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateVolumeBackupPolicyDetails.
+        :type freeform_tags: dict(str, str)
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'schedules': 'list[VolumeBackupSchedule]',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'freeform_tags': 'dict(str, str)'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'schedules': 'schedules',
+            'defined_tags': 'definedTags',
+            'freeform_tags': 'freeformTags'
+        }
+
+        self._display_name = None
+        self._schedules = None
+        self._defined_tags = None
+        self._freeform_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateVolumeBackupPolicyDetails.
+        A user-friendly name for the volume backup policy. Does not have to be unique and it's changeable.
+        Avoid entering confidential information.
+
+
+        :return: The display_name of this UpdateVolumeBackupPolicyDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateVolumeBackupPolicyDetails.
+        A user-friendly name for the volume backup policy. Does not have to be unique and it's changeable.
+        Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this UpdateVolumeBackupPolicyDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def schedules(self):
+        """
+        Gets the schedules of this UpdateVolumeBackupPolicyDetails.
+        The collection of schedules that this policy will apply.
+
+
+        :return: The schedules of this UpdateVolumeBackupPolicyDetails.
+        :rtype: list[VolumeBackupSchedule]
+        """
+        return self._schedules
+
+    @schedules.setter
+    def schedules(self, schedules):
+        """
+        Sets the schedules of this UpdateVolumeBackupPolicyDetails.
+        The collection of schedules that this policy will apply.
+
+
+        :param schedules: The schedules of this UpdateVolumeBackupPolicyDetails.
+        :type: list[VolumeBackupSchedule]
+        """
+        self._schedules = schedules
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateVolumeBackupPolicyDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateVolumeBackupPolicyDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateVolumeBackupPolicyDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateVolumeBackupPolicyDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateVolumeBackupPolicyDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateVolumeBackupPolicyDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateVolumeBackupPolicyDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateVolumeBackupPolicyDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/volume_backup_policy.py
+++ b/src/oci/core/models/volume_backup_policy.py
@@ -38,25 +38,46 @@ class VolumeBackupPolicy(object):
             The value to assign to the time_created property of this VolumeBackupPolicy.
         :type time_created: datetime
 
+        :param compartment_id:
+            The value to assign to the compartment_id property of this VolumeBackupPolicy.
+        :type compartment_id: str
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this VolumeBackupPolicy.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this VolumeBackupPolicy.
+        :type freeform_tags: dict(str, str)
+
         """
         self.swagger_types = {
             'display_name': 'str',
             'id': 'str',
             'schedules': 'list[VolumeBackupSchedule]',
-            'time_created': 'datetime'
+            'time_created': 'datetime',
+            'compartment_id': 'str',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'freeform_tags': 'dict(str, str)'
         }
 
         self.attribute_map = {
             'display_name': 'displayName',
             'id': 'id',
             'schedules': 'schedules',
-            'time_created': 'timeCreated'
+            'time_created': 'timeCreated',
+            'compartment_id': 'compartmentId',
+            'defined_tags': 'definedTags',
+            'freeform_tags': 'freeformTags'
         }
 
         self._display_name = None
         self._id = None
         self._schedules = None
         self._time_created = None
+        self._compartment_id = None
+        self._defined_tags = None
+        self._freeform_tags = None
 
     @property
     def display_name(self):
@@ -155,6 +176,98 @@ class VolumeBackupPolicy(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this VolumeBackupPolicy.
+        The OCID of the compartment that contains the volume backup.
+
+
+        :return: The compartment_id of this VolumeBackupPolicy.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this VolumeBackupPolicy.
+        The OCID of the compartment that contains the volume backup.
+
+
+        :param compartment_id: The compartment_id of this VolumeBackupPolicy.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this VolumeBackupPolicy.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this VolumeBackupPolicy.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this VolumeBackupPolicy.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this VolumeBackupPolicy.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this VolumeBackupPolicy.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this VolumeBackupPolicy.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this VolumeBackupPolicy.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this VolumeBackupPolicy.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/volume_backup_schedule.py
+++ b/src/oci/core/models/volume_backup_schedule.py
@@ -40,6 +40,98 @@ class VolumeBackupSchedule(object):
     #: This constant has a value of "ONE_YEAR"
     PERIOD_ONE_YEAR = "ONE_YEAR"
 
+    #: A constant which can be used with the offset_type property of a VolumeBackupSchedule.
+    #: This constant has a value of "STRUCTURED"
+    OFFSET_TYPE_STRUCTURED = "STRUCTURED"
+
+    #: A constant which can be used with the offset_type property of a VolumeBackupSchedule.
+    #: This constant has a value of "NUMERIC_SECONDS"
+    OFFSET_TYPE_NUMERIC_SECONDS = "NUMERIC_SECONDS"
+
+    #: A constant which can be used with the day_of_week property of a VolumeBackupSchedule.
+    #: This constant has a value of "MONDAY"
+    DAY_OF_WEEK_MONDAY = "MONDAY"
+
+    #: A constant which can be used with the day_of_week property of a VolumeBackupSchedule.
+    #: This constant has a value of "TUESDAY"
+    DAY_OF_WEEK_TUESDAY = "TUESDAY"
+
+    #: A constant which can be used with the day_of_week property of a VolumeBackupSchedule.
+    #: This constant has a value of "WEDNESDAY"
+    DAY_OF_WEEK_WEDNESDAY = "WEDNESDAY"
+
+    #: A constant which can be used with the day_of_week property of a VolumeBackupSchedule.
+    #: This constant has a value of "THURSDAY"
+    DAY_OF_WEEK_THURSDAY = "THURSDAY"
+
+    #: A constant which can be used with the day_of_week property of a VolumeBackupSchedule.
+    #: This constant has a value of "FRIDAY"
+    DAY_OF_WEEK_FRIDAY = "FRIDAY"
+
+    #: A constant which can be used with the day_of_week property of a VolumeBackupSchedule.
+    #: This constant has a value of "SATURDAY"
+    DAY_OF_WEEK_SATURDAY = "SATURDAY"
+
+    #: A constant which can be used with the day_of_week property of a VolumeBackupSchedule.
+    #: This constant has a value of "SUNDAY"
+    DAY_OF_WEEK_SUNDAY = "SUNDAY"
+
+    #: A constant which can be used with the month property of a VolumeBackupSchedule.
+    #: This constant has a value of "JANUARY"
+    MONTH_JANUARY = "JANUARY"
+
+    #: A constant which can be used with the month property of a VolumeBackupSchedule.
+    #: This constant has a value of "FEBRUARY"
+    MONTH_FEBRUARY = "FEBRUARY"
+
+    #: A constant which can be used with the month property of a VolumeBackupSchedule.
+    #: This constant has a value of "MARCH"
+    MONTH_MARCH = "MARCH"
+
+    #: A constant which can be used with the month property of a VolumeBackupSchedule.
+    #: This constant has a value of "APRIL"
+    MONTH_APRIL = "APRIL"
+
+    #: A constant which can be used with the month property of a VolumeBackupSchedule.
+    #: This constant has a value of "MAY"
+    MONTH_MAY = "MAY"
+
+    #: A constant which can be used with the month property of a VolumeBackupSchedule.
+    #: This constant has a value of "JUNE"
+    MONTH_JUNE = "JUNE"
+
+    #: A constant which can be used with the month property of a VolumeBackupSchedule.
+    #: This constant has a value of "JULY"
+    MONTH_JULY = "JULY"
+
+    #: A constant which can be used with the month property of a VolumeBackupSchedule.
+    #: This constant has a value of "AUGUST"
+    MONTH_AUGUST = "AUGUST"
+
+    #: A constant which can be used with the month property of a VolumeBackupSchedule.
+    #: This constant has a value of "SEPTEMBER"
+    MONTH_SEPTEMBER = "SEPTEMBER"
+
+    #: A constant which can be used with the month property of a VolumeBackupSchedule.
+    #: This constant has a value of "OCTOBER"
+    MONTH_OCTOBER = "OCTOBER"
+
+    #: A constant which can be used with the month property of a VolumeBackupSchedule.
+    #: This constant has a value of "NOVEMBER"
+    MONTH_NOVEMBER = "NOVEMBER"
+
+    #: A constant which can be used with the month property of a VolumeBackupSchedule.
+    #: This constant has a value of "DECEMBER"
+    MONTH_DECEMBER = "DECEMBER"
+
+    #: A constant which can be used with the time_zone property of a VolumeBackupSchedule.
+    #: This constant has a value of "UTC"
+    TIME_ZONE_UTC = "UTC"
+
+    #: A constant which can be used with the time_zone property of a VolumeBackupSchedule.
+    #: This constant has a value of "REGIONAL_DATA_CENTER_TIME"
+    TIME_ZONE_REGIONAL_DATA_CENTER_TIME = "REGIONAL_DATA_CENTER_TIME"
+
     def __init__(self, **kwargs):
         """
         Initializes a new VolumeBackupSchedule object with values from keyword arguments.
@@ -61,29 +153,79 @@ class VolumeBackupSchedule(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type period: str
 
+        :param offset_type:
+            The value to assign to the offset_type property of this VolumeBackupSchedule.
+            Allowed values for this property are: "STRUCTURED", "NUMERIC_SECONDS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type offset_type: str
+
+        :param hour_of_day:
+            The value to assign to the hour_of_day property of this VolumeBackupSchedule.
+        :type hour_of_day: int
+
+        :param day_of_week:
+            The value to assign to the day_of_week property of this VolumeBackupSchedule.
+            Allowed values for this property are: "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type day_of_week: str
+
+        :param day_of_month:
+            The value to assign to the day_of_month property of this VolumeBackupSchedule.
+        :type day_of_month: int
+
+        :param month:
+            The value to assign to the month property of this VolumeBackupSchedule.
+            Allowed values for this property are: "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type month: str
+
         :param retention_seconds:
             The value to assign to the retention_seconds property of this VolumeBackupSchedule.
         :type retention_seconds: int
+
+        :param time_zone:
+            The value to assign to the time_zone property of this VolumeBackupSchedule.
+            Allowed values for this property are: "UTC", "REGIONAL_DATA_CENTER_TIME", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type time_zone: str
 
         """
         self.swagger_types = {
             'backup_type': 'str',
             'offset_seconds': 'int',
             'period': 'str',
-            'retention_seconds': 'int'
+            'offset_type': 'str',
+            'hour_of_day': 'int',
+            'day_of_week': 'str',
+            'day_of_month': 'int',
+            'month': 'str',
+            'retention_seconds': 'int',
+            'time_zone': 'str'
         }
 
         self.attribute_map = {
             'backup_type': 'backupType',
             'offset_seconds': 'offsetSeconds',
             'period': 'period',
-            'retention_seconds': 'retentionSeconds'
+            'offset_type': 'offsetType',
+            'hour_of_day': 'hourOfDay',
+            'day_of_week': 'dayOfWeek',
+            'day_of_month': 'dayOfMonth',
+            'month': 'month',
+            'retention_seconds': 'retentionSeconds',
+            'time_zone': 'timeZone'
         }
 
         self._backup_type = None
         self._offset_seconds = None
         self._period = None
+        self._offset_type = None
+        self._hour_of_day = None
+        self._day_of_week = None
+        self._day_of_month = None
+        self._month = None
         self._retention_seconds = None
+        self._time_zone = None
 
     @property
     def backup_type(self):
@@ -170,6 +312,144 @@ class VolumeBackupSchedule(object):
         self._period = period
 
     @property
+    def offset_type(self):
+        """
+        Gets the offset_type of this VolumeBackupSchedule.
+        Indicates how offset is defined. If value is `STRUCTURED`, then `hourOfDay`, `dayOfWeek`, `dayOfMonth`, and `month` fields are used and `offsetSeconds` will be ignored in requests and users should ignore its value from the respones. `hourOfDay` is applicable for periods `ONE_DAY`, `ONE_WEEK`, `ONE_MONTH` and `ONE_YEAR`. `dayOfWeek` is applicable for period `ONE_WEEK`. `dayOfMonth` is applicable for periods `ONE_MONTH` and `ONE_YEAR`. 'month' is applicable for period 'ONE_YEAR'. They will be ignored in the requests for inapplicable periods. If value is `NUMERIC_SECONDS`, then `offsetSeconds` will be used for both requests and responses and the structured fields will be ignored in the requests and users should ignore their values from the respones. For clients using older versions of Apis and not sending `offsetType` in their requests, the behaviour is just like `NUMERIC_SECONDS`.
+
+        Allowed values for this property are: "STRUCTURED", "NUMERIC_SECONDS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The offset_type of this VolumeBackupSchedule.
+        :rtype: str
+        """
+        return self._offset_type
+
+    @offset_type.setter
+    def offset_type(self, offset_type):
+        """
+        Sets the offset_type of this VolumeBackupSchedule.
+        Indicates how offset is defined. If value is `STRUCTURED`, then `hourOfDay`, `dayOfWeek`, `dayOfMonth`, and `month` fields are used and `offsetSeconds` will be ignored in requests and users should ignore its value from the respones. `hourOfDay` is applicable for periods `ONE_DAY`, `ONE_WEEK`, `ONE_MONTH` and `ONE_YEAR`. `dayOfWeek` is applicable for period `ONE_WEEK`. `dayOfMonth` is applicable for periods `ONE_MONTH` and `ONE_YEAR`. 'month' is applicable for period 'ONE_YEAR'. They will be ignored in the requests for inapplicable periods. If value is `NUMERIC_SECONDS`, then `offsetSeconds` will be used for both requests and responses and the structured fields will be ignored in the requests and users should ignore their values from the respones. For clients using older versions of Apis and not sending `offsetType` in their requests, the behaviour is just like `NUMERIC_SECONDS`.
+
+
+        :param offset_type: The offset_type of this VolumeBackupSchedule.
+        :type: str
+        """
+        allowed_values = ["STRUCTURED", "NUMERIC_SECONDS"]
+        if not value_allowed_none_or_none_sentinel(offset_type, allowed_values):
+            offset_type = 'UNKNOWN_ENUM_VALUE'
+        self._offset_type = offset_type
+
+    @property
+    def hour_of_day(self):
+        """
+        Gets the hour_of_day of this VolumeBackupSchedule.
+        The hour of the day to schedule the backup
+
+
+        :return: The hour_of_day of this VolumeBackupSchedule.
+        :rtype: int
+        """
+        return self._hour_of_day
+
+    @hour_of_day.setter
+    def hour_of_day(self, hour_of_day):
+        """
+        Sets the hour_of_day of this VolumeBackupSchedule.
+        The hour of the day to schedule the backup
+
+
+        :param hour_of_day: The hour_of_day of this VolumeBackupSchedule.
+        :type: int
+        """
+        self._hour_of_day = hour_of_day
+
+    @property
+    def day_of_week(self):
+        """
+        Gets the day_of_week of this VolumeBackupSchedule.
+        The day of the week to schedule the backup
+
+        Allowed values for this property are: "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The day_of_week of this VolumeBackupSchedule.
+        :rtype: str
+        """
+        return self._day_of_week
+
+    @day_of_week.setter
+    def day_of_week(self, day_of_week):
+        """
+        Sets the day_of_week of this VolumeBackupSchedule.
+        The day of the week to schedule the backup
+
+
+        :param day_of_week: The day_of_week of this VolumeBackupSchedule.
+        :type: str
+        """
+        allowed_values = ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"]
+        if not value_allowed_none_or_none_sentinel(day_of_week, allowed_values):
+            day_of_week = 'UNKNOWN_ENUM_VALUE'
+        self._day_of_week = day_of_week
+
+    @property
+    def day_of_month(self):
+        """
+        Gets the day_of_month of this VolumeBackupSchedule.
+        The day of the month to schedule the backup
+
+
+        :return: The day_of_month of this VolumeBackupSchedule.
+        :rtype: int
+        """
+        return self._day_of_month
+
+    @day_of_month.setter
+    def day_of_month(self, day_of_month):
+        """
+        Sets the day_of_month of this VolumeBackupSchedule.
+        The day of the month to schedule the backup
+
+
+        :param day_of_month: The day_of_month of this VolumeBackupSchedule.
+        :type: int
+        """
+        self._day_of_month = day_of_month
+
+    @property
+    def month(self):
+        """
+        Gets the month of this VolumeBackupSchedule.
+        The month of the year to schedule the backup
+
+        Allowed values for this property are: "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The month of this VolumeBackupSchedule.
+        :rtype: str
+        """
+        return self._month
+
+    @month.setter
+    def month(self, month):
+        """
+        Sets the month of this VolumeBackupSchedule.
+        The month of the year to schedule the backup
+
+
+        :param month: The month of this VolumeBackupSchedule.
+        :type: str
+        """
+        allowed_values = ["JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER"]
+        if not value_allowed_none_or_none_sentinel(month, allowed_values):
+            month = 'UNKNOWN_ENUM_VALUE'
+        self._month = month
+
+    @property
     def retention_seconds(self):
         """
         **[Required]** Gets the retention_seconds of this VolumeBackupSchedule.
@@ -192,6 +472,36 @@ class VolumeBackupSchedule(object):
         :type: int
         """
         self._retention_seconds = retention_seconds
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this VolumeBackupSchedule.
+        Specifies what time zone is the schedule in
+
+        Allowed values for this property are: "UTC", "REGIONAL_DATA_CENTER_TIME", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The time_zone of this VolumeBackupSchedule.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this VolumeBackupSchedule.
+        Specifies what time zone is the schedule in
+
+
+        :param time_zone: The time_zone of this VolumeBackupSchedule.
+        :type: str
+        """
+        allowed_values = ["UTC", "REGIONAL_DATA_CENTER_TIME"]
+        if not value_allowed_none_or_none_sentinel(time_zone, allowed_values):
+            time_zone = 'UNKNOWN_ENUM_VALUE'
+        self._time_zone = time_zone
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/dts/models/__init__.py
+++ b/src/oci/dts/models/__init__.py
@@ -21,6 +21,7 @@ from .transfer_appliance import TransferAppliance
 from .transfer_appliance_certificate import TransferApplianceCertificate
 from .transfer_appliance_encryption_passphrase import TransferApplianceEncryptionPassphrase
 from .transfer_appliance_entitlement import TransferApplianceEntitlement
+from .transfer_appliance_entitlement_summary import TransferApplianceEntitlementSummary
 from .transfer_appliance_public_key import TransferAppliancePublicKey
 from .transfer_appliance_summary import TransferApplianceSummary
 from .transfer_device import TransferDevice
@@ -54,6 +55,7 @@ dts_type_mapping = {
     "TransferApplianceCertificate": TransferApplianceCertificate,
     "TransferApplianceEncryptionPassphrase": TransferApplianceEncryptionPassphrase,
     "TransferApplianceEntitlement": TransferApplianceEntitlement,
+    "TransferApplianceEntitlementSummary": TransferApplianceEntitlementSummary,
     "TransferAppliancePublicKey": TransferAppliancePublicKey,
     "TransferApplianceSummary": TransferApplianceSummary,
     "TransferDevice": TransferDevice,

--- a/src/oci/dts/models/create_transfer_appliance_entitlement_details.py
+++ b/src/oci/dts/models/create_transfer_appliance_entitlement_details.py
@@ -21,6 +21,10 @@ class CreateTransferApplianceEntitlementDetails(object):
             The value to assign to the compartment_id property of this CreateTransferApplianceEntitlementDetails.
         :type compartment_id: str
 
+        :param display_name:
+            The value to assign to the display_name property of this CreateTransferApplianceEntitlementDetails.
+        :type display_name: str
+
         :param requestor_name:
             The value to assign to the requestor_name property of this CreateTransferApplianceEntitlementDetails.
         :type requestor_name: str
@@ -29,22 +33,39 @@ class CreateTransferApplianceEntitlementDetails(object):
             The value to assign to the requestor_email property of this CreateTransferApplianceEntitlementDetails.
         :type requestor_email: str
 
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateTransferApplianceEntitlementDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateTransferApplianceEntitlementDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
+            'display_name': 'str',
             'requestor_name': 'str',
-            'requestor_email': 'str'
+            'requestor_email': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
         }
 
         self.attribute_map = {
             'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
             'requestor_name': 'requestorName',
-            'requestor_email': 'requestorEmail'
+            'requestor_email': 'requestorEmail',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
         }
 
         self._compartment_id = None
+        self._display_name = None
         self._requestor_name = None
         self._requestor_email = None
+        self._freeform_tags = None
+        self._defined_tags = None
 
     @property
     def compartment_id(self):
@@ -65,6 +86,26 @@ class CreateTransferApplianceEntitlementDetails(object):
         :type: str
         """
         self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateTransferApplianceEntitlementDetails.
+
+        :return: The display_name of this CreateTransferApplianceEntitlementDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateTransferApplianceEntitlementDetails.
+
+        :param display_name: The display_name of this CreateTransferApplianceEntitlementDetails.
+        :type: str
+        """
+        self._display_name = display_name
 
     @property
     def requestor_name(self):
@@ -105,6 +146,58 @@ class CreateTransferApplianceEntitlementDetails(object):
         :type: str
         """
         self._requestor_email = requestor_email
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateTransferApplianceEntitlementDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this CreateTransferApplianceEntitlementDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateTransferApplianceEntitlementDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this CreateTransferApplianceEntitlementDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateTransferApplianceEntitlementDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :return: The defined_tags of this CreateTransferApplianceEntitlementDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateTransferApplianceEntitlementDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :param defined_tags: The defined_tags of this CreateTransferApplianceEntitlementDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/dts/models/transfer_appliance.py
+++ b/src/oci/dts/models/transfer_appliance.py
@@ -33,6 +33,14 @@ class TransferAppliance(object):
     LIFECYCLE_STATE_PREPARING = "PREPARING"
 
     #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "FINALIZED"
+    LIFECYCLE_STATE_FINALIZED = "FINALIZED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
+    #: This constant has a value of "RETURN_DELAYED"
+    LIFECYCLE_STATE_RETURN_DELAYED = "RETURN_DELAYED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferAppliance.
     #: This constant has a value of "RETURN_SHIPPED"
     LIFECYCLE_STATE_RETURN_SHIPPED = "RETURN_SHIPPED"
 
@@ -95,7 +103,7 @@ class TransferAppliance(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this TransferAppliance.
-            Allowed values for this property are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "FINALIZED", "RETURN_DELAYED", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -232,7 +240,7 @@ class TransferAppliance(object):
     def lifecycle_state(self):
         """
         Gets the lifecycle_state of this TransferAppliance.
-        Allowed values for this property are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "FINALIZED", "RETURN_DELAYED", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -249,7 +257,7 @@ class TransferAppliance(object):
         :param lifecycle_state: The lifecycle_state of this TransferAppliance.
         :type: str
         """
-        allowed_values = ["REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR"]
+        allowed_values = ["REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "FINALIZED", "RETURN_DELAYED", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state

--- a/src/oci/dts/models/transfer_appliance_entitlement.py
+++ b/src/oci/dts/models/transfer_appliance_entitlement.py
@@ -12,42 +12,38 @@ class TransferApplianceEntitlement(object):
     TransferApplianceEntitlement model.
     """
 
-    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
-    #: This constant has a value of "REQUESTED"
-    STATUS_REQUESTED = "REQUESTED"
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceEntitlement.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
 
-    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
-    #: This constant has a value of "PENDING_SIGNING"
-    STATUS_PENDING_SIGNING = "PENDING_SIGNING"
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceEntitlement.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
 
-    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
-    #: This constant has a value of "PENDING_APPROVAL"
-    STATUS_PENDING_APPROVAL = "PENDING_APPROVAL"
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceEntitlement.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
 
-    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
-    #: This constant has a value of "TERMS_EXPIRED"
-    STATUS_TERMS_EXPIRED = "TERMS_EXPIRED"
-
-    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
-    #: This constant has a value of "APPROVED"
-    STATUS_APPROVED = "APPROVED"
-
-    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
-    #: This constant has a value of "REJECTED"
-    STATUS_REJECTED = "REJECTED"
-
-    #: A constant which can be used with the status property of a TransferApplianceEntitlement.
-    #: This constant has a value of "CANCELLED"
-    STATUS_CANCELLED = "CANCELLED"
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceEntitlement.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
 
     def __init__(self, **kwargs):
         """
         Initializes a new TransferApplianceEntitlement object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
-        :param tenant_id:
-            The value to assign to the tenant_id property of this TransferApplianceEntitlement.
-        :type tenant_id: str
+        :param id:
+            The value to assign to the id property of this TransferApplianceEntitlement.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this TransferApplianceEntitlement.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this TransferApplianceEntitlement.
+        :type display_name: str
 
         :param requestor_name:
             The value to assign to the requestor_name property of this TransferApplianceEntitlement.
@@ -57,11 +53,15 @@ class TransferApplianceEntitlement(object):
             The value to assign to the requestor_email property of this TransferApplianceEntitlement.
         :type requestor_email: str
 
-        :param status:
-            The value to assign to the status property of this TransferApplianceEntitlement.
-            Allowed values for this property are: "REQUESTED", "PENDING_SIGNING", "PENDING_APPROVAL", "TERMS_EXPIRED", "APPROVED", "REJECTED", "CANCELLED", 'UNKNOWN_ENUM_VALUE'.
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TransferApplianceEntitlement.
+            Allowed values for this property are: "CREATING", "ACTIVE", "INACTIVE", "DELETED", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
-        :type status: str
+        :type lifecycle_state: str
+
+        :param lifecycle_state_details:
+            The value to assign to the lifecycle_state_details property of this TransferApplianceEntitlement.
+        :type lifecycle_state_details: str
 
         :param creation_time:
             The value to assign to the creation_time property of this TransferApplianceEntitlement.
@@ -71,51 +71,114 @@ class TransferApplianceEntitlement(object):
             The value to assign to the update_time property of this TransferApplianceEntitlement.
         :type update_time: datetime
 
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this TransferApplianceEntitlement.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this TransferApplianceEntitlement.
+        :type defined_tags: dict(str, dict(str, object))
+
         """
         self.swagger_types = {
-            'tenant_id': 'str',
+            'id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
             'requestor_name': 'str',
             'requestor_email': 'str',
-            'status': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_state_details': 'str',
             'creation_time': 'datetime',
-            'update_time': 'datetime'
+            'update_time': 'datetime',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
         }
 
         self.attribute_map = {
-            'tenant_id': 'tenantId',
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
             'requestor_name': 'requestorName',
             'requestor_email': 'requestorEmail',
-            'status': 'status',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_state_details': 'lifecycleStateDetails',
             'creation_time': 'creationTime',
-            'update_time': 'updateTime'
+            'update_time': 'updateTime',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
         }
 
-        self._tenant_id = None
+        self._id = None
+        self._compartment_id = None
+        self._display_name = None
         self._requestor_name = None
         self._requestor_email = None
-        self._status = None
+        self._lifecycle_state = None
+        self._lifecycle_state_details = None
         self._creation_time = None
         self._update_time = None
+        self._freeform_tags = None
+        self._defined_tags = None
 
     @property
-    def tenant_id(self):
+    def id(self):
         """
-        **[Required]** Gets the tenant_id of this TransferApplianceEntitlement.
+        Gets the id of this TransferApplianceEntitlement.
 
-        :return: The tenant_id of this TransferApplianceEntitlement.
+        :return: The id of this TransferApplianceEntitlement.
         :rtype: str
         """
-        return self._tenant_id
+        return self._id
 
-    @tenant_id.setter
-    def tenant_id(self, tenant_id):
+    @id.setter
+    def id(self, id):
         """
-        Sets the tenant_id of this TransferApplianceEntitlement.
+        Sets the id of this TransferApplianceEntitlement.
 
-        :param tenant_id: The tenant_id of this TransferApplianceEntitlement.
+        :param id: The id of this TransferApplianceEntitlement.
         :type: str
         """
-        self._tenant_id = tenant_id
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this TransferApplianceEntitlement.
+
+        :return: The compartment_id of this TransferApplianceEntitlement.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this TransferApplianceEntitlement.
+
+        :param compartment_id: The compartment_id of this TransferApplianceEntitlement.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this TransferApplianceEntitlement.
+
+        :return: The display_name of this TransferApplianceEntitlement.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this TransferApplianceEntitlement.
+
+        :param display_name: The display_name of this TransferApplianceEntitlement.
+        :type: str
+        """
+        self._display_name = display_name
 
     @property
     def requestor_name(self):
@@ -158,30 +221,54 @@ class TransferApplianceEntitlement(object):
         self._requestor_email = requestor_email
 
     @property
-    def status(self):
+    def lifecycle_state(self):
         """
-        **[Required]** Gets the status of this TransferApplianceEntitlement.
-        Allowed values for this property are: "REQUESTED", "PENDING_SIGNING", "PENDING_APPROVAL", "TERMS_EXPIRED", "APPROVED", "REJECTED", "CANCELLED", 'UNKNOWN_ENUM_VALUE'.
+        **[Required]** Gets the lifecycle_state of this TransferApplianceEntitlement.
+        Allowed values for this property are: "CREATING", "ACTIVE", "INACTIVE", "DELETED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
-        :return: The status of this TransferApplianceEntitlement.
+        :return: The lifecycle_state of this TransferApplianceEntitlement.
         :rtype: str
         """
-        return self._status
+        return self._lifecycle_state
 
-    @status.setter
-    def status(self, status):
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
         """
-        Sets the status of this TransferApplianceEntitlement.
+        Sets the lifecycle_state of this TransferApplianceEntitlement.
 
-        :param status: The status of this TransferApplianceEntitlement.
+        :param lifecycle_state: The lifecycle_state of this TransferApplianceEntitlement.
         :type: str
         """
-        allowed_values = ["REQUESTED", "PENDING_SIGNING", "PENDING_APPROVAL", "TERMS_EXPIRED", "APPROVED", "REJECTED", "CANCELLED"]
-        if not value_allowed_none_or_none_sentinel(status, allowed_values):
-            status = 'UNKNOWN_ENUM_VALUE'
-        self._status = status
+        allowed_values = ["CREATING", "ACTIVE", "INACTIVE", "DELETED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_state_details(self):
+        """
+        Gets the lifecycle_state_details of this TransferApplianceEntitlement.
+        A property that can contain details on the lifecycle.
+
+
+        :return: The lifecycle_state_details of this TransferApplianceEntitlement.
+        :rtype: str
+        """
+        return self._lifecycle_state_details
+
+    @lifecycle_state_details.setter
+    def lifecycle_state_details(self, lifecycle_state_details):
+        """
+        Sets the lifecycle_state_details of this TransferApplianceEntitlement.
+        A property that can contain details on the lifecycle.
+
+
+        :param lifecycle_state_details: The lifecycle_state_details of this TransferApplianceEntitlement.
+        :type: str
+        """
+        self._lifecycle_state_details = lifecycle_state_details
 
     @property
     def creation_time(self):
@@ -222,6 +309,58 @@ class TransferApplianceEntitlement(object):
         :type: datetime
         """
         self._update_time = update_time
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this TransferApplianceEntitlement.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this TransferApplianceEntitlement.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this TransferApplianceEntitlement.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this TransferApplianceEntitlement.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this TransferApplianceEntitlement.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :return: The defined_tags of this TransferApplianceEntitlement.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this TransferApplianceEntitlement.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :param defined_tags: The defined_tags of this TransferApplianceEntitlement.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/dts/models/transfer_appliance_entitlement_summary.py
+++ b/src/oci/dts/models/transfer_appliance_entitlement_summary.py
@@ -1,0 +1,297 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TransferApplianceEntitlementSummary(object):
+    """
+    TransferApplianceEntitlementSummary model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TransferApplianceEntitlementSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this TransferApplianceEntitlementSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this TransferApplianceEntitlementSummary.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this TransferApplianceEntitlementSummary.
+        :type display_name: str
+
+        :param requestor_name:
+            The value to assign to the requestor_name property of this TransferApplianceEntitlementSummary.
+        :type requestor_name: str
+
+        :param requestor_email:
+            The value to assign to the requestor_email property of this TransferApplianceEntitlementSummary.
+        :type requestor_email: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TransferApplianceEntitlementSummary.
+        :type lifecycle_state: str
+
+        :param lifecycle_state_details:
+            The value to assign to the lifecycle_state_details property of this TransferApplianceEntitlementSummary.
+        :type lifecycle_state_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this TransferApplianceEntitlementSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this TransferApplianceEntitlementSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'requestor_name': 'str',
+            'requestor_email': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_state_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'requestor_name': 'requestorName',
+            'requestor_email': 'requestorEmail',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_state_details': 'lifecycleStateDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._display_name = None
+        self._requestor_name = None
+        self._requestor_email = None
+        self._lifecycle_state = None
+        self._lifecycle_state_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this TransferApplianceEntitlementSummary.
+
+        :return: The id of this TransferApplianceEntitlementSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this TransferApplianceEntitlementSummary.
+
+        :param id: The id of this TransferApplianceEntitlementSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this TransferApplianceEntitlementSummary.
+
+        :return: The compartment_id of this TransferApplianceEntitlementSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this TransferApplianceEntitlementSummary.
+
+        :param compartment_id: The compartment_id of this TransferApplianceEntitlementSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this TransferApplianceEntitlementSummary.
+
+        :return: The display_name of this TransferApplianceEntitlementSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this TransferApplianceEntitlementSummary.
+
+        :param display_name: The display_name of this TransferApplianceEntitlementSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def requestor_name(self):
+        """
+        Gets the requestor_name of this TransferApplianceEntitlementSummary.
+
+        :return: The requestor_name of this TransferApplianceEntitlementSummary.
+        :rtype: str
+        """
+        return self._requestor_name
+
+    @requestor_name.setter
+    def requestor_name(self, requestor_name):
+        """
+        Sets the requestor_name of this TransferApplianceEntitlementSummary.
+
+        :param requestor_name: The requestor_name of this TransferApplianceEntitlementSummary.
+        :type: str
+        """
+        self._requestor_name = requestor_name
+
+    @property
+    def requestor_email(self):
+        """
+        Gets the requestor_email of this TransferApplianceEntitlementSummary.
+
+        :return: The requestor_email of this TransferApplianceEntitlementSummary.
+        :rtype: str
+        """
+        return self._requestor_email
+
+    @requestor_email.setter
+    def requestor_email(self, requestor_email):
+        """
+        Sets the requestor_email of this TransferApplianceEntitlementSummary.
+
+        :param requestor_email: The requestor_email of this TransferApplianceEntitlementSummary.
+        :type: str
+        """
+        self._requestor_email = requestor_email
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this TransferApplianceEntitlementSummary.
+
+        :return: The lifecycle_state of this TransferApplianceEntitlementSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this TransferApplianceEntitlementSummary.
+
+        :param lifecycle_state: The lifecycle_state of this TransferApplianceEntitlementSummary.
+        :type: str
+        """
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_state_details(self):
+        """
+        Gets the lifecycle_state_details of this TransferApplianceEntitlementSummary.
+        A property that can contain details on the lifecycle.
+
+
+        :return: The lifecycle_state_details of this TransferApplianceEntitlementSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state_details
+
+    @lifecycle_state_details.setter
+    def lifecycle_state_details(self, lifecycle_state_details):
+        """
+        Sets the lifecycle_state_details of this TransferApplianceEntitlementSummary.
+        A property that can contain details on the lifecycle.
+
+
+        :param lifecycle_state_details: The lifecycle_state_details of this TransferApplianceEntitlementSummary.
+        :type: str
+        """
+        self._lifecycle_state_details = lifecycle_state_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this TransferApplianceEntitlementSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this TransferApplianceEntitlementSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this TransferApplianceEntitlementSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this TransferApplianceEntitlementSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this TransferApplianceEntitlementSummary.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :return: The defined_tags of this TransferApplianceEntitlementSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this TransferApplianceEntitlementSummary.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+
+
+        :param defined_tags: The defined_tags of this TransferApplianceEntitlementSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/dts/models/transfer_appliance_summary.py
+++ b/src/oci/dts/models/transfer_appliance_summary.py
@@ -33,6 +33,14 @@ class TransferApplianceSummary(object):
     LIFECYCLE_STATE_PREPARING = "PREPARING"
 
     #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "FINALIZED"
+    LIFECYCLE_STATE_FINALIZED = "FINALIZED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
+    #: This constant has a value of "RETURN_DELAYED"
+    LIFECYCLE_STATE_RETURN_DELAYED = "RETURN_DELAYED"
+
+    #: A constant which can be used with the lifecycle_state property of a TransferApplianceSummary.
     #: This constant has a value of "RETURN_SHIPPED"
     LIFECYCLE_STATE_RETURN_SHIPPED = "RETURN_SHIPPED"
 
@@ -95,7 +103,7 @@ class TransferApplianceSummary(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this TransferApplianceSummary.
-            Allowed values for this property are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "FINALIZED", "RETURN_DELAYED", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -151,7 +159,7 @@ class TransferApplianceSummary(object):
     def lifecycle_state(self):
         """
         Gets the lifecycle_state of this TransferApplianceSummary.
-        Allowed values for this property are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "FINALIZED", "RETURN_DELAYED", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -168,7 +176,7 @@ class TransferApplianceSummary(object):
         :param lifecycle_state: The lifecycle_state of this TransferApplianceSummary.
         :type: str
         """
-        allowed_values = ["REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR"]
+        allowed_values = ["REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "FINALIZED", "RETURN_DELAYED", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state

--- a/src/oci/dts/models/transfer_job.py
+++ b/src/oci/dts/models/transfer_job.py
@@ -171,7 +171,7 @@ class TransferJob(object):
     @property
     def compartment_id(self):
         """
-        **[Required]** Gets the compartment_id of this TransferJob.
+        Gets the compartment_id of this TransferJob.
 
         :return: The compartment_id of this TransferJob.
         :rtype: str
@@ -191,7 +191,7 @@ class TransferJob(object):
     @property
     def upload_bucket_name(self):
         """
-        **[Required]** Gets the upload_bucket_name of this TransferJob.
+        Gets the upload_bucket_name of this TransferJob.
 
         :return: The upload_bucket_name of this TransferJob.
         :rtype: str
@@ -211,7 +211,7 @@ class TransferJob(object):
     @property
     def display_name(self):
         """
-        **[Required]** Gets the display_name of this TransferJob.
+        Gets the display_name of this TransferJob.
 
         :return: The display_name of this TransferJob.
         :rtype: str
@@ -271,7 +271,7 @@ class TransferJob(object):
     @property
     def device_type(self):
         """
-        **[Required]** Gets the device_type of this TransferJob.
+        Gets the device_type of this TransferJob.
         Allowed values for this property are: "DISK", "APPLIANCE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 

--- a/src/oci/dts/models/update_transfer_appliance_details.py
+++ b/src/oci/dts/models/update_transfer_appliance_details.py
@@ -17,6 +17,10 @@ class UpdateTransferApplianceDetails(object):
     LIFECYCLE_STATE_PREPARING = "PREPARING"
 
     #: A constant which can be used with the lifecycle_state property of a UpdateTransferApplianceDetails.
+    #: This constant has a value of "FINALIZED"
+    LIFECYCLE_STATE_FINALIZED = "FINALIZED"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateTransferApplianceDetails.
     #: This constant has a value of "DELETED"
     LIFECYCLE_STATE_DELETED = "DELETED"
 
@@ -35,7 +39,7 @@ class UpdateTransferApplianceDetails(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this UpdateTransferApplianceDetails.
-            Allowed values for this property are: "PREPARING", "DELETED", "CUSTOMER_NEVER_RECEIVED", "CANCELLED"
+            Allowed values for this property are: "PREPARING", "FINALIZED", "DELETED", "CUSTOMER_NEVER_RECEIVED", "CANCELLED"
         :type lifecycle_state: str
 
         :param customer_shipping_address:
@@ -60,7 +64,7 @@ class UpdateTransferApplianceDetails(object):
     def lifecycle_state(self):
         """
         Gets the lifecycle_state of this UpdateTransferApplianceDetails.
-        Allowed values for this property are: "PREPARING", "DELETED", "CUSTOMER_NEVER_RECEIVED", "CANCELLED"
+        Allowed values for this property are: "PREPARING", "FINALIZED", "DELETED", "CUSTOMER_NEVER_RECEIVED", "CANCELLED"
 
 
         :return: The lifecycle_state of this UpdateTransferApplianceDetails.
@@ -76,7 +80,7 @@ class UpdateTransferApplianceDetails(object):
         :param lifecycle_state: The lifecycle_state of this UpdateTransferApplianceDetails.
         :type: str
         """
-        allowed_values = ["PREPARING", "DELETED", "CUSTOMER_NEVER_RECEIVED", "CANCELLED"]
+        allowed_values = ["PREPARING", "FINALIZED", "DELETED", "CUSTOMER_NEVER_RECEIVED", "CANCELLED"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             raise ValueError(
                 "Invalid value for `lifecycle_state`, must be None or one of {0}"

--- a/src/oci/dts/shipping_vendors_client.py
+++ b/src/oci/dts/shipping_vendors_client.py
@@ -17,7 +17,7 @@ missing = Sentinel("Missing")
 
 class ShippingVendorsClient(object):
     """
-    A description of the DTS API
+    Data Transfer Service API Specification
     """
 
     def __init__(self, config, **kwargs):

--- a/src/oci/dts/transfer_appliance_client.py
+++ b/src/oci/dts/transfer_appliance_client.py
@@ -17,7 +17,7 @@ missing = Sentinel("Missing")
 
 class TransferApplianceClient(object):
     """
-    A description of the DTS API
+    Data Transfer Service API Specification
     """
 
     def __init__(self, config, **kwargs):
@@ -514,7 +514,7 @@ class TransferApplianceClient(object):
         :param str lifecycle_state: (optional)
             filtering by lifecycleState
 
-            Allowed values are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR"
+            Allowed values are: "REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "FINALIZED", "RETURN_DELAYED", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR"
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -551,7 +551,7 @@ class TransferApplianceClient(object):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
 
         if 'lifecycle_state' in kwargs:
-            lifecycle_state_allowed_values = ["REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR"]
+            lifecycle_state_allowed_values = ["REQUESTED", "ORACLE_PREPARING", "SHIPPING", "DELIVERED", "PREPARING", "FINALIZED", "RETURN_DELAYED", "RETURN_SHIPPED", "RETURN_SHIPPED_CANCELLED", "ORACLE_RECEIVED", "ORACLE_RECEIVED_CANCELLED", "PROCESSING", "COMPLETE", "CUSTOMER_NEVER_RECEIVED", "ORACLE_NEVER_RECEIVED", "CUSTOMER_LOST", "CANCELLED", "DELETED", "REJECTED", "ERROR"]
             if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
                 raise ValueError(
                     "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)

--- a/src/oci/dts/transfer_appliance_entitlement_client.py
+++ b/src/oci/dts/transfer_appliance_entitlement_client.py
@@ -17,7 +17,7 @@ missing = Sentinel("Missing")
 
 class TransferApplianceEntitlementClient(object):
     """
-    A description of the DTS API
+    Data Transfer Service API Specification
     """
 
     def __init__(self, config, **kwargs):
@@ -83,17 +83,22 @@ class TransferApplianceEntitlementClient(object):
     def create_transfer_appliance_entitlement(self, create_transfer_appliance_entitlement_details, **kwargs):
         """
         Create the Transfer Appliance Entitlement
-        Create the Transfer Appliance Entitlement that allows customers to use Transfer Appliance
+        Create the Entitlement to use a Transfer Appliance. It requires some offline process of review and signatures before request is granted.
 
 
         :param CreateTransferApplianceEntitlementDetails create_transfer_appliance_entitlement_details: (required)
             Creates a Transfer Appliance Entitlement
 
         :param str opc_retry_token: (optional)
-            opc retry token
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
 
         :param str opc_request_id: (optional)
-            opc request id
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+            a particular request, please provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -150,17 +155,25 @@ class TransferApplianceEntitlementClient(object):
                 body=create_transfer_appliance_entitlement_details,
                 response_type="TransferApplianceEntitlement")
 
-    def get_transfer_appliance_entitlement(self, tenant_id, **kwargs):
+    def get_transfer_appliance_entitlement(self, id, **kwargs):
         """
         Describes the Transfer Appliance Entitlement in detail
         Describes the Transfer Appliance Entitlement in detail
 
 
-        :param str tenant_id: (required)
-            Tenant Id
+        :param str id: (required)
+            Id of the Transfer Appliance Entitlement
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
 
         :param str opc_request_id: (optional)
-            opc request id
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+            a particular request, please provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -173,12 +186,13 @@ class TransferApplianceEntitlementClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.dts.models.TransferApplianceEntitlement`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/transferApplianceEntitlement/{tenantId}"
+        resource_path = "/transferApplianceEntitlement/{id}"
         method = "GET"
 
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
+            "opc_retry_token",
             "opc_request_id"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
@@ -187,7 +201,7 @@ class TransferApplianceEntitlementClient(object):
                 "get_transfer_appliance_entitlement got unknown kwargs: {!r}".format(extra_kwargs))
 
         path_params = {
-            "tenantId": tenant_id
+            "id": id
         }
 
         path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
@@ -195,6 +209,88 @@ class TransferApplianceEntitlementClient(object):
         for (k, v) in six.iteritems(path_params):
             if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferApplianceEntitlement")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TransferApplianceEntitlement")
+
+    def list_transfer_appliance_entitlement(self, compartment_id, **kwargs):
+        """
+        Lists Transfer Transfer Appliance Entitlement
+        Lists Transfer Transfer Appliance Entitlement
+
+
+        :param str compartment_id: (required)
+            compartment id
+
+        :param str id: (optional)
+            filtering by Transfer Appliance Entitlement id
+
+        :param str display_name: (optional)
+            filtering by displayName
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+            a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.dts.models.TransferApplianceEntitlementSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/transferApplianceEntitlement"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "id",
+            "display_name",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_transfer_appliance_entitlement got unknown kwargs: {!r}".format(extra_kwargs))
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "id": kwargs.get("id", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
         header_params = {
             "accept": "application/json",
@@ -212,13 +308,13 @@ class TransferApplianceEntitlementClient(object):
                 self.base_client.call_api,
                 resource_path=resource_path,
                 method=method,
-                path_params=path_params,
+                query_params=query_params,
                 header_params=header_params,
-                response_type="TransferApplianceEntitlement")
+                response_type="list[TransferApplianceEntitlementSummary]")
         else:
             return self.base_client.call_api(
                 resource_path=resource_path,
                 method=method,
-                path_params=path_params,
+                query_params=query_params,
                 header_params=header_params,
-                response_type="TransferApplianceEntitlement")
+                response_type="list[TransferApplianceEntitlementSummary]")

--- a/src/oci/dts/transfer_appliance_entitlement_client_composite_operations.py
+++ b/src/oci/dts/transfer_appliance_entitlement_client_composite_operations.py
@@ -21,3 +21,41 @@ class TransferApplianceEntitlementClientCompositeOperations(object):
             The service client which will be wrapped by this object
         """
         self.client = client
+
+    def create_transfer_appliance_entitlement_and_wait_for_state(self, create_transfer_appliance_entitlement_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.dts.TransferApplianceEntitlementClient.create_transfer_appliance_entitlement` and waits for the :py:class:`~oci.dts.models.TransferApplianceEntitlement` acted upon
+        to enter the given state(s).
+
+        :param CreateTransferApplianceEntitlementDetails create_transfer_appliance_entitlement_details: (required)
+            Creates a Transfer Appliance Entitlement
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.dts.models.TransferApplianceEntitlement.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.dts.TransferApplianceEntitlementClient.create_transfer_appliance_entitlement`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_transfer_appliance_entitlement(create_transfer_appliance_entitlement_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_transfer_appliance_entitlement(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)

--- a/src/oci/dts/transfer_device_client.py
+++ b/src/oci/dts/transfer_device_client.py
@@ -17,7 +17,7 @@ missing = Sentinel("Missing")
 
 class TransferDeviceClient(object):
     """
-    A description of the DTS API
+    Data Transfer Service API Specification
     """
 
     def __init__(self, config, **kwargs):

--- a/src/oci/dts/transfer_job_client.py
+++ b/src/oci/dts/transfer_job_client.py
@@ -17,7 +17,7 @@ missing = Sentinel("Missing")
 
 class TransferJobClient(object):
     """
-    A description of the DTS API
+    Data Transfer Service API Specification
     """
 
     def __init__(self, config, **kwargs):

--- a/src/oci/dts/transfer_package_client.py
+++ b/src/oci/dts/transfer_package_client.py
@@ -17,7 +17,7 @@ missing = Sentinel("Missing")
 
 class TransferPackageClient(object):
     """
-    A description of the DTS API
+    Data Transfer Service API Specification
     """
 
     def __init__(self, config, **kwargs):

--- a/src/oci/healthchecks/health_checks_client.py
+++ b/src/oci/healthchecks/health_checks_client.py
@@ -1031,7 +1031,7 @@ class HealthChecksClient(object):
         :param str sort_by: (optional)
             The field to sort by when listing monitors.
 
-            Allowed values are: "id", "displayName"
+            Allowed values are: "id", "displayName", "timeCreated"
 
         :param str sort_order: (optional)
             Controls the sort order of results.
@@ -1040,6 +1040,9 @@ class HealthChecksClient(object):
 
         :param str display_name: (optional)
             Filters results that exactly match the `displayName` field.
+
+        :param str home_region: (optional)
+            Filters results that match the `homeRegion`.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1063,7 +1066,8 @@ class HealthChecksClient(object):
             "page",
             "sort_by",
             "sort_order",
-            "display_name"
+            "display_name",
+            "home_region"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -1071,7 +1075,7 @@ class HealthChecksClient(object):
                 "list_http_monitors got unknown kwargs: {!r}".format(extra_kwargs))
 
         if 'sort_by' in kwargs:
-            sort_by_allowed_values = ["id", "displayName"]
+            sort_by_allowed_values = ["id", "displayName", "timeCreated"]
             if kwargs['sort_by'] not in sort_by_allowed_values:
                 raise ValueError(
                     "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
@@ -1090,7 +1094,8 @@ class HealthChecksClient(object):
             "compartmentId": compartment_id,
             "sortBy": kwargs.get("sort_by", missing),
             "sortOrder": kwargs.get("sort_order", missing),
-            "displayName": kwargs.get("display_name", missing)
+            "displayName": kwargs.get("display_name", missing),
+            "homeRegion": kwargs.get("home_region", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -1269,7 +1274,7 @@ class HealthChecksClient(object):
         :param str sort_by: (optional)
             The field to sort by when listing monitors.
 
-            Allowed values are: "id", "displayName"
+            Allowed values are: "id", "displayName", "timeCreated"
 
         :param str sort_order: (optional)
             Controls the sort order of results.
@@ -1278,6 +1283,9 @@ class HealthChecksClient(object):
 
         :param str display_name: (optional)
             Filters results that exactly match the `displayName` field.
+
+        :param str home_region: (optional)
+            Filters results that match the `homeRegion`.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1301,7 +1309,8 @@ class HealthChecksClient(object):
             "page",
             "sort_by",
             "sort_order",
-            "display_name"
+            "display_name",
+            "home_region"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -1309,7 +1318,7 @@ class HealthChecksClient(object):
                 "list_ping_monitors got unknown kwargs: {!r}".format(extra_kwargs))
 
         if 'sort_by' in kwargs:
-            sort_by_allowed_values = ["id", "displayName"]
+            sort_by_allowed_values = ["id", "displayName", "timeCreated"]
             if kwargs['sort_by'] not in sort_by_allowed_values:
                 raise ValueError(
                     "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
@@ -1328,7 +1337,8 @@ class HealthChecksClient(object):
             "compartmentId": compartment_id,
             "sortBy": kwargs.get("sort_by", missing),
             "sortOrder": kwargs.get("sort_order", missing),
-            "displayName": kwargs.get("display_name", missing)
+            "displayName": kwargs.get("display_name", missing),
+            "homeRegion": kwargs.get("home_region", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 

--- a/src/oci/healthchecks/models/http_monitor.py
+++ b/src/oci/healthchecks/models/http_monitor.py
@@ -41,6 +41,14 @@ class HttpMonitor(object):
             The value to assign to the results_url property of this HttpMonitor.
         :type results_url: str
 
+        :param home_region:
+            The value to assign to the home_region property of this HttpMonitor.
+        :type home_region: str
+
+        :param time_created:
+            The value to assign to the time_created property of this HttpMonitor.
+        :type time_created: datetime
+
         :param compartment_id:
             The value to assign to the compartment_id property of this HttpMonitor.
         :type compartment_id: str
@@ -105,6 +113,8 @@ class HttpMonitor(object):
         self.swagger_types = {
             'id': 'str',
             'results_url': 'str',
+            'home_region': 'str',
+            'time_created': 'datetime',
             'compartment_id': 'str',
             'targets': 'list[str]',
             'vantage_point_names': 'list[str]',
@@ -124,6 +134,8 @@ class HttpMonitor(object):
         self.attribute_map = {
             'id': 'id',
             'results_url': 'resultsUrl',
+            'home_region': 'homeRegion',
+            'time_created': 'timeCreated',
             'compartment_id': 'compartmentId',
             'targets': 'targets',
             'vantage_point_names': 'vantagePointNames',
@@ -142,6 +154,8 @@ class HttpMonitor(object):
 
         self._id = None
         self._results_url = None
+        self._home_region = None
+        self._time_created = None
         self._compartment_id = None
         self._targets = None
         self._vantage_point_names = None
@@ -204,6 +218,54 @@ class HttpMonitor(object):
         :type: str
         """
         self._results_url = results_url
+
+    @property
+    def home_region(self):
+        """
+        Gets the home_region of this HttpMonitor.
+        The region where updates must be made and where results must be fetched from.
+
+
+        :return: The home_region of this HttpMonitor.
+        :rtype: str
+        """
+        return self._home_region
+
+    @home_region.setter
+    def home_region(self, home_region):
+        """
+        Sets the home_region of this HttpMonitor.
+        The region where updates must be made and where results must be fetched from.
+
+
+        :param home_region: The home_region of this HttpMonitor.
+        :type: str
+        """
+        self._home_region = home_region
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this HttpMonitor.
+        The RFC 3339-formatted creation date and time of the probe.
+
+
+        :return: The time_created of this HttpMonitor.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this HttpMonitor.
+        The RFC 3339-formatted creation date and time of the probe.
+
+
+        :param time_created: The time_created of this HttpMonitor.
+        :type: datetime
+        """
+        self._time_created = time_created
 
     @property
     def compartment_id(self):

--- a/src/oci/healthchecks/models/http_monitor_summary.py
+++ b/src/oci/healthchecks/models/http_monitor_summary.py
@@ -33,6 +33,14 @@ class HttpMonitorSummary(object):
             The value to assign to the results_url property of this HttpMonitorSummary.
         :type results_url: str
 
+        :param home_region:
+            The value to assign to the home_region property of this HttpMonitorSummary.
+        :type home_region: str
+
+        :param time_created:
+            The value to assign to the time_created property of this HttpMonitorSummary.
+        :type time_created: datetime
+
         :param compartment_id:
             The value to assign to the compartment_id property of this HttpMonitorSummary.
         :type compartment_id: str
@@ -67,6 +75,8 @@ class HttpMonitorSummary(object):
         self.swagger_types = {
             'id': 'str',
             'results_url': 'str',
+            'home_region': 'str',
+            'time_created': 'datetime',
             'compartment_id': 'str',
             'display_name': 'str',
             'interval_in_seconds': 'int',
@@ -79,6 +89,8 @@ class HttpMonitorSummary(object):
         self.attribute_map = {
             'id': 'id',
             'results_url': 'resultsUrl',
+            'home_region': 'homeRegion',
+            'time_created': 'timeCreated',
             'compartment_id': 'compartmentId',
             'display_name': 'displayName',
             'interval_in_seconds': 'intervalInSeconds',
@@ -90,6 +102,8 @@ class HttpMonitorSummary(object):
 
         self._id = None
         self._results_url = None
+        self._home_region = None
+        self._time_created = None
         self._compartment_id = None
         self._display_name = None
         self._interval_in_seconds = None
@@ -145,6 +159,54 @@ class HttpMonitorSummary(object):
         :type: str
         """
         self._results_url = results_url
+
+    @property
+    def home_region(self):
+        """
+        Gets the home_region of this HttpMonitorSummary.
+        The region where updates must be made and where results must be fetched from.
+
+
+        :return: The home_region of this HttpMonitorSummary.
+        :rtype: str
+        """
+        return self._home_region
+
+    @home_region.setter
+    def home_region(self, home_region):
+        """
+        Sets the home_region of this HttpMonitorSummary.
+        The region where updates must be made and where results must be fetched from.
+
+
+        :param home_region: The home_region of this HttpMonitorSummary.
+        :type: str
+        """
+        self._home_region = home_region
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this HttpMonitorSummary.
+        The RFC 3339-formatted creation date and time of the probe.
+
+
+        :return: The time_created of this HttpMonitorSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this HttpMonitorSummary.
+        The RFC 3339-formatted creation date and time of the probe.
+
+
+        :param time_created: The time_created of this HttpMonitorSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
 
     @property
     def compartment_id(self):

--- a/src/oci/healthchecks/models/http_probe.py
+++ b/src/oci/healthchecks/models/http_probe.py
@@ -41,6 +41,14 @@ class HttpProbe(object):
             The value to assign to the results_url property of this HttpProbe.
         :type results_url: str
 
+        :param home_region:
+            The value to assign to the home_region property of this HttpProbe.
+        :type home_region: str
+
+        :param time_created:
+            The value to assign to the time_created property of this HttpProbe.
+        :type time_created: datetime
+
         :param compartment_id:
             The value to assign to the compartment_id property of this HttpProbe.
         :type compartment_id: str
@@ -85,6 +93,8 @@ class HttpProbe(object):
         self.swagger_types = {
             'id': 'str',
             'results_url': 'str',
+            'home_region': 'str',
+            'time_created': 'datetime',
             'compartment_id': 'str',
             'targets': 'list[str]',
             'vantage_point_names': 'list[str]',
@@ -99,6 +109,8 @@ class HttpProbe(object):
         self.attribute_map = {
             'id': 'id',
             'results_url': 'resultsUrl',
+            'home_region': 'homeRegion',
+            'time_created': 'timeCreated',
             'compartment_id': 'compartmentId',
             'targets': 'targets',
             'vantage_point_names': 'vantagePointNames',
@@ -112,6 +124,8 @@ class HttpProbe(object):
 
         self._id = None
         self._results_url = None
+        self._home_region = None
+        self._time_created = None
         self._compartment_id = None
         self._targets = None
         self._vantage_point_names = None
@@ -169,6 +183,54 @@ class HttpProbe(object):
         :type: str
         """
         self._results_url = results_url
+
+    @property
+    def home_region(self):
+        """
+        Gets the home_region of this HttpProbe.
+        The region where updates must be made and where results must be fetched from.
+
+
+        :return: The home_region of this HttpProbe.
+        :rtype: str
+        """
+        return self._home_region
+
+    @home_region.setter
+    def home_region(self, home_region):
+        """
+        Sets the home_region of this HttpProbe.
+        The region where updates must be made and where results must be fetched from.
+
+
+        :param home_region: The home_region of this HttpProbe.
+        :type: str
+        """
+        self._home_region = home_region
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this HttpProbe.
+        The RFC 3339-formatted creation date and time of the probe.
+
+
+        :return: The time_created of this HttpProbe.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this HttpProbe.
+        The RFC 3339-formatted creation date and time of the probe.
+
+
+        :param time_created: The time_created of this HttpProbe.
+        :type: datetime
+        """
+        self._time_created = time_created
 
     @property
     def compartment_id(self):

--- a/src/oci/healthchecks/models/ping_monitor.py
+++ b/src/oci/healthchecks/models/ping_monitor.py
@@ -33,6 +33,14 @@ class PingMonitor(object):
             The value to assign to the results_url property of this PingMonitor.
         :type results_url: str
 
+        :param home_region:
+            The value to assign to the home_region property of this PingMonitor.
+        :type home_region: str
+
+        :param time_created:
+            The value to assign to the time_created property of this PingMonitor.
+        :type time_created: datetime
+
         :param compartment_id:
             The value to assign to the compartment_id property of this PingMonitor.
         :type compartment_id: str
@@ -83,6 +91,8 @@ class PingMonitor(object):
         self.swagger_types = {
             'id': 'str',
             'results_url': 'str',
+            'home_region': 'str',
+            'time_created': 'datetime',
             'compartment_id': 'str',
             'targets': 'list[str]',
             'vantage_point_names': 'list[str]',
@@ -99,6 +109,8 @@ class PingMonitor(object):
         self.attribute_map = {
             'id': 'id',
             'results_url': 'resultsUrl',
+            'home_region': 'homeRegion',
+            'time_created': 'timeCreated',
             'compartment_id': 'compartmentId',
             'targets': 'targets',
             'vantage_point_names': 'vantagePointNames',
@@ -114,6 +126,8 @@ class PingMonitor(object):
 
         self._id = None
         self._results_url = None
+        self._home_region = None
+        self._time_created = None
         self._compartment_id = None
         self._targets = None
         self._vantage_point_names = None
@@ -173,6 +187,54 @@ class PingMonitor(object):
         :type: str
         """
         self._results_url = results_url
+
+    @property
+    def home_region(self):
+        """
+        Gets the home_region of this PingMonitor.
+        The region where updates must be made and where results must be fetched from.
+
+
+        :return: The home_region of this PingMonitor.
+        :rtype: str
+        """
+        return self._home_region
+
+    @home_region.setter
+    def home_region(self, home_region):
+        """
+        Sets the home_region of this PingMonitor.
+        The region where updates must be made and where results must be fetched from.
+
+
+        :param home_region: The home_region of this PingMonitor.
+        :type: str
+        """
+        self._home_region = home_region
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this PingMonitor.
+        The RFC 3339-formatted creation date and time of the probe.
+
+
+        :return: The time_created of this PingMonitor.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this PingMonitor.
+        The RFC 3339-formatted creation date and time of the probe.
+
+
+        :param time_created: The time_created of this PingMonitor.
+        :type: datetime
+        """
+        self._time_created = time_created
 
     @property
     def compartment_id(self):

--- a/src/oci/healthchecks/models/ping_monitor_summary.py
+++ b/src/oci/healthchecks/models/ping_monitor_summary.py
@@ -33,6 +33,14 @@ class PingMonitorSummary(object):
             The value to assign to the results_url property of this PingMonitorSummary.
         :type results_url: str
 
+        :param home_region:
+            The value to assign to the home_region property of this PingMonitorSummary.
+        :type home_region: str
+
+        :param time_created:
+            The value to assign to the time_created property of this PingMonitorSummary.
+        :type time_created: datetime
+
         :param compartment_id:
             The value to assign to the compartment_id property of this PingMonitorSummary.
         :type compartment_id: str
@@ -67,6 +75,8 @@ class PingMonitorSummary(object):
         self.swagger_types = {
             'id': 'str',
             'results_url': 'str',
+            'home_region': 'str',
+            'time_created': 'datetime',
             'compartment_id': 'str',
             'display_name': 'str',
             'interval_in_seconds': 'int',
@@ -79,6 +89,8 @@ class PingMonitorSummary(object):
         self.attribute_map = {
             'id': 'id',
             'results_url': 'resultsUrl',
+            'home_region': 'homeRegion',
+            'time_created': 'timeCreated',
             'compartment_id': 'compartmentId',
             'display_name': 'displayName',
             'interval_in_seconds': 'intervalInSeconds',
@@ -90,6 +102,8 @@ class PingMonitorSummary(object):
 
         self._id = None
         self._results_url = None
+        self._home_region = None
+        self._time_created = None
         self._compartment_id = None
         self._display_name = None
         self._interval_in_seconds = None
@@ -145,6 +159,54 @@ class PingMonitorSummary(object):
         :type: str
         """
         self._results_url = results_url
+
+    @property
+    def home_region(self):
+        """
+        Gets the home_region of this PingMonitorSummary.
+        The region where updates must be made and where results must be fetched from.
+
+
+        :return: The home_region of this PingMonitorSummary.
+        :rtype: str
+        """
+        return self._home_region
+
+    @home_region.setter
+    def home_region(self, home_region):
+        """
+        Sets the home_region of this PingMonitorSummary.
+        The region where updates must be made and where results must be fetched from.
+
+
+        :param home_region: The home_region of this PingMonitorSummary.
+        :type: str
+        """
+        self._home_region = home_region
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this PingMonitorSummary.
+        The RFC 3339-formatted creation date and time of the probe.
+
+
+        :return: The time_created of this PingMonitorSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this PingMonitorSummary.
+        The RFC 3339-formatted creation date and time of the probe.
+
+
+        :param time_created: The time_created of this PingMonitorSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
 
     @property
     def compartment_id(self):

--- a/src/oci/healthchecks/models/ping_probe.py
+++ b/src/oci/healthchecks/models/ping_probe.py
@@ -33,6 +33,14 @@ class PingProbe(object):
             The value to assign to the results_url property of this PingProbe.
         :type results_url: str
 
+        :param home_region:
+            The value to assign to the home_region property of this PingProbe.
+        :type home_region: str
+
+        :param time_created:
+            The value to assign to the time_created property of this PingProbe.
+        :type time_created: datetime
+
         :param compartment_id:
             The value to assign to the compartment_id property of this PingProbe.
         :type compartment_id: str
@@ -63,6 +71,8 @@ class PingProbe(object):
         self.swagger_types = {
             'id': 'str',
             'results_url': 'str',
+            'home_region': 'str',
+            'time_created': 'datetime',
             'compartment_id': 'str',
             'targets': 'list[str]',
             'vantage_point_names': 'list[str]',
@@ -74,6 +84,8 @@ class PingProbe(object):
         self.attribute_map = {
             'id': 'id',
             'results_url': 'resultsUrl',
+            'home_region': 'homeRegion',
+            'time_created': 'timeCreated',
             'compartment_id': 'compartmentId',
             'targets': 'targets',
             'vantage_point_names': 'vantagePointNames',
@@ -84,6 +96,8 @@ class PingProbe(object):
 
         self._id = None
         self._results_url = None
+        self._home_region = None
+        self._time_created = None
         self._compartment_id = None
         self._targets = None
         self._vantage_point_names = None
@@ -138,6 +152,54 @@ class PingProbe(object):
         :type: str
         """
         self._results_url = results_url
+
+    @property
+    def home_region(self):
+        """
+        Gets the home_region of this PingProbe.
+        The region where updates must be made and where results must be fetched from.
+
+
+        :return: The home_region of this PingProbe.
+        :rtype: str
+        """
+        return self._home_region
+
+    @home_region.setter
+    def home_region(self, home_region):
+        """
+        Sets the home_region of this PingProbe.
+        The region where updates must be made and where results must be fetched from.
+
+
+        :param home_region: The home_region of this PingProbe.
+        :type: str
+        """
+        self._home_region = home_region
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this PingProbe.
+        The RFC 3339-formatted creation date and time of the probe.
+
+
+        :return: The time_created of this PingProbe.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this PingProbe.
+        The RFC 3339-formatted creation date and time of the probe.
+
+
+        :param time_created: The time_created of this PingProbe.
+        :type: datetime
+        """
+        self._time_created = time_created
 
     @property
     def compartment_id(self):

--- a/src/oci/ons/models/confirmation_result.py
+++ b/src/oci/ons/models/confirmation_result.py
@@ -200,7 +200,7 @@ class ConfirmationResult(object):
     @property
     def subscription_id(self):
         """
-        Gets the subscription_id of this ConfirmationResult.
+        **[Required]** Gets the subscription_id of this ConfirmationResult.
         The `OCID`__ of the subscription specified in the request.
 
         __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm

--- a/src/oci/ons/models/create_subscription_details.py
+++ b/src/oci/ons/models/create_subscription_details.py
@@ -136,6 +136,13 @@ class CreateSubscriptionDetails(object):
         **[Required]** Gets the protocol of this CreateSubscriptionDetails.
         The protocol used for the subscription.
 
+        Allowed values:
+          * `CUSTOM_HTTPS`
+          * `EMAIL`
+          * `HTTPS` (deprecated; for PagerDuty endpoints, use `PAGERDUTY`)
+          * `PAGERDUTY`
+          * `SLACK`
+
         For information about subscription protocols, see
         `To create a subscription`__.
 
@@ -152,6 +159,13 @@ class CreateSubscriptionDetails(object):
         """
         Sets the protocol of this CreateSubscriptionDetails.
         The protocol used for the subscription.
+
+        Allowed values:
+          * `CUSTOM_HTTPS`
+          * `EMAIL`
+          * `HTTPS` (deprecated; for PagerDuty endpoints, use `PAGERDUTY`)
+          * `PAGERDUTY`
+          * `SLACK`
 
         For information about subscription protocols, see
         `To create a subscription`__.

--- a/src/oci/ons/notification_control_plane_client.py
+++ b/src/oci/ons/notification_control_plane_client.py
@@ -573,7 +573,7 @@ class NotificationControlPlaneClient(object):
                 header_params=header_params,
                 response_type="list[NotificationTopicSummary]")
 
-    def update_topic(self, topic_id, **kwargs):
+    def update_topic(self, topic_id, topic_attributes_details, **kwargs):
         """
         Updates the specified topic's configuration.
 
@@ -585,7 +585,7 @@ class NotificationControlPlaneClient(object):
 
             __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
-        :param TopicAttributesDetails topic_attributes_details: (optional)
+        :param TopicAttributesDetails topic_attributes_details: (required)
             TopicAttributes
 
         :param str opc_request_id: (optional)
@@ -614,7 +614,6 @@ class NotificationControlPlaneClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
-            "topic_attributes_details",
             "opc_request_id",
             "if_match"
         ]
@@ -652,7 +651,7 @@ class NotificationControlPlaneClient(object):
                 method=method,
                 path_params=path_params,
                 header_params=header_params,
-                body=kwargs.get('topic_attributes_details'),
+                body=topic_attributes_details,
                 response_type="NotificationTopic")
         else:
             return self.base_client.call_api(
@@ -660,5 +659,5 @@ class NotificationControlPlaneClient(object):
                 method=method,
                 path_params=path_params,
                 header_params=header_params,
-                body=kwargs.get('topic_attributes_details'),
+                body=topic_attributes_details,
                 response_type="NotificationTopic")

--- a/src/oci/ons/notification_data_plane_client.py
+++ b/src/oci/ons/notification_data_plane_client.py
@@ -363,6 +363,13 @@ class NotificationDataPlaneClient(object):
         :param str protocol: (required)
             The protocol used for the subscription.
 
+            Allowed values:
+              * `CUSTOM_HTTPS`
+              * `EMAIL`
+              * `HTTPS` (deprecated; for PagerDuty endpoints, use `PAGERDUTY`)
+              * `PAGERDUTY`
+              * `SLACK`
+
             For information about subscription protocols, see
             `To create a subscription`__.
 
@@ -535,6 +542,13 @@ class NotificationDataPlaneClient(object):
 
         :param str protocol: (required)
             The protocol used for the subscription.
+
+            Allowed values:
+              * `CUSTOM_HTTPS`
+              * `EMAIL`
+              * `HTTPS` (deprecated; for PagerDuty endpoints, use `PAGERDUTY`)
+              * `PAGERDUTY`
+              * `SLACK`
 
             For information about subscription protocols, see
             `To create a subscription`__.

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "2.5.2"
+__version__ = "2.6.0"


### PR DESCRIPTION
## Added

- Support for the new schema for events in the Audit service

- Support for entitlements in the Data Transfer service

- Support for custom scheduled backup policies on volumes in the Block Storage service

- Support for specifying the network type when launching virtual machine instances in the Compute service

- Support for Monitoring service integration in the Health Checks service



##Breaking

- The tenant_id parameter is now id (Id of the Transfer Application Entitlement) for get_transfer_appliance_entitlement in TransferApplianceEntitlementClient

- The topic_attributes_details parameter is now required for update_topic in NotificationControlPlaneClient

- The Audit service version was bumped to 20190901, use older version of Python SDK for Audit service version 20160918
