### PR TITLE
Releasing version 2.8.0

### DIFF
--- a/src/oci/apigateway/__init__.py
+++ b/src/oci/apigateway/__init__.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+
+from .deployment_client import DeploymentClient
+from .deployment_client_composite_operations import DeploymentClientCompositeOperations
+from .gateway_client import GatewayClient
+from .gateway_client_composite_operations import GatewayClientCompositeOperations
+from .work_requests_client import WorkRequestsClient
+from .work_requests_client_composite_operations import WorkRequestsClientCompositeOperations
+from . import models
+
+__all__ = ["DeploymentClient", "DeploymentClientCompositeOperations", "GatewayClient", "GatewayClientCompositeOperations", "WorkRequestsClient", "WorkRequestsClientCompositeOperations", "models"]

--- a/src/oci/apigateway/deployment_client.py
+++ b/src/oci/apigateway/deployment_client.py
@@ -1,0 +1,628 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import apigateway_type_mapping
+missing = Sentinel("Missing")
+
+
+class DeploymentClient(object):
+    """
+    API for the API Gateway service. Use this API to manage gateways, deployments, and related items.
+    For more information, see
+    [Overview of API Gateway](/iaas/Content/APIGateway/Concepts/apigatewayoverview.htm).
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20190501',
+            'service_endpoint_template': 'https://apigateway.{region}.oci.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("deployment", config, signer, apigateway_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def change_deployment_compartment(self, deployment_id, change_deployment_compartment_details, **kwargs):
+        """
+        Change the deployment compartment.
+        Changes the deployment compartment.
+
+
+        :param str deployment_id: (required)
+            The ocid of the deployment.
+
+        :param ChangeDeploymentCompartmentDetails change_deployment_compartment_details: (required)
+            Details of the target compartment.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/deployments/{deploymentId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_deployment_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "deploymentId": deployment_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_deployment_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_deployment_compartment_details)
+
+    def create_deployment(self, create_deployment_details, **kwargs):
+        """
+        Creates a new Deployment
+        Creates a new deployment.
+
+
+        :param CreateDeploymentDetails create_deployment_details: (required)
+            Details for the new deployment
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.apigateway.models.Deployment`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/deployments"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_deployment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_deployment_details,
+                response_type="Deployment")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_deployment_details,
+                response_type="Deployment")
+
+    def delete_deployment(self, deployment_id, **kwargs):
+        """
+        Delete a provisioned Deployment
+        Deletes the deployment with the given identifier.
+
+
+        :param str deployment_id: (required)
+            The ocid of the deployment.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/deployments/{deploymentId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_deployment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "deploymentId": deployment_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def get_deployment(self, deployment_id, **kwargs):
+        """
+        Get Deployment
+        Gets a deployment by identifier.
+
+
+        :param str deployment_id: (required)
+            The ocid of the deployment.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.apigateway.models.Deployment`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/deployments/{deploymentId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_deployment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "deploymentId": deployment_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Deployment")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Deployment")
+
+    def list_deployments(self, compartment_id, **kwargs):
+        """
+        Gets a list of all Deployments in a compartment
+        Returns a list of deployments.
+
+
+        :param str compartment_id: (required)
+            The ocid of the compartment in which to list resources.
+
+        :param str gateway_id: (optional)
+            Filter deployments by the gateway ocid.
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the given lifecycle state.
+
+            Example: `SUCCEEDED`
+
+            Allowed values are: "CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED"
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'. The default order depends on the sortBy value.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`).
+            Default order for `timeCreated` is descending. Default order for
+            `displayName` is ascending. The `displayName` sort order is case
+            sensitive.
+
+            Allowed values are: "timeCreated", "displayName"
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.apigateway.models.DeploymentCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/deployments"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "gateway_id",
+            "display_name",
+            "lifecycle_state",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_deployments got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["timeCreated", "displayName"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "gatewayId": kwargs.get("gateway_id", missing),
+            "displayName": kwargs.get("display_name", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="DeploymentCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="DeploymentCollection")
+
+    def update_deployment(self, deployment_id, update_deployment_details, **kwargs):
+        """
+        Update the Deployment identified by the id
+        Updates the deployment with the given identifier.
+
+
+        :param str deployment_id: (required)
+            The ocid of the deployment.
+
+        :param UpdateDeploymentDetails update_deployment_details: (required)
+            The information to be updated.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/deployments/{deploymentId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_deployment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "deploymentId": deployment_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_deployment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_deployment_details)

--- a/src/oci/apigateway/deployment_client_composite_operations.py
+++ b/src/oci/apigateway/deployment_client_composite_operations.py
@@ -1,0 +1,189 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class DeploymentClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.apigateway.DeploymentClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new DeploymentClientCompositeOperations object
+
+        :param DeploymentClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client
+
+    def change_deployment_compartment_and_wait_for_state(self, deployment_id, change_deployment_compartment_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.apigateway.DeploymentClient.change_deployment_compartment` and waits for the :py:class:`~oci.apigateway.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str deployment_id: (required)
+            The ocid of the deployment.
+
+        :param ChangeDeploymentCompartmentDetails change_deployment_compartment_details: (required)
+            Details of the target compartment.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.apigateway.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.apigateway.DeploymentClient.change_deployment_compartment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.change_deployment_compartment(deployment_id, change_deployment_compartment_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_deployment_and_wait_for_state(self, create_deployment_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.apigateway.DeploymentClient.create_deployment` and waits for the :py:class:`~oci.apigateway.models.WorkRequest`
+        to enter the given state(s).
+
+        :param CreateDeploymentDetails create_deployment_details: (required)
+            Details for the new deployment
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.apigateway.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.apigateway.DeploymentClient.create_deployment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_deployment(create_deployment_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_deployment_and_wait_for_state(self, deployment_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.apigateway.DeploymentClient.delete_deployment` and waits for the :py:class:`~oci.apigateway.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str deployment_id: (required)
+            The ocid of the deployment.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.apigateway.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.apigateway.DeploymentClient.delete_deployment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = None
+        try:
+            operation_result = self.client.delete_deployment(deployment_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_deployment_and_wait_for_state(self, deployment_id, update_deployment_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.apigateway.DeploymentClient.update_deployment` and waits for the :py:class:`~oci.apigateway.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str deployment_id: (required)
+            The ocid of the deployment.
+
+        :param UpdateDeploymentDetails update_deployment_details: (required)
+            The information to be updated.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.apigateway.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.apigateway.DeploymentClient.update_deployment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_deployment(deployment_id, update_deployment_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)

--- a/src/oci/apigateway/gateway_client.py
+++ b/src/oci/apigateway/gateway_client.py
@@ -1,0 +1,623 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import apigateway_type_mapping
+missing = Sentinel("Missing")
+
+
+class GatewayClient(object):
+    """
+    API for the API Gateway service. Use this API to manage gateways, deployments, and related items.
+    For more information, see
+    [Overview of API Gateway](/iaas/Content/APIGateway/Concepts/apigatewayoverview.htm).
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20190501',
+            'service_endpoint_template': 'https://apigateway.{region}.oci.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("gateway", config, signer, apigateway_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def change_gateway_compartment(self, gateway_id, change_gateway_compartment_details, **kwargs):
+        """
+        Change the gateway compartment.
+        Changes the gateway compartment.
+
+
+        :param str gateway_id: (required)
+            The ocid of the gateway.
+
+        :param ChangeGatewayCompartmentDetails change_gateway_compartment_details: (required)
+            Details of the target compartment.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/gateways/{gatewayId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_gateway_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "gatewayId": gateway_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_gateway_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_gateway_compartment_details)
+
+    def create_gateway(self, create_gateway_details, **kwargs):
+        """
+        Creates a new Gateway
+        Creates a new gateway.
+
+
+        :param CreateGatewayDetails create_gateway_details: (required)
+            Details for the new gateway.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.apigateway.models.Gateway`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/gateways"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_gateway got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_gateway_details,
+                response_type="Gateway")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_gateway_details,
+                response_type="Gateway")
+
+    def delete_gateway(self, gateway_id, **kwargs):
+        """
+        Delete a provisioned Gateway
+        Deletes the gateway with the given identifier.
+
+
+        :param str gateway_id: (required)
+            The ocid of the gateway.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/gateways/{gatewayId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_gateway got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "gatewayId": gateway_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def get_gateway(self, gateway_id, **kwargs):
+        """
+        Get Gateway
+        Gets a gateway by identifier.
+
+
+        :param str gateway_id: (required)
+            The ocid of the gateway.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.apigateway.models.Gateway`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/gateways/{gatewayId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_gateway got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "gatewayId": gateway_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Gateway")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Gateway")
+
+    def list_gateways(self, compartment_id, **kwargs):
+        """
+        Gets a list of all Gateways in a compartment
+        Returns a list of gateways.
+
+
+        :param str compartment_id: (required)
+            The ocid of the compartment in which to list resources.
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the given lifecycle state.
+
+            Example: `SUCCEEDED`
+
+            Allowed values are: "CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED"
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'. The default order depends on the sortBy value.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`).
+            Default order for `timeCreated` is descending. Default order for
+            `displayName` is ascending. The `displayName` sort order is case
+            sensitive.
+
+            Allowed values are: "timeCreated", "displayName"
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.apigateway.models.GatewayCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/gateways"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "lifecycle_state",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_gateways got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["timeCreated", "displayName"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "displayName": kwargs.get("display_name", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="GatewayCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="GatewayCollection")
+
+    def update_gateway(self, gateway_id, update_gateway_details, **kwargs):
+        """
+        Update the Gateway by the identifier
+        Updates the gateway with the given identifier.
+
+
+        :param str gateway_id: (required)
+            The ocid of the gateway.
+
+        :param UpdateGatewayDetails update_gateway_details: (required)
+            The information to be updated.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/gateways/{gatewayId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_gateway got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "gatewayId": gateway_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_gateway_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_gateway_details)

--- a/src/oci/apigateway/gateway_client_composite_operations.py
+++ b/src/oci/apigateway/gateway_client_composite_operations.py
@@ -1,0 +1,189 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class GatewayClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.apigateway.GatewayClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new GatewayClientCompositeOperations object
+
+        :param GatewayClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client
+
+    def change_gateway_compartment_and_wait_for_state(self, gateway_id, change_gateway_compartment_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.apigateway.GatewayClient.change_gateway_compartment` and waits for the :py:class:`~oci.apigateway.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str gateway_id: (required)
+            The ocid of the gateway.
+
+        :param ChangeGatewayCompartmentDetails change_gateway_compartment_details: (required)
+            Details of the target compartment.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.apigateway.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.apigateway.GatewayClient.change_gateway_compartment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.change_gateway_compartment(gateway_id, change_gateway_compartment_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_gateway_and_wait_for_state(self, create_gateway_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.apigateway.GatewayClient.create_gateway` and waits for the :py:class:`~oci.apigateway.models.WorkRequest`
+        to enter the given state(s).
+
+        :param CreateGatewayDetails create_gateway_details: (required)
+            Details for the new gateway.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.apigateway.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.apigateway.GatewayClient.create_gateway`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_gateway(create_gateway_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_gateway_and_wait_for_state(self, gateway_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.apigateway.GatewayClient.delete_gateway` and waits for the :py:class:`~oci.apigateway.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str gateway_id: (required)
+            The ocid of the gateway.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.apigateway.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.apigateway.GatewayClient.delete_gateway`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = None
+        try:
+            operation_result = self.client.delete_gateway(gateway_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_gateway_and_wait_for_state(self, gateway_id, update_gateway_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.apigateway.GatewayClient.update_gateway` and waits for the :py:class:`~oci.apigateway.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str gateway_id: (required)
+            The ocid of the gateway.
+
+        :param UpdateGatewayDetails update_gateway_details: (required)
+            The information to be updated.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.apigateway.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.apigateway.GatewayClient.update_gateway`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_gateway(gateway_id, update_gateway_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)

--- a/src/oci/apigateway/models/__init__.py
+++ b/src/oci/apigateway/models/__init__.py
@@ -1,0 +1,89 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from .access_log_policy import AccessLogPolicy
+from .anonymous_route_authorization_policy import AnonymousRouteAuthorizationPolicy
+from .any_of_route_authorization_policy import AnyOfRouteAuthorizationPolicy
+from .api_specification import ApiSpecification
+from .api_specification_logging_policies import ApiSpecificationLoggingPolicies
+from .api_specification_request_policies import ApiSpecificationRequestPolicies
+from .api_specification_route import ApiSpecificationRoute
+from .api_specification_route_backend import ApiSpecificationRouteBackend
+from .api_specification_route_request_policies import ApiSpecificationRouteRequestPolicies
+from .authentication_only_route_authorization_policy import AuthenticationOnlyRouteAuthorizationPolicy
+from .authentication_policy import AuthenticationPolicy
+from .change_deployment_compartment_details import ChangeDeploymentCompartmentDetails
+from .change_gateway_compartment_details import ChangeGatewayCompartmentDetails
+from .cors_policy import CorsPolicy
+from .create_deployment_details import CreateDeploymentDetails
+from .create_gateway_details import CreateGatewayDetails
+from .custom_authentication_policy import CustomAuthenticationPolicy
+from .deployment import Deployment
+from .deployment_collection import DeploymentCollection
+from .deployment_summary import DeploymentSummary
+from .execution_log_policy import ExecutionLogPolicy
+from .gateway import Gateway
+from .gateway_collection import GatewayCollection
+from .gateway_summary import GatewaySummary
+from .http_backend import HTTPBackend
+from .header_field_specification import HeaderFieldSpecification
+from .oracle_function_backend import OracleFunctionBackend
+from .rate_limiting_policy import RateLimitingPolicy
+from .route_authorization_policy import RouteAuthorizationPolicy
+from .stock_response_backend import StockResponseBackend
+from .update_deployment_details import UpdateDeploymentDetails
+from .update_gateway_details import UpdateGatewayDetails
+from .work_request import WorkRequest
+from .work_request_collection import WorkRequestCollection
+from .work_request_error import WorkRequestError
+from .work_request_error_collection import WorkRequestErrorCollection
+from .work_request_log import WorkRequestLog
+from .work_request_log_collection import WorkRequestLogCollection
+from .work_request_resource import WorkRequestResource
+from .work_request_summary import WorkRequestSummary
+
+# Maps type names to classes for apigateway services.
+apigateway_type_mapping = {
+    "AccessLogPolicy": AccessLogPolicy,
+    "AnonymousRouteAuthorizationPolicy": AnonymousRouteAuthorizationPolicy,
+    "AnyOfRouteAuthorizationPolicy": AnyOfRouteAuthorizationPolicy,
+    "ApiSpecification": ApiSpecification,
+    "ApiSpecificationLoggingPolicies": ApiSpecificationLoggingPolicies,
+    "ApiSpecificationRequestPolicies": ApiSpecificationRequestPolicies,
+    "ApiSpecificationRoute": ApiSpecificationRoute,
+    "ApiSpecificationRouteBackend": ApiSpecificationRouteBackend,
+    "ApiSpecificationRouteRequestPolicies": ApiSpecificationRouteRequestPolicies,
+    "AuthenticationOnlyRouteAuthorizationPolicy": AuthenticationOnlyRouteAuthorizationPolicy,
+    "AuthenticationPolicy": AuthenticationPolicy,
+    "ChangeDeploymentCompartmentDetails": ChangeDeploymentCompartmentDetails,
+    "ChangeGatewayCompartmentDetails": ChangeGatewayCompartmentDetails,
+    "CorsPolicy": CorsPolicy,
+    "CreateDeploymentDetails": CreateDeploymentDetails,
+    "CreateGatewayDetails": CreateGatewayDetails,
+    "CustomAuthenticationPolicy": CustomAuthenticationPolicy,
+    "Deployment": Deployment,
+    "DeploymentCollection": DeploymentCollection,
+    "DeploymentSummary": DeploymentSummary,
+    "ExecutionLogPolicy": ExecutionLogPolicy,
+    "Gateway": Gateway,
+    "GatewayCollection": GatewayCollection,
+    "GatewaySummary": GatewaySummary,
+    "HTTPBackend": HTTPBackend,
+    "HeaderFieldSpecification": HeaderFieldSpecification,
+    "OracleFunctionBackend": OracleFunctionBackend,
+    "RateLimitingPolicy": RateLimitingPolicy,
+    "RouteAuthorizationPolicy": RouteAuthorizationPolicy,
+    "StockResponseBackend": StockResponseBackend,
+    "UpdateDeploymentDetails": UpdateDeploymentDetails,
+    "UpdateGatewayDetails": UpdateGatewayDetails,
+    "WorkRequest": WorkRequest,
+    "WorkRequestCollection": WorkRequestCollection,
+    "WorkRequestError": WorkRequestError,
+    "WorkRequestErrorCollection": WorkRequestErrorCollection,
+    "WorkRequestLog": WorkRequestLog,
+    "WorkRequestLogCollection": WorkRequestLogCollection,
+    "WorkRequestResource": WorkRequestResource,
+    "WorkRequestSummary": WorkRequestSummary
+}

--- a/src/oci/apigateway/models/access_log_policy.py
+++ b/src/oci/apigateway/models/access_log_policy.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AccessLogPolicy(object):
+    """
+    Configures the pushing of access logs to OCI Public Logging.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AccessLogPolicy object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param is_enabled:
+            The value to assign to the is_enabled property of this AccessLogPolicy.
+        :type is_enabled: bool
+
+        """
+        self.swagger_types = {
+            'is_enabled': 'bool'
+        }
+
+        self.attribute_map = {
+            'is_enabled': 'isEnabled'
+        }
+
+        self._is_enabled = None
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this AccessLogPolicy.
+        Enables pushing of access logs to OCI Public Logging.
+
+
+        :return: The is_enabled of this AccessLogPolicy.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this AccessLogPolicy.
+        Enables pushing of access logs to OCI Public Logging.
+
+
+        :param is_enabled: The is_enabled of this AccessLogPolicy.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/anonymous_route_authorization_policy.py
+++ b/src/oci/apigateway/models/anonymous_route_authorization_policy.py
@@ -1,0 +1,49 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .route_authorization_policy import RouteAuthorizationPolicy
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AnonymousRouteAuthorizationPolicy(RouteAuthorizationPolicy):
+    """
+    For a type of ANONYMOUS, an authenticated API must have the \"isAnonymousAccessAllowed\" property set to \"true\"
+    in the authentication policy.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AnonymousRouteAuthorizationPolicy object with values from keyword arguments. The default value of the :py:attr:`~oci.apigateway.models.AnonymousRouteAuthorizationPolicy.type` attribute
+        of this class is ``ANONYMOUS`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param type:
+            The value to assign to the type property of this AnonymousRouteAuthorizationPolicy.
+            Allowed values for this property are: "ANONYMOUS", "ANY_OF", "AUTHENTICATION_ONLY"
+        :type type: str
+
+        """
+        self.swagger_types = {
+            'type': 'str'
+        }
+
+        self.attribute_map = {
+            'type': 'type'
+        }
+
+        self._type = None
+        self._type = 'ANONYMOUS'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/any_of_route_authorization_policy.py
+++ b/src/oci/apigateway/models/any_of_route_authorization_policy.py
@@ -1,0 +1,81 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .route_authorization_policy import RouteAuthorizationPolicy
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AnyOfRouteAuthorizationPolicy(RouteAuthorizationPolicy):
+    """
+    If authentication has been performed, validate whether the request scope (if any) applies to this route.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AnyOfRouteAuthorizationPolicy object with values from keyword arguments. The default value of the :py:attr:`~oci.apigateway.models.AnyOfRouteAuthorizationPolicy.type` attribute
+        of this class is ``ANY_OF`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param type:
+            The value to assign to the type property of this AnyOfRouteAuthorizationPolicy.
+            Allowed values for this property are: "ANONYMOUS", "ANY_OF", "AUTHENTICATION_ONLY"
+        :type type: str
+
+        :param allowed_scope:
+            The value to assign to the allowed_scope property of this AnyOfRouteAuthorizationPolicy.
+        :type allowed_scope: list[str]
+
+        """
+        self.swagger_types = {
+            'type': 'str',
+            'allowed_scope': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'type': 'type',
+            'allowed_scope': 'allowedScope'
+        }
+
+        self._type = None
+        self._allowed_scope = None
+        self._type = 'ANY_OF'
+
+    @property
+    def allowed_scope(self):
+        """
+        **[Required]** Gets the allowed_scope of this AnyOfRouteAuthorizationPolicy.
+        A user whose scope includes any of these access ranges is allowed on
+        this route. Access ranges are case-sensitive.
+
+
+        :return: The allowed_scope of this AnyOfRouteAuthorizationPolicy.
+        :rtype: list[str]
+        """
+        return self._allowed_scope
+
+    @allowed_scope.setter
+    def allowed_scope(self, allowed_scope):
+        """
+        Sets the allowed_scope of this AnyOfRouteAuthorizationPolicy.
+        A user whose scope includes any of these access ranges is allowed on
+        this route. Access ranges are case-sensitive.
+
+
+        :param allowed_scope: The allowed_scope of this AnyOfRouteAuthorizationPolicy.
+        :type: list[str]
+        """
+        self._allowed_scope = allowed_scope
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/api_specification.py
+++ b/src/oci/apigateway/models/api_specification.py
@@ -1,0 +1,123 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ApiSpecification(object):
+    """
+    The logical configuration of the API exposed by a deployment.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ApiSpecification object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param request_policies:
+            The value to assign to the request_policies property of this ApiSpecification.
+        :type request_policies: ApiSpecificationRequestPolicies
+
+        :param logging_policies:
+            The value to assign to the logging_policies property of this ApiSpecification.
+        :type logging_policies: ApiSpecificationLoggingPolicies
+
+        :param routes:
+            The value to assign to the routes property of this ApiSpecification.
+        :type routes: list[ApiSpecificationRoute]
+
+        """
+        self.swagger_types = {
+            'request_policies': 'ApiSpecificationRequestPolicies',
+            'logging_policies': 'ApiSpecificationLoggingPolicies',
+            'routes': 'list[ApiSpecificationRoute]'
+        }
+
+        self.attribute_map = {
+            'request_policies': 'requestPolicies',
+            'logging_policies': 'loggingPolicies',
+            'routes': 'routes'
+        }
+
+        self._request_policies = None
+        self._logging_policies = None
+        self._routes = None
+
+    @property
+    def request_policies(self):
+        """
+        Gets the request_policies of this ApiSpecification.
+
+        :return: The request_policies of this ApiSpecification.
+        :rtype: ApiSpecificationRequestPolicies
+        """
+        return self._request_policies
+
+    @request_policies.setter
+    def request_policies(self, request_policies):
+        """
+        Sets the request_policies of this ApiSpecification.
+
+        :param request_policies: The request_policies of this ApiSpecification.
+        :type: ApiSpecificationRequestPolicies
+        """
+        self._request_policies = request_policies
+
+    @property
+    def logging_policies(self):
+        """
+        Gets the logging_policies of this ApiSpecification.
+
+        :return: The logging_policies of this ApiSpecification.
+        :rtype: ApiSpecificationLoggingPolicies
+        """
+        return self._logging_policies
+
+    @logging_policies.setter
+    def logging_policies(self, logging_policies):
+        """
+        Sets the logging_policies of this ApiSpecification.
+
+        :param logging_policies: The logging_policies of this ApiSpecification.
+        :type: ApiSpecificationLoggingPolicies
+        """
+        self._logging_policies = logging_policies
+
+    @property
+    def routes(self):
+        """
+        Gets the routes of this ApiSpecification.
+        A list of routes that this API exposes.
+
+
+        :return: The routes of this ApiSpecification.
+        :rtype: list[ApiSpecificationRoute]
+        """
+        return self._routes
+
+    @routes.setter
+    def routes(self, routes):
+        """
+        Sets the routes of this ApiSpecification.
+        A list of routes that this API exposes.
+
+
+        :param routes: The routes of this ApiSpecification.
+        :type: list[ApiSpecificationRoute]
+        """
+        self._routes = routes
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/api_specification_logging_policies.py
+++ b/src/oci/apigateway/models/api_specification_logging_policies.py
@@ -1,0 +1,92 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ApiSpecificationLoggingPolicies(object):
+    """
+    Policies controlling the pushing of logs to OCI Public Logging.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ApiSpecificationLoggingPolicies object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param access_log:
+            The value to assign to the access_log property of this ApiSpecificationLoggingPolicies.
+        :type access_log: AccessLogPolicy
+
+        :param execution_log:
+            The value to assign to the execution_log property of this ApiSpecificationLoggingPolicies.
+        :type execution_log: ExecutionLogPolicy
+
+        """
+        self.swagger_types = {
+            'access_log': 'AccessLogPolicy',
+            'execution_log': 'ExecutionLogPolicy'
+        }
+
+        self.attribute_map = {
+            'access_log': 'accessLog',
+            'execution_log': 'executionLog'
+        }
+
+        self._access_log = None
+        self._execution_log = None
+
+    @property
+    def access_log(self):
+        """
+        Gets the access_log of this ApiSpecificationLoggingPolicies.
+
+        :return: The access_log of this ApiSpecificationLoggingPolicies.
+        :rtype: AccessLogPolicy
+        """
+        return self._access_log
+
+    @access_log.setter
+    def access_log(self, access_log):
+        """
+        Sets the access_log of this ApiSpecificationLoggingPolicies.
+
+        :param access_log: The access_log of this ApiSpecificationLoggingPolicies.
+        :type: AccessLogPolicy
+        """
+        self._access_log = access_log
+
+    @property
+    def execution_log(self):
+        """
+        Gets the execution_log of this ApiSpecificationLoggingPolicies.
+
+        :return: The execution_log of this ApiSpecificationLoggingPolicies.
+        :rtype: ExecutionLogPolicy
+        """
+        return self._execution_log
+
+    @execution_log.setter
+    def execution_log(self, execution_log):
+        """
+        Sets the execution_log of this ApiSpecificationLoggingPolicies.
+
+        :param execution_log: The execution_log of this ApiSpecificationLoggingPolicies.
+        :type: ExecutionLogPolicy
+        """
+        self._execution_log = execution_log
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/api_specification_request_policies.py
+++ b/src/oci/apigateway/models/api_specification_request_policies.py
@@ -1,0 +1,119 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ApiSpecificationRequestPolicies(object):
+    """
+    Global behavior applied to all requests received by the API.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ApiSpecificationRequestPolicies object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param authentication:
+            The value to assign to the authentication property of this ApiSpecificationRequestPolicies.
+        :type authentication: AuthenticationPolicy
+
+        :param rate_limiting:
+            The value to assign to the rate_limiting property of this ApiSpecificationRequestPolicies.
+        :type rate_limiting: RateLimitingPolicy
+
+        :param cors:
+            The value to assign to the cors property of this ApiSpecificationRequestPolicies.
+        :type cors: CorsPolicy
+
+        """
+        self.swagger_types = {
+            'authentication': 'AuthenticationPolicy',
+            'rate_limiting': 'RateLimitingPolicy',
+            'cors': 'CorsPolicy'
+        }
+
+        self.attribute_map = {
+            'authentication': 'authentication',
+            'rate_limiting': 'rateLimiting',
+            'cors': 'cors'
+        }
+
+        self._authentication = None
+        self._rate_limiting = None
+        self._cors = None
+
+    @property
+    def authentication(self):
+        """
+        Gets the authentication of this ApiSpecificationRequestPolicies.
+
+        :return: The authentication of this ApiSpecificationRequestPolicies.
+        :rtype: AuthenticationPolicy
+        """
+        return self._authentication
+
+    @authentication.setter
+    def authentication(self, authentication):
+        """
+        Sets the authentication of this ApiSpecificationRequestPolicies.
+
+        :param authentication: The authentication of this ApiSpecificationRequestPolicies.
+        :type: AuthenticationPolicy
+        """
+        self._authentication = authentication
+
+    @property
+    def rate_limiting(self):
+        """
+        Gets the rate_limiting of this ApiSpecificationRequestPolicies.
+
+        :return: The rate_limiting of this ApiSpecificationRequestPolicies.
+        :rtype: RateLimitingPolicy
+        """
+        return self._rate_limiting
+
+    @rate_limiting.setter
+    def rate_limiting(self, rate_limiting):
+        """
+        Sets the rate_limiting of this ApiSpecificationRequestPolicies.
+
+        :param rate_limiting: The rate_limiting of this ApiSpecificationRequestPolicies.
+        :type: RateLimitingPolicy
+        """
+        self._rate_limiting = rate_limiting
+
+    @property
+    def cors(self):
+        """
+        Gets the cors of this ApiSpecificationRequestPolicies.
+
+        :return: The cors of this ApiSpecificationRequestPolicies.
+        :rtype: CorsPolicy
+        """
+        return self._cors
+
+    @cors.setter
+    def cors(self, cors):
+        """
+        Sets the cors of this ApiSpecificationRequestPolicies.
+
+        :param cors: The cors of this ApiSpecificationRequestPolicies.
+        :type: CorsPolicy
+        """
+        self._cors = cors
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/api_specification_route.py
+++ b/src/oci/apigateway/models/api_specification_route.py
@@ -1,0 +1,223 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ApiSpecificationRoute(object):
+    """
+    A single route that forwards requests to a particular backend and may contain some additional policies.
+    """
+
+    #: A constant which can be used with the methods property of a ApiSpecificationRoute.
+    #: This constant has a value of "ANY"
+    METHODS_ANY = "ANY"
+
+    #: A constant which can be used with the methods property of a ApiSpecificationRoute.
+    #: This constant has a value of "HEAD"
+    METHODS_HEAD = "HEAD"
+
+    #: A constant which can be used with the methods property of a ApiSpecificationRoute.
+    #: This constant has a value of "GET"
+    METHODS_GET = "GET"
+
+    #: A constant which can be used with the methods property of a ApiSpecificationRoute.
+    #: This constant has a value of "POST"
+    METHODS_POST = "POST"
+
+    #: A constant which can be used with the methods property of a ApiSpecificationRoute.
+    #: This constant has a value of "PUT"
+    METHODS_PUT = "PUT"
+
+    #: A constant which can be used with the methods property of a ApiSpecificationRoute.
+    #: This constant has a value of "PATCH"
+    METHODS_PATCH = "PATCH"
+
+    #: A constant which can be used with the methods property of a ApiSpecificationRoute.
+    #: This constant has a value of "DELETE"
+    METHODS_DELETE = "DELETE"
+
+    #: A constant which can be used with the methods property of a ApiSpecificationRoute.
+    #: This constant has a value of "OPTIONS"
+    METHODS_OPTIONS = "OPTIONS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ApiSpecificationRoute object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param path:
+            The value to assign to the path property of this ApiSpecificationRoute.
+        :type path: str
+
+        :param methods:
+            The value to assign to the methods property of this ApiSpecificationRoute.
+            Allowed values for items in this list are: "ANY", "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type methods: list[str]
+
+        :param request_policies:
+            The value to assign to the request_policies property of this ApiSpecificationRoute.
+        :type request_policies: ApiSpecificationRouteRequestPolicies
+
+        :param logging_policies:
+            The value to assign to the logging_policies property of this ApiSpecificationRoute.
+        :type logging_policies: ApiSpecificationLoggingPolicies
+
+        :param backend:
+            The value to assign to the backend property of this ApiSpecificationRoute.
+        :type backend: ApiSpecificationRouteBackend
+
+        """
+        self.swagger_types = {
+            'path': 'str',
+            'methods': 'list[str]',
+            'request_policies': 'ApiSpecificationRouteRequestPolicies',
+            'logging_policies': 'ApiSpecificationLoggingPolicies',
+            'backend': 'ApiSpecificationRouteBackend'
+        }
+
+        self.attribute_map = {
+            'path': 'path',
+            'methods': 'methods',
+            'request_policies': 'requestPolicies',
+            'logging_policies': 'loggingPolicies',
+            'backend': 'backend'
+        }
+
+        self._path = None
+        self._methods = None
+        self._request_policies = None
+        self._logging_policies = None
+        self._backend = None
+
+    @property
+    def path(self):
+        """
+        **[Required]** Gets the path of this ApiSpecificationRoute.
+        A URL path pattern that must be matched on this route. The path pattern may contain a subset of RFC 6570 identifiers
+        to allow wildcard and parameterized matching.
+
+
+        :return: The path of this ApiSpecificationRoute.
+        :rtype: str
+        """
+        return self._path
+
+    @path.setter
+    def path(self, path):
+        """
+        Sets the path of this ApiSpecificationRoute.
+        A URL path pattern that must be matched on this route. The path pattern may contain a subset of RFC 6570 identifiers
+        to allow wildcard and parameterized matching.
+
+
+        :param path: The path of this ApiSpecificationRoute.
+        :type: str
+        """
+        self._path = path
+
+    @property
+    def methods(self):
+        """
+        Gets the methods of this ApiSpecificationRoute.
+        A list of allowed methods on this route.
+
+        Allowed values for items in this list are: "ANY", "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The methods of this ApiSpecificationRoute.
+        :rtype: list[str]
+        """
+        return self._methods
+
+    @methods.setter
+    def methods(self, methods):
+        """
+        Sets the methods of this ApiSpecificationRoute.
+        A list of allowed methods on this route.
+
+
+        :param methods: The methods of this ApiSpecificationRoute.
+        :type: list[str]
+        """
+        allowed_values = ["ANY", "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+        if methods:
+            methods[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in methods]
+        self._methods = methods
+
+    @property
+    def request_policies(self):
+        """
+        Gets the request_policies of this ApiSpecificationRoute.
+
+        :return: The request_policies of this ApiSpecificationRoute.
+        :rtype: ApiSpecificationRouteRequestPolicies
+        """
+        return self._request_policies
+
+    @request_policies.setter
+    def request_policies(self, request_policies):
+        """
+        Sets the request_policies of this ApiSpecificationRoute.
+
+        :param request_policies: The request_policies of this ApiSpecificationRoute.
+        :type: ApiSpecificationRouteRequestPolicies
+        """
+        self._request_policies = request_policies
+
+    @property
+    def logging_policies(self):
+        """
+        Gets the logging_policies of this ApiSpecificationRoute.
+
+        :return: The logging_policies of this ApiSpecificationRoute.
+        :rtype: ApiSpecificationLoggingPolicies
+        """
+        return self._logging_policies
+
+    @logging_policies.setter
+    def logging_policies(self, logging_policies):
+        """
+        Sets the logging_policies of this ApiSpecificationRoute.
+
+        :param logging_policies: The logging_policies of this ApiSpecificationRoute.
+        :type: ApiSpecificationLoggingPolicies
+        """
+        self._logging_policies = logging_policies
+
+    @property
+    def backend(self):
+        """
+        **[Required]** Gets the backend of this ApiSpecificationRoute.
+
+        :return: The backend of this ApiSpecificationRoute.
+        :rtype: ApiSpecificationRouteBackend
+        """
+        return self._backend
+
+    @backend.setter
+    def backend(self, backend):
+        """
+        Sets the backend of this ApiSpecificationRoute.
+
+        :param backend: The backend of this ApiSpecificationRoute.
+        :type: ApiSpecificationRouteBackend
+        """
+        self._backend = backend
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/api_specification_route_backend.py
+++ b/src/oci/apigateway/models/api_specification_route_backend.py
@@ -1,0 +1,114 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ApiSpecificationRouteBackend(object):
+    """
+    The backend to forward requests to.
+    """
+
+    #: A constant which can be used with the type property of a ApiSpecificationRouteBackend.
+    #: This constant has a value of "ORACLE_FUNCTIONS_BACKEND"
+    TYPE_ORACLE_FUNCTIONS_BACKEND = "ORACLE_FUNCTIONS_BACKEND"
+
+    #: A constant which can be used with the type property of a ApiSpecificationRouteBackend.
+    #: This constant has a value of "HTTP_BACKEND"
+    TYPE_HTTP_BACKEND = "HTTP_BACKEND"
+
+    #: A constant which can be used with the type property of a ApiSpecificationRouteBackend.
+    #: This constant has a value of "STOCK_RESPONSE_BACKEND"
+    TYPE_STOCK_RESPONSE_BACKEND = "STOCK_RESPONSE_BACKEND"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ApiSpecificationRouteBackend object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.apigateway.models.HTTPBackend`
+        * :class:`~oci.apigateway.models.OracleFunctionBackend`
+        * :class:`~oci.apigateway.models.StockResponseBackend`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param type:
+            The value to assign to the type property of this ApiSpecificationRouteBackend.
+            Allowed values for this property are: "ORACLE_FUNCTIONS_BACKEND", "HTTP_BACKEND", "STOCK_RESPONSE_BACKEND", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type type: str
+
+        """
+        self.swagger_types = {
+            'type': 'str'
+        }
+
+        self.attribute_map = {
+            'type': 'type'
+        }
+
+        self._type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['type']
+
+        if type == 'HTTP_BACKEND':
+            return 'HTTPBackend'
+
+        if type == 'ORACLE_FUNCTIONS_BACKEND':
+            return 'OracleFunctionBackend'
+
+        if type == 'STOCK_RESPONSE_BACKEND':
+            return 'StockResponseBackend'
+        else:
+            return 'ApiSpecificationRouteBackend'
+
+    @property
+    def type(self):
+        """
+        **[Required]** Gets the type of this ApiSpecificationRouteBackend.
+        Type of the API backend.
+
+        Allowed values for this property are: "ORACLE_FUNCTIONS_BACKEND", "HTTP_BACKEND", "STOCK_RESPONSE_BACKEND", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The type of this ApiSpecificationRouteBackend.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this ApiSpecificationRouteBackend.
+        Type of the API backend.
+
+
+        :param type: The type of this ApiSpecificationRouteBackend.
+        :type: str
+        """
+        allowed_values = ["ORACLE_FUNCTIONS_BACKEND", "HTTP_BACKEND", "STOCK_RESPONSE_BACKEND"]
+        if not value_allowed_none_or_none_sentinel(type, allowed_values):
+            type = 'UNKNOWN_ENUM_VALUE'
+        self._type = type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/api_specification_route_request_policies.py
+++ b/src/oci/apigateway/models/api_specification_route_request_policies.py
@@ -1,0 +1,92 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ApiSpecificationRouteRequestPolicies(object):
+    """
+    Behavior applied to any requests received by the API on this route.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ApiSpecificationRouteRequestPolicies object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param authorization:
+            The value to assign to the authorization property of this ApiSpecificationRouteRequestPolicies.
+        :type authorization: RouteAuthorizationPolicy
+
+        :param cors:
+            The value to assign to the cors property of this ApiSpecificationRouteRequestPolicies.
+        :type cors: CorsPolicy
+
+        """
+        self.swagger_types = {
+            'authorization': 'RouteAuthorizationPolicy',
+            'cors': 'CorsPolicy'
+        }
+
+        self.attribute_map = {
+            'authorization': 'authorization',
+            'cors': 'cors'
+        }
+
+        self._authorization = None
+        self._cors = None
+
+    @property
+    def authorization(self):
+        """
+        Gets the authorization of this ApiSpecificationRouteRequestPolicies.
+
+        :return: The authorization of this ApiSpecificationRouteRequestPolicies.
+        :rtype: RouteAuthorizationPolicy
+        """
+        return self._authorization
+
+    @authorization.setter
+    def authorization(self, authorization):
+        """
+        Sets the authorization of this ApiSpecificationRouteRequestPolicies.
+
+        :param authorization: The authorization of this ApiSpecificationRouteRequestPolicies.
+        :type: RouteAuthorizationPolicy
+        """
+        self._authorization = authorization
+
+    @property
+    def cors(self):
+        """
+        Gets the cors of this ApiSpecificationRouteRequestPolicies.
+
+        :return: The cors of this ApiSpecificationRouteRequestPolicies.
+        :rtype: CorsPolicy
+        """
+        return self._cors
+
+    @cors.setter
+    def cors(self, cors):
+        """
+        Sets the cors of this ApiSpecificationRouteRequestPolicies.
+
+        :param cors: The cors of this ApiSpecificationRouteRequestPolicies.
+        :type: CorsPolicy
+        """
+        self._cors = cors
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/authentication_only_route_authorization_policy.py
+++ b/src/oci/apigateway/models/authentication_only_route_authorization_policy.py
@@ -1,0 +1,48 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .route_authorization_policy import RouteAuthorizationPolicy
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AuthenticationOnlyRouteAuthorizationPolicy(RouteAuthorizationPolicy):
+    """
+    Only authentication is performed for the request and authorization is skipped.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AuthenticationOnlyRouteAuthorizationPolicy object with values from keyword arguments. The default value of the :py:attr:`~oci.apigateway.models.AuthenticationOnlyRouteAuthorizationPolicy.type` attribute
+        of this class is ``AUTHENTICATION_ONLY`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param type:
+            The value to assign to the type property of this AuthenticationOnlyRouteAuthorizationPolicy.
+            Allowed values for this property are: "ANONYMOUS", "ANY_OF", "AUTHENTICATION_ONLY"
+        :type type: str
+
+        """
+        self.swagger_types = {
+            'type': 'str'
+        }
+
+        self.attribute_map = {
+            'type': 'type'
+        }
+
+        self._type = None
+        self._type = 'AUTHENTICATION_ONLY'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/authentication_policy.py
+++ b/src/oci/apigateway/models/authentication_policy.py
@@ -1,0 +1,131 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AuthenticationPolicy(object):
+    """
+    Information on how to authenticate incoming requests.
+    """
+
+    #: A constant which can be used with the type property of a AuthenticationPolicy.
+    #: This constant has a value of "CUSTOM_AUTHENTICATION"
+    TYPE_CUSTOM_AUTHENTICATION = "CUSTOM_AUTHENTICATION"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AuthenticationPolicy object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.apigateway.models.CustomAuthenticationPolicy`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param is_anonymous_access_allowed:
+            The value to assign to the is_anonymous_access_allowed property of this AuthenticationPolicy.
+        :type is_anonymous_access_allowed: bool
+
+        :param type:
+            The value to assign to the type property of this AuthenticationPolicy.
+            Allowed values for this property are: "CUSTOM_AUTHENTICATION", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type type: str
+
+        """
+        self.swagger_types = {
+            'is_anonymous_access_allowed': 'bool',
+            'type': 'str'
+        }
+
+        self.attribute_map = {
+            'is_anonymous_access_allowed': 'isAnonymousAccessAllowed',
+            'type': 'type'
+        }
+
+        self._is_anonymous_access_allowed = None
+        self._type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['type']
+
+        if type == 'CUSTOM_AUTHENTICATION':
+            return 'CustomAuthenticationPolicy'
+        else:
+            return 'AuthenticationPolicy'
+
+    @property
+    def is_anonymous_access_allowed(self):
+        """
+        Gets the is_anonymous_access_allowed of this AuthenticationPolicy.
+        Whether an unauthenticated user may access the API. Must be \"true\" to enable ANONYMOUS
+        route authorization.
+
+
+        :return: The is_anonymous_access_allowed of this AuthenticationPolicy.
+        :rtype: bool
+        """
+        return self._is_anonymous_access_allowed
+
+    @is_anonymous_access_allowed.setter
+    def is_anonymous_access_allowed(self, is_anonymous_access_allowed):
+        """
+        Sets the is_anonymous_access_allowed of this AuthenticationPolicy.
+        Whether an unauthenticated user may access the API. Must be \"true\" to enable ANONYMOUS
+        route authorization.
+
+
+        :param is_anonymous_access_allowed: The is_anonymous_access_allowed of this AuthenticationPolicy.
+        :type: bool
+        """
+        self._is_anonymous_access_allowed = is_anonymous_access_allowed
+
+    @property
+    def type(self):
+        """
+        **[Required]** Gets the type of this AuthenticationPolicy.
+        Type of the authentication policy to use.
+
+        Allowed values for this property are: "CUSTOM_AUTHENTICATION", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The type of this AuthenticationPolicy.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this AuthenticationPolicy.
+        Type of the authentication policy to use.
+
+
+        :param type: The type of this AuthenticationPolicy.
+        :type: str
+        """
+        allowed_values = ["CUSTOM_AUTHENTICATION"]
+        if not value_allowed_none_or_none_sentinel(type, allowed_values):
+            type = 'UNKNOWN_ENUM_VALUE'
+        self._type = type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/change_deployment_compartment_details.py
+++ b/src/oci/apigateway/models/change_deployment_compartment_details.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeDeploymentCompartmentDetails(object):
+    """
+    The new compartment details for the deployment.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeDeploymentCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeDeploymentCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeDeploymentCompartmentDetails.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeDeploymentCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeDeploymentCompartmentDetails.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeDeploymentCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/change_gateway_compartment_details.py
+++ b/src/oci/apigateway/models/change_gateway_compartment_details.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeGatewayCompartmentDetails(object):
+    """
+    The new compartment details for the gateway.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeGatewayCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeGatewayCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeGatewayCompartmentDetails.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeGatewayCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeGatewayCompartmentDetails.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeGatewayCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/cors_policy.py
+++ b/src/oci/apigateway/models/cors_policy.py
@@ -1,0 +1,238 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CorsPolicy(object):
+    """
+    Enable CORS (Cross-Origin-Resource-Sharing) request handling.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CorsPolicy object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param allowed_origins:
+            The value to assign to the allowed_origins property of this CorsPolicy.
+        :type allowed_origins: list[str]
+
+        :param allowed_methods:
+            The value to assign to the allowed_methods property of this CorsPolicy.
+        :type allowed_methods: list[str]
+
+        :param allowed_headers:
+            The value to assign to the allowed_headers property of this CorsPolicy.
+        :type allowed_headers: list[str]
+
+        :param exposed_headers:
+            The value to assign to the exposed_headers property of this CorsPolicy.
+        :type exposed_headers: list[str]
+
+        :param is_allow_credentials_enabled:
+            The value to assign to the is_allow_credentials_enabled property of this CorsPolicy.
+        :type is_allow_credentials_enabled: bool
+
+        :param max_age_in_seconds:
+            The value to assign to the max_age_in_seconds property of this CorsPolicy.
+        :type max_age_in_seconds: int
+
+        """
+        self.swagger_types = {
+            'allowed_origins': 'list[str]',
+            'allowed_methods': 'list[str]',
+            'allowed_headers': 'list[str]',
+            'exposed_headers': 'list[str]',
+            'is_allow_credentials_enabled': 'bool',
+            'max_age_in_seconds': 'int'
+        }
+
+        self.attribute_map = {
+            'allowed_origins': 'allowedOrigins',
+            'allowed_methods': 'allowedMethods',
+            'allowed_headers': 'allowedHeaders',
+            'exposed_headers': 'exposedHeaders',
+            'is_allow_credentials_enabled': 'isAllowCredentialsEnabled',
+            'max_age_in_seconds': 'maxAgeInSeconds'
+        }
+
+        self._allowed_origins = None
+        self._allowed_methods = None
+        self._allowed_headers = None
+        self._exposed_headers = None
+        self._is_allow_credentials_enabled = None
+        self._max_age_in_seconds = None
+
+    @property
+    def allowed_origins(self):
+        """
+        **[Required]** Gets the allowed_origins of this CorsPolicy.
+        The list of allowed origins that the CORS handler will use to respond to CORS requests. The gateway will
+        send the Access-Control-Allow-Origin header with the best origin match for the circumstances. '*' will match
+        any origins, and 'null' will match queries from 'file:' origins. All other origins must be qualified with the
+        scheme, full hostname, and port if necessary.
+
+
+        :return: The allowed_origins of this CorsPolicy.
+        :rtype: list[str]
+        """
+        return self._allowed_origins
+
+    @allowed_origins.setter
+    def allowed_origins(self, allowed_origins):
+        """
+        Sets the allowed_origins of this CorsPolicy.
+        The list of allowed origins that the CORS handler will use to respond to CORS requests. The gateway will
+        send the Access-Control-Allow-Origin header with the best origin match for the circumstances. '*' will match
+        any origins, and 'null' will match queries from 'file:' origins. All other origins must be qualified with the
+        scheme, full hostname, and port if necessary.
+
+
+        :param allowed_origins: The allowed_origins of this CorsPolicy.
+        :type: list[str]
+        """
+        self._allowed_origins = allowed_origins
+
+    @property
+    def allowed_methods(self):
+        """
+        Gets the allowed_methods of this CorsPolicy.
+        The list of allowed HTTP methods that will be returned for the preflight OPTIONS request in the
+        Access-Control-Allow-Methods header. '*' will allow all methods.
+
+
+        :return: The allowed_methods of this CorsPolicy.
+        :rtype: list[str]
+        """
+        return self._allowed_methods
+
+    @allowed_methods.setter
+    def allowed_methods(self, allowed_methods):
+        """
+        Sets the allowed_methods of this CorsPolicy.
+        The list of allowed HTTP methods that will be returned for the preflight OPTIONS request in the
+        Access-Control-Allow-Methods header. '*' will allow all methods.
+
+
+        :param allowed_methods: The allowed_methods of this CorsPolicy.
+        :type: list[str]
+        """
+        self._allowed_methods = allowed_methods
+
+    @property
+    def allowed_headers(self):
+        """
+        Gets the allowed_headers of this CorsPolicy.
+        The list of headers that will be allowed from the client via the Access-Control-Allow-Headers header.
+        '*' will allow all headers.
+
+
+        :return: The allowed_headers of this CorsPolicy.
+        :rtype: list[str]
+        """
+        return self._allowed_headers
+
+    @allowed_headers.setter
+    def allowed_headers(self, allowed_headers):
+        """
+        Sets the allowed_headers of this CorsPolicy.
+        The list of headers that will be allowed from the client via the Access-Control-Allow-Headers header.
+        '*' will allow all headers.
+
+
+        :param allowed_headers: The allowed_headers of this CorsPolicy.
+        :type: list[str]
+        """
+        self._allowed_headers = allowed_headers
+
+    @property
+    def exposed_headers(self):
+        """
+        Gets the exposed_headers of this CorsPolicy.
+        The list of headers that the client will be allowed to see from the response as indicated by the
+        Access-Control-Expose-Headers header. '*' will expose all headers.
+
+
+        :return: The exposed_headers of this CorsPolicy.
+        :rtype: list[str]
+        """
+        return self._exposed_headers
+
+    @exposed_headers.setter
+    def exposed_headers(self, exposed_headers):
+        """
+        Sets the exposed_headers of this CorsPolicy.
+        The list of headers that the client will be allowed to see from the response as indicated by the
+        Access-Control-Expose-Headers header. '*' will expose all headers.
+
+
+        :param exposed_headers: The exposed_headers of this CorsPolicy.
+        :type: list[str]
+        """
+        self._exposed_headers = exposed_headers
+
+    @property
+    def is_allow_credentials_enabled(self):
+        """
+        Gets the is_allow_credentials_enabled of this CorsPolicy.
+        Whether to send the Access-Control-Allow-Credentials header to allow CORS requests with cookies.
+
+
+        :return: The is_allow_credentials_enabled of this CorsPolicy.
+        :rtype: bool
+        """
+        return self._is_allow_credentials_enabled
+
+    @is_allow_credentials_enabled.setter
+    def is_allow_credentials_enabled(self, is_allow_credentials_enabled):
+        """
+        Sets the is_allow_credentials_enabled of this CorsPolicy.
+        Whether to send the Access-Control-Allow-Credentials header to allow CORS requests with cookies.
+
+
+        :param is_allow_credentials_enabled: The is_allow_credentials_enabled of this CorsPolicy.
+        :type: bool
+        """
+        self._is_allow_credentials_enabled = is_allow_credentials_enabled
+
+    @property
+    def max_age_in_seconds(self):
+        """
+        Gets the max_age_in_seconds of this CorsPolicy.
+        The time in seconds for the client to cache preflight responses. This is sent as the Access-Control-Max-Age
+        if greater than 0.
+
+
+        :return: The max_age_in_seconds of this CorsPolicy.
+        :rtype: int
+        """
+        return self._max_age_in_seconds
+
+    @max_age_in_seconds.setter
+    def max_age_in_seconds(self, max_age_in_seconds):
+        """
+        Sets the max_age_in_seconds of this CorsPolicy.
+        The time in seconds for the client to cache preflight responses. This is sent as the Access-Control-Max-Age
+        if greater than 0.
+
+
+        :param max_age_in_seconds: The max_age_in_seconds of this CorsPolicy.
+        :type: int
+        """
+        self._max_age_in_seconds = max_age_in_seconds
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/create_deployment_details.py
+++ b/src/oci/apigateway/models/create_deployment_details.py
@@ -1,0 +1,301 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDeploymentDetails(object):
+    """
+    Information about a new deployment.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDeploymentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateDeploymentDetails.
+        :type display_name: str
+
+        :param gateway_id:
+            The value to assign to the gateway_id property of this CreateDeploymentDetails.
+        :type gateway_id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateDeploymentDetails.
+        :type compartment_id: str
+
+        :param path_prefix:
+            The value to assign to the path_prefix property of this CreateDeploymentDetails.
+        :type path_prefix: str
+
+        :param specification:
+            The value to assign to the specification property of this CreateDeploymentDetails.
+        :type specification: ApiSpecification
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateDeploymentDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateDeploymentDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'gateway_id': 'str',
+            'compartment_id': 'str',
+            'path_prefix': 'str',
+            'specification': 'ApiSpecification',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'gateway_id': 'gatewayId',
+            'compartment_id': 'compartmentId',
+            'path_prefix': 'pathPrefix',
+            'specification': 'specification',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._gateway_id = None
+        self._compartment_id = None
+        self._path_prefix = None
+        self._specification = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateDeploymentDetails.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :return: The display_name of this CreateDeploymentDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateDeploymentDetails.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :param display_name: The display_name of this CreateDeploymentDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def gateway_id(self):
+        """
+        **[Required]** Gets the gateway_id of this CreateDeploymentDetails.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The gateway_id of this CreateDeploymentDetails.
+        :rtype: str
+        """
+        return self._gateway_id
+
+    @gateway_id.setter
+    def gateway_id(self, gateway_id):
+        """
+        Sets the gateway_id of this CreateDeploymentDetails.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param gateway_id: The gateway_id of this CreateDeploymentDetails.
+        :type: str
+        """
+        self._gateway_id = gateway_id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateDeploymentDetails.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateDeploymentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateDeploymentDetails.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateDeploymentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def path_prefix(self):
+        """
+        **[Required]** Gets the path_prefix of this CreateDeploymentDetails.
+        A path on which to deploy all routes contained in the API
+        deployment specification. For more information, see
+        `Deploying an API on an API Gateway by Creating an API
+        Deployment`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/APIGateway/Tasks/apigatewaycreatingdeployment.htm
+
+
+        :return: The path_prefix of this CreateDeploymentDetails.
+        :rtype: str
+        """
+        return self._path_prefix
+
+    @path_prefix.setter
+    def path_prefix(self, path_prefix):
+        """
+        Sets the path_prefix of this CreateDeploymentDetails.
+        A path on which to deploy all routes contained in the API
+        deployment specification. For more information, see
+        `Deploying an API on an API Gateway by Creating an API
+        Deployment`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/APIGateway/Tasks/apigatewaycreatingdeployment.htm
+
+
+        :param path_prefix: The path_prefix of this CreateDeploymentDetails.
+        :type: str
+        """
+        self._path_prefix = path_prefix
+
+    @property
+    def specification(self):
+        """
+        **[Required]** Gets the specification of this CreateDeploymentDetails.
+
+        :return: The specification of this CreateDeploymentDetails.
+        :rtype: ApiSpecification
+        """
+        return self._specification
+
+    @specification.setter
+    def specification(self, specification):
+        """
+        Sets the specification of this CreateDeploymentDetails.
+
+        :param specification: The specification of this CreateDeploymentDetails.
+        :type: ApiSpecification
+        """
+        self._specification = specification
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateDeploymentDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateDeploymentDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateDeploymentDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateDeploymentDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateDeploymentDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateDeploymentDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateDeploymentDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateDeploymentDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/create_gateway_details.py
+++ b/src/oci/apigateway/models/create_gateway_details.py
@@ -1,0 +1,266 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateGatewayDetails(object):
+    """
+    Information about the new gateway.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateGatewayDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateGatewayDetails.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateGatewayDetails.
+        :type compartment_id: str
+
+        :param endpoint_type:
+            The value to assign to the endpoint_type property of this CreateGatewayDetails.
+        :type endpoint_type: str
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this CreateGatewayDetails.
+        :type subnet_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateGatewayDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateGatewayDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'endpoint_type': 'str',
+            'subnet_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'endpoint_type': 'endpointType',
+            'subnet_id': 'subnetId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._compartment_id = None
+        self._endpoint_type = None
+        self._subnet_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateGatewayDetails.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :return: The display_name of this CreateGatewayDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateGatewayDetails.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :param display_name: The display_name of this CreateGatewayDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateGatewayDetails.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateGatewayDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateGatewayDetails.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateGatewayDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def endpoint_type(self):
+        """
+        **[Required]** Gets the endpoint_type of this CreateGatewayDetails.
+        Gateway endpoint type.
+
+
+        :return: The endpoint_type of this CreateGatewayDetails.
+        :rtype: str
+        """
+        return self._endpoint_type
+
+    @endpoint_type.setter
+    def endpoint_type(self, endpoint_type):
+        """
+        Sets the endpoint_type of this CreateGatewayDetails.
+        Gateway endpoint type.
+
+
+        :param endpoint_type: The endpoint_type of this CreateGatewayDetails.
+        :type: str
+        """
+        self._endpoint_type = endpoint_type
+
+    @property
+    def subnet_id(self):
+        """
+        **[Required]** Gets the subnet_id of this CreateGatewayDetails.
+        The `OCID`__ of the subnet in which
+        related resources are created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The subnet_id of this CreateGatewayDetails.
+        :rtype: str
+        """
+        return self._subnet_id
+
+    @subnet_id.setter
+    def subnet_id(self, subnet_id):
+        """
+        Sets the subnet_id of this CreateGatewayDetails.
+        The `OCID`__ of the subnet in which
+        related resources are created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param subnet_id: The subnet_id of this CreateGatewayDetails.
+        :type: str
+        """
+        self._subnet_id = subnet_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateGatewayDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateGatewayDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateGatewayDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateGatewayDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateGatewayDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateGatewayDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateGatewayDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateGatewayDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/custom_authentication_policy.py
+++ b/src/oci/apigateway/models/custom_authentication_policy.py
@@ -1,0 +1,153 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .authentication_policy import AuthenticationPolicy
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CustomAuthenticationPolicy(AuthenticationPolicy):
+    """
+    Use a function to validate a custom header or query parameter sent with the request authentication.
+    A valid policy must specify either tokenHeader or tokenQueryParam.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CustomAuthenticationPolicy object with values from keyword arguments. The default value of the :py:attr:`~oci.apigateway.models.CustomAuthenticationPolicy.type` attribute
+        of this class is ``CUSTOM_AUTHENTICATION`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param is_anonymous_access_allowed:
+            The value to assign to the is_anonymous_access_allowed property of this CustomAuthenticationPolicy.
+        :type is_anonymous_access_allowed: bool
+
+        :param type:
+            The value to assign to the type property of this CustomAuthenticationPolicy.
+            Allowed values for this property are: "CUSTOM_AUTHENTICATION"
+        :type type: str
+
+        :param function_id:
+            The value to assign to the function_id property of this CustomAuthenticationPolicy.
+        :type function_id: str
+
+        :param token_header:
+            The value to assign to the token_header property of this CustomAuthenticationPolicy.
+        :type token_header: str
+
+        :param token_query_param:
+            The value to assign to the token_query_param property of this CustomAuthenticationPolicy.
+        :type token_query_param: str
+
+        """
+        self.swagger_types = {
+            'is_anonymous_access_allowed': 'bool',
+            'type': 'str',
+            'function_id': 'str',
+            'token_header': 'str',
+            'token_query_param': 'str'
+        }
+
+        self.attribute_map = {
+            'is_anonymous_access_allowed': 'isAnonymousAccessAllowed',
+            'type': 'type',
+            'function_id': 'functionId',
+            'token_header': 'tokenHeader',
+            'token_query_param': 'tokenQueryParam'
+        }
+
+        self._is_anonymous_access_allowed = None
+        self._type = None
+        self._function_id = None
+        self._token_header = None
+        self._token_query_param = None
+        self._type = 'CUSTOM_AUTHENTICATION'
+
+    @property
+    def function_id(self):
+        """
+        **[Required]** Gets the function_id of this CustomAuthenticationPolicy.
+        The `OCID`__ of the Oracle Functions function resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The function_id of this CustomAuthenticationPolicy.
+        :rtype: str
+        """
+        return self._function_id
+
+    @function_id.setter
+    def function_id(self, function_id):
+        """
+        Sets the function_id of this CustomAuthenticationPolicy.
+        The `OCID`__ of the Oracle Functions function resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param function_id: The function_id of this CustomAuthenticationPolicy.
+        :type: str
+        """
+        self._function_id = function_id
+
+    @property
+    def token_header(self):
+        """
+        Gets the token_header of this CustomAuthenticationPolicy.
+        The name of the header containing the authentication token.
+
+
+        :return: The token_header of this CustomAuthenticationPolicy.
+        :rtype: str
+        """
+        return self._token_header
+
+    @token_header.setter
+    def token_header(self, token_header):
+        """
+        Sets the token_header of this CustomAuthenticationPolicy.
+        The name of the header containing the authentication token.
+
+
+        :param token_header: The token_header of this CustomAuthenticationPolicy.
+        :type: str
+        """
+        self._token_header = token_header
+
+    @property
+    def token_query_param(self):
+        """
+        Gets the token_query_param of this CustomAuthenticationPolicy.
+        The name of the query parameter containing the authentication token.
+
+
+        :return: The token_query_param of this CustomAuthenticationPolicy.
+        :rtype: str
+        """
+        return self._token_query_param
+
+    @token_query_param.setter
+    def token_query_param(self, token_query_param):
+        """
+        Sets the token_query_param of this CustomAuthenticationPolicy.
+        The name of the query parameter containing the authentication token.
+
+
+        :param token_query_param: The token_query_param of this CustomAuthenticationPolicy.
+        :type: str
+        """
+        self._token_query_param = token_query_param
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/deployment.py
+++ b/src/oci/apigateway/models/deployment.py
@@ -1,0 +1,531 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Deployment(object):
+    """
+    A deployment deploys an API on a gateway. Avoid entering confidential information.
+    For more information, see
+    `API Gateway Concepts`__.
+
+    __ https://docs.cloud.oracle.com/iaas/Content/APIGateway/Concepts/apigatewayconcepts.htm
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a Deployment.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a Deployment.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a Deployment.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a Deployment.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a Deployment.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a Deployment.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Deployment object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this Deployment.
+        :type id: str
+
+        :param gateway_id:
+            The value to assign to the gateway_id property of this Deployment.
+        :type gateway_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this Deployment.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this Deployment.
+        :type compartment_id: str
+
+        :param path_prefix:
+            The value to assign to the path_prefix property of this Deployment.
+        :type path_prefix: str
+
+        :param endpoint:
+            The value to assign to the endpoint property of this Deployment.
+        :type endpoint: str
+
+        :param specification:
+            The value to assign to the specification property of this Deployment.
+        :type specification: ApiSpecification
+
+        :param time_created:
+            The value to assign to the time_created property of this Deployment.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this Deployment.
+        :type time_updated: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this Deployment.
+            Allowed values for this property are: "CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this Deployment.
+        :type lifecycle_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this Deployment.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this Deployment.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'gateway_id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'path_prefix': 'str',
+            'endpoint': 'str',
+            'specification': 'ApiSpecification',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'gateway_id': 'gatewayId',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'path_prefix': 'pathPrefix',
+            'endpoint': 'endpoint',
+            'specification': 'specification',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._gateway_id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._path_prefix = None
+        self._endpoint = None
+        self._specification = None
+        self._time_created = None
+        self._time_updated = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this Deployment.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this Deployment.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this Deployment.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this Deployment.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def gateway_id(self):
+        """
+        **[Required]** Gets the gateway_id of this Deployment.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The gateway_id of this Deployment.
+        :rtype: str
+        """
+        return self._gateway_id
+
+    @gateway_id.setter
+    def gateway_id(self, gateway_id):
+        """
+        Sets the gateway_id of this Deployment.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param gateway_id: The gateway_id of this Deployment.
+        :type: str
+        """
+        self._gateway_id = gateway_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this Deployment.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :return: The display_name of this Deployment.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this Deployment.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :param display_name: The display_name of this Deployment.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this Deployment.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this Deployment.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this Deployment.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this Deployment.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def path_prefix(self):
+        """
+        **[Required]** Gets the path_prefix of this Deployment.
+        A path on which to deploy all routes contained in the API
+        deployment specification. For more information, see
+        `Deploying an API on an API Gateway by Creating an API
+        Deployment`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/APIGateway/Tasks/apigatewaycreatingdeployment.htm
+
+
+        :return: The path_prefix of this Deployment.
+        :rtype: str
+        """
+        return self._path_prefix
+
+    @path_prefix.setter
+    def path_prefix(self, path_prefix):
+        """
+        Sets the path_prefix of this Deployment.
+        A path on which to deploy all routes contained in the API
+        deployment specification. For more information, see
+        `Deploying an API on an API Gateway by Creating an API
+        Deployment`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/APIGateway/Tasks/apigatewaycreatingdeployment.htm
+
+
+        :param path_prefix: The path_prefix of this Deployment.
+        :type: str
+        """
+        self._path_prefix = path_prefix
+
+    @property
+    def endpoint(self):
+        """
+        **[Required]** Gets the endpoint of this Deployment.
+        The endpoint to access this deployment on the gateway.
+
+
+        :return: The endpoint of this Deployment.
+        :rtype: str
+        """
+        return self._endpoint
+
+    @endpoint.setter
+    def endpoint(self, endpoint):
+        """
+        Sets the endpoint of this Deployment.
+        The endpoint to access this deployment on the gateway.
+
+
+        :param endpoint: The endpoint of this Deployment.
+        :type: str
+        """
+        self._endpoint = endpoint
+
+    @property
+    def specification(self):
+        """
+        **[Required]** Gets the specification of this Deployment.
+
+        :return: The specification of this Deployment.
+        :rtype: ApiSpecification
+        """
+        return self._specification
+
+    @specification.setter
+    def specification(self, specification):
+        """
+        Sets the specification of this Deployment.
+
+        :param specification: The specification of this Deployment.
+        :type: ApiSpecification
+        """
+        self._specification = specification
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this Deployment.
+        The time this resource was created. An RFC3339 formatted datetime string.
+
+
+        :return: The time_created of this Deployment.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this Deployment.
+        The time this resource was created. An RFC3339 formatted datetime string.
+
+
+        :param time_created: The time_created of this Deployment.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this Deployment.
+        The time this resource was last updated. An RFC3339 formatted datetime string.
+
+
+        :return: The time_updated of this Deployment.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this Deployment.
+        The time this resource was last updated. An RFC3339 formatted datetime string.
+
+
+        :param time_updated: The time_updated of this Deployment.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this Deployment.
+        The current state of the deployment.
+
+        Allowed values for this property are: "CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this Deployment.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this Deployment.
+        The current state of the deployment.
+
+
+        :param lifecycle_state: The lifecycle_state of this Deployment.
+        :type: str
+        """
+        allowed_values = ["CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this Deployment.
+        A message describing the current state in more detail.
+        For example, can be used to provide actionable information for a
+        resource in a Failed state.
+
+
+        :return: The lifecycle_details of this Deployment.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this Deployment.
+        A message describing the current state in more detail.
+        For example, can be used to provide actionable information for a
+        resource in a Failed state.
+
+
+        :param lifecycle_details: The lifecycle_details of this Deployment.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this Deployment.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this Deployment.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this Deployment.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this Deployment.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this Deployment.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this Deployment.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this Deployment.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this Deployment.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/deployment_collection.py
+++ b/src/oci/apigateway/models/deployment_collection.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DeploymentCollection(object):
+    """
+    Collection of deployment summaries.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DeploymentCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this DeploymentCollection.
+        :type items: list[DeploymentSummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[DeploymentSummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this DeploymentCollection.
+        Deployment summaries.
+
+
+        :return: The items of this DeploymentCollection.
+        :rtype: list[DeploymentSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this DeploymentCollection.
+        Deployment summaries.
+
+
+        :param items: The items of this DeploymentCollection.
+        :type: list[DeploymentSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/deployment_summary.py
+++ b/src/oci/apigateway/models/deployment_summary.py
@@ -1,0 +1,468 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DeploymentSummary(object):
+    """
+    A summary of the deployment.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DeploymentSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this DeploymentSummary.
+        :type id: str
+
+        :param gateway_id:
+            The value to assign to the gateway_id property of this DeploymentSummary.
+        :type gateway_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this DeploymentSummary.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this DeploymentSummary.
+        :type compartment_id: str
+
+        :param path_prefix:
+            The value to assign to the path_prefix property of this DeploymentSummary.
+        :type path_prefix: str
+
+        :param endpoint:
+            The value to assign to the endpoint property of this DeploymentSummary.
+        :type endpoint: str
+
+        :param time_created:
+            The value to assign to the time_created property of this DeploymentSummary.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this DeploymentSummary.
+        :type time_updated: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this DeploymentSummary.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this DeploymentSummary.
+        :type lifecycle_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this DeploymentSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this DeploymentSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'gateway_id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'path_prefix': 'str',
+            'endpoint': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'gateway_id': 'gatewayId',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'path_prefix': 'pathPrefix',
+            'endpoint': 'endpoint',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._gateway_id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._path_prefix = None
+        self._endpoint = None
+        self._time_created = None
+        self._time_updated = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this DeploymentSummary.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this DeploymentSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this DeploymentSummary.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this DeploymentSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def gateway_id(self):
+        """
+        **[Required]** Gets the gateway_id of this DeploymentSummary.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The gateway_id of this DeploymentSummary.
+        :rtype: str
+        """
+        return self._gateway_id
+
+    @gateway_id.setter
+    def gateway_id(self, gateway_id):
+        """
+        Sets the gateway_id of this DeploymentSummary.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param gateway_id: The gateway_id of this DeploymentSummary.
+        :type: str
+        """
+        self._gateway_id = gateway_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this DeploymentSummary.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :return: The display_name of this DeploymentSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this DeploymentSummary.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :param display_name: The display_name of this DeploymentSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this DeploymentSummary.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this DeploymentSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this DeploymentSummary.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this DeploymentSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def path_prefix(self):
+        """
+        **[Required]** Gets the path_prefix of this DeploymentSummary.
+        The path on which all routes contained in the API
+        deployment specification are deployed. For more information, see
+        `Deploying an API on an API Gateway by Creating an API
+        Deployment`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/APIGateway/Tasks/apigatewaycreatingdeployment.htm
+
+
+        :return: The path_prefix of this DeploymentSummary.
+        :rtype: str
+        """
+        return self._path_prefix
+
+    @path_prefix.setter
+    def path_prefix(self, path_prefix):
+        """
+        Sets the path_prefix of this DeploymentSummary.
+        The path on which all routes contained in the API
+        deployment specification are deployed. For more information, see
+        `Deploying an API on an API Gateway by Creating an API
+        Deployment`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/APIGateway/Tasks/apigatewaycreatingdeployment.htm
+
+
+        :param path_prefix: The path_prefix of this DeploymentSummary.
+        :type: str
+        """
+        self._path_prefix = path_prefix
+
+    @property
+    def endpoint(self):
+        """
+        **[Required]** Gets the endpoint of this DeploymentSummary.
+        The endpoint to access this deployment on the gateway.
+
+
+        :return: The endpoint of this DeploymentSummary.
+        :rtype: str
+        """
+        return self._endpoint
+
+    @endpoint.setter
+    def endpoint(self, endpoint):
+        """
+        Sets the endpoint of this DeploymentSummary.
+        The endpoint to access this deployment on the gateway.
+
+
+        :param endpoint: The endpoint of this DeploymentSummary.
+        :type: str
+        """
+        self._endpoint = endpoint
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this DeploymentSummary.
+        The time this resource was created. An RFC3339 formatted datetime string.
+
+
+        :return: The time_created of this DeploymentSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this DeploymentSummary.
+        The time this resource was created. An RFC3339 formatted datetime string.
+
+
+        :param time_created: The time_created of this DeploymentSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this DeploymentSummary.
+        The time this resource was last updated. An RFC3339 formatted datetime string.
+
+
+        :return: The time_updated of this DeploymentSummary.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this DeploymentSummary.
+        The time this resource was last updated. An RFC3339 formatted datetime string.
+
+
+        :param time_updated: The time_updated of this DeploymentSummary.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this DeploymentSummary.
+        The current state of the deployment.
+
+
+        :return: The lifecycle_state of this DeploymentSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this DeploymentSummary.
+        The current state of the deployment.
+
+
+        :param lifecycle_state: The lifecycle_state of this DeploymentSummary.
+        :type: str
+        """
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this DeploymentSummary.
+        A message describing the current state in more detail.
+        For example, can be used to provide actionable information for a
+        resource in a Failed state.
+
+
+        :return: The lifecycle_details of this DeploymentSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this DeploymentSummary.
+        A message describing the current state in more detail.
+        For example, can be used to provide actionable information for a
+        resource in a Failed state.
+
+
+        :param lifecycle_details: The lifecycle_details of this DeploymentSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this DeploymentSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this DeploymentSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this DeploymentSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this DeploymentSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this DeploymentSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this DeploymentSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this DeploymentSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this DeploymentSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/execution_log_policy.py
+++ b/src/oci/apigateway/models/execution_log_policy.py
@@ -1,0 +1,122 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExecutionLogPolicy(object):
+    """
+    Configures the pushing of execution logs to OCI Public Logging.
+    """
+
+    #: A constant which can be used with the log_level property of a ExecutionLogPolicy.
+    #: This constant has a value of "INFO"
+    LOG_LEVEL_INFO = "INFO"
+
+    #: A constant which can be used with the log_level property of a ExecutionLogPolicy.
+    #: This constant has a value of "WARN"
+    LOG_LEVEL_WARN = "WARN"
+
+    #: A constant which can be used with the log_level property of a ExecutionLogPolicy.
+    #: This constant has a value of "ERROR"
+    LOG_LEVEL_ERROR = "ERROR"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExecutionLogPolicy object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param is_enabled:
+            The value to assign to the is_enabled property of this ExecutionLogPolicy.
+        :type is_enabled: bool
+
+        :param log_level:
+            The value to assign to the log_level property of this ExecutionLogPolicy.
+            Allowed values for this property are: "INFO", "WARN", "ERROR", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type log_level: str
+
+        """
+        self.swagger_types = {
+            'is_enabled': 'bool',
+            'log_level': 'str'
+        }
+
+        self.attribute_map = {
+            'is_enabled': 'isEnabled',
+            'log_level': 'logLevel'
+        }
+
+        self._is_enabled = None
+        self._log_level = None
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this ExecutionLogPolicy.
+        Enables pushing of execution logs to OCI Public Logging.
+
+
+        :return: The is_enabled of this ExecutionLogPolicy.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this ExecutionLogPolicy.
+        Enables pushing of execution logs to OCI Public Logging.
+
+
+        :param is_enabled: The is_enabled of this ExecutionLogPolicy.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
+
+    @property
+    def log_level(self):
+        """
+        Gets the log_level of this ExecutionLogPolicy.
+        Specifies the logging level, which affects the log entries pushed to
+        OCI Public Logging if `isEnabled` is set to True.
+
+        Allowed values for this property are: "INFO", "WARN", "ERROR", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The log_level of this ExecutionLogPolicy.
+        :rtype: str
+        """
+        return self._log_level
+
+    @log_level.setter
+    def log_level(self, log_level):
+        """
+        Sets the log_level of this ExecutionLogPolicy.
+        Specifies the logging level, which affects the log entries pushed to
+        OCI Public Logging if `isEnabled` is set to True.
+
+
+        :param log_level: The log_level of this ExecutionLogPolicy.
+        :type: str
+        """
+        allowed_values = ["INFO", "WARN", "ERROR"]
+        if not value_allowed_none_or_none_sentinel(log_level, allowed_values):
+            log_level = 'UNKNOWN_ENUM_VALUE'
+        self._log_level = log_level
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/gateway.py
+++ b/src/oci/apigateway/models/gateway.py
@@ -1,0 +1,511 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Gateway(object):
+    """
+    A gateway is a virtual network appliance in a regional subnet. A gateway routes inbound traffic to back-end services including public, private, and partner HTTP APIs, as well as Oracle Functions. Avoid entering confidential information. For more information, see
+    `API Gateway Concepts`__.
+
+    __ https://docs.cloud.oracle.com/iaas/Content/APIGateway/Concepts/apigatewayconcepts.htm
+    """
+
+    #: A constant which can be used with the endpoint_type property of a Gateway.
+    #: This constant has a value of "PUBLIC"
+    ENDPOINT_TYPE_PUBLIC = "PUBLIC"
+
+    #: A constant which can be used with the endpoint_type property of a Gateway.
+    #: This constant has a value of "PRIVATE"
+    ENDPOINT_TYPE_PRIVATE = "PRIVATE"
+
+    #: A constant which can be used with the lifecycle_state property of a Gateway.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a Gateway.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a Gateway.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a Gateway.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a Gateway.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a Gateway.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Gateway object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this Gateway.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this Gateway.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this Gateway.
+        :type compartment_id: str
+
+        :param endpoint_type:
+            The value to assign to the endpoint_type property of this Gateway.
+            Allowed values for this property are: "PUBLIC", "PRIVATE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type endpoint_type: str
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this Gateway.
+        :type subnet_id: str
+
+        :param time_created:
+            The value to assign to the time_created property of this Gateway.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this Gateway.
+        :type time_updated: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this Gateway.
+            Allowed values for this property are: "CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this Gateway.
+        :type lifecycle_details: str
+
+        :param hostname:
+            The value to assign to the hostname property of this Gateway.
+        :type hostname: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this Gateway.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this Gateway.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'endpoint_type': 'str',
+            'subnet_id': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'hostname': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'endpoint_type': 'endpointType',
+            'subnet_id': 'subnetId',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'hostname': 'hostname',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._endpoint_type = None
+        self._subnet_id = None
+        self._time_created = None
+        self._time_updated = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._hostname = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this Gateway.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this Gateway.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this Gateway.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this Gateway.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this Gateway.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :return: The display_name of this Gateway.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this Gateway.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :param display_name: The display_name of this Gateway.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this Gateway.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this Gateway.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this Gateway.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this Gateway.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def endpoint_type(self):
+        """
+        **[Required]** Gets the endpoint_type of this Gateway.
+        Gateway endpoint type.
+
+        Allowed values for this property are: "PUBLIC", "PRIVATE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The endpoint_type of this Gateway.
+        :rtype: str
+        """
+        return self._endpoint_type
+
+    @endpoint_type.setter
+    def endpoint_type(self, endpoint_type):
+        """
+        Sets the endpoint_type of this Gateway.
+        Gateway endpoint type.
+
+
+        :param endpoint_type: The endpoint_type of this Gateway.
+        :type: str
+        """
+        allowed_values = ["PUBLIC", "PRIVATE"]
+        if not value_allowed_none_or_none_sentinel(endpoint_type, allowed_values):
+            endpoint_type = 'UNKNOWN_ENUM_VALUE'
+        self._endpoint_type = endpoint_type
+
+    @property
+    def subnet_id(self):
+        """
+        Gets the subnet_id of this Gateway.
+        The `OCID`__ of the subnet in which
+        related resources are created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The subnet_id of this Gateway.
+        :rtype: str
+        """
+        return self._subnet_id
+
+    @subnet_id.setter
+    def subnet_id(self, subnet_id):
+        """
+        Sets the subnet_id of this Gateway.
+        The `OCID`__ of the subnet in which
+        related resources are created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param subnet_id: The subnet_id of this Gateway.
+        :type: str
+        """
+        self._subnet_id = subnet_id
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this Gateway.
+        The time this resource was created. An RFC3339 formatted datetime string.
+
+
+        :return: The time_created of this Gateway.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this Gateway.
+        The time this resource was created. An RFC3339 formatted datetime string.
+
+
+        :param time_created: The time_created of this Gateway.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this Gateway.
+        The time this resource was last updated. An RFC3339 formatted datetime string.
+
+
+        :return: The time_updated of this Gateway.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this Gateway.
+        The time this resource was last updated. An RFC3339 formatted datetime string.
+
+
+        :param time_updated: The time_updated of this Gateway.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this Gateway.
+        The current state of the gateway.
+
+        Allowed values for this property are: "CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this Gateway.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this Gateway.
+        The current state of the gateway.
+
+
+        :param lifecycle_state: The lifecycle_state of this Gateway.
+        :type: str
+        """
+        allowed_values = ["CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this Gateway.
+        A message describing the current state in more detail.
+        For example, can be used to provide actionable information for a
+        resource in a Failed state.
+
+
+        :return: The lifecycle_details of this Gateway.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this Gateway.
+        A message describing the current state in more detail.
+        For example, can be used to provide actionable information for a
+        resource in a Failed state.
+
+
+        :param lifecycle_details: The lifecycle_details of this Gateway.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def hostname(self):
+        """
+        Gets the hostname of this Gateway.
+        The hostname for APIs deployed on the gateway.
+
+
+        :return: The hostname of this Gateway.
+        :rtype: str
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, hostname):
+        """
+        Sets the hostname of this Gateway.
+        The hostname for APIs deployed on the gateway.
+
+
+        :param hostname: The hostname of this Gateway.
+        :type: str
+        """
+        self._hostname = hostname
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this Gateway.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this Gateway.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this Gateway.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this Gateway.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this Gateway.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this Gateway.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this Gateway.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this Gateway.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/gateway_collection.py
+++ b/src/oci/apigateway/models/gateway_collection.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class GatewayCollection(object):
+    """
+    Collection of gateway summaries.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new GatewayCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this GatewayCollection.
+        :type items: list[GatewaySummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[GatewaySummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this GatewayCollection.
+        Gateway summaries.
+
+
+        :return: The items of this GatewayCollection.
+        :rtype: list[GatewaySummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this GatewayCollection.
+        Gateway summaries.
+
+
+        :param items: The items of this GatewayCollection.
+        :type: list[GatewaySummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/gateway_summary.py
+++ b/src/oci/apigateway/models/gateway_summary.py
@@ -1,0 +1,460 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class GatewaySummary(object):
+    """
+    A summary of the gateway.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new GatewaySummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this GatewaySummary.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this GatewaySummary.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this GatewaySummary.
+        :type compartment_id: str
+
+        :param endpoint_type:
+            The value to assign to the endpoint_type property of this GatewaySummary.
+        :type endpoint_type: str
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this GatewaySummary.
+        :type subnet_id: str
+
+        :param time_created:
+            The value to assign to the time_created property of this GatewaySummary.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this GatewaySummary.
+        :type time_updated: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this GatewaySummary.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this GatewaySummary.
+        :type lifecycle_details: str
+
+        :param hostname:
+            The value to assign to the hostname property of this GatewaySummary.
+        :type hostname: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this GatewaySummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this GatewaySummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'endpoint_type': 'str',
+            'subnet_id': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'hostname': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'endpoint_type': 'endpointType',
+            'subnet_id': 'subnetId',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'hostname': 'hostname',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._endpoint_type = None
+        self._subnet_id = None
+        self._time_created = None
+        self._time_updated = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._hostname = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this GatewaySummary.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this GatewaySummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this GatewaySummary.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this GatewaySummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this GatewaySummary.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :return: The display_name of this GatewaySummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this GatewaySummary.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :param display_name: The display_name of this GatewaySummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this GatewaySummary.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this GatewaySummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this GatewaySummary.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this GatewaySummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def endpoint_type(self):
+        """
+        **[Required]** Gets the endpoint_type of this GatewaySummary.
+        Gateway endpoint type.
+
+
+        :return: The endpoint_type of this GatewaySummary.
+        :rtype: str
+        """
+        return self._endpoint_type
+
+    @endpoint_type.setter
+    def endpoint_type(self, endpoint_type):
+        """
+        Sets the endpoint_type of this GatewaySummary.
+        Gateway endpoint type.
+
+
+        :param endpoint_type: The endpoint_type of this GatewaySummary.
+        :type: str
+        """
+        self._endpoint_type = endpoint_type
+
+    @property
+    def subnet_id(self):
+        """
+        Gets the subnet_id of this GatewaySummary.
+        The `OCID`__ of the subnet in which
+        related resources are created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The subnet_id of this GatewaySummary.
+        :rtype: str
+        """
+        return self._subnet_id
+
+    @subnet_id.setter
+    def subnet_id(self, subnet_id):
+        """
+        Sets the subnet_id of this GatewaySummary.
+        The `OCID`__ of the subnet in which
+        related resources are created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param subnet_id: The subnet_id of this GatewaySummary.
+        :type: str
+        """
+        self._subnet_id = subnet_id
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this GatewaySummary.
+        The time this resource was created. An RFC3339 formatted datetime string.
+
+
+        :return: The time_created of this GatewaySummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this GatewaySummary.
+        The time this resource was created. An RFC3339 formatted datetime string.
+
+
+        :param time_created: The time_created of this GatewaySummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this GatewaySummary.
+        The time this resource was last updated. An RFC3339 formatted datetime string.
+
+
+        :return: The time_updated of this GatewaySummary.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this GatewaySummary.
+        The time this resource was last updated. An RFC3339 formatted datetime string.
+
+
+        :param time_updated: The time_updated of this GatewaySummary.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this GatewaySummary.
+        The current state of the gateway.
+
+
+        :return: The lifecycle_state of this GatewaySummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this GatewaySummary.
+        The current state of the gateway.
+
+
+        :param lifecycle_state: The lifecycle_state of this GatewaySummary.
+        :type: str
+        """
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this GatewaySummary.
+        A message describing the current state in more detail.
+        For example, can be used to provide actionable information for a
+        resource in a Failed state.
+
+
+        :return: The lifecycle_details of this GatewaySummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this GatewaySummary.
+        A message describing the current state in more detail.
+        For example, can be used to provide actionable information for a
+        resource in a Failed state.
+
+
+        :param lifecycle_details: The lifecycle_details of this GatewaySummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def hostname(self):
+        """
+        Gets the hostname of this GatewaySummary.
+        The hostname for the APIs deployed on the gateway.
+
+
+        :return: The hostname of this GatewaySummary.
+        :rtype: str
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, hostname):
+        """
+        Sets the hostname of this GatewaySummary.
+        The hostname for the APIs deployed on the gateway.
+
+
+        :param hostname: The hostname of this GatewaySummary.
+        :type: str
+        """
+        self._hostname = hostname
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this GatewaySummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this GatewaySummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this GatewaySummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this GatewaySummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this GatewaySummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this GatewaySummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this GatewaySummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this GatewaySummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/header_field_specification.py
+++ b/src/oci/apigateway/models/header_field_specification.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class HeaderFieldSpecification(object):
+    """
+    Header in key/value pair.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new HeaderFieldSpecification object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this HeaderFieldSpecification.
+        :type name: str
+
+        :param value:
+            The value to assign to the value property of this HeaderFieldSpecification.
+        :type value: str
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'value': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'value': 'value'
+        }
+
+        self._name = None
+        self._value = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this HeaderFieldSpecification.
+        Name of the header.
+
+
+        :return: The name of this HeaderFieldSpecification.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this HeaderFieldSpecification.
+        Name of the header.
+
+
+        :param name: The name of this HeaderFieldSpecification.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def value(self):
+        """
+        Gets the value of this HeaderFieldSpecification.
+        Value of the header.
+
+
+        :return: The value of this HeaderFieldSpecification.
+        :rtype: str
+        """
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        """
+        Sets the value of this HeaderFieldSpecification.
+        Value of the header.
+
+
+        :param value: The value of this HeaderFieldSpecification.
+        :type: str
+        """
+        self._value = value
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/http_backend.py
+++ b/src/oci/apigateway/models/http_backend.py
@@ -1,0 +1,199 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .api_specification_route_backend import ApiSpecificationRouteBackend
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class HTTPBackend(ApiSpecificationRouteBackend):
+    """
+    Send the request to an HTTP backend.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new HTTPBackend object with values from keyword arguments. The default value of the :py:attr:`~oci.apigateway.models.HTTPBackend.type` attribute
+        of this class is ``HTTP_BACKEND`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param type:
+            The value to assign to the type property of this HTTPBackend.
+            Allowed values for this property are: "ORACLE_FUNCTIONS_BACKEND", "HTTP_BACKEND", "STOCK_RESPONSE_BACKEND"
+        :type type: str
+
+        :param url:
+            The value to assign to the url property of this HTTPBackend.
+        :type url: str
+
+        :param connect_timeout_in_seconds:
+            The value to assign to the connect_timeout_in_seconds property of this HTTPBackend.
+        :type connect_timeout_in_seconds: float
+
+        :param read_timeout_in_seconds:
+            The value to assign to the read_timeout_in_seconds property of this HTTPBackend.
+        :type read_timeout_in_seconds: float
+
+        :param send_timeout_in_seconds:
+            The value to assign to the send_timeout_in_seconds property of this HTTPBackend.
+        :type send_timeout_in_seconds: float
+
+        :param is_ssl_verify_disabled:
+            The value to assign to the is_ssl_verify_disabled property of this HTTPBackend.
+        :type is_ssl_verify_disabled: bool
+
+        """
+        self.swagger_types = {
+            'type': 'str',
+            'url': 'str',
+            'connect_timeout_in_seconds': 'float',
+            'read_timeout_in_seconds': 'float',
+            'send_timeout_in_seconds': 'float',
+            'is_ssl_verify_disabled': 'bool'
+        }
+
+        self.attribute_map = {
+            'type': 'type',
+            'url': 'url',
+            'connect_timeout_in_seconds': 'connectTimeoutInSeconds',
+            'read_timeout_in_seconds': 'readTimeoutInSeconds',
+            'send_timeout_in_seconds': 'sendTimeoutInSeconds',
+            'is_ssl_verify_disabled': 'isSslVerifyDisabled'
+        }
+
+        self._type = None
+        self._url = None
+        self._connect_timeout_in_seconds = None
+        self._read_timeout_in_seconds = None
+        self._send_timeout_in_seconds = None
+        self._is_ssl_verify_disabled = None
+        self._type = 'HTTP_BACKEND'
+
+    @property
+    def url(self):
+        """
+        **[Required]** Gets the url of this HTTPBackend.
+
+        :return: The url of this HTTPBackend.
+        :rtype: str
+        """
+        return self._url
+
+    @url.setter
+    def url(self, url):
+        """
+        Sets the url of this HTTPBackend.
+
+        :param url: The url of this HTTPBackend.
+        :type: str
+        """
+        self._url = url
+
+    @property
+    def connect_timeout_in_seconds(self):
+        """
+        Gets the connect_timeout_in_seconds of this HTTPBackend.
+        Defines a timeout for establishing a connection with a proxied server.
+
+
+        :return: The connect_timeout_in_seconds of this HTTPBackend.
+        :rtype: float
+        """
+        return self._connect_timeout_in_seconds
+
+    @connect_timeout_in_seconds.setter
+    def connect_timeout_in_seconds(self, connect_timeout_in_seconds):
+        """
+        Sets the connect_timeout_in_seconds of this HTTPBackend.
+        Defines a timeout for establishing a connection with a proxied server.
+
+
+        :param connect_timeout_in_seconds: The connect_timeout_in_seconds of this HTTPBackend.
+        :type: float
+        """
+        self._connect_timeout_in_seconds = connect_timeout_in_seconds
+
+    @property
+    def read_timeout_in_seconds(self):
+        """
+        Gets the read_timeout_in_seconds of this HTTPBackend.
+        Defines a timeout for reading a response from the proxied server.
+
+
+        :return: The read_timeout_in_seconds of this HTTPBackend.
+        :rtype: float
+        """
+        return self._read_timeout_in_seconds
+
+    @read_timeout_in_seconds.setter
+    def read_timeout_in_seconds(self, read_timeout_in_seconds):
+        """
+        Sets the read_timeout_in_seconds of this HTTPBackend.
+        Defines a timeout for reading a response from the proxied server.
+
+
+        :param read_timeout_in_seconds: The read_timeout_in_seconds of this HTTPBackend.
+        :type: float
+        """
+        self._read_timeout_in_seconds = read_timeout_in_seconds
+
+    @property
+    def send_timeout_in_seconds(self):
+        """
+        Gets the send_timeout_in_seconds of this HTTPBackend.
+        Defines a timeout for transmitting a request to the proxied server.
+
+
+        :return: The send_timeout_in_seconds of this HTTPBackend.
+        :rtype: float
+        """
+        return self._send_timeout_in_seconds
+
+    @send_timeout_in_seconds.setter
+    def send_timeout_in_seconds(self, send_timeout_in_seconds):
+        """
+        Sets the send_timeout_in_seconds of this HTTPBackend.
+        Defines a timeout for transmitting a request to the proxied server.
+
+
+        :param send_timeout_in_seconds: The send_timeout_in_seconds of this HTTPBackend.
+        :type: float
+        """
+        self._send_timeout_in_seconds = send_timeout_in_seconds
+
+    @property
+    def is_ssl_verify_disabled(self):
+        """
+        Gets the is_ssl_verify_disabled of this HTTPBackend.
+        Defines whether or not to uphold SSL verification.
+
+
+        :return: The is_ssl_verify_disabled of this HTTPBackend.
+        :rtype: bool
+        """
+        return self._is_ssl_verify_disabled
+
+    @is_ssl_verify_disabled.setter
+    def is_ssl_verify_disabled(self, is_ssl_verify_disabled):
+        """
+        Sets the is_ssl_verify_disabled of this HTTPBackend.
+        Defines whether or not to uphold SSL verification.
+
+
+        :param is_ssl_verify_disabled: The is_ssl_verify_disabled of this HTTPBackend.
+        :type: bool
+        """
+        self._is_ssl_verify_disabled = is_ssl_verify_disabled
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/oracle_function_backend.py
+++ b/src/oci/apigateway/models/oracle_function_backend.py
@@ -1,0 +1,83 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .api_specification_route_backend import ApiSpecificationRouteBackend
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OracleFunctionBackend(ApiSpecificationRouteBackend):
+    """
+    Send the request to an Oracle Functions function.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OracleFunctionBackend object with values from keyword arguments. The default value of the :py:attr:`~oci.apigateway.models.OracleFunctionBackend.type` attribute
+        of this class is ``ORACLE_FUNCTIONS_BACKEND`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param type:
+            The value to assign to the type property of this OracleFunctionBackend.
+            Allowed values for this property are: "ORACLE_FUNCTIONS_BACKEND", "HTTP_BACKEND", "STOCK_RESPONSE_BACKEND"
+        :type type: str
+
+        :param function_id:
+            The value to assign to the function_id property of this OracleFunctionBackend.
+        :type function_id: str
+
+        """
+        self.swagger_types = {
+            'type': 'str',
+            'function_id': 'str'
+        }
+
+        self.attribute_map = {
+            'type': 'type',
+            'function_id': 'functionId'
+        }
+
+        self._type = None
+        self._function_id = None
+        self._type = 'ORACLE_FUNCTIONS_BACKEND'
+
+    @property
+    def function_id(self):
+        """
+        **[Required]** Gets the function_id of this OracleFunctionBackend.
+        The `OCID`__ of the Oracle Functions function resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The function_id of this OracleFunctionBackend.
+        :rtype: str
+        """
+        return self._function_id
+
+    @function_id.setter
+    def function_id(self, function_id):
+        """
+        Sets the function_id of this OracleFunctionBackend.
+        The `OCID`__ of the Oracle Functions function resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param function_id: The function_id of this OracleFunctionBackend.
+        :type: str
+        """
+        self._function_id = function_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/rate_limiting_policy.py
+++ b/src/oci/apigateway/models/rate_limiting_policy.py
@@ -1,0 +1,116 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class RateLimitingPolicy(object):
+    """
+    Limit the number of requests that should be handled for the specified window using a specfic key.
+    """
+
+    #: A constant which can be used with the rate_key property of a RateLimitingPolicy.
+    #: This constant has a value of "CLIENT_IP"
+    RATE_KEY_CLIENT_IP = "CLIENT_IP"
+
+    #: A constant which can be used with the rate_key property of a RateLimitingPolicy.
+    #: This constant has a value of "TOTAL"
+    RATE_KEY_TOTAL = "TOTAL"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new RateLimitingPolicy object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param rate_in_requests_per_second:
+            The value to assign to the rate_in_requests_per_second property of this RateLimitingPolicy.
+        :type rate_in_requests_per_second: int
+
+        :param rate_key:
+            The value to assign to the rate_key property of this RateLimitingPolicy.
+            Allowed values for this property are: "CLIENT_IP", "TOTAL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type rate_key: str
+
+        """
+        self.swagger_types = {
+            'rate_in_requests_per_second': 'int',
+            'rate_key': 'str'
+        }
+
+        self.attribute_map = {
+            'rate_in_requests_per_second': 'rateInRequestsPerSecond',
+            'rate_key': 'rateKey'
+        }
+
+        self._rate_in_requests_per_second = None
+        self._rate_key = None
+
+    @property
+    def rate_in_requests_per_second(self):
+        """
+        **[Required]** Gets the rate_in_requests_per_second of this RateLimitingPolicy.
+        The maximum number of requests per second to allow.
+
+
+        :return: The rate_in_requests_per_second of this RateLimitingPolicy.
+        :rtype: int
+        """
+        return self._rate_in_requests_per_second
+
+    @rate_in_requests_per_second.setter
+    def rate_in_requests_per_second(self, rate_in_requests_per_second):
+        """
+        Sets the rate_in_requests_per_second of this RateLimitingPolicy.
+        The maximum number of requests per second to allow.
+
+
+        :param rate_in_requests_per_second: The rate_in_requests_per_second of this RateLimitingPolicy.
+        :type: int
+        """
+        self._rate_in_requests_per_second = rate_in_requests_per_second
+
+    @property
+    def rate_key(self):
+        """
+        **[Required]** Gets the rate_key of this RateLimitingPolicy.
+        The key used to group requests together.
+
+        Allowed values for this property are: "CLIENT_IP", "TOTAL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The rate_key of this RateLimitingPolicy.
+        :rtype: str
+        """
+        return self._rate_key
+
+    @rate_key.setter
+    def rate_key(self, rate_key):
+        """
+        Sets the rate_key of this RateLimitingPolicy.
+        The key used to group requests together.
+
+
+        :param rate_key: The rate_key of this RateLimitingPolicy.
+        :type: str
+        """
+        allowed_values = ["CLIENT_IP", "TOTAL"]
+        if not value_allowed_none_or_none_sentinel(rate_key, allowed_values):
+            rate_key = 'UNKNOWN_ENUM_VALUE'
+        self._rate_key = rate_key
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/route_authorization_policy.py
+++ b/src/oci/apigateway/models/route_authorization_policy.py
@@ -1,0 +1,121 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class RouteAuthorizationPolicy(object):
+    """
+    If authentication has been performed, validate whether the request scope (if any) applies to this route.
+    If no RouteAuthorizationPolicy is defined for a route, a policy with a type of AUTHENTICATION_ONLY is applied.
+    """
+
+    #: A constant which can be used with the type property of a RouteAuthorizationPolicy.
+    #: This constant has a value of "ANONYMOUS"
+    TYPE_ANONYMOUS = "ANONYMOUS"
+
+    #: A constant which can be used with the type property of a RouteAuthorizationPolicy.
+    #: This constant has a value of "ANY_OF"
+    TYPE_ANY_OF = "ANY_OF"
+
+    #: A constant which can be used with the type property of a RouteAuthorizationPolicy.
+    #: This constant has a value of "AUTHENTICATION_ONLY"
+    TYPE_AUTHENTICATION_ONLY = "AUTHENTICATION_ONLY"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new RouteAuthorizationPolicy object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.apigateway.models.AnyOfRouteAuthorizationPolicy`
+        * :class:`~oci.apigateway.models.AnonymousRouteAuthorizationPolicy`
+        * :class:`~oci.apigateway.models.AuthenticationOnlyRouteAuthorizationPolicy`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param type:
+            The value to assign to the type property of this RouteAuthorizationPolicy.
+            Allowed values for this property are: "ANONYMOUS", "ANY_OF", "AUTHENTICATION_ONLY", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type type: str
+
+        """
+        self.swagger_types = {
+            'type': 'str'
+        }
+
+        self.attribute_map = {
+            'type': 'type'
+        }
+
+        self._type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['type']
+
+        if type == 'ANY_OF':
+            return 'AnyOfRouteAuthorizationPolicy'
+
+        if type == 'ANONYMOUS':
+            return 'AnonymousRouteAuthorizationPolicy'
+
+        if type == 'AUTHENTICATION_ONLY':
+            return 'AuthenticationOnlyRouteAuthorizationPolicy'
+        else:
+            return 'RouteAuthorizationPolicy'
+
+    @property
+    def type(self):
+        """
+        Gets the type of this RouteAuthorizationPolicy.
+        Indicates how authorization should be applied. For a type of ANY_OF, an \"allowedScope\"
+        property must also be specfied. Otherwise, only a type is required. For a type of ANONYMOUS, an
+        authenticated API must have the \"isAnonymousAccessAllowed\" property set to \"true\" in the authentication
+        policy.
+
+        Allowed values for this property are: "ANONYMOUS", "ANY_OF", "AUTHENTICATION_ONLY", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The type of this RouteAuthorizationPolicy.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this RouteAuthorizationPolicy.
+        Indicates how authorization should be applied. For a type of ANY_OF, an \"allowedScope\"
+        property must also be specfied. Otherwise, only a type is required. For a type of ANONYMOUS, an
+        authenticated API must have the \"isAnonymousAccessAllowed\" property set to \"true\" in the authentication
+        policy.
+
+
+        :param type: The type of this RouteAuthorizationPolicy.
+        :type: str
+        """
+        allowed_values = ["ANONYMOUS", "ANY_OF", "AUTHENTICATION_ONLY"]
+        if not value_allowed_none_or_none_sentinel(type, allowed_values):
+            type = 'UNKNOWN_ENUM_VALUE'
+        self._type = type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/stock_response_backend.py
+++ b/src/oci/apigateway/models/stock_response_backend.py
@@ -1,0 +1,141 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .api_specification_route_backend import ApiSpecificationRouteBackend
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class StockResponseBackend(ApiSpecificationRouteBackend):
+    """
+    Send the request to a mock backend.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new StockResponseBackend object with values from keyword arguments. The default value of the :py:attr:`~oci.apigateway.models.StockResponseBackend.type` attribute
+        of this class is ``STOCK_RESPONSE_BACKEND`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param type:
+            The value to assign to the type property of this StockResponseBackend.
+            Allowed values for this property are: "ORACLE_FUNCTIONS_BACKEND", "HTTP_BACKEND", "STOCK_RESPONSE_BACKEND"
+        :type type: str
+
+        :param body:
+            The value to assign to the body property of this StockResponseBackend.
+        :type body: str
+
+        :param status:
+            The value to assign to the status property of this StockResponseBackend.
+        :type status: int
+
+        :param headers:
+            The value to assign to the headers property of this StockResponseBackend.
+        :type headers: list[HeaderFieldSpecification]
+
+        """
+        self.swagger_types = {
+            'type': 'str',
+            'body': 'str',
+            'status': 'int',
+            'headers': 'list[HeaderFieldSpecification]'
+        }
+
+        self.attribute_map = {
+            'type': 'type',
+            'body': 'body',
+            'status': 'status',
+            'headers': 'headers'
+        }
+
+        self._type = None
+        self._body = None
+        self._status = None
+        self._headers = None
+        self._type = 'STOCK_RESPONSE_BACKEND'
+
+    @property
+    def body(self):
+        """
+        Gets the body of this StockResponseBackend.
+        The body of the stock response from the mock backend.
+
+
+        :return: The body of this StockResponseBackend.
+        :rtype: str
+        """
+        return self._body
+
+    @body.setter
+    def body(self, body):
+        """
+        Sets the body of this StockResponseBackend.
+        The body of the stock response from the mock backend.
+
+
+        :param body: The body of this StockResponseBackend.
+        :type: str
+        """
+        self._body = body
+
+    @property
+    def status(self):
+        """
+        **[Required]** Gets the status of this StockResponseBackend.
+        The status code of the stock response from the mock backend.
+
+
+        :return: The status of this StockResponseBackend.
+        :rtype: int
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this StockResponseBackend.
+        The status code of the stock response from the mock backend.
+
+
+        :param status: The status of this StockResponseBackend.
+        :type: int
+        """
+        self._status = status
+
+    @property
+    def headers(self):
+        """
+        Gets the headers of this StockResponseBackend.
+        The headers of the stock response from the mock backend.
+
+
+        :return: The headers of this StockResponseBackend.
+        :rtype: list[HeaderFieldSpecification]
+        """
+        return self._headers
+
+    @headers.setter
+    def headers(self, headers):
+        """
+        Sets the headers of this StockResponseBackend.
+        The headers of the stock response from the mock backend.
+
+
+        :param headers: The headers of this StockResponseBackend.
+        :type: list[HeaderFieldSpecification]
+        """
+        self._headers = headers
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/update_deployment_details.py
+++ b/src/oci/apigateway/models/update_deployment_details.py
@@ -1,0 +1,188 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateDeploymentDetails(object):
+    """
+    The information to be updated.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateDeploymentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateDeploymentDetails.
+        :type display_name: str
+
+        :param specification:
+            The value to assign to the specification property of this UpdateDeploymentDetails.
+        :type specification: ApiSpecification
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateDeploymentDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateDeploymentDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'specification': 'ApiSpecification',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'specification': 'specification',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._specification = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateDeploymentDetails.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :return: The display_name of this UpdateDeploymentDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateDeploymentDetails.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :param display_name: The display_name of this UpdateDeploymentDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def specification(self):
+        """
+        Gets the specification of this UpdateDeploymentDetails.
+
+        :return: The specification of this UpdateDeploymentDetails.
+        :rtype: ApiSpecification
+        """
+        return self._specification
+
+    @specification.setter
+    def specification(self, specification):
+        """
+        Sets the specification of this UpdateDeploymentDetails.
+
+        :param specification: The specification of this UpdateDeploymentDetails.
+        :type: ApiSpecification
+        """
+        self._specification = specification
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateDeploymentDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateDeploymentDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateDeploymentDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateDeploymentDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateDeploymentDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateDeploymentDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateDeploymentDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateDeploymentDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/update_gateway_details.py
+++ b/src/oci/apigateway/models/update_gateway_details.py
@@ -1,0 +1,161 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateGatewayDetails(object):
+    """
+    The information to be updated.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateGatewayDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateGatewayDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateGatewayDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateGatewayDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateGatewayDetails.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :return: The display_name of this UpdateGatewayDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateGatewayDetails.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        Example: `My new resource`
+
+
+        :param display_name: The display_name of this UpdateGatewayDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateGatewayDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateGatewayDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateGatewayDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair
+        with no predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateGatewayDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateGatewayDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateGatewayDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateGatewayDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateGatewayDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/work_request.py
+++ b/src/oci/apigateway/models/work_request.py
@@ -1,0 +1,407 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequest(object):
+    """
+    A description of the work request status.
+    """
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "CREATE_GATEWAY"
+    OPERATION_TYPE_CREATE_GATEWAY = "CREATE_GATEWAY"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "UPDATE_GATEWAY"
+    OPERATION_TYPE_UPDATE_GATEWAY = "UPDATE_GATEWAY"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "DELETE_GATEWAY"
+    OPERATION_TYPE_DELETE_GATEWAY = "DELETE_GATEWAY"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "CREATE_DEPLOYMENT"
+    OPERATION_TYPE_CREATE_DEPLOYMENT = "CREATE_DEPLOYMENT"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "UPDATE_DEPLOYMENT"
+    OPERATION_TYPE_UPDATE_DEPLOYMENT = "UPDATE_DEPLOYMENT"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "DELETE_DEPLOYMENT"
+    OPERATION_TYPE_DELETE_DEPLOYMENT = "DELETE_DEPLOYMENT"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "ACCEPTED"
+    STATUS_ACCEPTED = "ACCEPTED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "IN_PROGRESS"
+    STATUS_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "FAILED"
+    STATUS_FAILED = "FAILED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "SUCCEEDED"
+    STATUS_SUCCEEDED = "SUCCEEDED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "CANCELING"
+    STATUS_CANCELING = "CANCELING"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "CANCELED"
+    STATUS_CANCELED = "CANCELED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequest object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this WorkRequest.
+        :type id: str
+
+        :param operation_type:
+            The value to assign to the operation_type property of this WorkRequest.
+            Allowed values for this property are: "CREATE_GATEWAY", "UPDATE_GATEWAY", "DELETE_GATEWAY", "CREATE_DEPLOYMENT", "UPDATE_DEPLOYMENT", "DELETE_DEPLOYMENT", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type operation_type: str
+
+        :param status:
+            The value to assign to the status property of this WorkRequest.
+            Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this WorkRequest.
+        :type compartment_id: str
+
+        :param resources:
+            The value to assign to the resources property of this WorkRequest.
+        :type resources: list[WorkRequestResource]
+
+        :param percent_complete:
+            The value to assign to the percent_complete property of this WorkRequest.
+        :type percent_complete: float
+
+        :param time_accepted:
+            The value to assign to the time_accepted property of this WorkRequest.
+        :type time_accepted: datetime
+
+        :param time_started:
+            The value to assign to the time_started property of this WorkRequest.
+        :type time_started: datetime
+
+        :param time_finished:
+            The value to assign to the time_finished property of this WorkRequest.
+        :type time_finished: datetime
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'operation_type': 'str',
+            'status': 'str',
+            'compartment_id': 'str',
+            'resources': 'list[WorkRequestResource]',
+            'percent_complete': 'float',
+            'time_accepted': 'datetime',
+            'time_started': 'datetime',
+            'time_finished': 'datetime'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'operation_type': 'operationType',
+            'status': 'status',
+            'compartment_id': 'compartmentId',
+            'resources': 'resources',
+            'percent_complete': 'percentComplete',
+            'time_accepted': 'timeAccepted',
+            'time_started': 'timeStarted',
+            'time_finished': 'timeFinished'
+        }
+
+        self._id = None
+        self._operation_type = None
+        self._status = None
+        self._compartment_id = None
+        self._resources = None
+        self._percent_complete = None
+        self._time_accepted = None
+        self._time_started = None
+        self._time_finished = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this WorkRequest.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this WorkRequest.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this WorkRequest.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this WorkRequest.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def operation_type(self):
+        """
+        **[Required]** Gets the operation_type of this WorkRequest.
+        The type of the work request.
+
+        Allowed values for this property are: "CREATE_GATEWAY", "UPDATE_GATEWAY", "DELETE_GATEWAY", "CREATE_DEPLOYMENT", "UPDATE_DEPLOYMENT", "DELETE_DEPLOYMENT", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The operation_type of this WorkRequest.
+        :rtype: str
+        """
+        return self._operation_type
+
+    @operation_type.setter
+    def operation_type(self, operation_type):
+        """
+        Sets the operation_type of this WorkRequest.
+        The type of the work request.
+
+
+        :param operation_type: The operation_type of this WorkRequest.
+        :type: str
+        """
+        allowed_values = ["CREATE_GATEWAY", "UPDATE_GATEWAY", "DELETE_GATEWAY", "CREATE_DEPLOYMENT", "UPDATE_DEPLOYMENT", "DELETE_DEPLOYMENT"]
+        if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
+            operation_type = 'UNKNOWN_ENUM_VALUE'
+        self._operation_type = operation_type
+
+    @property
+    def status(self):
+        """
+        **[Required]** Gets the status of this WorkRequest.
+        The status of the work request.
+
+        Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this WorkRequest.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this WorkRequest.
+        The status of the work request.
+
+
+        :param status: The status of this WorkRequest.
+        :type: str
+        """
+        allowed_values = ["ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this WorkRequest.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this WorkRequest.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this WorkRequest.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this WorkRequest.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def resources(self):
+        """
+        **[Required]** Gets the resources of this WorkRequest.
+        The resources affected by this work request.
+
+
+        :return: The resources of this WorkRequest.
+        :rtype: list[WorkRequestResource]
+        """
+        return self._resources
+
+    @resources.setter
+    def resources(self, resources):
+        """
+        Sets the resources of this WorkRequest.
+        The resources affected by this work request.
+
+
+        :param resources: The resources of this WorkRequest.
+        :type: list[WorkRequestResource]
+        """
+        self._resources = resources
+
+    @property
+    def percent_complete(self):
+        """
+        **[Required]** Gets the percent_complete of this WorkRequest.
+        Percentage of the request completed.
+
+
+        :return: The percent_complete of this WorkRequest.
+        :rtype: float
+        """
+        return self._percent_complete
+
+    @percent_complete.setter
+    def percent_complete(self, percent_complete):
+        """
+        Sets the percent_complete of this WorkRequest.
+        Percentage of the request completed.
+
+
+        :param percent_complete: The percent_complete of this WorkRequest.
+        :type: float
+        """
+        self._percent_complete = percent_complete
+
+    @property
+    def time_accepted(self):
+        """
+        **[Required]** Gets the time_accepted of this WorkRequest.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_accepted of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_accepted
+
+    @time_accepted.setter
+    def time_accepted(self, time_accepted):
+        """
+        Sets the time_accepted of this WorkRequest.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_accepted: The time_accepted of this WorkRequest.
+        :type: datetime
+        """
+        self._time_accepted = time_accepted
+
+    @property
+    def time_started(self):
+        """
+        Gets the time_started of this WorkRequest.
+        The date and time the request was started, as described in `RFC 3339`__,
+        section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_started of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_started
+
+    @time_started.setter
+    def time_started(self, time_started):
+        """
+        Sets the time_started of this WorkRequest.
+        The date and time the request was started, as described in `RFC 3339`__,
+        section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_started: The time_started of this WorkRequest.
+        :type: datetime
+        """
+        self._time_started = time_started
+
+    @property
+    def time_finished(self):
+        """
+        Gets the time_finished of this WorkRequest.
+        The date and time the request was finished, as described in `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_finished of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_finished
+
+    @time_finished.setter
+    def time_finished(self, time_finished):
+        """
+        Sets the time_finished of this WorkRequest.
+        The date and time the request was finished, as described in `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_finished: The time_finished of this WorkRequest.
+        :type: datetime
+        """
+        self._time_finished = time_finished
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/work_request_collection.py
+++ b/src/oci/apigateway/models/work_request_collection.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestCollection(object):
+    """
+    Collection of work request summaries.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this WorkRequestCollection.
+        :type items: list[WorkRequestSummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[WorkRequestSummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this WorkRequestCollection.
+        Work request summaries.
+
+
+        :return: The items of this WorkRequestCollection.
+        :rtype: list[WorkRequestSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this WorkRequestCollection.
+        Work request summaries.
+
+
+        :param items: The items of this WorkRequestCollection.
+        :type: list[WorkRequestSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/work_request_error.py
+++ b/src/oci/apigateway/models/work_request_error.py
@@ -1,0 +1,133 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestError(object):
+    """
+    An error encountered while executing a work request.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestError object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param code:
+            The value to assign to the code property of this WorkRequestError.
+        :type code: str
+
+        :param message:
+            The value to assign to the message property of this WorkRequestError.
+        :type message: str
+
+        :param timestamp:
+            The value to assign to the timestamp property of this WorkRequestError.
+        :type timestamp: datetime
+
+        """
+        self.swagger_types = {
+            'code': 'str',
+            'message': 'str',
+            'timestamp': 'datetime'
+        }
+
+        self.attribute_map = {
+            'code': 'code',
+            'message': 'message',
+            'timestamp': 'timestamp'
+        }
+
+        self._code = None
+        self._message = None
+        self._timestamp = None
+
+    @property
+    def code(self):
+        """
+        **[Required]** Gets the code of this WorkRequestError.
+        A machine-usable code for the error that occured. See
+        <a href=\"/Content/API/References/apierrors.htm\">API Errors</a>.
+
+
+        :return: The code of this WorkRequestError.
+        :rtype: str
+        """
+        return self._code
+
+    @code.setter
+    def code(self, code):
+        """
+        Sets the code of this WorkRequestError.
+        A machine-usable code for the error that occured. See
+        <a href=\"/Content/API/References/apierrors.htm\">API Errors</a>.
+
+
+        :param code: The code of this WorkRequestError.
+        :type: str
+        """
+        self._code = code
+
+    @property
+    def message(self):
+        """
+        **[Required]** Gets the message of this WorkRequestError.
+        A human-readable description of the issue encountered.
+
+
+        :return: The message of this WorkRequestError.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this WorkRequestError.
+        A human-readable description of the issue encountered.
+
+
+        :param message: The message of this WorkRequestError.
+        :type: str
+        """
+        self._message = message
+
+    @property
+    def timestamp(self):
+        """
+        **[Required]** Gets the timestamp of this WorkRequestError.
+        The time the error occured. An RFC3339 formatted datetime string.
+
+
+        :return: The timestamp of this WorkRequestError.
+        :rtype: datetime
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp):
+        """
+        Sets the timestamp of this WorkRequestError.
+        The time the error occured. An RFC3339 formatted datetime string.
+
+
+        :param timestamp: The timestamp of this WorkRequestError.
+        :type: datetime
+        """
+        self._timestamp = timestamp
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/work_request_error_collection.py
+++ b/src/oci/apigateway/models/work_request_error_collection.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestErrorCollection(object):
+    """
+    Collection of work request errors.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestErrorCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this WorkRequestErrorCollection.
+        :type items: list[WorkRequestError]
+
+        """
+        self.swagger_types = {
+            'items': 'list[WorkRequestError]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this WorkRequestErrorCollection.
+        Work request errors.
+
+
+        :return: The items of this WorkRequestErrorCollection.
+        :rtype: list[WorkRequestError]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this WorkRequestErrorCollection.
+        Work request errors.
+
+
+        :param items: The items of this WorkRequestErrorCollection.
+        :type: list[WorkRequestError]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/work_request_log.py
+++ b/src/oci/apigateway/models/work_request_log.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestLog(object):
+    """
+    A log message from the execution of a work request.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestLog object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param message:
+            The value to assign to the message property of this WorkRequestLog.
+        :type message: str
+
+        :param timestamp:
+            The value to assign to the timestamp property of this WorkRequestLog.
+        :type timestamp: datetime
+
+        """
+        self.swagger_types = {
+            'message': 'str',
+            'timestamp': 'datetime'
+        }
+
+        self.attribute_map = {
+            'message': 'message',
+            'timestamp': 'timestamp'
+        }
+
+        self._message = None
+        self._timestamp = None
+
+    @property
+    def message(self):
+        """
+        **[Required]** Gets the message of this WorkRequestLog.
+        Human-readable log message.
+
+
+        :return: The message of this WorkRequestLog.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this WorkRequestLog.
+        Human-readable log message.
+
+
+        :param message: The message of this WorkRequestLog.
+        :type: str
+        """
+        self._message = message
+
+    @property
+    def timestamp(self):
+        """
+        **[Required]** Gets the timestamp of this WorkRequestLog.
+        The time the log message was written. An RFC3339 formatted datetime string.
+
+
+        :return: The timestamp of this WorkRequestLog.
+        :rtype: datetime
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp):
+        """
+        Sets the timestamp of this WorkRequestLog.
+        The time the log message was written. An RFC3339 formatted datetime string.
+
+
+        :param timestamp: The timestamp of this WorkRequestLog.
+        :type: datetime
+        """
+        self._timestamp = timestamp
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/work_request_log_collection.py
+++ b/src/oci/apigateway/models/work_request_log_collection.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestLogCollection(object):
+    """
+    Collection of work request logs.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestLogCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this WorkRequestLogCollection.
+        :type items: list[WorkRequestLog]
+
+        """
+        self.swagger_types = {
+            'items': 'list[WorkRequestLog]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this WorkRequestLogCollection.
+        Work request logs.
+
+
+        :return: The items of this WorkRequestLogCollection.
+        :rtype: list[WorkRequestLog]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this WorkRequestLogCollection.
+        Work request logs.
+
+
+        :param items: The items of this WorkRequestLogCollection.
+        :type: list[WorkRequestLog]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/work_request_resource.py
+++ b/src/oci/apigateway/models/work_request_resource.py
@@ -1,0 +1,196 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestResource(object):
+    """
+    A resource created or operated on by a work request.
+    """
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "CREATED"
+    ACTION_TYPE_CREATED = "CREATED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "UPDATED"
+    ACTION_TYPE_UPDATED = "UPDATED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "DELETED"
+    ACTION_TYPE_DELETED = "DELETED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "IN_PROGRESS"
+    ACTION_TYPE_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "FAILED"
+    ACTION_TYPE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestResource object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param entity_type:
+            The value to assign to the entity_type property of this WorkRequestResource.
+        :type entity_type: str
+
+        :param action_type:
+            The value to assign to the action_type property of this WorkRequestResource.
+            Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "IN_PROGRESS", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type action_type: str
+
+        :param identifier:
+            The value to assign to the identifier property of this WorkRequestResource.
+        :type identifier: str
+
+        :param entity_uri:
+            The value to assign to the entity_uri property of this WorkRequestResource.
+        :type entity_uri: str
+
+        """
+        self.swagger_types = {
+            'entity_type': 'str',
+            'action_type': 'str',
+            'identifier': 'str',
+            'entity_uri': 'str'
+        }
+
+        self.attribute_map = {
+            'entity_type': 'entityType',
+            'action_type': 'actionType',
+            'identifier': 'identifier',
+            'entity_uri': 'entityUri'
+        }
+
+        self._entity_type = None
+        self._action_type = None
+        self._identifier = None
+        self._entity_uri = None
+
+    @property
+    def entity_type(self):
+        """
+        **[Required]** Gets the entity_type of this WorkRequestResource.
+        The resource type the work request affects.
+
+
+        :return: The entity_type of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._entity_type
+
+    @entity_type.setter
+    def entity_type(self, entity_type):
+        """
+        Sets the entity_type of this WorkRequestResource.
+        The resource type the work request affects.
+
+
+        :param entity_type: The entity_type of this WorkRequestResource.
+        :type: str
+        """
+        self._entity_type = entity_type
+
+    @property
+    def action_type(self):
+        """
+        **[Required]** Gets the action_type of this WorkRequestResource.
+        The way in which this resource is affected by the work tracked in the work request.
+        A resource being created, updated, or deleted will remain in the IN_PROGRESS state until
+        work is complete for that resource; at which point, it will transition to CREATED, UPDATED,
+        or DELETED, respectively.
+
+        Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "IN_PROGRESS", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The action_type of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._action_type
+
+    @action_type.setter
+    def action_type(self, action_type):
+        """
+        Sets the action_type of this WorkRequestResource.
+        The way in which this resource is affected by the work tracked in the work request.
+        A resource being created, updated, or deleted will remain in the IN_PROGRESS state until
+        work is complete for that resource; at which point, it will transition to CREATED, UPDATED,
+        or DELETED, respectively.
+
+
+        :param action_type: The action_type of this WorkRequestResource.
+        :type: str
+        """
+        allowed_values = ["CREATED", "UPDATED", "DELETED", "IN_PROGRESS", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(action_type, allowed_values):
+            action_type = 'UNKNOWN_ENUM_VALUE'
+        self._action_type = action_type
+
+    @property
+    def identifier(self):
+        """
+        **[Required]** Gets the identifier of this WorkRequestResource.
+        The identifier of the resource the work request affects.
+
+
+        :return: The identifier of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this WorkRequestResource.
+        The identifier of the resource the work request affects.
+
+
+        :param identifier: The identifier of this WorkRequestResource.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def entity_uri(self):
+        """
+        Gets the entity_uri of this WorkRequestResource.
+        The URI path on which the user can perform a GET operation to access the resource metadata.
+
+
+        :return: The entity_uri of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._entity_uri
+
+    @entity_uri.setter
+    def entity_uri(self, entity_uri):
+        """
+        Sets the entity_uri of this WorkRequestResource.
+        The URI path on which the user can perform a GET operation to access the resource metadata.
+
+
+        :param entity_uri: The entity_uri of this WorkRequestResource.
+        :type: str
+        """
+        self._entity_uri = entity_uri
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/models/work_request_summary.py
+++ b/src/oci/apigateway/models/work_request_summary.py
@@ -1,0 +1,312 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestSummary(object):
+    """
+    A summary of the work request.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation_type:
+            The value to assign to the operation_type property of this WorkRequestSummary.
+        :type operation_type: str
+
+        :param status:
+            The value to assign to the status property of this WorkRequestSummary.
+        :type status: str
+
+        :param work_request_id:
+            The value to assign to the work_request_id property of this WorkRequestSummary.
+        :type work_request_id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this WorkRequestSummary.
+        :type compartment_id: str
+
+        :param percent_complete:
+            The value to assign to the percent_complete property of this WorkRequestSummary.
+        :type percent_complete: float
+
+        :param time_accepted:
+            The value to assign to the time_accepted property of this WorkRequestSummary.
+        :type time_accepted: datetime
+
+        :param time_started:
+            The value to assign to the time_started property of this WorkRequestSummary.
+        :type time_started: datetime
+
+        :param time_finished:
+            The value to assign to the time_finished property of this WorkRequestSummary.
+        :type time_finished: datetime
+
+        """
+        self.swagger_types = {
+            'operation_type': 'str',
+            'status': 'str',
+            'work_request_id': 'str',
+            'compartment_id': 'str',
+            'percent_complete': 'float',
+            'time_accepted': 'datetime',
+            'time_started': 'datetime',
+            'time_finished': 'datetime'
+        }
+
+        self.attribute_map = {
+            'operation_type': 'operationType',
+            'status': 'status',
+            'work_request_id': 'workRequestId',
+            'compartment_id': 'compartmentId',
+            'percent_complete': 'percentComplete',
+            'time_accepted': 'timeAccepted',
+            'time_started': 'timeStarted',
+            'time_finished': 'timeFinished'
+        }
+
+        self._operation_type = None
+        self._status = None
+        self._work_request_id = None
+        self._compartment_id = None
+        self._percent_complete = None
+        self._time_accepted = None
+        self._time_started = None
+        self._time_finished = None
+
+    @property
+    def operation_type(self):
+        """
+        **[Required]** Gets the operation_type of this WorkRequestSummary.
+        The type of the work request.
+
+
+        :return: The operation_type of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._operation_type
+
+    @operation_type.setter
+    def operation_type(self, operation_type):
+        """
+        Sets the operation_type of this WorkRequestSummary.
+        The type of the work request.
+
+
+        :param operation_type: The operation_type of this WorkRequestSummary.
+        :type: str
+        """
+        self._operation_type = operation_type
+
+    @property
+    def status(self):
+        """
+        **[Required]** Gets the status of this WorkRequestSummary.
+        The status of the work request.
+
+
+        :return: The status of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this WorkRequestSummary.
+        The status of the work request.
+
+
+        :param status: The status of this WorkRequestSummary.
+        :type: str
+        """
+        self._status = status
+
+    @property
+    def work_request_id(self):
+        """
+        **[Required]** Gets the work_request_id of this WorkRequestSummary.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The work_request_id of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._work_request_id
+
+    @work_request_id.setter
+    def work_request_id(self, work_request_id):
+        """
+        Sets the work_request_id of this WorkRequestSummary.
+        The `OCID`__ of the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param work_request_id: The work_request_id of this WorkRequestSummary.
+        :type: str
+        """
+        self._work_request_id = work_request_id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this WorkRequestSummary.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this WorkRequestSummary.
+        The `OCID`__ of the compartment in which the
+        resource is created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this WorkRequestSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def percent_complete(self):
+        """
+        **[Required]** Gets the percent_complete of this WorkRequestSummary.
+        Percentage of the request completed.
+
+
+        :return: The percent_complete of this WorkRequestSummary.
+        :rtype: float
+        """
+        return self._percent_complete
+
+    @percent_complete.setter
+    def percent_complete(self, percent_complete):
+        """
+        Sets the percent_complete of this WorkRequestSummary.
+        Percentage of the request completed.
+
+
+        :param percent_complete: The percent_complete of this WorkRequestSummary.
+        :type: float
+        """
+        self._percent_complete = percent_complete
+
+    @property
+    def time_accepted(self):
+        """
+        **[Required]** Gets the time_accepted of this WorkRequestSummary.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_accepted of this WorkRequestSummary.
+        :rtype: datetime
+        """
+        return self._time_accepted
+
+    @time_accepted.setter
+    def time_accepted(self, time_accepted):
+        """
+        Sets the time_accepted of this WorkRequestSummary.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_accepted: The time_accepted of this WorkRequestSummary.
+        :type: datetime
+        """
+        self._time_accepted = time_accepted
+
+    @property
+    def time_started(self):
+        """
+        Gets the time_started of this WorkRequestSummary.
+        The date and time the request was started, as described in `RFC 3339`__,
+        section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_started of this WorkRequestSummary.
+        :rtype: datetime
+        """
+        return self._time_started
+
+    @time_started.setter
+    def time_started(self, time_started):
+        """
+        Sets the time_started of this WorkRequestSummary.
+        The date and time the request was started, as described in `RFC 3339`__,
+        section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_started: The time_started of this WorkRequestSummary.
+        :type: datetime
+        """
+        self._time_started = time_started
+
+    @property
+    def time_finished(self):
+        """
+        Gets the time_finished of this WorkRequestSummary.
+        The date and time the request was finished, as described in `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_finished of this WorkRequestSummary.
+        :rtype: datetime
+        """
+        return self._time_finished
+
+    @time_finished.setter
+    def time_finished(self, time_finished):
+        """
+        Sets the time_finished of this WorkRequestSummary.
+        The date and time the request was finished, as described in `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_finished: The time_finished of this WorkRequestSummary.
+        :type: datetime
+        """
+        self._time_finished = time_finished
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/apigateway/work_requests_client.py
+++ b/src/oci/apigateway/work_requests_client.py
@@ -1,0 +1,601 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import apigateway_type_mapping
+missing = Sentinel("Missing")
+
+
+class WorkRequestsClient(object):
+    """
+    API for the API Gateway service. Use this API to manage gateways, deployments, and related items.
+    For more information, see
+    [Overview of API Gateway](/iaas/Content/APIGateway/Concepts/apigatewayoverview.htm).
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20190501',
+            'service_endpoint_template': 'https://apigateway.{region}.oci.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("work_requests", config, signer, apigateway_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def cancel_work_request(self, work_request_id, **kwargs):
+        """
+        Cancel the work request
+        Cancels the work request.
+
+
+        :param str work_request_id: (required)
+            The ocid of the asynchronous request.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "cancel_work_request got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def get_work_request(self, work_request_id, **kwargs):
+        """
+        Gets work request status
+        Gets the status of the work request with the given identifier.
+
+
+        :param str work_request_id: (required)
+            The ocid of the asynchronous request.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.apigateway.models.WorkRequest`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_work_request got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="WorkRequest")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="WorkRequest")
+
+    def list_work_request_errors(self, work_request_id, **kwargs):
+        """
+        Lists work request errors
+        Returns a (paginated) list of errors for a given work request.
+
+
+        :param str work_request_id: (required)
+            The ocid of the asynchronous request.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'. The default order depends on the sortBy value.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`).
+            Default order for `timeCreated` is descending. Default order for
+            `displayName` is ascending. The `displayName` sort order is case
+            sensitive.
+
+            Allowed values are: "timeCreated", "displayName"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.apigateway.models.WorkRequestErrorCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}/errors"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "page",
+            "limit",
+            "sort_order",
+            "sort_by"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_request_errors got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["timeCreated", "displayName"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="WorkRequestErrorCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="WorkRequestErrorCollection")
+
+    def list_work_request_logs(self, work_request_id, **kwargs):
+        """
+        Lists work request logs
+        Returns a (paginated) list of logs for a given work request.
+
+
+        :param str work_request_id: (required)
+            The ocid of the asynchronous request.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'. The default order depends on the sortBy value.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`).
+            Default order for `timeCreated` is descending. Default order for
+            `displayName` is ascending. The `displayName` sort order is case
+            sensitive.
+
+            Allowed values are: "timeCreated", "displayName"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.apigateway.models.WorkRequestLogCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}/logs"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "page",
+            "limit",
+            "sort_order",
+            "sort_by"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_request_logs got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["timeCreated", "displayName"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="WorkRequestLogCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="WorkRequestLogCollection")
+
+    def list_work_requests(self, compartment_id, **kwargs):
+        """
+        List work requests
+        Lists the work requests in a compartment.
+
+
+        :param str compartment_id: (required)
+            The ocid of the compartment in which to list resources.
+
+        :param str resource_id: (optional)
+            Filter work requests by the resource ocid.
+
+        :param str opc_request_id: (optional)
+            The client request id for tracing.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'. The default order depends on the sortBy value.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`).
+            Default order for `timeCreated` is descending. Default order for
+            `displayName` is ascending. The `displayName` sort order is case
+            sensitive.
+
+            Allowed values are: "timeCreated", "displayName"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.apigateway.models.WorkRequestCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "resource_id",
+            "opc_request_id",
+            "page",
+            "limit",
+            "sort_order",
+            "sort_by"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_requests got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["timeCreated", "displayName"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "resourceId": kwargs.get("resource_id", missing),
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="WorkRequestCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="WorkRequestCollection")

--- a/src/oci/apigateway/work_requests_client_composite_operations.py
+++ b/src/oci/apigateway/work_requests_client_composite_operations.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class WorkRequestsClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.apigateway.WorkRequestsClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new WorkRequestsClientCompositeOperations object
+
+        :param WorkRequestsClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client

--- a/src/oci/integration/__init__.py
+++ b/src/oci/integration/__init__.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+
+from .integration_instance_client import IntegrationInstanceClient
+from .integration_instance_client_composite_operations import IntegrationInstanceClientCompositeOperations
+from . import models
+
+__all__ = ["IntegrationInstanceClient", "IntegrationInstanceClientCompositeOperations", "models"]

--- a/src/oci/integration/integration_instance_client.py
+++ b/src/oci/integration/integration_instance_client.py
@@ -1,0 +1,948 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import integration_type_mapping
+missing = Sentinel("Missing")
+
+
+class IntegrationInstanceClient(object):
+    """
+    Oracle Integration API.
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20190131',
+            'service_endpoint_template': 'https://integration.{region}.ocp.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("integration_instance", config, signer, integration_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def change_integration_instance_compartment(self, integration_instance_id, change_integration_instance_compartment_details, **kwargs):
+        """
+        Change the compartment for an integration instance
+        Change the compartment for an integration instance
+
+
+        :param str integration_instance_id: (required)
+            Unique Integration Instance identifier.
+
+        :param ChangeIntegrationInstanceCompartmentDetails change_integration_instance_compartment_details: (required)
+            Details for the update integration instance
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/integrationInstances/{integrationInstanceId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_integration_instance_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "integrationInstanceId": integration_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_integration_instance_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_integration_instance_compartment_details)
+
+    def create_integration_instance(self, create_integration_instance_details, **kwargs):
+        """
+        Creates a new Integration Instance
+        Creates a new Integration Instance.
+
+
+        :param CreateIntegrationInstanceDetails create_integration_instance_details: (required)
+            Details for the new Integration Instance.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case
+            of a timeout or server error without risk of executing that same action
+            again. Retry tokens expire after 24 hours, but can be invalidated before
+            then due to conflicting operations. For example, if a resource has been
+            deleted and purged from the system, then a retry of the original creation
+            request might be rejected.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/integrationInstances"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_integration_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_integration_instance_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_integration_instance_details)
+
+    def delete_integration_instance(self, integration_instance_id, **kwargs):
+        """
+        Delete a provisioned Integration Instance
+        Deletes an Integration Instance resource by identifier.
+
+
+        :param str integration_instance_id: (required)
+            Unique Integration Instance identifier.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/integrationInstances/{integrationInstanceId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_integration_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "integrationInstanceId": integration_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def get_integration_instance(self, integration_instance_id, **kwargs):
+        """
+        Get Integration Instance
+        Gets a IntegrationInstance by identifier
+
+
+        :param str integration_instance_id: (required)
+            Unique Integration Instance identifier.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.integration.models.IntegrationInstance`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/integrationInstances/{integrationInstanceId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_integration_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "integrationInstanceId": integration_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="IntegrationInstance")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="IntegrationInstance")
+
+    def get_work_request(self, work_request_id, **kwargs):
+        """
+        Get Work Request Status
+        Gets the status of the work request with the given ID.
+
+
+        :param str work_request_id: (required)
+            The ID of the asynchronous request.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.integration.models.WorkRequest`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_work_request got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="WorkRequest")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="WorkRequest")
+
+    def list_integration_instances(self, compartment_id, **kwargs):
+        """
+        Gets a list of all Integration Instances in a compartment
+        Returns a list of Integration Instances.
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param str lifecycle_state: (optional)
+            Life cycle state to query on.
+
+            Allowed values are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order
+            for TIMECREATED is descending. Default order for DISPLAYNAME is
+            ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.integration.models.IntegrationInstanceSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/integrationInstances"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "lifecycle_state",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_integration_instances got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "displayName": kwargs.get("display_name", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[IntegrationInstanceSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[IntegrationInstanceSummary]")
+
+    def list_work_request_errors(self, compartment_id, work_request_id, **kwargs):
+        """
+        Get work request errors.
+        Get the errors of a work request.
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str work_request_id: (required)
+            The ID of the asynchronous request.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.integration.models.WorkRequestError`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}/errors"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "limit",
+            "page"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_request_errors got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestError]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestError]")
+
+    def list_work_request_logs(self, compartment_id, work_request_id, **kwargs):
+        """
+        Get work request logs.
+        Get the logs of a work request.
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str work_request_id: (required)
+            The ID of the asynchronous request.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.integration.models.WorkRequestLogEntry`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}/logs"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "limit",
+            "page"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_request_logs got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestLogEntry]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestLogEntry]")
+
+    def list_work_requests(self, compartment_id, **kwargs):
+        """
+        List Work Requests
+        Lists the work requests in a compartment.
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str integration_instance_id: (optional)
+            The Integration Instance identifier to use to filter results
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.integration.models.WorkRequestSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "page",
+            "limit",
+            "integration_instance_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_requests got unknown kwargs: {!r}".format(extra_kwargs))
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing),
+            "integrationInstanceId": kwargs.get("integration_instance_id", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestSummary]")
+
+    def update_integration_instance(self, integration_instance_id, update_integration_instance_details, **kwargs):
+        """
+        Update the Integration Instance identified by the id
+        Updates the Integration Instance.
+
+
+        :param str integration_instance_id: (required)
+            Unique Integration Instance identifier.
+
+        :param UpdateIntegrationInstanceDetails update_integration_instance_details: (required)
+            The information to be updated.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/integrationInstances/{integrationInstanceId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_integration_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "integrationInstanceId": integration_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_integration_instance_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_integration_instance_details)

--- a/src/oci/integration/integration_instance_client_composite_operations.py
+++ b/src/oci/integration/integration_instance_client_composite_operations.py
@@ -1,0 +1,189 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class IntegrationInstanceClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.integration.IntegrationInstanceClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new IntegrationInstanceClientCompositeOperations object
+
+        :param IntegrationInstanceClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client
+
+    def change_integration_instance_compartment_and_wait_for_state(self, integration_instance_id, change_integration_instance_compartment_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.integration.IntegrationInstanceClient.change_integration_instance_compartment` and waits for the :py:class:`~oci.integration.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str integration_instance_id: (required)
+            Unique Integration Instance identifier.
+
+        :param ChangeIntegrationInstanceCompartmentDetails change_integration_instance_compartment_details: (required)
+            Details for the update integration instance
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.integration.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.integration.IntegrationInstanceClient.change_integration_instance_compartment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.change_integration_instance_compartment(integration_instance_id, change_integration_instance_compartment_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_integration_instance_and_wait_for_state(self, create_integration_instance_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.integration.IntegrationInstanceClient.create_integration_instance` and waits for the :py:class:`~oci.integration.models.WorkRequest`
+        to enter the given state(s).
+
+        :param CreateIntegrationInstanceDetails create_integration_instance_details: (required)
+            Details for the new Integration Instance.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.integration.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.integration.IntegrationInstanceClient.create_integration_instance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_integration_instance(create_integration_instance_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_integration_instance_and_wait_for_state(self, integration_instance_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.integration.IntegrationInstanceClient.delete_integration_instance` and waits for the :py:class:`~oci.integration.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str integration_instance_id: (required)
+            Unique Integration Instance identifier.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.integration.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.integration.IntegrationInstanceClient.delete_integration_instance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = None
+        try:
+            operation_result = self.client.delete_integration_instance(integration_instance_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_integration_instance_and_wait_for_state(self, integration_instance_id, update_integration_instance_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.integration.IntegrationInstanceClient.update_integration_instance` and waits for the :py:class:`~oci.integration.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str integration_instance_id: (required)
+            Unique Integration Instance identifier.
+
+        :param UpdateIntegrationInstanceDetails update_integration_instance_details: (required)
+            The information to be updated.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.integration.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.integration.IntegrationInstanceClient.update_integration_instance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_integration_instance(integration_instance_id, update_integration_instance_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)

--- a/src/oci/integration/models/__init__.py
+++ b/src/oci/integration/models/__init__.py
@@ -1,0 +1,29 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from .change_integration_instance_compartment_details import ChangeIntegrationInstanceCompartmentDetails
+from .create_integration_instance_details import CreateIntegrationInstanceDetails
+from .integration_instance import IntegrationInstance
+from .integration_instance_summary import IntegrationInstanceSummary
+from .update_integration_instance_details import UpdateIntegrationInstanceDetails
+from .work_request import WorkRequest
+from .work_request_error import WorkRequestError
+from .work_request_log_entry import WorkRequestLogEntry
+from .work_request_resource import WorkRequestResource
+from .work_request_summary import WorkRequestSummary
+
+# Maps type names to classes for integration services.
+integration_type_mapping = {
+    "ChangeIntegrationInstanceCompartmentDetails": ChangeIntegrationInstanceCompartmentDetails,
+    "CreateIntegrationInstanceDetails": CreateIntegrationInstanceDetails,
+    "IntegrationInstance": IntegrationInstance,
+    "IntegrationInstanceSummary": IntegrationInstanceSummary,
+    "UpdateIntegrationInstanceDetails": UpdateIntegrationInstanceDetails,
+    "WorkRequest": WorkRequest,
+    "WorkRequestError": WorkRequestError,
+    "WorkRequestLogEntry": WorkRequestLogEntry,
+    "WorkRequestResource": WorkRequestResource,
+    "WorkRequestSummary": WorkRequestSummary
+}

--- a/src/oci/integration/models/change_integration_instance_compartment_details.py
+++ b/src/oci/integration/models/change_integration_instance_compartment_details.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeIntegrationInstanceCompartmentDetails(object):
+    """
+    The information to be updated.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeIntegrationInstanceCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeIntegrationInstanceCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this ChangeIntegrationInstanceCompartmentDetails.
+        Compartment Identifier.
+
+
+        :return: The compartment_id of this ChangeIntegrationInstanceCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeIntegrationInstanceCompartmentDetails.
+        Compartment Identifier.
+
+
+        :param compartment_id: The compartment_id of this ChangeIntegrationInstanceCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/integration/models/create_integration_instance_details.py
+++ b/src/oci/integration/models/create_integration_instance_details.py
@@ -1,0 +1,311 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateIntegrationInstanceDetails(object):
+    """
+    The information about new IntegrationInstance.
+    """
+
+    #: A constant which can be used with the integration_instance_type property of a CreateIntegrationInstanceDetails.
+    #: This constant has a value of "STANDARD"
+    INTEGRATION_INSTANCE_TYPE_STANDARD = "STANDARD"
+
+    #: A constant which can be used with the integration_instance_type property of a CreateIntegrationInstanceDetails.
+    #: This constant has a value of "ENTERPRISE"
+    INTEGRATION_INSTANCE_TYPE_ENTERPRISE = "ENTERPRISE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateIntegrationInstanceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateIntegrationInstanceDetails.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateIntegrationInstanceDetails.
+        :type compartment_id: str
+
+        :param integration_instance_type:
+            The value to assign to the integration_instance_type property of this CreateIntegrationInstanceDetails.
+            Allowed values for this property are: "STANDARD", "ENTERPRISE"
+        :type integration_instance_type: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateIntegrationInstanceDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateIntegrationInstanceDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param is_byol:
+            The value to assign to the is_byol property of this CreateIntegrationInstanceDetails.
+        :type is_byol: bool
+
+        :param idcs_at:
+            The value to assign to the idcs_at property of this CreateIntegrationInstanceDetails.
+        :type idcs_at: str
+
+        :param message_packs:
+            The value to assign to the message_packs property of this CreateIntegrationInstanceDetails.
+        :type message_packs: int
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'integration_instance_type': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'is_byol': 'bool',
+            'idcs_at': 'str',
+            'message_packs': 'int'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'integration_instance_type': 'integrationInstanceType',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'is_byol': 'isByol',
+            'idcs_at': 'idcsAt',
+            'message_packs': 'messagePacks'
+        }
+
+        self._display_name = None
+        self._compartment_id = None
+        self._integration_instance_type = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._is_byol = None
+        self._idcs_at = None
+        self._message_packs = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateIntegrationInstanceDetails.
+        Integration Instance Identifier.
+
+
+        :return: The display_name of this CreateIntegrationInstanceDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateIntegrationInstanceDetails.
+        Integration Instance Identifier.
+
+
+        :param display_name: The display_name of this CreateIntegrationInstanceDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateIntegrationInstanceDetails.
+        Compartment Identifier.
+
+
+        :return: The compartment_id of this CreateIntegrationInstanceDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateIntegrationInstanceDetails.
+        Compartment Identifier.
+
+
+        :param compartment_id: The compartment_id of this CreateIntegrationInstanceDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def integration_instance_type(self):
+        """
+        **[Required]** Gets the integration_instance_type of this CreateIntegrationInstanceDetails.
+        Standard or Enterprise type
+
+        Allowed values for this property are: "STANDARD", "ENTERPRISE"
+
+
+        :return: The integration_instance_type of this CreateIntegrationInstanceDetails.
+        :rtype: str
+        """
+        return self._integration_instance_type
+
+    @integration_instance_type.setter
+    def integration_instance_type(self, integration_instance_type):
+        """
+        Sets the integration_instance_type of this CreateIntegrationInstanceDetails.
+        Standard or Enterprise type
+
+
+        :param integration_instance_type: The integration_instance_type of this CreateIntegrationInstanceDetails.
+        :type: str
+        """
+        allowed_values = ["STANDARD", "ENTERPRISE"]
+        if not value_allowed_none_or_none_sentinel(integration_instance_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `integration_instance_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._integration_instance_type = integration_instance_type
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateIntegrationInstanceDetails.
+        Simple key-value pair that is applied without any predefined name,
+        type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this CreateIntegrationInstanceDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateIntegrationInstanceDetails.
+        Simple key-value pair that is applied without any predefined name,
+        type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this CreateIntegrationInstanceDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateIntegrationInstanceDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to
+        namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this CreateIntegrationInstanceDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateIntegrationInstanceDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to
+        namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this CreateIntegrationInstanceDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def is_byol(self):
+        """
+        **[Required]** Gets the is_byol of this CreateIntegrationInstanceDetails.
+        Bring your own license.
+
+
+        :return: The is_byol of this CreateIntegrationInstanceDetails.
+        :rtype: bool
+        """
+        return self._is_byol
+
+    @is_byol.setter
+    def is_byol(self, is_byol):
+        """
+        Sets the is_byol of this CreateIntegrationInstanceDetails.
+        Bring your own license.
+
+
+        :param is_byol: The is_byol of this CreateIntegrationInstanceDetails.
+        :type: bool
+        """
+        self._is_byol = is_byol
+
+    @property
+    def idcs_at(self):
+        """
+        Gets the idcs_at of this CreateIntegrationInstanceDetails.
+        IDCS Authentication token. This is is required for pre-UCPIS cloud accounts, but not UCPIS, hence not a required parameter
+
+
+        :return: The idcs_at of this CreateIntegrationInstanceDetails.
+        :rtype: str
+        """
+        return self._idcs_at
+
+    @idcs_at.setter
+    def idcs_at(self, idcs_at):
+        """
+        Sets the idcs_at of this CreateIntegrationInstanceDetails.
+        IDCS Authentication token. This is is required for pre-UCPIS cloud accounts, but not UCPIS, hence not a required parameter
+
+
+        :param idcs_at: The idcs_at of this CreateIntegrationInstanceDetails.
+        :type: str
+        """
+        self._idcs_at = idcs_at
+
+    @property
+    def message_packs(self):
+        """
+        **[Required]** Gets the message_packs of this CreateIntegrationInstanceDetails.
+        The number of configured message packs
+
+
+        :return: The message_packs of this CreateIntegrationInstanceDetails.
+        :rtype: int
+        """
+        return self._message_packs
+
+    @message_packs.setter
+    def message_packs(self, message_packs):
+        """
+        Sets the message_packs of this CreateIntegrationInstanceDetails.
+        The number of configured message packs
+
+
+        :param message_packs: The message_packs of this CreateIntegrationInstanceDetails.
+        :type: int
+        """
+        self._message_packs = message_packs
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/integration/models/integration_instance.py
+++ b/src/oci/integration/models/integration_instance.py
@@ -1,0 +1,497 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class IntegrationInstance(object):
+    """
+    Description of Integration Instance.
+    """
+
+    #: A constant which can be used with the integration_instance_type property of a IntegrationInstance.
+    #: This constant has a value of "STANDARD"
+    INTEGRATION_INSTANCE_TYPE_STANDARD = "STANDARD"
+
+    #: A constant which can be used with the integration_instance_type property of a IntegrationInstance.
+    #: This constant has a value of "ENTERPRISE"
+    INTEGRATION_INSTANCE_TYPE_ENTERPRISE = "ENTERPRISE"
+
+    #: A constant which can be used with the lifecycle_state property of a IntegrationInstance.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a IntegrationInstance.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a IntegrationInstance.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a IntegrationInstance.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a IntegrationInstance.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a IntegrationInstance.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new IntegrationInstance object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this IntegrationInstance.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this IntegrationInstance.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this IntegrationInstance.
+        :type compartment_id: str
+
+        :param integration_instance_type:
+            The value to assign to the integration_instance_type property of this IntegrationInstance.
+            Allowed values for this property are: "STANDARD", "ENTERPRISE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type integration_instance_type: str
+
+        :param time_created:
+            The value to assign to the time_created property of this IntegrationInstance.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this IntegrationInstance.
+        :type time_updated: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this IntegrationInstance.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param state_message:
+            The value to assign to the state_message property of this IntegrationInstance.
+        :type state_message: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this IntegrationInstance.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this IntegrationInstance.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param is_byol:
+            The value to assign to the is_byol property of this IntegrationInstance.
+        :type is_byol: bool
+
+        :param instance_url:
+            The value to assign to the instance_url property of this IntegrationInstance.
+        :type instance_url: str
+
+        :param message_packs:
+            The value to assign to the message_packs property of this IntegrationInstance.
+        :type message_packs: int
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'integration_instance_type': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'lifecycle_state': 'str',
+            'state_message': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'is_byol': 'bool',
+            'instance_url': 'str',
+            'message_packs': 'int'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'integration_instance_type': 'integrationInstanceType',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'lifecycle_state': 'lifecycleState',
+            'state_message': 'stateMessage',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'is_byol': 'isByol',
+            'instance_url': 'instanceUrl',
+            'message_packs': 'messagePacks'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._integration_instance_type = None
+        self._time_created = None
+        self._time_updated = None
+        self._lifecycle_state = None
+        self._state_message = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._is_byol = None
+        self._instance_url = None
+        self._message_packs = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this IntegrationInstance.
+        Unique identifier that is immutable on creation.
+
+
+        :return: The id of this IntegrationInstance.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this IntegrationInstance.
+        Unique identifier that is immutable on creation.
+
+
+        :param id: The id of this IntegrationInstance.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this IntegrationInstance.
+        Integration Instance Identifier, can be renamed.
+
+
+        :return: The display_name of this IntegrationInstance.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this IntegrationInstance.
+        Integration Instance Identifier, can be renamed.
+
+
+        :param display_name: The display_name of this IntegrationInstance.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this IntegrationInstance.
+        Compartment Identifier.
+
+
+        :return: The compartment_id of this IntegrationInstance.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this IntegrationInstance.
+        Compartment Identifier.
+
+
+        :param compartment_id: The compartment_id of this IntegrationInstance.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def integration_instance_type(self):
+        """
+        **[Required]** Gets the integration_instance_type of this IntegrationInstance.
+        Standard or Enterprise type
+
+        Allowed values for this property are: "STANDARD", "ENTERPRISE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The integration_instance_type of this IntegrationInstance.
+        :rtype: str
+        """
+        return self._integration_instance_type
+
+    @integration_instance_type.setter
+    def integration_instance_type(self, integration_instance_type):
+        """
+        Sets the integration_instance_type of this IntegrationInstance.
+        Standard or Enterprise type
+
+
+        :param integration_instance_type: The integration_instance_type of this IntegrationInstance.
+        :type: str
+        """
+        allowed_values = ["STANDARD", "ENTERPRISE"]
+        if not value_allowed_none_or_none_sentinel(integration_instance_type, allowed_values):
+            integration_instance_type = 'UNKNOWN_ENUM_VALUE'
+        self._integration_instance_type = integration_instance_type
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this IntegrationInstance.
+        The time the the IntegrationInstance was created. An RFC3339 formatted datetime string.
+
+
+        :return: The time_created of this IntegrationInstance.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this IntegrationInstance.
+        The time the the IntegrationInstance was created. An RFC3339 formatted datetime string.
+
+
+        :param time_created: The time_created of this IntegrationInstance.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this IntegrationInstance.
+        The time the IntegrationInstance was updated. An RFC3339 formatted datetime string.
+
+
+        :return: The time_updated of this IntegrationInstance.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this IntegrationInstance.
+        The time the IntegrationInstance was updated. An RFC3339 formatted datetime string.
+
+
+        :param time_updated: The time_updated of this IntegrationInstance.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this IntegrationInstance.
+        The current state of the integration instance.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this IntegrationInstance.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this IntegrationInstance.
+        The current state of the integration instance.
+
+
+        :param lifecycle_state: The lifecycle_state of this IntegrationInstance.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def state_message(self):
+        """
+        Gets the state_message of this IntegrationInstance.
+        An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+
+
+        :return: The state_message of this IntegrationInstance.
+        :rtype: str
+        """
+        return self._state_message
+
+    @state_message.setter
+    def state_message(self, state_message):
+        """
+        Sets the state_message of this IntegrationInstance.
+        An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+
+
+        :param state_message: The state_message of this IntegrationInstance.
+        :type: str
+        """
+        self._state_message = state_message
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this IntegrationInstance.
+        Simple key-value pair that is applied without any predefined name,
+        type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this IntegrationInstance.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this IntegrationInstance.
+        Simple key-value pair that is applied without any predefined name,
+        type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this IntegrationInstance.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this IntegrationInstance.
+        Usage of predefined tag keys. These predefined keys are scoped to
+        namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this IntegrationInstance.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this IntegrationInstance.
+        Usage of predefined tag keys. These predefined keys are scoped to
+        namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this IntegrationInstance.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def is_byol(self):
+        """
+        **[Required]** Gets the is_byol of this IntegrationInstance.
+        Bring your own license.
+
+
+        :return: The is_byol of this IntegrationInstance.
+        :rtype: bool
+        """
+        return self._is_byol
+
+    @is_byol.setter
+    def is_byol(self, is_byol):
+        """
+        Sets the is_byol of this IntegrationInstance.
+        Bring your own license.
+
+
+        :param is_byol: The is_byol of this IntegrationInstance.
+        :type: bool
+        """
+        self._is_byol = is_byol
+
+    @property
+    def instance_url(self):
+        """
+        **[Required]** Gets the instance_url of this IntegrationInstance.
+        The Integration Instance URL.
+
+
+        :return: The instance_url of this IntegrationInstance.
+        :rtype: str
+        """
+        return self._instance_url
+
+    @instance_url.setter
+    def instance_url(self, instance_url):
+        """
+        Sets the instance_url of this IntegrationInstance.
+        The Integration Instance URL.
+
+
+        :param instance_url: The instance_url of this IntegrationInstance.
+        :type: str
+        """
+        self._instance_url = instance_url
+
+    @property
+    def message_packs(self):
+        """
+        **[Required]** Gets the message_packs of this IntegrationInstance.
+        The number of configured message packs (if any)
+
+
+        :return: The message_packs of this IntegrationInstance.
+        :rtype: int
+        """
+        return self._message_packs
+
+    @message_packs.setter
+    def message_packs(self, message_packs):
+        """
+        Sets the message_packs of this IntegrationInstance.
+        The number of configured message packs (if any)
+
+
+        :param message_packs: The message_packs of this IntegrationInstance.
+        :type: int
+        """
+        self._message_packs = message_packs
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/integration/models/integration_instance_summary.py
+++ b/src/oci/integration/models/integration_instance_summary.py
@@ -1,0 +1,427 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class IntegrationInstanceSummary(object):
+    """
+    Summary of the Integration Instance.
+    """
+
+    #: A constant which can be used with the integration_instance_type property of a IntegrationInstanceSummary.
+    #: This constant has a value of "STANDARD"
+    INTEGRATION_INSTANCE_TYPE_STANDARD = "STANDARD"
+
+    #: A constant which can be used with the integration_instance_type property of a IntegrationInstanceSummary.
+    #: This constant has a value of "ENTERPRISE"
+    INTEGRATION_INSTANCE_TYPE_ENTERPRISE = "ENTERPRISE"
+
+    #: A constant which can be used with the lifecycle_state property of a IntegrationInstanceSummary.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a IntegrationInstanceSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a IntegrationInstanceSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a IntegrationInstanceSummary.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a IntegrationInstanceSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a IntegrationInstanceSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new IntegrationInstanceSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this IntegrationInstanceSummary.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this IntegrationInstanceSummary.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this IntegrationInstanceSummary.
+        :type compartment_id: str
+
+        :param integration_instance_type:
+            The value to assign to the integration_instance_type property of this IntegrationInstanceSummary.
+            Allowed values for this property are: "STANDARD", "ENTERPRISE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type integration_instance_type: str
+
+        :param time_created:
+            The value to assign to the time_created property of this IntegrationInstanceSummary.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this IntegrationInstanceSummary.
+        :type time_updated: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this IntegrationInstanceSummary.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param state_message:
+            The value to assign to the state_message property of this IntegrationInstanceSummary.
+        :type state_message: str
+
+        :param is_byol:
+            The value to assign to the is_byol property of this IntegrationInstanceSummary.
+        :type is_byol: bool
+
+        :param instance_url:
+            The value to assign to the instance_url property of this IntegrationInstanceSummary.
+        :type instance_url: str
+
+        :param message_packs:
+            The value to assign to the message_packs property of this IntegrationInstanceSummary.
+        :type message_packs: int
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'integration_instance_type': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'lifecycle_state': 'str',
+            'state_message': 'str',
+            'is_byol': 'bool',
+            'instance_url': 'str',
+            'message_packs': 'int'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'integration_instance_type': 'integrationInstanceType',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'lifecycle_state': 'lifecycleState',
+            'state_message': 'stateMessage',
+            'is_byol': 'isByol',
+            'instance_url': 'instanceUrl',
+            'message_packs': 'messagePacks'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._integration_instance_type = None
+        self._time_created = None
+        self._time_updated = None
+        self._lifecycle_state = None
+        self._state_message = None
+        self._is_byol = None
+        self._instance_url = None
+        self._message_packs = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this IntegrationInstanceSummary.
+        Unique identifier that is immutable on creation.
+
+
+        :return: The id of this IntegrationInstanceSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this IntegrationInstanceSummary.
+        Unique identifier that is immutable on creation.
+
+
+        :param id: The id of this IntegrationInstanceSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this IntegrationInstanceSummary.
+        Integration Instance Identifier, can be renamed.
+
+
+        :return: The display_name of this IntegrationInstanceSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this IntegrationInstanceSummary.
+        Integration Instance Identifier, can be renamed.
+
+
+        :param display_name: The display_name of this IntegrationInstanceSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this IntegrationInstanceSummary.
+        Compartment Identifier.
+
+
+        :return: The compartment_id of this IntegrationInstanceSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this IntegrationInstanceSummary.
+        Compartment Identifier.
+
+
+        :param compartment_id: The compartment_id of this IntegrationInstanceSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def integration_instance_type(self):
+        """
+        **[Required]** Gets the integration_instance_type of this IntegrationInstanceSummary.
+        Standard or Enterprise type
+
+        Allowed values for this property are: "STANDARD", "ENTERPRISE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The integration_instance_type of this IntegrationInstanceSummary.
+        :rtype: str
+        """
+        return self._integration_instance_type
+
+    @integration_instance_type.setter
+    def integration_instance_type(self, integration_instance_type):
+        """
+        Sets the integration_instance_type of this IntegrationInstanceSummary.
+        Standard or Enterprise type
+
+
+        :param integration_instance_type: The integration_instance_type of this IntegrationInstanceSummary.
+        :type: str
+        """
+        allowed_values = ["STANDARD", "ENTERPRISE"]
+        if not value_allowed_none_or_none_sentinel(integration_instance_type, allowed_values):
+            integration_instance_type = 'UNKNOWN_ENUM_VALUE'
+        self._integration_instance_type = integration_instance_type
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this IntegrationInstanceSummary.
+        The time the the Integration Instance was created. An RFC3339 formatted datetime string.
+
+
+        :return: The time_created of this IntegrationInstanceSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this IntegrationInstanceSummary.
+        The time the the Integration Instance was created. An RFC3339 formatted datetime string.
+
+
+        :param time_created: The time_created of this IntegrationInstanceSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this IntegrationInstanceSummary.
+        The time the IntegrationInstance was updated. An RFC3339 formatted datetime string.
+
+
+        :return: The time_updated of this IntegrationInstanceSummary.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this IntegrationInstanceSummary.
+        The time the IntegrationInstance was updated. An RFC3339 formatted datetime string.
+
+
+        :param time_updated: The time_updated of this IntegrationInstanceSummary.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this IntegrationInstanceSummary.
+        The current state of the Integration Instance.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this IntegrationInstanceSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this IntegrationInstanceSummary.
+        The current state of the Integration Instance.
+
+
+        :param lifecycle_state: The lifecycle_state of this IntegrationInstanceSummary.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def state_message(self):
+        """
+        Gets the state_message of this IntegrationInstanceSummary.
+        An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+
+
+        :return: The state_message of this IntegrationInstanceSummary.
+        :rtype: str
+        """
+        return self._state_message
+
+    @state_message.setter
+    def state_message(self, state_message):
+        """
+        Sets the state_message of this IntegrationInstanceSummary.
+        An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+
+
+        :param state_message: The state_message of this IntegrationInstanceSummary.
+        :type: str
+        """
+        self._state_message = state_message
+
+    @property
+    def is_byol(self):
+        """
+        **[Required]** Gets the is_byol of this IntegrationInstanceSummary.
+        Bring your own license.
+
+
+        :return: The is_byol of this IntegrationInstanceSummary.
+        :rtype: bool
+        """
+        return self._is_byol
+
+    @is_byol.setter
+    def is_byol(self, is_byol):
+        """
+        Sets the is_byol of this IntegrationInstanceSummary.
+        Bring your own license.
+
+
+        :param is_byol: The is_byol of this IntegrationInstanceSummary.
+        :type: bool
+        """
+        self._is_byol = is_byol
+
+    @property
+    def instance_url(self):
+        """
+        **[Required]** Gets the instance_url of this IntegrationInstanceSummary.
+        The Integration Instance URL.
+
+
+        :return: The instance_url of this IntegrationInstanceSummary.
+        :rtype: str
+        """
+        return self._instance_url
+
+    @instance_url.setter
+    def instance_url(self, instance_url):
+        """
+        Sets the instance_url of this IntegrationInstanceSummary.
+        The Integration Instance URL.
+
+
+        :param instance_url: The instance_url of this IntegrationInstanceSummary.
+        :type: str
+        """
+        self._instance_url = instance_url
+
+    @property
+    def message_packs(self):
+        """
+        **[Required]** Gets the message_packs of this IntegrationInstanceSummary.
+        The number of configured message packs (if any)
+
+
+        :return: The message_packs of this IntegrationInstanceSummary.
+        :rtype: int
+        """
+        return self._message_packs
+
+    @message_packs.setter
+    def message_packs(self, message_packs):
+        """
+        Sets the message_packs of this IntegrationInstanceSummary.
+        The number of configured message packs (if any)
+
+
+        :param message_packs: The message_packs of this IntegrationInstanceSummary.
+        :type: int
+        """
+        self._message_packs = message_packs
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/integration/models/update_integration_instance_details.py
+++ b/src/oci/integration/models/update_integration_instance_details.py
@@ -1,0 +1,249 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateIntegrationInstanceDetails(object):
+    """
+    The information to be updated.
+    """
+
+    #: A constant which can be used with the integration_instance_type property of a UpdateIntegrationInstanceDetails.
+    #: This constant has a value of "STANDARD"
+    INTEGRATION_INSTANCE_TYPE_STANDARD = "STANDARD"
+
+    #: A constant which can be used with the integration_instance_type property of a UpdateIntegrationInstanceDetails.
+    #: This constant has a value of "ENTERPRISE"
+    INTEGRATION_INSTANCE_TYPE_ENTERPRISE = "ENTERPRISE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateIntegrationInstanceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateIntegrationInstanceDetails.
+        :type display_name: str
+
+        :param integration_instance_type:
+            The value to assign to the integration_instance_type property of this UpdateIntegrationInstanceDetails.
+            Allowed values for this property are: "STANDARD", "ENTERPRISE"
+        :type integration_instance_type: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateIntegrationInstanceDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateIntegrationInstanceDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param is_byol:
+            The value to assign to the is_byol property of this UpdateIntegrationInstanceDetails.
+        :type is_byol: bool
+
+        :param message_packs:
+            The value to assign to the message_packs property of this UpdateIntegrationInstanceDetails.
+        :type message_packs: int
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'integration_instance_type': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'is_byol': 'bool',
+            'message_packs': 'int'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'integration_instance_type': 'integrationInstanceType',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'is_byol': 'isByol',
+            'message_packs': 'messagePacks'
+        }
+
+        self._display_name = None
+        self._integration_instance_type = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._is_byol = None
+        self._message_packs = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateIntegrationInstanceDetails.
+        Integration Instance Identifier.
+
+
+        :return: The display_name of this UpdateIntegrationInstanceDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateIntegrationInstanceDetails.
+        Integration Instance Identifier.
+
+
+        :param display_name: The display_name of this UpdateIntegrationInstanceDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def integration_instance_type(self):
+        """
+        Gets the integration_instance_type of this UpdateIntegrationInstanceDetails.
+        Standard or Enterprise type
+
+        Allowed values for this property are: "STANDARD", "ENTERPRISE"
+
+
+        :return: The integration_instance_type of this UpdateIntegrationInstanceDetails.
+        :rtype: str
+        """
+        return self._integration_instance_type
+
+    @integration_instance_type.setter
+    def integration_instance_type(self, integration_instance_type):
+        """
+        Sets the integration_instance_type of this UpdateIntegrationInstanceDetails.
+        Standard or Enterprise type
+
+
+        :param integration_instance_type: The integration_instance_type of this UpdateIntegrationInstanceDetails.
+        :type: str
+        """
+        allowed_values = ["STANDARD", "ENTERPRISE"]
+        if not value_allowed_none_or_none_sentinel(integration_instance_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `integration_instance_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._integration_instance_type = integration_instance_type
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateIntegrationInstanceDetails.
+        Simple key-value pair that is applied without any predefined name,
+        type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this UpdateIntegrationInstanceDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateIntegrationInstanceDetails.
+        Simple key-value pair that is applied without any predefined name,
+        type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this UpdateIntegrationInstanceDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateIntegrationInstanceDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to
+        namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this UpdateIntegrationInstanceDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateIntegrationInstanceDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to
+        namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this UpdateIntegrationInstanceDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def is_byol(self):
+        """
+        Gets the is_byol of this UpdateIntegrationInstanceDetails.
+        Bring your own license.
+
+
+        :return: The is_byol of this UpdateIntegrationInstanceDetails.
+        :rtype: bool
+        """
+        return self._is_byol
+
+    @is_byol.setter
+    def is_byol(self, is_byol):
+        """
+        Sets the is_byol of this UpdateIntegrationInstanceDetails.
+        Bring your own license.
+
+
+        :param is_byol: The is_byol of this UpdateIntegrationInstanceDetails.
+        :type: bool
+        """
+        self._is_byol = is_byol
+
+    @property
+    def message_packs(self):
+        """
+        Gets the message_packs of this UpdateIntegrationInstanceDetails.
+        The number of configured message packs
+
+
+        :return: The message_packs of this UpdateIntegrationInstanceDetails.
+        :rtype: int
+        """
+        return self._message_packs
+
+    @message_packs.setter
+    def message_packs(self, message_packs):
+        """
+        Sets the message_packs of this UpdateIntegrationInstanceDetails.
+        The number of configured message packs
+
+
+        :param message_packs: The message_packs of this UpdateIntegrationInstanceDetails.
+        :type: int
+        """
+        self._message_packs = message_packs
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/integration/models/work_request.py
+++ b/src/oci/integration/models/work_request.py
@@ -1,0 +1,399 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequest(object):
+    """
+    A description of work request status.
+    """
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "CREATE_INTEGRATION_INSTANCE"
+    OPERATION_TYPE_CREATE_INTEGRATION_INSTANCE = "CREATE_INTEGRATION_INSTANCE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "UPDATE_INTEGRATION_INSTANCE"
+    OPERATION_TYPE_UPDATE_INTEGRATION_INSTANCE = "UPDATE_INTEGRATION_INSTANCE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "DELETE_INTEGRATION_INSTANCE"
+    OPERATION_TYPE_DELETE_INTEGRATION_INSTANCE = "DELETE_INTEGRATION_INSTANCE"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "ACCEPTED"
+    STATUS_ACCEPTED = "ACCEPTED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "IN_PROGRESS"
+    STATUS_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "FAILED"
+    STATUS_FAILED = "FAILED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "SUCCEEDED"
+    STATUS_SUCCEEDED = "SUCCEEDED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "CANCELING"
+    STATUS_CANCELING = "CANCELING"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "CANCELED"
+    STATUS_CANCELED = "CANCELED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequest object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation_type:
+            The value to assign to the operation_type property of this WorkRequest.
+            Allowed values for this property are: "CREATE_INTEGRATION_INSTANCE", "UPDATE_INTEGRATION_INSTANCE", "DELETE_INTEGRATION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type operation_type: str
+
+        :param status:
+            The value to assign to the status property of this WorkRequest.
+            Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param id:
+            The value to assign to the id property of this WorkRequest.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this WorkRequest.
+        :type compartment_id: str
+
+        :param resources:
+            The value to assign to the resources property of this WorkRequest.
+        :type resources: list[WorkRequestResource]
+
+        :param percent_complete:
+            The value to assign to the percent_complete property of this WorkRequest.
+        :type percent_complete: float
+
+        :param time_accepted:
+            The value to assign to the time_accepted property of this WorkRequest.
+        :type time_accepted: datetime
+
+        :param time_started:
+            The value to assign to the time_started property of this WorkRequest.
+        :type time_started: datetime
+
+        :param time_finished:
+            The value to assign to the time_finished property of this WorkRequest.
+        :type time_finished: datetime
+
+        """
+        self.swagger_types = {
+            'operation_type': 'str',
+            'status': 'str',
+            'id': 'str',
+            'compartment_id': 'str',
+            'resources': 'list[WorkRequestResource]',
+            'percent_complete': 'float',
+            'time_accepted': 'datetime',
+            'time_started': 'datetime',
+            'time_finished': 'datetime'
+        }
+
+        self.attribute_map = {
+            'operation_type': 'operationType',
+            'status': 'status',
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'resources': 'resources',
+            'percent_complete': 'percentComplete',
+            'time_accepted': 'timeAccepted',
+            'time_started': 'timeStarted',
+            'time_finished': 'timeFinished'
+        }
+
+        self._operation_type = None
+        self._status = None
+        self._id = None
+        self._compartment_id = None
+        self._resources = None
+        self._percent_complete = None
+        self._time_accepted = None
+        self._time_started = None
+        self._time_finished = None
+
+    @property
+    def operation_type(self):
+        """
+        **[Required]** Gets the operation_type of this WorkRequest.
+        Type of the work request.
+
+        Allowed values for this property are: "CREATE_INTEGRATION_INSTANCE", "UPDATE_INTEGRATION_INSTANCE", "DELETE_INTEGRATION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The operation_type of this WorkRequest.
+        :rtype: str
+        """
+        return self._operation_type
+
+    @operation_type.setter
+    def operation_type(self, operation_type):
+        """
+        Sets the operation_type of this WorkRequest.
+        Type of the work request.
+
+
+        :param operation_type: The operation_type of this WorkRequest.
+        :type: str
+        """
+        allowed_values = ["CREATE_INTEGRATION_INSTANCE", "UPDATE_INTEGRATION_INSTANCE", "DELETE_INTEGRATION_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
+            operation_type = 'UNKNOWN_ENUM_VALUE'
+        self._operation_type = operation_type
+
+    @property
+    def status(self):
+        """
+        **[Required]** Gets the status of this WorkRequest.
+        Status of current work request.
+
+        Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this WorkRequest.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this WorkRequest.
+        Status of current work request.
+
+
+        :param status: The status of this WorkRequest.
+        :type: str
+        """
+        allowed_values = ["ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this WorkRequest.
+        The id of the work request.
+
+
+        :return: The id of this WorkRequest.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this WorkRequest.
+        The id of the work request.
+
+
+        :param id: The id of this WorkRequest.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this WorkRequest.
+        The ocid of the compartment that contains the work request. Work
+        requests should be scoped to the same compartment as the resource the
+        work request affects. If the work request affects multiple resources,
+        and those resources are not in the same compartment, it is up to the
+        service team to pick the primary resource whose compartment should be
+        used.
+
+
+        :return: The compartment_id of this WorkRequest.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this WorkRequest.
+        The ocid of the compartment that contains the work request. Work
+        requests should be scoped to the same compartment as the resource the
+        work request affects. If the work request affects multiple resources,
+        and those resources are not in the same compartment, it is up to the
+        service team to pick the primary resource whose compartment should be
+        used.
+
+
+        :param compartment_id: The compartment_id of this WorkRequest.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def resources(self):
+        """
+        **[Required]** Gets the resources of this WorkRequest.
+        The resources affected by this work request.
+
+
+        :return: The resources of this WorkRequest.
+        :rtype: list[WorkRequestResource]
+        """
+        return self._resources
+
+    @resources.setter
+    def resources(self, resources):
+        """
+        Sets the resources of this WorkRequest.
+        The resources affected by this work request.
+
+
+        :param resources: The resources of this WorkRequest.
+        :type: list[WorkRequestResource]
+        """
+        self._resources = resources
+
+    @property
+    def percent_complete(self):
+        """
+        **[Required]** Gets the percent_complete of this WorkRequest.
+        Percentage of the request completed.
+
+
+        :return: The percent_complete of this WorkRequest.
+        :rtype: float
+        """
+        return self._percent_complete
+
+    @percent_complete.setter
+    def percent_complete(self, percent_complete):
+        """
+        Sets the percent_complete of this WorkRequest.
+        Percentage of the request completed.
+
+
+        :param percent_complete: The percent_complete of this WorkRequest.
+        :type: float
+        """
+        self._percent_complete = percent_complete
+
+    @property
+    def time_accepted(self):
+        """
+        **[Required]** Gets the time_accepted of this WorkRequest.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_accepted of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_accepted
+
+    @time_accepted.setter
+    def time_accepted(self, time_accepted):
+        """
+        Sets the time_accepted of this WorkRequest.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_accepted: The time_accepted of this WorkRequest.
+        :type: datetime
+        """
+        self._time_accepted = time_accepted
+
+    @property
+    def time_started(self):
+        """
+        Gets the time_started of this WorkRequest.
+        The date and time the request was started, as described in
+        `RFC 3339`__,
+        section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_started of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_started
+
+    @time_started.setter
+    def time_started(self, time_started):
+        """
+        Sets the time_started of this WorkRequest.
+        The date and time the request was started, as described in
+        `RFC 3339`__,
+        section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_started: The time_started of this WorkRequest.
+        :type: datetime
+        """
+        self._time_started = time_started
+
+    @property
+    def time_finished(self):
+        """
+        Gets the time_finished of this WorkRequest.
+        The date and time the object was finished, as described in
+        `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_finished of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_finished
+
+    @time_finished.setter
+    def time_finished(self, time_finished):
+        """
+        Sets the time_finished of this WorkRequest.
+        The date and time the object was finished, as described in
+        `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_finished: The time_finished of this WorkRequest.
+        :type: datetime
+        """
+        self._time_finished = time_finished
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/integration/models/work_request_error.py
+++ b/src/oci/integration/models/work_request_error.py
@@ -1,0 +1,131 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestError(object):
+    """
+    Errors related to a specific work request.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestError object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param code:
+            The value to assign to the code property of this WorkRequestError.
+        :type code: str
+
+        :param message:
+            The value to assign to the message property of this WorkRequestError.
+        :type message: str
+
+        :param timestamp:
+            The value to assign to the timestamp property of this WorkRequestError.
+        :type timestamp: datetime
+
+        """
+        self.swagger_types = {
+            'code': 'str',
+            'message': 'str',
+            'timestamp': 'datetime'
+        }
+
+        self.attribute_map = {
+            'code': 'code',
+            'message': 'message',
+            'timestamp': 'timestamp'
+        }
+
+        self._code = None
+        self._message = None
+        self._timestamp = None
+
+    @property
+    def code(self):
+        """
+        **[Required]** Gets the code of this WorkRequestError.
+        A short error code that defines the error, meant for programmatic parsing
+
+
+        :return: The code of this WorkRequestError.
+        :rtype: str
+        """
+        return self._code
+
+    @code.setter
+    def code(self, code):
+        """
+        Sets the code of this WorkRequestError.
+        A short error code that defines the error, meant for programmatic parsing
+
+
+        :param code: The code of this WorkRequestError.
+        :type: str
+        """
+        self._code = code
+
+    @property
+    def message(self):
+        """
+        **[Required]** Gets the message of this WorkRequestError.
+        A human-readable error string.
+
+
+        :return: The message of this WorkRequestError.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this WorkRequestError.
+        A human-readable error string.
+
+
+        :param message: The message of this WorkRequestError.
+        :type: str
+        """
+        self._message = message
+
+    @property
+    def timestamp(self):
+        """
+        **[Required]** Gets the timestamp of this WorkRequestError.
+        The date and time the error occurred.
+
+
+        :return: The timestamp of this WorkRequestError.
+        :rtype: datetime
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp):
+        """
+        Sets the timestamp of this WorkRequestError.
+        The date and time the error occurred.
+
+
+        :param timestamp: The timestamp of this WorkRequestError.
+        :type: datetime
+        """
+        self._timestamp = timestamp
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/integration/models/work_request_log_entry.py
+++ b/src/oci/integration/models/work_request_log_entry.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestLogEntry(object):
+    """
+    Log entries related to a specific work request.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestLogEntry object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param message:
+            The value to assign to the message property of this WorkRequestLogEntry.
+        :type message: str
+
+        :param timestamp:
+            The value to assign to the timestamp property of this WorkRequestLogEntry.
+        :type timestamp: datetime
+
+        """
+        self.swagger_types = {
+            'message': 'str',
+            'timestamp': 'datetime'
+        }
+
+        self.attribute_map = {
+            'message': 'message',
+            'timestamp': 'timestamp'
+        }
+
+        self._message = None
+        self._timestamp = None
+
+    @property
+    def message(self):
+        """
+        **[Required]** Gets the message of this WorkRequestLogEntry.
+        The description of an action that occurred.
+
+
+        :return: The message of this WorkRequestLogEntry.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this WorkRequestLogEntry.
+        The description of an action that occurred.
+
+
+        :param message: The message of this WorkRequestLogEntry.
+        :type: str
+        """
+        self._message = message
+
+    @property
+    def timestamp(self):
+        """
+        **[Required]** Gets the timestamp of this WorkRequestLogEntry.
+        The date and time the log entry occurred.
+
+
+        :return: The timestamp of this WorkRequestLogEntry.
+        :rtype: datetime
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp):
+        """
+        Sets the timestamp of this WorkRequestLogEntry.
+        The date and time the log entry occurred.
+
+
+        :param timestamp: The timestamp of this WorkRequestLogEntry.
+        :type: datetime
+        """
+        self._timestamp = timestamp
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/integration/models/work_request_resource.py
+++ b/src/oci/integration/models/work_request_resource.py
@@ -1,0 +1,194 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestResource(object):
+    """
+    A resource created or operated on by a work request.
+    """
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "CREATED"
+    ACTION_TYPE_CREATED = "CREATED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "UPDATED"
+    ACTION_TYPE_UPDATED = "UPDATED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "DELETED"
+    ACTION_TYPE_DELETED = "DELETED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "IN_PROGRESS"
+    ACTION_TYPE_IN_PROGRESS = "IN_PROGRESS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestResource object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param entity_type:
+            The value to assign to the entity_type property of this WorkRequestResource.
+        :type entity_type: str
+
+        :param action_type:
+            The value to assign to the action_type property of this WorkRequestResource.
+            Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type action_type: str
+
+        :param identifier:
+            The value to assign to the identifier property of this WorkRequestResource.
+        :type identifier: str
+
+        :param entity_uri:
+            The value to assign to the entity_uri property of this WorkRequestResource.
+        :type entity_uri: str
+
+        """
+        self.swagger_types = {
+            'entity_type': 'str',
+            'action_type': 'str',
+            'identifier': 'str',
+            'entity_uri': 'str'
+        }
+
+        self.attribute_map = {
+            'entity_type': 'entityType',
+            'action_type': 'actionType',
+            'identifier': 'identifier',
+            'entity_uri': 'entityUri'
+        }
+
+        self._entity_type = None
+        self._action_type = None
+        self._identifier = None
+        self._entity_uri = None
+
+    @property
+    def entity_type(self):
+        """
+        **[Required]** Gets the entity_type of this WorkRequestResource.
+        The resource type the work request is affects.
+
+
+        :return: The entity_type of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._entity_type
+
+    @entity_type.setter
+    def entity_type(self, entity_type):
+        """
+        Sets the entity_type of this WorkRequestResource.
+        The resource type the work request is affects.
+
+
+        :param entity_type: The entity_type of this WorkRequestResource.
+        :type: str
+        """
+        self._entity_type = entity_type
+
+    @property
+    def action_type(self):
+        """
+        **[Required]** Gets the action_type of this WorkRequestResource.
+        The way in which this resource is affected by the work tracked in the
+        work request. A resource being created, updated, or deleted will
+        remain in the IN_PROGRESS state until work is complete for that
+        resource at which point it will transition to CREATED, UPDATED,
+        or DELETED, respectively.
+
+        Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The action_type of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._action_type
+
+    @action_type.setter
+    def action_type(self, action_type):
+        """
+        Sets the action_type of this WorkRequestResource.
+        The way in which this resource is affected by the work tracked in the
+        work request. A resource being created, updated, or deleted will
+        remain in the IN_PROGRESS state until work is complete for that
+        resource at which point it will transition to CREATED, UPDATED,
+        or DELETED, respectively.
+
+
+        :param action_type: The action_type of this WorkRequestResource.
+        :type: str
+        """
+        allowed_values = ["CREATED", "UPDATED", "DELETED", "IN_PROGRESS"]
+        if not value_allowed_none_or_none_sentinel(action_type, allowed_values):
+            action_type = 'UNKNOWN_ENUM_VALUE'
+        self._action_type = action_type
+
+    @property
+    def identifier(self):
+        """
+        **[Required]** Gets the identifier of this WorkRequestResource.
+        The identifier of the resource the work request affects.
+
+
+        :return: The identifier of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this WorkRequestResource.
+        The identifier of the resource the work request affects.
+
+
+        :param identifier: The identifier of this WorkRequestResource.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def entity_uri(self):
+        """
+        Gets the entity_uri of this WorkRequestResource.
+        The URI path that the user can do a GET on to access the resource metadata.
+
+
+        :return: The entity_uri of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._entity_uri
+
+    @entity_uri.setter
+    def entity_uri(self, entity_uri):
+        """
+        Sets the entity_uri of this WorkRequestResource.
+        The URI path that the user can do a GET on to access the resource metadata.
+
+
+        :param entity_uri: The entity_uri of this WorkRequestResource.
+        :type: str
+        """
+        self._entity_uri = entity_uri
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/integration/models/work_request_summary.py
+++ b/src/oci/integration/models/work_request_summary.py
@@ -1,0 +1,399 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestSummary(object):
+    """
+    A description of work request status.
+    """
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "CREATE_INTEGRATION_INSTANCE"
+    OPERATION_TYPE_CREATE_INTEGRATION_INSTANCE = "CREATE_INTEGRATION_INSTANCE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "UPDATE_INTEGRATION_INSTANCE"
+    OPERATION_TYPE_UPDATE_INTEGRATION_INSTANCE = "UPDATE_INTEGRATION_INSTANCE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "DELETE_INTEGRATION_INSTANCE"
+    OPERATION_TYPE_DELETE_INTEGRATION_INSTANCE = "DELETE_INTEGRATION_INSTANCE"
+
+    #: A constant which can be used with the status property of a WorkRequestSummary.
+    #: This constant has a value of "ACCEPTED"
+    STATUS_ACCEPTED = "ACCEPTED"
+
+    #: A constant which can be used with the status property of a WorkRequestSummary.
+    #: This constant has a value of "IN_PROGRESS"
+    STATUS_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the status property of a WorkRequestSummary.
+    #: This constant has a value of "FAILED"
+    STATUS_FAILED = "FAILED"
+
+    #: A constant which can be used with the status property of a WorkRequestSummary.
+    #: This constant has a value of "SUCCEEDED"
+    STATUS_SUCCEEDED = "SUCCEEDED"
+
+    #: A constant which can be used with the status property of a WorkRequestSummary.
+    #: This constant has a value of "CANCELING"
+    STATUS_CANCELING = "CANCELING"
+
+    #: A constant which can be used with the status property of a WorkRequestSummary.
+    #: This constant has a value of "CANCELED"
+    STATUS_CANCELED = "CANCELED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation_type:
+            The value to assign to the operation_type property of this WorkRequestSummary.
+            Allowed values for this property are: "CREATE_INTEGRATION_INSTANCE", "UPDATE_INTEGRATION_INSTANCE", "DELETE_INTEGRATION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type operation_type: str
+
+        :param status:
+            The value to assign to the status property of this WorkRequestSummary.
+            Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param id:
+            The value to assign to the id property of this WorkRequestSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this WorkRequestSummary.
+        :type compartment_id: str
+
+        :param resources:
+            The value to assign to the resources property of this WorkRequestSummary.
+        :type resources: list[WorkRequestResource]
+
+        :param percent_complete:
+            The value to assign to the percent_complete property of this WorkRequestSummary.
+        :type percent_complete: float
+
+        :param time_accepted:
+            The value to assign to the time_accepted property of this WorkRequestSummary.
+        :type time_accepted: datetime
+
+        :param time_started:
+            The value to assign to the time_started property of this WorkRequestSummary.
+        :type time_started: datetime
+
+        :param time_finished:
+            The value to assign to the time_finished property of this WorkRequestSummary.
+        :type time_finished: datetime
+
+        """
+        self.swagger_types = {
+            'operation_type': 'str',
+            'status': 'str',
+            'id': 'str',
+            'compartment_id': 'str',
+            'resources': 'list[WorkRequestResource]',
+            'percent_complete': 'float',
+            'time_accepted': 'datetime',
+            'time_started': 'datetime',
+            'time_finished': 'datetime'
+        }
+
+        self.attribute_map = {
+            'operation_type': 'operationType',
+            'status': 'status',
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'resources': 'resources',
+            'percent_complete': 'percentComplete',
+            'time_accepted': 'timeAccepted',
+            'time_started': 'timeStarted',
+            'time_finished': 'timeFinished'
+        }
+
+        self._operation_type = None
+        self._status = None
+        self._id = None
+        self._compartment_id = None
+        self._resources = None
+        self._percent_complete = None
+        self._time_accepted = None
+        self._time_started = None
+        self._time_finished = None
+
+    @property
+    def operation_type(self):
+        """
+        **[Required]** Gets the operation_type of this WorkRequestSummary.
+        Type of the work request.
+
+        Allowed values for this property are: "CREATE_INTEGRATION_INSTANCE", "UPDATE_INTEGRATION_INSTANCE", "DELETE_INTEGRATION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The operation_type of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._operation_type
+
+    @operation_type.setter
+    def operation_type(self, operation_type):
+        """
+        Sets the operation_type of this WorkRequestSummary.
+        Type of the work request.
+
+
+        :param operation_type: The operation_type of this WorkRequestSummary.
+        :type: str
+        """
+        allowed_values = ["CREATE_INTEGRATION_INSTANCE", "UPDATE_INTEGRATION_INSTANCE", "DELETE_INTEGRATION_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
+            operation_type = 'UNKNOWN_ENUM_VALUE'
+        self._operation_type = operation_type
+
+    @property
+    def status(self):
+        """
+        **[Required]** Gets the status of this WorkRequestSummary.
+        Status of current work request.
+
+        Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this WorkRequestSummary.
+        Status of current work request.
+
+
+        :param status: The status of this WorkRequestSummary.
+        :type: str
+        """
+        allowed_values = ["ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this WorkRequestSummary.
+        The id of the work request.
+
+
+        :return: The id of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this WorkRequestSummary.
+        The id of the work request.
+
+
+        :param id: The id of this WorkRequestSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this WorkRequestSummary.
+        The ocid of the compartment that contains the work request. Work
+        requests should be scoped to the same compartment as the resource the
+        work request affects. If the work request affects multiple resources,
+        and those resources are not in the same compartment, it is up to the
+        service team to pick the primary resource whose compartment should be
+        used.
+
+
+        :return: The compartment_id of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this WorkRequestSummary.
+        The ocid of the compartment that contains the work request. Work
+        requests should be scoped to the same compartment as the resource the
+        work request affects. If the work request affects multiple resources,
+        and those resources are not in the same compartment, it is up to the
+        service team to pick the primary resource whose compartment should be
+        used.
+
+
+        :param compartment_id: The compartment_id of this WorkRequestSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def resources(self):
+        """
+        **[Required]** Gets the resources of this WorkRequestSummary.
+        The resources affected by this work request.
+
+
+        :return: The resources of this WorkRequestSummary.
+        :rtype: list[WorkRequestResource]
+        """
+        return self._resources
+
+    @resources.setter
+    def resources(self, resources):
+        """
+        Sets the resources of this WorkRequestSummary.
+        The resources affected by this work request.
+
+
+        :param resources: The resources of this WorkRequestSummary.
+        :type: list[WorkRequestResource]
+        """
+        self._resources = resources
+
+    @property
+    def percent_complete(self):
+        """
+        **[Required]** Gets the percent_complete of this WorkRequestSummary.
+        Percentage of the request completed.
+
+
+        :return: The percent_complete of this WorkRequestSummary.
+        :rtype: float
+        """
+        return self._percent_complete
+
+    @percent_complete.setter
+    def percent_complete(self, percent_complete):
+        """
+        Sets the percent_complete of this WorkRequestSummary.
+        Percentage of the request completed.
+
+
+        :param percent_complete: The percent_complete of this WorkRequestSummary.
+        :type: float
+        """
+        self._percent_complete = percent_complete
+
+    @property
+    def time_accepted(self):
+        """
+        **[Required]** Gets the time_accepted of this WorkRequestSummary.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_accepted of this WorkRequestSummary.
+        :rtype: datetime
+        """
+        return self._time_accepted
+
+    @time_accepted.setter
+    def time_accepted(self, time_accepted):
+        """
+        Sets the time_accepted of this WorkRequestSummary.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_accepted: The time_accepted of this WorkRequestSummary.
+        :type: datetime
+        """
+        self._time_accepted = time_accepted
+
+    @property
+    def time_started(self):
+        """
+        Gets the time_started of this WorkRequestSummary.
+        The date and time the request was started, as described in
+        `RFC 3339`__,
+        section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_started of this WorkRequestSummary.
+        :rtype: datetime
+        """
+        return self._time_started
+
+    @time_started.setter
+    def time_started(self, time_started):
+        """
+        Sets the time_started of this WorkRequestSummary.
+        The date and time the request was started, as described in
+        `RFC 3339`__,
+        section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_started: The time_started of this WorkRequestSummary.
+        :type: datetime
+        """
+        self._time_started = time_started
+
+    @property
+    def time_finished(self):
+        """
+        Gets the time_finished of this WorkRequestSummary.
+        The date and time the object was finished, as described in
+        `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_finished of this WorkRequestSummary.
+        :rtype: datetime
+        """
+        return self._time_finished
+
+    @time_finished.setter
+    def time_finished(self, time_finished):
+        """
+        Sets the time_finished of this WorkRequestSummary.
+        The date and time the object was finished, as described in
+        `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_finished: The time_finished of this WorkRequestSummary.
+        :type: datetime
+        """
+        self._time_finished = time_finished
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/__init__.py
+++ b/src/oci/marketplace/__init__.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+
+from .marketplace_client import MarketplaceClient
+from .marketplace_client_composite_operations import MarketplaceClientCompositeOperations
+from . import models
+
+__all__ = ["MarketplaceClient", "MarketplaceClientCompositeOperations", "models"]

--- a/src/oci/marketplace/marketplace_client.py
+++ b/src/oci/marketplace/marketplace_client.py
@@ -1,0 +1,1316 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import marketplace_type_mapping
+missing = Sentinel("Missing")
+
+
+class MarketplaceClient(object):
+    """
+    Manage applications in Oracle Cloud Infrastructure Marketplace.
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20181001',
+            'service_endpoint_template': 'https://marketplace.{region}.oci.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("marketplace", config, signer, marketplace_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def create_accepted_agreement(self, create_accepted_agreement_details, **kwargs):
+        """
+        Accepts a terms of use agreement for a listing.
+        Accepts a terms of use agreement for a specific package version of a listing. You must accept all
+        terms of use for a package before you can deploy the package.
+
+
+        :param CreateAcceptedAgreementDetails create_accepted_agreement_details: (required)
+            Details necessary to accept an agreement.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without
+            risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before
+            then due to conflicting operations (for example, if a resource has been deleted and purged from the system,
+            then a retry of the original creation request might be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.marketplace.models.AcceptedAgreement`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/acceptedAgreements"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_accepted_agreement got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_accepted_agreement_details,
+                response_type="AcceptedAgreement")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_accepted_agreement_details,
+                response_type="AcceptedAgreement")
+
+    def delete_accepted_agreement(self, accepted_agreement_id, signature, **kwargs):
+        """
+        Removes an accepted terms of use agreement.
+        Removes a previously accepted terms of use agreement from the list of agreements that Marketplace checks
+        before initiating a deployment. Listings in the Marketplace that require acceptance of the specified terms
+        of use can no longer be deployed, but existing deployments aren't affected.
+
+
+        :param str accepted_agreement_id: (required)
+            The unique identifier for the accepted terms of use agreement.
+
+        :param str signature: (required)
+            A signature generated for the listing package terms of use agreements that can be retrieved with GetAgreement.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to
+            the value of the etag from a previous GET or POST response for that resource.  The resource will be updated or
+            deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/acceptedAgreements/{acceptedAgreementId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_accepted_agreement got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "acceptedAgreementId": accepted_agreement_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "signature": signature
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+
+    def get_accepted_agreement(self, accepted_agreement_id, **kwargs):
+        """
+        Gets the details of a terms of use agreement.
+        Gets the details of a specific, previously accepted terms of use agreement.
+
+
+        :param str accepted_agreement_id: (required)
+            The unique identifier for the accepted terms of use agreement.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.marketplace.models.AcceptedAgreement`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/acceptedAgreements/{acceptedAgreementId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_accepted_agreement got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "acceptedAgreementId": accepted_agreement_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="AcceptedAgreement")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="AcceptedAgreement")
+
+    def get_agreement(self, listing_id, package_version, agreement_id, **kwargs):
+        """
+        Gets a terms of use agreement for a package.
+        Returns a terms of use agreement for a package with a time-based signature that can be used to
+        accept the agreement.
+
+
+        :param str listing_id: (required)
+            The unique identifier for the listing.
+
+        :param str package_version: (required)
+            The version of the package. Package versions are unique within a listing.
+
+        :param str agreement_id: (required)
+            The unique identifier for the agreement.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.marketplace.models.Agreement`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/listings/{listingId}/packages/{packageVersion}/agreements/{agreementId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_agreement got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "listingId": listing_id,
+            "packageVersion": package_version,
+            "agreementId": agreement_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Agreement")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Agreement")
+
+    def get_listing(self, listing_id, **kwargs):
+        """
+        Gets the details of a listing.
+        Gets detailed information about a listing, including the listing's name, version, description, and
+        resources.
+
+
+        :param str listing_id: (required)
+            The unique identifier for the listing.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.marketplace.models.Listing`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/listings/{listingId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_listing got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "listingId": listing_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Listing")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Listing")
+
+    def get_package(self, listing_id, package_version, **kwargs):
+        """
+        Get the details of a specific package version.
+        Get the details of the specified version of a package, including information needed to launch the package.
+
+
+        :param str listing_id: (required)
+            The unique identifier for the listing.
+
+        :param str package_version: (required)
+            The version of the package. Package versions are unique within a listing.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.marketplace.models.ListingPackage`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/listings/{listingId}/packages/{packageVersion}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_package got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "listingId": listing_id,
+            "packageVersion": package_version
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ListingPackage")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ListingPackage")
+
+    def list_accepted_agreements(self, compartment_id, **kwargs):
+        """
+        Gets the list of accepted terms of use agreements in the specified compartment.
+        Lists the terms of use agreements that have been accepted in the specified compartment.
+        You can filter results by specifying query parameters.
+
+
+        :param str compartment_id: (required)
+            The unique identifier for the compartment.
+
+        :param str display_name: (optional)
+            The display name of the resource.
+
+        :param str listing_id: (optional)
+            The unique identifier for the listing.
+
+        :param str package_version: (optional)
+            The version of the package. Package versions are unique within a listing.
+
+        :param str accepted_agreement_id: (optional)
+            The unique identifier for the accepted terms of use agreement.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param str sort_by: (optional)
+            The field to use to sort listed results. You can only specify one field to sort by.
+            `TIMEACCEPTED` displays results in descending order by default. You can change your
+            preference by specifying a different sort order.
+
+            Allowed values are: "TIMEACCEPTED"
+
+        :param str sort_order: (optional)
+            The sort order to use, either `ASC` or `DESC`.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param int limit: (optional)
+            How many records to return. Specify a value greater than zero and less than or equal to 1000. The default is 30.
+
+        :param str page: (optional)
+            The value of the `opc-next-page` response header from the previous \"List\" call.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.marketplace.models.AcceptedAgreementSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/acceptedAgreements"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "listing_id",
+            "package_version",
+            "accepted_agreement_id",
+            "opc_request_id",
+            "sort_by",
+            "sort_order",
+            "limit",
+            "page"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_accepted_agreements got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMEACCEPTED"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "displayName": kwargs.get("display_name", missing),
+            "listingId": kwargs.get("listing_id", missing),
+            "packageVersion": kwargs.get("package_version", missing),
+            "acceptedAgreementId": kwargs.get("accepted_agreement_id", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AcceptedAgreementSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AcceptedAgreementSummary]")
+
+    def list_agreements(self, listing_id, package_version, **kwargs):
+        """
+        Lists terms of use agreements for a package.
+        Returns the terms of use agreements that must be accepted before you can deploy the specified version of a package.
+
+
+        :param str listing_id: (required)
+            The unique identifier for the listing.
+
+        :param str package_version: (required)
+            The version of the package. Package versions are unique within a listing.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param int limit: (optional)
+            How many records to return. Specify a value greater than zero and less than or equal to 1000. The default is 30.
+
+        :param str page: (optional)
+            The value of the `opc-next-page` response header from the previous \"List\" call.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.marketplace.models.AgreementSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/listings/{listingId}/packages/{packageVersion}/agreements"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "limit",
+            "page"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_agreements got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "listingId": listing_id,
+            "packageVersion": package_version
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AgreementSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AgreementSummary]")
+
+    def list_categories(self, **kwargs):
+        """
+        Gets a list of listing categories.
+        Gets the list of all the categories for listings published to Oracle Cloud Infrastructure Marketplace. Categories apply
+        to the software product provided by the listing.
+
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param int limit: (optional)
+            How many records to return. Specify a value greater than zero and less than or equal to 1000. The default is 30.
+
+        :param str page: (optional)
+            The value of the `opc-next-page` response header from the previous \"List\" call.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.marketplace.models.CategorySummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/categories"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "limit",
+            "page"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_categories got unknown kwargs: {!r}".format(extra_kwargs))
+
+        query_params = {
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[CategorySummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[CategorySummary]")
+
+    def list_listings(self, **kwargs):
+        """
+        Gets a list of listings.
+        Gets a list of listings from Oracle Cloud Infrastructure Marketplace by searching keywords and
+        filtering according to listing attributes.
+
+
+        :param list[str] name: (optional)
+            The name of the listing.
+
+        :param str listing_id: (optional)
+            The unique identifier for the listing.
+
+        :param str publisher_id: (optional)
+            Limit results to just this publisher.
+
+        :param str package_type: (optional)
+            A filter to return only packages that match the given package type exactly.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param int limit: (optional)
+            How many records to return. Specify a value greater than zero and less than or equal to 1000. The default is 30.
+
+        :param str page: (optional)
+            The value of the `opc-next-page` response header from the previous \"List\" call.
+
+        :param str sort_by: (optional)
+            The field to use to sort listed results. You can only specify one field to sort by.
+            `TIMERELEASED` displays results in descending order by default.
+            You can change your preference by specifying a different sort order.
+
+            Allowed values are: "TIMERELEASED"
+
+        :param str sort_order: (optional)
+            The sort order to use, either `ASC` or `DESC`.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param list[str] category: (optional)
+            Name of the product category or categories. If you specify multiple categories, then Marketplace returns any listing with
+            one or more matching categories.
+
+        :param list[str] pricing: (optional)
+            Name of the pricing type. If multiple pricing types are provided, then any listing with
+            one or more matching pricing models will be returned.
+
+            Allowed values are: "FREE", "BYOL", "PAYGO"
+
+        :param bool is_featured: (optional)
+            Indicates whether to show only featured listings. If this is set to `false` or is omitted, then all listings will be returned.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.marketplace.models.ListingSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/listings"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "name",
+            "listing_id",
+            "publisher_id",
+            "package_type",
+            "opc_request_id",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order",
+            "category",
+            "pricing",
+            "is_featured"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_listings got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMERELEASED"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'pricing' in kwargs:
+            pricing_allowed_values = ["FREE", "BYOL", "PAYGO"]
+            for pricing_item in kwargs['pricing']:
+                if pricing_item not in pricing_allowed_values:
+                    raise ValueError(
+                        "Invalid value for `pricing`, must be one of {0}".format(pricing_allowed_values)
+                    )
+
+        query_params = {
+            "name": self.base_client.generate_collection_format_param(kwargs.get("name", missing), 'multi'),
+            "listingId": kwargs.get("listing_id", missing),
+            "publisherId": kwargs.get("publisher_id", missing),
+            "packageType": kwargs.get("package_type", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "category": self.base_client.generate_collection_format_param(kwargs.get("category", missing), 'multi'),
+            "pricing": self.base_client.generate_collection_format_param(kwargs.get("pricing", missing), 'multi'),
+            "isFeatured": kwargs.get("is_featured", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ListingSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ListingSummary]")
+
+    def list_packages(self, listing_id, **kwargs):
+        """
+        Gets the list of packages for a listing.
+        Gets the list of packages for a listing.
+
+
+        :param str listing_id: (required)
+            The unique identifier for the listing.
+
+        :param str package_version: (optional)
+            The version of the package. Package versions are unique within a listing.
+
+        :param str package_type: (optional)
+            A filter to return only packages that match the given package type exactly.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param int limit: (optional)
+            How many records to return. Specify a value greater than zero and less than or equal to 1000. The default is 30.
+
+        :param str page: (optional)
+            The value of the `opc-next-page` response header from the previous \"List\" call.
+
+        :param str sort_by: (optional)
+            The field to use to sort listed results. You can only specify one field to sort by.
+            `TIMERELEASED` displays results in descending order by default.
+            You can change your preference by specifying a different sort order.
+
+            Allowed values are: "TIMERELEASED"
+
+        :param str sort_order: (optional)
+            The sort order to use, either `ASC` or `DESC`.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.marketplace.models.ListingPackageSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/listings/{listingId}/packages"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "package_version",
+            "package_type",
+            "opc_request_id",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_packages got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "listingId": listing_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMERELEASED"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        query_params = {
+            "packageVersion": kwargs.get("package_version", missing),
+            "packageType": kwargs.get("package_type", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ListingPackageSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ListingPackageSummary]")
+
+    def list_publishers(self, **kwargs):
+        """
+        Gets a list of publishers.
+        Gets the list of all the publishers of listings available in Oracle Cloud Infrastructure Marketplace.
+
+
+        :param str publisher_id: (optional)
+            Limit results to just this publisher.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param int limit: (optional)
+            How many records to return. Specify a value greater than zero and less than or equal to 1000. The default is 30.
+
+        :param str page: (optional)
+            The value of the `opc-next-page` response header from the previous \"List\" call.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.marketplace.models.PublisherSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/publishers"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "publisher_id",
+            "opc_request_id",
+            "limit",
+            "page"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_publishers got unknown kwargs: {!r}".format(extra_kwargs))
+
+        query_params = {
+            "publisherId": kwargs.get("publisher_id", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[PublisherSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[PublisherSummary]")
+
+    def update_accepted_agreement(self, accepted_agreement_id, update_accepted_agreement_details, **kwargs):
+        """
+        Updates an accepted terms of use agreement.
+        Updates the display name or tags associated with a listing's previously accepted terms of use agreement.
+
+
+        :param str accepted_agreement_id: (required)
+            The unique identifier for the accepted terms of use agreement.
+
+        :param UpdateAcceptedAgreementDetails update_accepted_agreement_details: (required)
+            Details to update for an accepted agreement.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without
+            risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before
+            then due to conflicting operations (for example, if a resource has been deleted and purged from the system,
+            then a retry of the original creation request might be rejected).
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to
+            the value of the etag from a previous GET or POST response for that resource.  The resource will be updated or
+            deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.marketplace.models.AcceptedAgreement`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/acceptedAgreements/{acceptedAgreementId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_accepted_agreement got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "acceptedAgreementId": accepted_agreement_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_accepted_agreement_details,
+                response_type="AcceptedAgreement")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_accepted_agreement_details,
+                response_type="AcceptedAgreement")

--- a/src/oci/marketplace/marketplace_client_composite_operations.py
+++ b/src/oci/marketplace/marketplace_client_composite_operations.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class MarketplaceClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.marketplace.MarketplaceClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new MarketplaceClientCompositeOperations object
+
+        :param MarketplaceClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client

--- a/src/oci/marketplace/models/__init__.py
+++ b/src/oci/marketplace/models/__init__.py
@@ -1,0 +1,61 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from .accepted_agreement import AcceptedAgreement
+from .accepted_agreement_summary import AcceptedAgreementSummary
+from .agreement import Agreement
+from .agreement_summary import AgreementSummary
+from .category_summary import CategorySummary
+from .create_accepted_agreement_details import CreateAcceptedAgreementDetails
+from .documentation_link import DocumentationLink
+from .error_entity import ErrorEntity
+from .image_listing_package import ImageListingPackage
+from .item import Item
+from .link import Link
+from .listing import Listing
+from .listing_package import ListingPackage
+from .listing_package_summary import ListingPackageSummary
+from .listing_summary import ListingSummary
+from .named_link import NamedLink
+from .orchestration_listing_package import OrchestrationListingPackage
+from .orchestration_variable import OrchestrationVariable
+from .pricing_model import PricingModel
+from .publisher import Publisher
+from .publisher_summary import PublisherSummary
+from .region import Region
+from .screenshot import Screenshot
+from .support_contact import SupportContact
+from .update_accepted_agreement_details import UpdateAcceptedAgreementDetails
+from .upload_data import UploadData
+
+# Maps type names to classes for marketplace services.
+marketplace_type_mapping = {
+    "AcceptedAgreement": AcceptedAgreement,
+    "AcceptedAgreementSummary": AcceptedAgreementSummary,
+    "Agreement": Agreement,
+    "AgreementSummary": AgreementSummary,
+    "CategorySummary": CategorySummary,
+    "CreateAcceptedAgreementDetails": CreateAcceptedAgreementDetails,
+    "DocumentationLink": DocumentationLink,
+    "ErrorEntity": ErrorEntity,
+    "ImageListingPackage": ImageListingPackage,
+    "Item": Item,
+    "Link": Link,
+    "Listing": Listing,
+    "ListingPackage": ListingPackage,
+    "ListingPackageSummary": ListingPackageSummary,
+    "ListingSummary": ListingSummary,
+    "NamedLink": NamedLink,
+    "OrchestrationListingPackage": OrchestrationListingPackage,
+    "OrchestrationVariable": OrchestrationVariable,
+    "PricingModel": PricingModel,
+    "Publisher": Publisher,
+    "PublisherSummary": PublisherSummary,
+    "Region": Region,
+    "Screenshot": Screenshot,
+    "SupportContact": SupportContact,
+    "UpdateAcceptedAgreementDetails": UpdateAcceptedAgreementDetails,
+    "UploadData": UploadData
+}

--- a/src/oci/marketplace/models/accepted_agreement.py
+++ b/src/oci/marketplace/models/accepted_agreement.py
@@ -1,0 +1,339 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AcceptedAgreement(object):
+    """
+    The model for an accepted terms of use agreement.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AcceptedAgreement object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this AcceptedAgreement.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this AcceptedAgreement.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this AcceptedAgreement.
+        :type compartment_id: str
+
+        :param listing_id:
+            The value to assign to the listing_id property of this AcceptedAgreement.
+        :type listing_id: str
+
+        :param package_version:
+            The value to assign to the package_version property of this AcceptedAgreement.
+        :type package_version: str
+
+        :param agreement_id:
+            The value to assign to the agreement_id property of this AcceptedAgreement.
+        :type agreement_id: str
+
+        :param time_accepted:
+            The value to assign to the time_accepted property of this AcceptedAgreement.
+        :type time_accepted: datetime
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this AcceptedAgreement.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this AcceptedAgreement.
+        :type freeform_tags: dict(str, str)
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'listing_id': 'str',
+            'package_version': 'str',
+            'agreement_id': 'str',
+            'time_accepted': 'datetime',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'freeform_tags': 'dict(str, str)'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'listing_id': 'listingId',
+            'package_version': 'packageVersion',
+            'agreement_id': 'agreementId',
+            'time_accepted': 'timeAccepted',
+            'defined_tags': 'definedTags',
+            'freeform_tags': 'freeformTags'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._listing_id = None
+        self._package_version = None
+        self._agreement_id = None
+        self._time_accepted = None
+        self._defined_tags = None
+        self._freeform_tags = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this AcceptedAgreement.
+        The unique identifier for the acceptance of the agreement within a specific compartment.
+
+
+        :return: The id of this AcceptedAgreement.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this AcceptedAgreement.
+        The unique identifier for the acceptance of the agreement within a specific compartment.
+
+
+        :param id: The id of this AcceptedAgreement.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this AcceptedAgreement.
+        A display name for the accepted agreement.
+
+
+        :return: The display_name of this AcceptedAgreement.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this AcceptedAgreement.
+        A display name for the accepted agreement.
+
+
+        :param display_name: The display_name of this AcceptedAgreement.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this AcceptedAgreement.
+        The unique identifier for the compartment where the agreement was accepted.
+
+
+        :return: The compartment_id of this AcceptedAgreement.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this AcceptedAgreement.
+        The unique identifier for the compartment where the agreement was accepted.
+
+
+        :param compartment_id: The compartment_id of this AcceptedAgreement.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def listing_id(self):
+        """
+        Gets the listing_id of this AcceptedAgreement.
+        The unique identifier for the listing associated with the agreement.
+
+
+        :return: The listing_id of this AcceptedAgreement.
+        :rtype: str
+        """
+        return self._listing_id
+
+    @listing_id.setter
+    def listing_id(self, listing_id):
+        """
+        Sets the listing_id of this AcceptedAgreement.
+        The unique identifier for the listing associated with the agreement.
+
+
+        :param listing_id: The listing_id of this AcceptedAgreement.
+        :type: str
+        """
+        self._listing_id = listing_id
+
+    @property
+    def package_version(self):
+        """
+        Gets the package_version of this AcceptedAgreement.
+        The package version associated with the agreement.
+
+
+        :return: The package_version of this AcceptedAgreement.
+        :rtype: str
+        """
+        return self._package_version
+
+    @package_version.setter
+    def package_version(self, package_version):
+        """
+        Sets the package_version of this AcceptedAgreement.
+        The package version associated with the agreement.
+
+
+        :param package_version: The package_version of this AcceptedAgreement.
+        :type: str
+        """
+        self._package_version = package_version
+
+    @property
+    def agreement_id(self):
+        """
+        Gets the agreement_id of this AcceptedAgreement.
+        The unique identifier for the terms of use agreement itself.
+
+
+        :return: The agreement_id of this AcceptedAgreement.
+        :rtype: str
+        """
+        return self._agreement_id
+
+    @agreement_id.setter
+    def agreement_id(self, agreement_id):
+        """
+        Sets the agreement_id of this AcceptedAgreement.
+        The unique identifier for the terms of use agreement itself.
+
+
+        :param agreement_id: The agreement_id of this AcceptedAgreement.
+        :type: str
+        """
+        self._agreement_id = agreement_id
+
+    @property
+    def time_accepted(self):
+        """
+        Gets the time_accepted of this AcceptedAgreement.
+        The time the agreement was accepted.
+
+
+        :return: The time_accepted of this AcceptedAgreement.
+        :rtype: datetime
+        """
+        return self._time_accepted
+
+    @time_accepted.setter
+    def time_accepted(self, time_accepted):
+        """
+        Sets the time_accepted of this AcceptedAgreement.
+        The time the agreement was accepted.
+
+
+        :param time_accepted: The time_accepted of this AcceptedAgreement.
+        :type: datetime
+        """
+        self._time_accepted = time_accepted
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this AcceptedAgreement.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this AcceptedAgreement.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this AcceptedAgreement.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this AcceptedAgreement.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this AcceptedAgreement.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this AcceptedAgreement.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this AcceptedAgreement.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this AcceptedAgreement.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/accepted_agreement_summary.py
+++ b/src/oci/marketplace/models/accepted_agreement_summary.py
@@ -1,0 +1,255 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AcceptedAgreementSummary(object):
+    """
+    The model for a summary of an accepted agreement.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AcceptedAgreementSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this AcceptedAgreementSummary.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this AcceptedAgreementSummary.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this AcceptedAgreementSummary.
+        :type compartment_id: str
+
+        :param listing_id:
+            The value to assign to the listing_id property of this AcceptedAgreementSummary.
+        :type listing_id: str
+
+        :param package_version:
+            The value to assign to the package_version property of this AcceptedAgreementSummary.
+        :type package_version: str
+
+        :param agreement_id:
+            The value to assign to the agreement_id property of this AcceptedAgreementSummary.
+        :type agreement_id: str
+
+        :param time_accepted:
+            The value to assign to the time_accepted property of this AcceptedAgreementSummary.
+        :type time_accepted: datetime
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'listing_id': 'str',
+            'package_version': 'str',
+            'agreement_id': 'str',
+            'time_accepted': 'datetime'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'listing_id': 'listingId',
+            'package_version': 'packageVersion',
+            'agreement_id': 'agreementId',
+            'time_accepted': 'timeAccepted'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._listing_id = None
+        self._package_version = None
+        self._agreement_id = None
+        self._time_accepted = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this AcceptedAgreementSummary.
+        The unique identifier for the acceptance of the agreement within a specific compartment.
+
+
+        :return: The id of this AcceptedAgreementSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this AcceptedAgreementSummary.
+        The unique identifier for the acceptance of the agreement within a specific compartment.
+
+
+        :param id: The id of this AcceptedAgreementSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this AcceptedAgreementSummary.
+        A display name for the accepted agreement.
+
+
+        :return: The display_name of this AcceptedAgreementSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this AcceptedAgreementSummary.
+        A display name for the accepted agreement.
+
+
+        :param display_name: The display_name of this AcceptedAgreementSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this AcceptedAgreementSummary.
+        The unique identifier for the compartment where the agreement was accepted.
+
+
+        :return: The compartment_id of this AcceptedAgreementSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this AcceptedAgreementSummary.
+        The unique identifier for the compartment where the agreement was accepted.
+
+
+        :param compartment_id: The compartment_id of this AcceptedAgreementSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def listing_id(self):
+        """
+        Gets the listing_id of this AcceptedAgreementSummary.
+        The unique identifier for the listing associated with the agreement.
+
+
+        :return: The listing_id of this AcceptedAgreementSummary.
+        :rtype: str
+        """
+        return self._listing_id
+
+    @listing_id.setter
+    def listing_id(self, listing_id):
+        """
+        Sets the listing_id of this AcceptedAgreementSummary.
+        The unique identifier for the listing associated with the agreement.
+
+
+        :param listing_id: The listing_id of this AcceptedAgreementSummary.
+        :type: str
+        """
+        self._listing_id = listing_id
+
+    @property
+    def package_version(self):
+        """
+        Gets the package_version of this AcceptedAgreementSummary.
+        The package version associated with the agreement.
+
+
+        :return: The package_version of this AcceptedAgreementSummary.
+        :rtype: str
+        """
+        return self._package_version
+
+    @package_version.setter
+    def package_version(self, package_version):
+        """
+        Sets the package_version of this AcceptedAgreementSummary.
+        The package version associated with the agreement.
+
+
+        :param package_version: The package_version of this AcceptedAgreementSummary.
+        :type: str
+        """
+        self._package_version = package_version
+
+    @property
+    def agreement_id(self):
+        """
+        Gets the agreement_id of this AcceptedAgreementSummary.
+        The unique identifier for the terms of use agreement itself.
+
+
+        :return: The agreement_id of this AcceptedAgreementSummary.
+        :rtype: str
+        """
+        return self._agreement_id
+
+    @agreement_id.setter
+    def agreement_id(self, agreement_id):
+        """
+        Sets the agreement_id of this AcceptedAgreementSummary.
+        The unique identifier for the terms of use agreement itself.
+
+
+        :param agreement_id: The agreement_id of this AcceptedAgreementSummary.
+        :type: str
+        """
+        self._agreement_id = agreement_id
+
+    @property
+    def time_accepted(self):
+        """
+        Gets the time_accepted of this AcceptedAgreementSummary.
+        The time the agreement was accepted.
+
+
+        :return: The time_accepted of this AcceptedAgreementSummary.
+        :rtype: datetime
+        """
+        return self._time_accepted
+
+    @time_accepted.setter
+    def time_accepted(self, time_accepted):
+        """
+        Sets the time_accepted of this AcceptedAgreementSummary.
+        The time the agreement was accepted.
+
+
+        :param time_accepted: The time_accepted of this AcceptedAgreementSummary.
+        :type: datetime
+        """
+        self._time_accepted = time_accepted
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/agreement.py
+++ b/src/oci/marketplace/models/agreement.py
@@ -1,0 +1,242 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Agreement(object):
+    """
+    The model for an end user license agreement.
+    """
+
+    #: A constant which can be used with the author property of a Agreement.
+    #: This constant has a value of "ORACLE"
+    AUTHOR_ORACLE = "ORACLE"
+
+    #: A constant which can be used with the author property of a Agreement.
+    #: This constant has a value of "PARTNER"
+    AUTHOR_PARTNER = "PARTNER"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Agreement object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this Agreement.
+        :type id: str
+
+        :param content_url:
+            The value to assign to the content_url property of this Agreement.
+        :type content_url: str
+
+        :param signature:
+            The value to assign to the signature property of this Agreement.
+        :type signature: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this Agreement.
+        :type compartment_id: str
+
+        :param author:
+            The value to assign to the author property of this Agreement.
+            Allowed values for this property are: "ORACLE", "PARTNER", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type author: str
+
+        :param prompt:
+            The value to assign to the prompt property of this Agreement.
+        :type prompt: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'content_url': 'str',
+            'signature': 'str',
+            'compartment_id': 'str',
+            'author': 'str',
+            'prompt': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'content_url': 'contentUrl',
+            'signature': 'signature',
+            'compartment_id': 'compartmentId',
+            'author': 'author',
+            'prompt': 'prompt'
+        }
+
+        self._id = None
+        self._content_url = None
+        self._signature = None
+        self._compartment_id = None
+        self._author = None
+        self._prompt = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this Agreement.
+        The unique identifier for the agreement.
+
+
+        :return: The id of this Agreement.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this Agreement.
+        The unique identifier for the agreement.
+
+
+        :param id: The id of this Agreement.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def content_url(self):
+        """
+        **[Required]** Gets the content_url of this Agreement.
+        The content URL of the agreement.
+
+
+        :return: The content_url of this Agreement.
+        :rtype: str
+        """
+        return self._content_url
+
+    @content_url.setter
+    def content_url(self, content_url):
+        """
+        Sets the content_url of this Agreement.
+        The content URL of the agreement.
+
+
+        :param content_url: The content_url of this Agreement.
+        :type: str
+        """
+        self._content_url = content_url
+
+    @property
+    def signature(self):
+        """
+        **[Required]** Gets the signature of this Agreement.
+        A time-based signature that can be used to accept an agreement or remove a
+        previously accepted agreement from the list that Marketplace checks before a deployment.
+
+
+        :return: The signature of this Agreement.
+        :rtype: str
+        """
+        return self._signature
+
+    @signature.setter
+    def signature(self, signature):
+        """
+        Sets the signature of this Agreement.
+        A time-based signature that can be used to accept an agreement or remove a
+        previously accepted agreement from the list that Marketplace checks before a deployment.
+
+
+        :param signature: The signature of this Agreement.
+        :type: str
+        """
+        self._signature = signature
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this Agreement.
+        The unique identifier for the compartment.
+
+
+        :return: The compartment_id of this Agreement.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this Agreement.
+        The unique identifier for the compartment.
+
+
+        :param compartment_id: The compartment_id of this Agreement.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def author(self):
+        """
+        Gets the author of this Agreement.
+        Who authored the agreement.
+
+        Allowed values for this property are: "ORACLE", "PARTNER", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The author of this Agreement.
+        :rtype: str
+        """
+        return self._author
+
+    @author.setter
+    def author(self, author):
+        """
+        Sets the author of this Agreement.
+        Who authored the agreement.
+
+
+        :param author: The author of this Agreement.
+        :type: str
+        """
+        allowed_values = ["ORACLE", "PARTNER"]
+        if not value_allowed_none_or_none_sentinel(author, allowed_values):
+            author = 'UNKNOWN_ENUM_VALUE'
+        self._author = author
+
+    @property
+    def prompt(self):
+        """
+        Gets the prompt of this Agreement.
+        Textual prompt to read and accept the agreement.
+
+
+        :return: The prompt of this Agreement.
+        :rtype: str
+        """
+        return self._prompt
+
+    @prompt.setter
+    def prompt(self, prompt):
+        """
+        Sets the prompt of this Agreement.
+        Textual prompt to read and accept the agreement.
+
+
+        :param prompt: The prompt of this Agreement.
+        :type: str
+        """
+        self._prompt = prompt
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/agreement_summary.py
+++ b/src/oci/marketplace/models/agreement_summary.py
@@ -1,0 +1,182 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AgreementSummary(object):
+    """
+    The model for a summary of an end user license agreement.
+    """
+
+    #: A constant which can be used with the author property of a AgreementSummary.
+    #: This constant has a value of "ORACLE"
+    AUTHOR_ORACLE = "ORACLE"
+
+    #: A constant which can be used with the author property of a AgreementSummary.
+    #: This constant has a value of "PARTNER"
+    AUTHOR_PARTNER = "PARTNER"
+
+    #: A constant which can be used with the author property of a AgreementSummary.
+    #: This constant has a value of "PII"
+    AUTHOR_PII = "PII"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AgreementSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this AgreementSummary.
+        :type id: str
+
+        :param content_url:
+            The value to assign to the content_url property of this AgreementSummary.
+        :type content_url: str
+
+        :param author:
+            The value to assign to the author property of this AgreementSummary.
+            Allowed values for this property are: "ORACLE", "PARTNER", "PII", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type author: str
+
+        :param prompt:
+            The value to assign to the prompt property of this AgreementSummary.
+        :type prompt: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'content_url': 'str',
+            'author': 'str',
+            'prompt': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'content_url': 'contentUrl',
+            'author': 'author',
+            'prompt': 'prompt'
+        }
+
+        self._id = None
+        self._content_url = None
+        self._author = None
+        self._prompt = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this AgreementSummary.
+        The unique identifier for the agreement.
+
+
+        :return: The id of this AgreementSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this AgreementSummary.
+        The unique identifier for the agreement.
+
+
+        :param id: The id of this AgreementSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def content_url(self):
+        """
+        Gets the content_url of this AgreementSummary.
+        The content URL of the agreement.
+
+
+        :return: The content_url of this AgreementSummary.
+        :rtype: str
+        """
+        return self._content_url
+
+    @content_url.setter
+    def content_url(self, content_url):
+        """
+        Sets the content_url of this AgreementSummary.
+        The content URL of the agreement.
+
+
+        :param content_url: The content_url of this AgreementSummary.
+        :type: str
+        """
+        self._content_url = content_url
+
+    @property
+    def author(self):
+        """
+        Gets the author of this AgreementSummary.
+        Who authored the agreement.
+
+        Allowed values for this property are: "ORACLE", "PARTNER", "PII", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The author of this AgreementSummary.
+        :rtype: str
+        """
+        return self._author
+
+    @author.setter
+    def author(self, author):
+        """
+        Sets the author of this AgreementSummary.
+        Who authored the agreement.
+
+
+        :param author: The author of this AgreementSummary.
+        :type: str
+        """
+        allowed_values = ["ORACLE", "PARTNER", "PII"]
+        if not value_allowed_none_or_none_sentinel(author, allowed_values):
+            author = 'UNKNOWN_ENUM_VALUE'
+        self._author = author
+
+    @property
+    def prompt(self):
+        """
+        Gets the prompt of this AgreementSummary.
+        Textual prompt to read and accept the agreement.
+
+
+        :return: The prompt of this AgreementSummary.
+        :rtype: str
+        """
+        return self._prompt
+
+    @prompt.setter
+    def prompt(self, prompt):
+        """
+        Sets the prompt of this AgreementSummary.
+        Textual prompt to read and accept the agreement.
+
+
+        :param prompt: The prompt of this AgreementSummary.
+        :type: str
+        """
+        self._prompt = prompt
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/category_summary.py
+++ b/src/oci/marketplace/models/category_summary.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CategorySummary(object):
+    """
+    The model for a summary of product categories for listings.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CategorySummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this CategorySummary.
+        :type name: str
+
+        """
+        self.swagger_types = {
+            'name': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name'
+        }
+
+        self._name = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this CategorySummary.
+        Name of the product category.
+
+
+        :return: The name of this CategorySummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this CategorySummary.
+        Name of the product category.
+
+
+        :param name: The name of this CategorySummary.
+        :type: str
+        """
+        self._name = name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/create_accepted_agreement_details.py
+++ b/src/oci/marketplace/models/create_accepted_agreement_details.py
@@ -1,0 +1,314 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateAcceptedAgreementDetails(object):
+    """
+    The model for the parameters needed to accept a terms of use agreement.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateAcceptedAgreementDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateAcceptedAgreementDetails.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateAcceptedAgreementDetails.
+        :type compartment_id: str
+
+        :param listing_id:
+            The value to assign to the listing_id property of this CreateAcceptedAgreementDetails.
+        :type listing_id: str
+
+        :param package_version:
+            The value to assign to the package_version property of this CreateAcceptedAgreementDetails.
+        :type package_version: str
+
+        :param agreement_id:
+            The value to assign to the agreement_id property of this CreateAcceptedAgreementDetails.
+        :type agreement_id: str
+
+        :param signature:
+            The value to assign to the signature property of this CreateAcceptedAgreementDetails.
+        :type signature: str
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateAcceptedAgreementDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateAcceptedAgreementDetails.
+        :type freeform_tags: dict(str, str)
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'listing_id': 'str',
+            'package_version': 'str',
+            'agreement_id': 'str',
+            'signature': 'str',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'freeform_tags': 'dict(str, str)'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'listing_id': 'listingId',
+            'package_version': 'packageVersion',
+            'agreement_id': 'agreementId',
+            'signature': 'signature',
+            'defined_tags': 'definedTags',
+            'freeform_tags': 'freeformTags'
+        }
+
+        self._display_name = None
+        self._compartment_id = None
+        self._listing_id = None
+        self._package_version = None
+        self._agreement_id = None
+        self._signature = None
+        self._defined_tags = None
+        self._freeform_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateAcceptedAgreementDetails.
+        A display name for the accepted agreement.
+
+
+        :return: The display_name of this CreateAcceptedAgreementDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateAcceptedAgreementDetails.
+        A display name for the accepted agreement.
+
+
+        :param display_name: The display_name of this CreateAcceptedAgreementDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateAcceptedAgreementDetails.
+        The unique identifier for the compartment where the agreement will be accepted.
+
+
+        :return: The compartment_id of this CreateAcceptedAgreementDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateAcceptedAgreementDetails.
+        The unique identifier for the compartment where the agreement will be accepted.
+
+
+        :param compartment_id: The compartment_id of this CreateAcceptedAgreementDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def listing_id(self):
+        """
+        **[Required]** Gets the listing_id of this CreateAcceptedAgreementDetails.
+        The unique identifier for the listing associated with the agreement.
+
+
+        :return: The listing_id of this CreateAcceptedAgreementDetails.
+        :rtype: str
+        """
+        return self._listing_id
+
+    @listing_id.setter
+    def listing_id(self, listing_id):
+        """
+        Sets the listing_id of this CreateAcceptedAgreementDetails.
+        The unique identifier for the listing associated with the agreement.
+
+
+        :param listing_id: The listing_id of this CreateAcceptedAgreementDetails.
+        :type: str
+        """
+        self._listing_id = listing_id
+
+    @property
+    def package_version(self):
+        """
+        **[Required]** Gets the package_version of this CreateAcceptedAgreementDetails.
+        The package version associated with the agreement.
+
+
+        :return: The package_version of this CreateAcceptedAgreementDetails.
+        :rtype: str
+        """
+        return self._package_version
+
+    @package_version.setter
+    def package_version(self, package_version):
+        """
+        Sets the package_version of this CreateAcceptedAgreementDetails.
+        The package version associated with the agreement.
+
+
+        :param package_version: The package_version of this CreateAcceptedAgreementDetails.
+        :type: str
+        """
+        self._package_version = package_version
+
+    @property
+    def agreement_id(self):
+        """
+        **[Required]** Gets the agreement_id of this CreateAcceptedAgreementDetails.
+        The agreement to accept.
+
+
+        :return: The agreement_id of this CreateAcceptedAgreementDetails.
+        :rtype: str
+        """
+        return self._agreement_id
+
+    @agreement_id.setter
+    def agreement_id(self, agreement_id):
+        """
+        Sets the agreement_id of this CreateAcceptedAgreementDetails.
+        The agreement to accept.
+
+
+        :param agreement_id: The agreement_id of this CreateAcceptedAgreementDetails.
+        :type: str
+        """
+        self._agreement_id = agreement_id
+
+    @property
+    def signature(self):
+        """
+        **[Required]** Gets the signature of this CreateAcceptedAgreementDetails.
+        A signature generated for the listing package agreements that you can retrieve
+        with `GetAgreement`__.
+
+        __ https://docs.cloud.oracle.com/api/#/en/marketplace/20181001/Agreement/GetAgreement
+
+
+        :return: The signature of this CreateAcceptedAgreementDetails.
+        :rtype: str
+        """
+        return self._signature
+
+    @signature.setter
+    def signature(self, signature):
+        """
+        Sets the signature of this CreateAcceptedAgreementDetails.
+        A signature generated for the listing package agreements that you can retrieve
+        with `GetAgreement`__.
+
+        __ https://docs.cloud.oracle.com/api/#/en/marketplace/20181001/Agreement/GetAgreement
+
+
+        :param signature: The signature of this CreateAcceptedAgreementDetails.
+        :type: str
+        """
+        self._signature = signature
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateAcceptedAgreementDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateAcceptedAgreementDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateAcceptedAgreementDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateAcceptedAgreementDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateAcceptedAgreementDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateAcceptedAgreementDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateAcceptedAgreementDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateAcceptedAgreementDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/documentation_link.py
+++ b/src/oci/marketplace/models/documentation_link.py
@@ -1,0 +1,131 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DocumentationLink(object):
+    """
+    A link to a documentation resource on the internet.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DocumentationLink object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this DocumentationLink.
+        :type name: str
+
+        :param url:
+            The value to assign to the url property of this DocumentationLink.
+        :type url: str
+
+        :param document_category:
+            The value to assign to the document_category property of this DocumentationLink.
+        :type document_category: str
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'url': 'str',
+            'document_category': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'url': 'url',
+            'document_category': 'documentCategory'
+        }
+
+        self._name = None
+        self._url = None
+        self._document_category = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this DocumentationLink.
+        Text that describes the resource.
+
+
+        :return: The name of this DocumentationLink.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this DocumentationLink.
+        Text that describes the resource.
+
+
+        :param name: The name of this DocumentationLink.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def url(self):
+        """
+        Gets the url of this DocumentationLink.
+        The URL of the resource.
+
+
+        :return: The url of this DocumentationLink.
+        :rtype: str
+        """
+        return self._url
+
+    @url.setter
+    def url(self, url):
+        """
+        Sets the url of this DocumentationLink.
+        The URL of the resource.
+
+
+        :param url: The url of this DocumentationLink.
+        :type: str
+        """
+        self._url = url
+
+    @property
+    def document_category(self):
+        """
+        Gets the document_category of this DocumentationLink.
+        The category that the document belongs to.
+
+
+        :return: The document_category of this DocumentationLink.
+        :rtype: str
+        """
+        return self._document_category
+
+    @document_category.setter
+    def document_category(self, document_category):
+        """
+        Sets the document_category of this DocumentationLink.
+        The category that the document belongs to.
+
+
+        :param document_category: The document_category of this DocumentationLink.
+        :type: str
+        """
+        self._document_category = document_category
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/error_entity.py
+++ b/src/oci/marketplace/models/error_entity.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ErrorEntity(object):
+    """
+    The model for the error entity.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ErrorEntity object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param code:
+            The value to assign to the code property of this ErrorEntity.
+        :type code: str
+
+        :param message:
+            The value to assign to the message property of this ErrorEntity.
+        :type message: str
+
+        """
+        self.swagger_types = {
+            'code': 'str',
+            'message': 'str'
+        }
+
+        self.attribute_map = {
+            'code': 'code',
+            'message': 'message'
+        }
+
+        self._code = None
+        self._message = None
+
+    @property
+    def code(self):
+        """
+        **[Required]** Gets the code of this ErrorEntity.
+        A short error code that defines the error.
+
+
+        :return: The code of this ErrorEntity.
+        :rtype: str
+        """
+        return self._code
+
+    @code.setter
+    def code(self, code):
+        """
+        Sets the code of this ErrorEntity.
+        A short error code that defines the error.
+
+
+        :param code: The code of this ErrorEntity.
+        :type: str
+        """
+        self._code = code
+
+    @property
+    def message(self):
+        """
+        **[Required]** Gets the message of this ErrorEntity.
+        A human-readable error string.
+
+
+        :return: The message of this ErrorEntity.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this ErrorEntity.
+        A human-readable error string.
+
+
+        :param message: The message of this ErrorEntity.
+        :type: str
+        """
+        self._message = message
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/image_listing_package.py
+++ b/src/oci/marketplace/models/image_listing_package.py
@@ -1,0 +1,175 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .listing_package import ListingPackage
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ImageListingPackage(ListingPackage):
+    """
+    A package for image listings.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ImageListingPackage object with values from keyword arguments. The default value of the :py:attr:`~oci.marketplace.models.ImageListingPackage.package_type` attribute
+        of this class is ``IMAGE`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param description:
+            The value to assign to the description property of this ImageListingPackage.
+        :type description: str
+
+        :param listing_id:
+            The value to assign to the listing_id property of this ImageListingPackage.
+        :type listing_id: str
+
+        :param version:
+            The value to assign to the version property of this ImageListingPackage.
+        :type version: str
+
+        :param pricing:
+            The value to assign to the pricing property of this ImageListingPackage.
+        :type pricing: PricingModel
+
+        :param resource_id:
+            The value to assign to the resource_id property of this ImageListingPackage.
+        :type resource_id: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ImageListingPackage.
+        :type time_created: datetime
+
+        :param app_catalog_listing_id:
+            The value to assign to the app_catalog_listing_id property of this ImageListingPackage.
+        :type app_catalog_listing_id: str
+
+        :param app_catalog_listing_resource_version:
+            The value to assign to the app_catalog_listing_resource_version property of this ImageListingPackage.
+        :type app_catalog_listing_resource_version: str
+
+        :param regions:
+            The value to assign to the regions property of this ImageListingPackage.
+        :type regions: list[Region]
+
+        """
+        self.swagger_types = {
+            'description': 'str',
+            'listing_id': 'str',
+            'version': 'str',
+            'pricing': 'PricingModel',
+            'resource_id': 'str',
+            'time_created': 'datetime',
+            'app_catalog_listing_id': 'str',
+            'app_catalog_listing_resource_version': 'str',
+            'regions': 'list[Region]'
+        }
+
+        self.attribute_map = {
+            'description': 'description',
+            'listing_id': 'listingId',
+            'version': 'version',
+            'pricing': 'pricing',
+            'resource_id': 'resourceId',
+            'time_created': 'timeCreated',
+            'app_catalog_listing_id': 'appCatalogListingId',
+            'app_catalog_listing_resource_version': 'appCatalogListingResourceVersion',
+            'regions': 'regions'
+        }
+
+        self._description = None
+        self._listing_id = None
+        self._version = None
+        self._pricing = None
+        self._resource_id = None
+        self._time_created = None
+        self._app_catalog_listing_id = None
+        self._app_catalog_listing_resource_version = None
+        self._regions = None
+        self._package_type = 'IMAGE'
+
+    @property
+    def app_catalog_listing_id(self):
+        """
+        Gets the app_catalog_listing_id of this ImageListingPackage.
+        The id of the AppCatalogListing associated with this ListingPackage.
+
+
+        :return: The app_catalog_listing_id of this ImageListingPackage.
+        :rtype: str
+        """
+        return self._app_catalog_listing_id
+
+    @app_catalog_listing_id.setter
+    def app_catalog_listing_id(self, app_catalog_listing_id):
+        """
+        Sets the app_catalog_listing_id of this ImageListingPackage.
+        The id of the AppCatalogListing associated with this ListingPackage.
+
+
+        :param app_catalog_listing_id: The app_catalog_listing_id of this ImageListingPackage.
+        :type: str
+        """
+        self._app_catalog_listing_id = app_catalog_listing_id
+
+    @property
+    def app_catalog_listing_resource_version(self):
+        """
+        Gets the app_catalog_listing_resource_version of this ImageListingPackage.
+        The resource version of the AppCatalogListing associated with this ListingPackage.
+
+
+        :return: The app_catalog_listing_resource_version of this ImageListingPackage.
+        :rtype: str
+        """
+        return self._app_catalog_listing_resource_version
+
+    @app_catalog_listing_resource_version.setter
+    def app_catalog_listing_resource_version(self, app_catalog_listing_resource_version):
+        """
+        Sets the app_catalog_listing_resource_version of this ImageListingPackage.
+        The resource version of the AppCatalogListing associated with this ListingPackage.
+
+
+        :param app_catalog_listing_resource_version: The app_catalog_listing_resource_version of this ImageListingPackage.
+        :type: str
+        """
+        self._app_catalog_listing_resource_version = app_catalog_listing_resource_version
+
+    @property
+    def regions(self):
+        """
+        Gets the regions of this ImageListingPackage.
+        List of regions in which this ListingPackage is available.
+
+
+        :return: The regions of this ImageListingPackage.
+        :rtype: list[Region]
+        """
+        return self._regions
+
+    @regions.setter
+    def regions(self, regions):
+        """
+        Sets the regions of this ImageListingPackage.
+        List of regions in which this ListingPackage is available.
+
+
+        :param regions: The regions of this ImageListingPackage.
+        :type: list[Region]
+        """
+        self._regions = regions
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/item.py
+++ b/src/oci/marketplace/models/item.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Item(object):
+    """
+    The model for an item within an array of filter values.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Item object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this Item.
+        :type name: str
+
+        :param code:
+            The value to assign to the code property of this Item.
+        :type code: str
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'code': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'code': 'code'
+        }
+
+        self._name = None
+        self._code = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this Item.
+        The name of the item.
+
+
+        :return: The name of this Item.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this Item.
+        The name of the item.
+
+
+        :param name: The name of this Item.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def code(self):
+        """
+        Gets the code of this Item.
+        A code assigned to the item.
+
+
+        :return: The code of this Item.
+        :rtype: str
+        """
+        return self._code
+
+    @code.setter
+    def code(self, code):
+        """
+        Sets the code of this Item.
+        A code assigned to the item.
+
+
+        :param code: The code of this Item.
+        :type: str
+        """
+        self._code = code
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/link.py
+++ b/src/oci/marketplace/models/link.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Link(object):
+    """
+    The model for links.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Link object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param href:
+            The value to assign to the href property of this Link.
+        :type href: str
+
+        """
+        self.swagger_types = {
+            'href': 'str'
+        }
+
+        self.attribute_map = {
+            'href': 'href'
+        }
+
+        self._href = None
+
+    @property
+    def href(self):
+        """
+        Gets the href of this Link.
+        The anchor tag.
+
+
+        :return: The href of this Link.
+        :rtype: str
+        """
+        return self._href
+
+    @href.setter
+    def href(self, href):
+        """
+        Sets the href of this Link.
+        The anchor tag.
+
+
+        :param href: The href of this Link.
+        :type: str
+        """
+        self._href = href
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/listing.py
+++ b/src/oci/marketplace/models/listing.py
@@ -1,0 +1,879 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Listing(object):
+    """
+    The model for an Oracle Cloud Infrastructure Marketplace listing.
+    """
+
+    #: A constant which can be used with the package_type property of a Listing.
+    #: This constant has a value of "ORCHESTRATION"
+    PACKAGE_TYPE_ORCHESTRATION = "ORCHESTRATION"
+
+    #: A constant which can be used with the package_type property of a Listing.
+    #: This constant has a value of "IMAGE"
+    PACKAGE_TYPE_IMAGE = "IMAGE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Listing object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this Listing.
+        :type id: str
+
+        :param name:
+            The value to assign to the name property of this Listing.
+        :type name: str
+
+        :param version:
+            The value to assign to the version property of this Listing.
+        :type version: str
+
+        :param tagline:
+            The value to assign to the tagline property of this Listing.
+        :type tagline: str
+
+        :param keywords:
+            The value to assign to the keywords property of this Listing.
+        :type keywords: str
+
+        :param short_description:
+            The value to assign to the short_description property of this Listing.
+        :type short_description: str
+
+        :param usage_information:
+            The value to assign to the usage_information property of this Listing.
+        :type usage_information: str
+
+        :param long_description:
+            The value to assign to the long_description property of this Listing.
+        :type long_description: str
+
+        :param license_model_description:
+            The value to assign to the license_model_description property of this Listing.
+        :type license_model_description: str
+
+        :param system_requirements:
+            The value to assign to the system_requirements property of this Listing.
+        :type system_requirements: str
+
+        :param time_released:
+            The value to assign to the time_released property of this Listing.
+        :type time_released: datetime
+
+        :param release_notes:
+            The value to assign to the release_notes property of this Listing.
+        :type release_notes: str
+
+        :param categories:
+            The value to assign to the categories property of this Listing.
+        :type categories: list[str]
+
+        :param publisher:
+            The value to assign to the publisher property of this Listing.
+        :type publisher: Publisher
+
+        :param languages:
+            The value to assign to the languages property of this Listing.
+        :type languages: list[Item]
+
+        :param screenshots:
+            The value to assign to the screenshots property of this Listing.
+        :type screenshots: list[Screenshot]
+
+        :param videos:
+            The value to assign to the videos property of this Listing.
+        :type videos: list[NamedLink]
+
+        :param support_contacts:
+            The value to assign to the support_contacts property of this Listing.
+        :type support_contacts: list[SupportContact]
+
+        :param support_links:
+            The value to assign to the support_links property of this Listing.
+        :type support_links: list[NamedLink]
+
+        :param documentation_links:
+            The value to assign to the documentation_links property of this Listing.
+        :type documentation_links: list[DocumentationLink]
+
+        :param icon:
+            The value to assign to the icon property of this Listing.
+        :type icon: UploadData
+
+        :param banner:
+            The value to assign to the banner property of this Listing.
+        :type banner: UploadData
+
+        :param regions:
+            The value to assign to the regions property of this Listing.
+        :type regions: list[Region]
+
+        :param package_type:
+            The value to assign to the package_type property of this Listing.
+            Allowed values for this property are: "ORCHESTRATION", "IMAGE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type package_type: str
+
+        :param default_package_version:
+            The value to assign to the default_package_version property of this Listing.
+        :type default_package_version: str
+
+        :param links:
+            The value to assign to the links property of this Listing.
+        :type links: list[Link]
+
+        :param is_featured:
+            The value to assign to the is_featured property of this Listing.
+        :type is_featured: bool
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'name': 'str',
+            'version': 'str',
+            'tagline': 'str',
+            'keywords': 'str',
+            'short_description': 'str',
+            'usage_information': 'str',
+            'long_description': 'str',
+            'license_model_description': 'str',
+            'system_requirements': 'str',
+            'time_released': 'datetime',
+            'release_notes': 'str',
+            'categories': 'list[str]',
+            'publisher': 'Publisher',
+            'languages': 'list[Item]',
+            'screenshots': 'list[Screenshot]',
+            'videos': 'list[NamedLink]',
+            'support_contacts': 'list[SupportContact]',
+            'support_links': 'list[NamedLink]',
+            'documentation_links': 'list[DocumentationLink]',
+            'icon': 'UploadData',
+            'banner': 'UploadData',
+            'regions': 'list[Region]',
+            'package_type': 'str',
+            'default_package_version': 'str',
+            'links': 'list[Link]',
+            'is_featured': 'bool'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'name': 'name',
+            'version': 'version',
+            'tagline': 'tagline',
+            'keywords': 'keywords',
+            'short_description': 'shortDescription',
+            'usage_information': 'usageInformation',
+            'long_description': 'longDescription',
+            'license_model_description': 'licenseModelDescription',
+            'system_requirements': 'systemRequirements',
+            'time_released': 'timeReleased',
+            'release_notes': 'releaseNotes',
+            'categories': 'categories',
+            'publisher': 'publisher',
+            'languages': 'languages',
+            'screenshots': 'screenshots',
+            'videos': 'videos',
+            'support_contacts': 'supportContacts',
+            'support_links': 'supportLinks',
+            'documentation_links': 'documentationLinks',
+            'icon': 'icon',
+            'banner': 'banner',
+            'regions': 'regions',
+            'package_type': 'packageType',
+            'default_package_version': 'defaultPackageVersion',
+            'links': 'links',
+            'is_featured': 'isFeatured'
+        }
+
+        self._id = None
+        self._name = None
+        self._version = None
+        self._tagline = None
+        self._keywords = None
+        self._short_description = None
+        self._usage_information = None
+        self._long_description = None
+        self._license_model_description = None
+        self._system_requirements = None
+        self._time_released = None
+        self._release_notes = None
+        self._categories = None
+        self._publisher = None
+        self._languages = None
+        self._screenshots = None
+        self._videos = None
+        self._support_contacts = None
+        self._support_links = None
+        self._documentation_links = None
+        self._icon = None
+        self._banner = None
+        self._regions = None
+        self._package_type = None
+        self._default_package_version = None
+        self._links = None
+        self._is_featured = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this Listing.
+        The unique identifier for the listing in Marketplace.
+
+
+        :return: The id of this Listing.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this Listing.
+        The unique identifier for the listing in Marketplace.
+
+
+        :param id: The id of this Listing.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def name(self):
+        """
+        Gets the name of this Listing.
+        The name of the listing.
+
+
+        :return: The name of this Listing.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this Listing.
+        The name of the listing.
+
+
+        :param name: The name of this Listing.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def version(self):
+        """
+        Gets the version of this Listing.
+        The version of the listing.
+
+
+        :return: The version of this Listing.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this Listing.
+        The version of the listing.
+
+
+        :param version: The version of this Listing.
+        :type: str
+        """
+        self._version = version
+
+    @property
+    def tagline(self):
+        """
+        Gets the tagline of this Listing.
+        The tagline of the listing.
+
+
+        :return: The tagline of this Listing.
+        :rtype: str
+        """
+        return self._tagline
+
+    @tagline.setter
+    def tagline(self, tagline):
+        """
+        Sets the tagline of this Listing.
+        The tagline of the listing.
+
+
+        :param tagline: The tagline of this Listing.
+        :type: str
+        """
+        self._tagline = tagline
+
+    @property
+    def keywords(self):
+        """
+        Gets the keywords of this Listing.
+        Keywords associated with the listing.
+
+
+        :return: The keywords of this Listing.
+        :rtype: str
+        """
+        return self._keywords
+
+    @keywords.setter
+    def keywords(self, keywords):
+        """
+        Sets the keywords of this Listing.
+        Keywords associated with the listing.
+
+
+        :param keywords: The keywords of this Listing.
+        :type: str
+        """
+        self._keywords = keywords
+
+    @property
+    def short_description(self):
+        """
+        Gets the short_description of this Listing.
+        A short description of the listing.
+
+
+        :return: The short_description of this Listing.
+        :rtype: str
+        """
+        return self._short_description
+
+    @short_description.setter
+    def short_description(self, short_description):
+        """
+        Sets the short_description of this Listing.
+        A short description of the listing.
+
+
+        :param short_description: The short_description of this Listing.
+        :type: str
+        """
+        self._short_description = short_description
+
+    @property
+    def usage_information(self):
+        """
+        Gets the usage_information of this Listing.
+        Usage information for the listing.
+
+
+        :return: The usage_information of this Listing.
+        :rtype: str
+        """
+        return self._usage_information
+
+    @usage_information.setter
+    def usage_information(self, usage_information):
+        """
+        Sets the usage_information of this Listing.
+        Usage information for the listing.
+
+
+        :param usage_information: The usage_information of this Listing.
+        :type: str
+        """
+        self._usage_information = usage_information
+
+    @property
+    def long_description(self):
+        """
+        Gets the long_description of this Listing.
+        A long description of the listing.
+
+
+        :return: The long_description of this Listing.
+        :rtype: str
+        """
+        return self._long_description
+
+    @long_description.setter
+    def long_description(self, long_description):
+        """
+        Sets the long_description of this Listing.
+        A long description of the listing.
+
+
+        :param long_description: The long_description of this Listing.
+        :type: str
+        """
+        self._long_description = long_description
+
+    @property
+    def license_model_description(self):
+        """
+        Gets the license_model_description of this Listing.
+        A description of the publisher's licensing model for the listing.
+
+
+        :return: The license_model_description of this Listing.
+        :rtype: str
+        """
+        return self._license_model_description
+
+    @license_model_description.setter
+    def license_model_description(self, license_model_description):
+        """
+        Sets the license_model_description of this Listing.
+        A description of the publisher's licensing model for the listing.
+
+
+        :param license_model_description: The license_model_description of this Listing.
+        :type: str
+        """
+        self._license_model_description = license_model_description
+
+    @property
+    def system_requirements(self):
+        """
+        Gets the system_requirements of this Listing.
+        System requirements for the listing.
+
+
+        :return: The system_requirements of this Listing.
+        :rtype: str
+        """
+        return self._system_requirements
+
+    @system_requirements.setter
+    def system_requirements(self, system_requirements):
+        """
+        Sets the system_requirements of this Listing.
+        System requirements for the listing.
+
+
+        :param system_requirements: The system_requirements of this Listing.
+        :type: str
+        """
+        self._system_requirements = system_requirements
+
+    @property
+    def time_released(self):
+        """
+        Gets the time_released of this Listing.
+        The release date of the listing.
+
+
+        :return: The time_released of this Listing.
+        :rtype: datetime
+        """
+        return self._time_released
+
+    @time_released.setter
+    def time_released(self, time_released):
+        """
+        Sets the time_released of this Listing.
+        The release date of the listing.
+
+
+        :param time_released: The time_released of this Listing.
+        :type: datetime
+        """
+        self._time_released = time_released
+
+    @property
+    def release_notes(self):
+        """
+        Gets the release_notes of this Listing.
+        Release notes for the listing.
+
+
+        :return: The release_notes of this Listing.
+        :rtype: str
+        """
+        return self._release_notes
+
+    @release_notes.setter
+    def release_notes(self, release_notes):
+        """
+        Sets the release_notes of this Listing.
+        Release notes for the listing.
+
+
+        :param release_notes: The release_notes of this Listing.
+        :type: str
+        """
+        self._release_notes = release_notes
+
+    @property
+    def categories(self):
+        """
+        Gets the categories of this Listing.
+        Categories that the listing belongs to.
+
+
+        :return: The categories of this Listing.
+        :rtype: list[str]
+        """
+        return self._categories
+
+    @categories.setter
+    def categories(self, categories):
+        """
+        Sets the categories of this Listing.
+        Categories that the listing belongs to.
+
+
+        :param categories: The categories of this Listing.
+        :type: list[str]
+        """
+        self._categories = categories
+
+    @property
+    def publisher(self):
+        """
+        Gets the publisher of this Listing.
+
+        :return: The publisher of this Listing.
+        :rtype: Publisher
+        """
+        return self._publisher
+
+    @publisher.setter
+    def publisher(self, publisher):
+        """
+        Sets the publisher of this Listing.
+
+        :param publisher: The publisher of this Listing.
+        :type: Publisher
+        """
+        self._publisher = publisher
+
+    @property
+    def languages(self):
+        """
+        Gets the languages of this Listing.
+        Languages supported by the listing.
+
+
+        :return: The languages of this Listing.
+        :rtype: list[Item]
+        """
+        return self._languages
+
+    @languages.setter
+    def languages(self, languages):
+        """
+        Sets the languages of this Listing.
+        Languages supported by the listing.
+
+
+        :param languages: The languages of this Listing.
+        :type: list[Item]
+        """
+        self._languages = languages
+
+    @property
+    def screenshots(self):
+        """
+        Gets the screenshots of this Listing.
+        Screenshots of the listing.
+
+
+        :return: The screenshots of this Listing.
+        :rtype: list[Screenshot]
+        """
+        return self._screenshots
+
+    @screenshots.setter
+    def screenshots(self, screenshots):
+        """
+        Sets the screenshots of this Listing.
+        Screenshots of the listing.
+
+
+        :param screenshots: The screenshots of this Listing.
+        :type: list[Screenshot]
+        """
+        self._screenshots = screenshots
+
+    @property
+    def videos(self):
+        """
+        Gets the videos of this Listing.
+        Videos of the listing.
+
+
+        :return: The videos of this Listing.
+        :rtype: list[NamedLink]
+        """
+        return self._videos
+
+    @videos.setter
+    def videos(self, videos):
+        """
+        Sets the videos of this Listing.
+        Videos of the listing.
+
+
+        :param videos: The videos of this Listing.
+        :type: list[NamedLink]
+        """
+        self._videos = videos
+
+    @property
+    def support_contacts(self):
+        """
+        Gets the support_contacts of this Listing.
+        Contact information to use to get support from the publisher for the listing.
+
+
+        :return: The support_contacts of this Listing.
+        :rtype: list[SupportContact]
+        """
+        return self._support_contacts
+
+    @support_contacts.setter
+    def support_contacts(self, support_contacts):
+        """
+        Sets the support_contacts of this Listing.
+        Contact information to use to get support from the publisher for the listing.
+
+
+        :param support_contacts: The support_contacts of this Listing.
+        :type: list[SupportContact]
+        """
+        self._support_contacts = support_contacts
+
+    @property
+    def support_links(self):
+        """
+        Gets the support_links of this Listing.
+        Links to support resources for the listing.
+
+
+        :return: The support_links of this Listing.
+        :rtype: list[NamedLink]
+        """
+        return self._support_links
+
+    @support_links.setter
+    def support_links(self, support_links):
+        """
+        Sets the support_links of this Listing.
+        Links to support resources for the listing.
+
+
+        :param support_links: The support_links of this Listing.
+        :type: list[NamedLink]
+        """
+        self._support_links = support_links
+
+    @property
+    def documentation_links(self):
+        """
+        Gets the documentation_links of this Listing.
+        Links to additional documentation provided by the publisher specifically for the listing.
+
+
+        :return: The documentation_links of this Listing.
+        :rtype: list[DocumentationLink]
+        """
+        return self._documentation_links
+
+    @documentation_links.setter
+    def documentation_links(self, documentation_links):
+        """
+        Sets the documentation_links of this Listing.
+        Links to additional documentation provided by the publisher specifically for the listing.
+
+
+        :param documentation_links: The documentation_links of this Listing.
+        :type: list[DocumentationLink]
+        """
+        self._documentation_links = documentation_links
+
+    @property
+    def icon(self):
+        """
+        Gets the icon of this Listing.
+
+        :return: The icon of this Listing.
+        :rtype: UploadData
+        """
+        return self._icon
+
+    @icon.setter
+    def icon(self, icon):
+        """
+        Sets the icon of this Listing.
+
+        :param icon: The icon of this Listing.
+        :type: UploadData
+        """
+        self._icon = icon
+
+    @property
+    def banner(self):
+        """
+        Gets the banner of this Listing.
+
+        :return: The banner of this Listing.
+        :rtype: UploadData
+        """
+        return self._banner
+
+    @banner.setter
+    def banner(self, banner):
+        """
+        Sets the banner of this Listing.
+
+        :param banner: The banner of this Listing.
+        :type: UploadData
+        """
+        self._banner = banner
+
+    @property
+    def regions(self):
+        """
+        Gets the regions of this Listing.
+        The regions where the listing is available.
+
+
+        :return: The regions of this Listing.
+        :rtype: list[Region]
+        """
+        return self._regions
+
+    @regions.setter
+    def regions(self, regions):
+        """
+        Sets the regions of this Listing.
+        The regions where the listing is available.
+
+
+        :param regions: The regions of this Listing.
+        :type: list[Region]
+        """
+        self._regions = regions
+
+    @property
+    def package_type(self):
+        """
+        Gets the package_type of this Listing.
+        The listing's package type.
+
+        Allowed values for this property are: "ORCHESTRATION", "IMAGE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The package_type of this Listing.
+        :rtype: str
+        """
+        return self._package_type
+
+    @package_type.setter
+    def package_type(self, package_type):
+        """
+        Sets the package_type of this Listing.
+        The listing's package type.
+
+
+        :param package_type: The package_type of this Listing.
+        :type: str
+        """
+        allowed_values = ["ORCHESTRATION", "IMAGE"]
+        if not value_allowed_none_or_none_sentinel(package_type, allowed_values):
+            package_type = 'UNKNOWN_ENUM_VALUE'
+        self._package_type = package_type
+
+    @property
+    def default_package_version(self):
+        """
+        Gets the default_package_version of this Listing.
+        The default package version.
+
+
+        :return: The default_package_version of this Listing.
+        :rtype: str
+        """
+        return self._default_package_version
+
+    @default_package_version.setter
+    def default_package_version(self, default_package_version):
+        """
+        Sets the default_package_version of this Listing.
+        The default package version.
+
+
+        :param default_package_version: The default_package_version of this Listing.
+        :type: str
+        """
+        self._default_package_version = default_package_version
+
+    @property
+    def links(self):
+        """
+        Gets the links of this Listing.
+        Links to reference material.
+
+
+        :return: The links of this Listing.
+        :rtype: list[Link]
+        """
+        return self._links
+
+    @links.setter
+    def links(self, links):
+        """
+        Sets the links of this Listing.
+        Links to reference material.
+
+
+        :param links: The links of this Listing.
+        :type: list[Link]
+        """
+        self._links = links
+
+    @property
+    def is_featured(self):
+        """
+        Gets the is_featured of this Listing.
+        Indicates whether the listing is included in Featured Listings.
+
+
+        :return: The is_featured of this Listing.
+        :rtype: bool
+        """
+        return self._is_featured
+
+    @is_featured.setter
+    def is_featured(self, is_featured):
+        """
+        Sets the is_featured of this Listing.
+        Indicates whether the listing is included in Featured Listings.
+
+
+        :param is_featured: The is_featured of this Listing.
+        :type: bool
+        """
+        self._is_featured = is_featured
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/listing_package.py
+++ b/src/oci/marketplace/models/listing_package.py
@@ -1,0 +1,251 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ListingPackage(object):
+    """
+    A base object for all types of listing packages.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ListingPackage object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.marketplace.models.OrchestrationListingPackage`
+        * :class:`~oci.marketplace.models.ImageListingPackage`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param description:
+            The value to assign to the description property of this ListingPackage.
+        :type description: str
+
+        :param listing_id:
+            The value to assign to the listing_id property of this ListingPackage.
+        :type listing_id: str
+
+        :param version:
+            The value to assign to the version property of this ListingPackage.
+        :type version: str
+
+        :param pricing:
+            The value to assign to the pricing property of this ListingPackage.
+        :type pricing: PricingModel
+
+        :param resource_id:
+            The value to assign to the resource_id property of this ListingPackage.
+        :type resource_id: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ListingPackage.
+        :type time_created: datetime
+
+        """
+        self.swagger_types = {
+            'description': 'str',
+            'listing_id': 'str',
+            'version': 'str',
+            'pricing': 'PricingModel',
+            'resource_id': 'str',
+            'time_created': 'datetime'
+        }
+
+        self.attribute_map = {
+            'description': 'description',
+            'listing_id': 'listingId',
+            'version': 'version',
+            'pricing': 'pricing',
+            'resource_id': 'resourceId',
+            'time_created': 'timeCreated'
+        }
+
+        self._description = None
+        self._listing_id = None
+        self._version = None
+        self._pricing = None
+        self._resource_id = None
+        self._time_created = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['packageType']
+
+        if type == 'ORCHESTRATION':
+            return 'OrchestrationListingPackage'
+
+        if type == 'IMAGE':
+            return 'ImageListingPackage'
+        else:
+            return 'ListingPackage'
+
+    @property
+    def description(self):
+        """
+        Gets the description of this ListingPackage.
+        Description of this package.
+
+
+        :return: The description of this ListingPackage.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this ListingPackage.
+        Description of this package.
+
+
+        :param description: The description of this ListingPackage.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def listing_id(self):
+        """
+        **[Required]** Gets the listing_id of this ListingPackage.
+        The id of the listing this package belongs to.
+
+
+        :return: The listing_id of this ListingPackage.
+        :rtype: str
+        """
+        return self._listing_id
+
+    @listing_id.setter
+    def listing_id(self, listing_id):
+        """
+        Sets the listing_id of this ListingPackage.
+        The id of the listing this package belongs to.
+
+
+        :param listing_id: The listing_id of this ListingPackage.
+        :type: str
+        """
+        self._listing_id = listing_id
+
+    @property
+    def version(self):
+        """
+        **[Required]** Gets the version of this ListingPackage.
+        The version of this package.
+
+
+        :return: The version of this ListingPackage.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this ListingPackage.
+        The version of this package.
+
+
+        :param version: The version of this ListingPackage.
+        :type: str
+        """
+        self._version = version
+
+    @property
+    def pricing(self):
+        """
+        Gets the pricing of this ListingPackage.
+
+        :return: The pricing of this ListingPackage.
+        :rtype: PricingModel
+        """
+        return self._pricing
+
+    @pricing.setter
+    def pricing(self, pricing):
+        """
+        Sets the pricing of this ListingPackage.
+
+        :param pricing: The pricing of this ListingPackage.
+        :type: PricingModel
+        """
+        self._pricing = pricing
+
+    @property
+    def resource_id(self):
+        """
+        Gets the resource_id of this ListingPackage.
+        The unique identifier for the package resource.
+
+
+        :return: The resource_id of this ListingPackage.
+        :rtype: str
+        """
+        return self._resource_id
+
+    @resource_id.setter
+    def resource_id(self, resource_id):
+        """
+        Sets the resource_id of this ListingPackage.
+        The unique identifier for the package resource.
+
+
+        :param resource_id: The resource_id of this ListingPackage.
+        :type: str
+        """
+        self._resource_id = resource_id
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this ListingPackage.
+        The date and time this listing package was created, expressed in `RFC 3339`__
+        timestamp format.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this ListingPackage.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ListingPackage.
+        The date and time this listing package was created, expressed in `RFC 3339`__
+        timestamp format.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this ListingPackage.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/listing_package_summary.py
+++ b/src/oci/marketplace/models/listing_package_summary.py
@@ -1,0 +1,172 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ListingPackageSummary(object):
+    """
+    The model for a summary of a package.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ListingPackageSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param listing_id:
+            The value to assign to the listing_id property of this ListingPackageSummary.
+        :type listing_id: str
+
+        :param package_version:
+            The value to assign to the package_version property of this ListingPackageSummary.
+        :type package_version: str
+
+        :param resource_id:
+            The value to assign to the resource_id property of this ListingPackageSummary.
+        :type resource_id: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ListingPackageSummary.
+        :type time_created: datetime
+
+        """
+        self.swagger_types = {
+            'listing_id': 'str',
+            'package_version': 'str',
+            'resource_id': 'str',
+            'time_created': 'datetime'
+        }
+
+        self.attribute_map = {
+            'listing_id': 'listingId',
+            'package_version': 'packageVersion',
+            'resource_id': 'resourceId',
+            'time_created': 'timeCreated'
+        }
+
+        self._listing_id = None
+        self._package_version = None
+        self._resource_id = None
+        self._time_created = None
+
+    @property
+    def listing_id(self):
+        """
+        Gets the listing_id of this ListingPackageSummary.
+        The id of the listing the specified package belongs to.
+
+
+        :return: The listing_id of this ListingPackageSummary.
+        :rtype: str
+        """
+        return self._listing_id
+
+    @listing_id.setter
+    def listing_id(self, listing_id):
+        """
+        Sets the listing_id of this ListingPackageSummary.
+        The id of the listing the specified package belongs to.
+
+
+        :param listing_id: The listing_id of this ListingPackageSummary.
+        :type: str
+        """
+        self._listing_id = listing_id
+
+    @property
+    def package_version(self):
+        """
+        Gets the package_version of this ListingPackageSummary.
+        The version of the specified package.
+
+
+        :return: The package_version of this ListingPackageSummary.
+        :rtype: str
+        """
+        return self._package_version
+
+    @package_version.setter
+    def package_version(self, package_version):
+        """
+        Sets the package_version of this ListingPackageSummary.
+        The version of the specified package.
+
+
+        :param package_version: The package_version of this ListingPackageSummary.
+        :type: str
+        """
+        self._package_version = package_version
+
+    @property
+    def resource_id(self):
+        """
+        Gets the resource_id of this ListingPackageSummary.
+        The unique identifier for the package resource.
+
+
+        :return: The resource_id of this ListingPackageSummary.
+        :rtype: str
+        """
+        return self._resource_id
+
+    @resource_id.setter
+    def resource_id(self, resource_id):
+        """
+        Sets the resource_id of this ListingPackageSummary.
+        The unique identifier for the package resource.
+
+
+        :param resource_id: The resource_id of this ListingPackageSummary.
+        :type: str
+        """
+        self._resource_id = resource_id
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this ListingPackageSummary.
+        The date and time this listing package was created, expressed in `RFC 3339`__
+        timestamp format.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this ListingPackageSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ListingPackageSummary.
+        The date and time this listing package was created, expressed in `RFC 3339`__
+        timestamp format.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this ListingPackageSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/listing_summary.py
+++ b/src/oci/marketplace/models/listing_summary.py
@@ -1,0 +1,376 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ListingSummary(object):
+    """
+    The model for a summary of an Oracle Cloud Infrastructure Marketplace listing.
+    """
+
+    #: A constant which can be used with the package_type property of a ListingSummary.
+    #: This constant has a value of "ORCHESTRATION"
+    PACKAGE_TYPE_ORCHESTRATION = "ORCHESTRATION"
+
+    #: A constant which can be used with the package_type property of a ListingSummary.
+    #: This constant has a value of "IMAGE"
+    PACKAGE_TYPE_IMAGE = "IMAGE"
+
+    #: A constant which can be used with the pricing_types property of a ListingSummary.
+    #: This constant has a value of "FREE"
+    PRICING_TYPES_FREE = "FREE"
+
+    #: A constant which can be used with the pricing_types property of a ListingSummary.
+    #: This constant has a value of "BYOL"
+    PRICING_TYPES_BYOL = "BYOL"
+
+    #: A constant which can be used with the pricing_types property of a ListingSummary.
+    #: This constant has a value of "PAYGO"
+    PRICING_TYPES_PAYGO = "PAYGO"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ListingSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this ListingSummary.
+        :type id: str
+
+        :param name:
+            The value to assign to the name property of this ListingSummary.
+        :type name: str
+
+        :param short_description:
+            The value to assign to the short_description property of this ListingSummary.
+        :type short_description: str
+
+        :param tagline:
+            The value to assign to the tagline property of this ListingSummary.
+        :type tagline: str
+
+        :param icon:
+            The value to assign to the icon property of this ListingSummary.
+        :type icon: UploadData
+
+        :param package_type:
+            The value to assign to the package_type property of this ListingSummary.
+            Allowed values for this property are: "ORCHESTRATION", "IMAGE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type package_type: str
+
+        :param pricing_types:
+            The value to assign to the pricing_types property of this ListingSummary.
+            Allowed values for items in this list are: "FREE", "BYOL", "PAYGO", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type pricing_types: list[str]
+
+        :param is_featured:
+            The value to assign to the is_featured property of this ListingSummary.
+        :type is_featured: bool
+
+        :param categories:
+            The value to assign to the categories property of this ListingSummary.
+        :type categories: list[str]
+
+        :param publisher:
+            The value to assign to the publisher property of this ListingSummary.
+        :type publisher: PublisherSummary
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'name': 'str',
+            'short_description': 'str',
+            'tagline': 'str',
+            'icon': 'UploadData',
+            'package_type': 'str',
+            'pricing_types': 'list[str]',
+            'is_featured': 'bool',
+            'categories': 'list[str]',
+            'publisher': 'PublisherSummary'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'name': 'name',
+            'short_description': 'shortDescription',
+            'tagline': 'tagline',
+            'icon': 'icon',
+            'package_type': 'packageType',
+            'pricing_types': 'pricingTypes',
+            'is_featured': 'isFeatured',
+            'categories': 'categories',
+            'publisher': 'publisher'
+        }
+
+        self._id = None
+        self._name = None
+        self._short_description = None
+        self._tagline = None
+        self._icon = None
+        self._package_type = None
+        self._pricing_types = None
+        self._is_featured = None
+        self._categories = None
+        self._publisher = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this ListingSummary.
+        The unique identifier for the listing in Marketplace.
+
+
+        :return: The id of this ListingSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ListingSummary.
+        The unique identifier for the listing in Marketplace.
+
+
+        :param id: The id of this ListingSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def name(self):
+        """
+        Gets the name of this ListingSummary.
+        The name of the listing.
+
+
+        :return: The name of this ListingSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this ListingSummary.
+        The name of the listing.
+
+
+        :param name: The name of this ListingSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def short_description(self):
+        """
+        Gets the short_description of this ListingSummary.
+        A short description of the listing.
+
+
+        :return: The short_description of this ListingSummary.
+        :rtype: str
+        """
+        return self._short_description
+
+    @short_description.setter
+    def short_description(self, short_description):
+        """
+        Sets the short_description of this ListingSummary.
+        A short description of the listing.
+
+
+        :param short_description: The short_description of this ListingSummary.
+        :type: str
+        """
+        self._short_description = short_description
+
+    @property
+    def tagline(self):
+        """
+        Gets the tagline of this ListingSummary.
+        The tagline of the listing.
+
+
+        :return: The tagline of this ListingSummary.
+        :rtype: str
+        """
+        return self._tagline
+
+    @tagline.setter
+    def tagline(self, tagline):
+        """
+        Sets the tagline of this ListingSummary.
+        The tagline of the listing.
+
+
+        :param tagline: The tagline of this ListingSummary.
+        :type: str
+        """
+        self._tagline = tagline
+
+    @property
+    def icon(self):
+        """
+        Gets the icon of this ListingSummary.
+
+        :return: The icon of this ListingSummary.
+        :rtype: UploadData
+        """
+        return self._icon
+
+    @icon.setter
+    def icon(self, icon):
+        """
+        Sets the icon of this ListingSummary.
+
+        :param icon: The icon of this ListingSummary.
+        :type: UploadData
+        """
+        self._icon = icon
+
+    @property
+    def package_type(self):
+        """
+        Gets the package_type of this ListingSummary.
+        The listing's package type.
+
+        Allowed values for this property are: "ORCHESTRATION", "IMAGE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The package_type of this ListingSummary.
+        :rtype: str
+        """
+        return self._package_type
+
+    @package_type.setter
+    def package_type(self, package_type):
+        """
+        Sets the package_type of this ListingSummary.
+        The listing's package type.
+
+
+        :param package_type: The package_type of this ListingSummary.
+        :type: str
+        """
+        allowed_values = ["ORCHESTRATION", "IMAGE"]
+        if not value_allowed_none_or_none_sentinel(package_type, allowed_values):
+            package_type = 'UNKNOWN_ENUM_VALUE'
+        self._package_type = package_type
+
+    @property
+    def pricing_types(self):
+        """
+        Gets the pricing_types of this ListingSummary.
+        Summary of the pricing types available across all packages in the listing.
+
+        Allowed values for items in this list are: "FREE", "BYOL", "PAYGO", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The pricing_types of this ListingSummary.
+        :rtype: list[str]
+        """
+        return self._pricing_types
+
+    @pricing_types.setter
+    def pricing_types(self, pricing_types):
+        """
+        Sets the pricing_types of this ListingSummary.
+        Summary of the pricing types available across all packages in the listing.
+
+
+        :param pricing_types: The pricing_types of this ListingSummary.
+        :type: list[str]
+        """
+        allowed_values = ["FREE", "BYOL", "PAYGO"]
+        if pricing_types:
+            pricing_types[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in pricing_types]
+        self._pricing_types = pricing_types
+
+    @property
+    def is_featured(self):
+        """
+        Gets the is_featured of this ListingSummary.
+        Indicates whether the listing is featured.
+
+
+        :return: The is_featured of this ListingSummary.
+        :rtype: bool
+        """
+        return self._is_featured
+
+    @is_featured.setter
+    def is_featured(self, is_featured):
+        """
+        Sets the is_featured of this ListingSummary.
+        Indicates whether the listing is featured.
+
+
+        :param is_featured: The is_featured of this ListingSummary.
+        :type: bool
+        """
+        self._is_featured = is_featured
+
+    @property
+    def categories(self):
+        """
+        Gets the categories of this ListingSummary.
+        Product categories that the listing belongs to.
+
+
+        :return: The categories of this ListingSummary.
+        :rtype: list[str]
+        """
+        return self._categories
+
+    @categories.setter
+    def categories(self, categories):
+        """
+        Sets the categories of this ListingSummary.
+        Product categories that the listing belongs to.
+
+
+        :param categories: The categories of this ListingSummary.
+        :type: list[str]
+        """
+        self._categories = categories
+
+    @property
+    def publisher(self):
+        """
+        Gets the publisher of this ListingSummary.
+
+        :return: The publisher of this ListingSummary.
+        :rtype: PublisherSummary
+        """
+        return self._publisher
+
+    @publisher.setter
+    def publisher(self, publisher):
+        """
+        Sets the publisher of this ListingSummary.
+
+        :param publisher: The publisher of this ListingSummary.
+        :type: PublisherSummary
+        """
+        self._publisher = publisher
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/named_link.py
+++ b/src/oci/marketplace/models/named_link.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class NamedLink(object):
+    """
+    A link to a resource on the internet.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new NamedLink object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this NamedLink.
+        :type name: str
+
+        :param url:
+            The value to assign to the url property of this NamedLink.
+        :type url: str
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'url': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'url': 'url'
+        }
+
+        self._name = None
+        self._url = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this NamedLink.
+        Text that describes the resource.
+
+
+        :return: The name of this NamedLink.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this NamedLink.
+        Text that describes the resource.
+
+
+        :param name: The name of this NamedLink.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def url(self):
+        """
+        Gets the url of this NamedLink.
+        The URL of the resource.
+
+
+        :return: The url of this NamedLink.
+        :rtype: str
+        """
+        return self._url
+
+    @url.setter
+    def url(self, url):
+        """
+        Sets the url of this NamedLink.
+        The URL of the resource.
+
+
+        :param url: The url of this NamedLink.
+        :type: str
+        """
+        self._url = url
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/orchestration_listing_package.py
+++ b/src/oci/marketplace/models/orchestration_listing_package.py
@@ -1,0 +1,144 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from .listing_package import ListingPackage
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OrchestrationListingPackage(ListingPackage):
+    """
+    A listing package for orchestration.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OrchestrationListingPackage object with values from keyword arguments. The default value of the :py:attr:`~oci.marketplace.models.OrchestrationListingPackage.package_type` attribute
+        of this class is ``ORCHESTRATION`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param description:
+            The value to assign to the description property of this OrchestrationListingPackage.
+        :type description: str
+
+        :param listing_id:
+            The value to assign to the listing_id property of this OrchestrationListingPackage.
+        :type listing_id: str
+
+        :param version:
+            The value to assign to the version property of this OrchestrationListingPackage.
+        :type version: str
+
+        :param pricing:
+            The value to assign to the pricing property of this OrchestrationListingPackage.
+        :type pricing: PricingModel
+
+        :param resource_id:
+            The value to assign to the resource_id property of this OrchestrationListingPackage.
+        :type resource_id: str
+
+        :param time_created:
+            The value to assign to the time_created property of this OrchestrationListingPackage.
+        :type time_created: datetime
+
+        :param resource_link:
+            The value to assign to the resource_link property of this OrchestrationListingPackage.
+        :type resource_link: str
+
+        :param variables:
+            The value to assign to the variables property of this OrchestrationListingPackage.
+        :type variables: list[OrchestrationVariable]
+
+        """
+        self.swagger_types = {
+            'description': 'str',
+            'listing_id': 'str',
+            'version': 'str',
+            'pricing': 'PricingModel',
+            'resource_id': 'str',
+            'time_created': 'datetime',
+            'resource_link': 'str',
+            'variables': 'list[OrchestrationVariable]'
+        }
+
+        self.attribute_map = {
+            'description': 'description',
+            'listing_id': 'listingId',
+            'version': 'version',
+            'pricing': 'pricing',
+            'resource_id': 'resourceId',
+            'time_created': 'timeCreated',
+            'resource_link': 'resourceLink',
+            'variables': 'variables'
+        }
+
+        self._description = None
+        self._listing_id = None
+        self._version = None
+        self._pricing = None
+        self._resource_id = None
+        self._time_created = None
+        self._resource_link = None
+        self._variables = None
+        self._package_type = 'ORCHESTRATION'
+
+    @property
+    def resource_link(self):
+        """
+        Gets the resource_link of this OrchestrationListingPackage.
+        Link to the orchestration resource.
+
+
+        :return: The resource_link of this OrchestrationListingPackage.
+        :rtype: str
+        """
+        return self._resource_link
+
+    @resource_link.setter
+    def resource_link(self, resource_link):
+        """
+        Sets the resource_link of this OrchestrationListingPackage.
+        Link to the orchestration resource.
+
+
+        :param resource_link: The resource_link of this OrchestrationListingPackage.
+        :type: str
+        """
+        self._resource_link = resource_link
+
+    @property
+    def variables(self):
+        """
+        Gets the variables of this OrchestrationListingPackage.
+        List of variables for the orchestration resource.
+
+
+        :return: The variables of this OrchestrationListingPackage.
+        :rtype: list[OrchestrationVariable]
+        """
+        return self._variables
+
+    @variables.setter
+    def variables(self, variables):
+        """
+        Sets the variables of this OrchestrationListingPackage.
+        List of variables for the orchestration resource.
+
+
+        :param variables: The variables of this OrchestrationListingPackage.
+        :type: list[OrchestrationVariable]
+        """
+        self._variables = variables
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/orchestration_variable.py
+++ b/src/oci/marketplace/models/orchestration_variable.py
@@ -1,0 +1,193 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OrchestrationVariable(object):
+    """
+    The model of a variable for an orchestration resource.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OrchestrationVariable object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this OrchestrationVariable.
+        :type name: str
+
+        :param default_value:
+            The value to assign to the default_value property of this OrchestrationVariable.
+        :type default_value: str
+
+        :param description:
+            The value to assign to the description property of this OrchestrationVariable.
+        :type description: str
+
+        :param is_mandatory:
+            The value to assign to the is_mandatory property of this OrchestrationVariable.
+        :type is_mandatory: bool
+
+        :param hint_message:
+            The value to assign to the hint_message property of this OrchestrationVariable.
+        :type hint_message: str
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'default_value': 'str',
+            'description': 'str',
+            'is_mandatory': 'bool',
+            'hint_message': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'default_value': 'defaultValue',
+            'description': 'description',
+            'is_mandatory': 'isMandatory',
+            'hint_message': 'hintMessage'
+        }
+
+        self._name = None
+        self._default_value = None
+        self._description = None
+        self._is_mandatory = None
+        self._hint_message = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this OrchestrationVariable.
+        The name of the variable.
+
+
+        :return: The name of this OrchestrationVariable.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this OrchestrationVariable.
+        The name of the variable.
+
+
+        :param name: The name of this OrchestrationVariable.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def default_value(self):
+        """
+        Gets the default_value of this OrchestrationVariable.
+        The variable's default value.
+
+
+        :return: The default_value of this OrchestrationVariable.
+        :rtype: str
+        """
+        return self._default_value
+
+    @default_value.setter
+    def default_value(self, default_value):
+        """
+        Sets the default_value of this OrchestrationVariable.
+        The variable's default value.
+
+
+        :param default_value: The default_value of this OrchestrationVariable.
+        :type: str
+        """
+        self._default_value = default_value
+
+    @property
+    def description(self):
+        """
+        Gets the description of this OrchestrationVariable.
+        A description of the variable.
+
+
+        :return: The description of this OrchestrationVariable.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this OrchestrationVariable.
+        A description of the variable.
+
+
+        :param description: The description of this OrchestrationVariable.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def is_mandatory(self):
+        """
+        Gets the is_mandatory of this OrchestrationVariable.
+        Whether the variable is mandatory.
+
+
+        :return: The is_mandatory of this OrchestrationVariable.
+        :rtype: bool
+        """
+        return self._is_mandatory
+
+    @is_mandatory.setter
+    def is_mandatory(self, is_mandatory):
+        """
+        Sets the is_mandatory of this OrchestrationVariable.
+        Whether the variable is mandatory.
+
+
+        :param is_mandatory: The is_mandatory of this OrchestrationVariable.
+        :type: bool
+        """
+        self._is_mandatory = is_mandatory
+
+    @property
+    def hint_message(self):
+        """
+        Gets the hint_message of this OrchestrationVariable.
+        A brief textual description that helps to explain the variable.
+
+
+        :return: The hint_message of this OrchestrationVariable.
+        :rtype: str
+        """
+        return self._hint_message
+
+    @hint_message.setter
+    def hint_message(self, hint_message):
+        """
+        Sets the hint_message of this OrchestrationVariable.
+        A brief textual description that helps to explain the variable.
+
+
+        :param hint_message: The hint_message of this OrchestrationVariable.
+        :type: str
+        """
+        self._hint_message = hint_message
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/pricing_model.py
+++ b/src/oci/marketplace/models/pricing_model.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PricingModel(object):
+    """
+    The model for pricing.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PricingModel object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param rate:
+            The value to assign to the rate property of this PricingModel.
+        :type rate: float
+
+        """
+        self.swagger_types = {
+            'rate': 'float'
+        }
+
+        self.attribute_map = {
+            'rate': 'rate'
+        }
+
+        self._rate = None
+
+    @property
+    def rate(self):
+        """
+        Gets the rate of this PricingModel.
+        The pricing rate.
+
+
+        :return: The rate of this PricingModel.
+        :rtype: float
+        """
+        return self._rate
+
+    @rate.setter
+    def rate(self, rate):
+        """
+        Sets the rate of this PricingModel.
+        The pricing rate.
+
+
+        :param rate: The rate of this PricingModel.
+        :type: float
+        """
+        self._rate = rate
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/publisher.py
+++ b/src/oci/marketplace/models/publisher.py
@@ -1,0 +1,344 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Publisher(object):
+    """
+    The model for a publisher.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Publisher object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this Publisher.
+        :type id: str
+
+        :param name:
+            The value to assign to the name property of this Publisher.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this Publisher.
+        :type description: str
+
+        :param year_founded:
+            The value to assign to the year_founded property of this Publisher.
+        :type year_founded: int
+
+        :param website_url:
+            The value to assign to the website_url property of this Publisher.
+        :type website_url: str
+
+        :param contact_email:
+            The value to assign to the contact_email property of this Publisher.
+        :type contact_email: str
+
+        :param contact_phone:
+            The value to assign to the contact_phone property of this Publisher.
+        :type contact_phone: str
+
+        :param hq_address:
+            The value to assign to the hq_address property of this Publisher.
+        :type hq_address: str
+
+        :param logo:
+            The value to assign to the logo property of this Publisher.
+        :type logo: UploadData
+
+        :param links:
+            The value to assign to the links property of this Publisher.
+        :type links: list[Link]
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'name': 'str',
+            'description': 'str',
+            'year_founded': 'int',
+            'website_url': 'str',
+            'contact_email': 'str',
+            'contact_phone': 'str',
+            'hq_address': 'str',
+            'logo': 'UploadData',
+            'links': 'list[Link]'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'name': 'name',
+            'description': 'description',
+            'year_founded': 'yearFounded',
+            'website_url': 'websiteUrl',
+            'contact_email': 'contactEmail',
+            'contact_phone': 'contactPhone',
+            'hq_address': 'hqAddress',
+            'logo': 'logo',
+            'links': 'links'
+        }
+
+        self._id = None
+        self._name = None
+        self._description = None
+        self._year_founded = None
+        self._website_url = None
+        self._contact_email = None
+        self._contact_phone = None
+        self._hq_address = None
+        self._logo = None
+        self._links = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this Publisher.
+        Unique identifier for the publisher.
+
+
+        :return: The id of this Publisher.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this Publisher.
+        Unique identifier for the publisher.
+
+
+        :param id: The id of this Publisher.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def name(self):
+        """
+        Gets the name of this Publisher.
+        The name of the publisher.
+
+
+        :return: The name of this Publisher.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this Publisher.
+        The name of the publisher.
+
+
+        :param name: The name of this Publisher.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this Publisher.
+        A description of the publisher.
+
+
+        :return: The description of this Publisher.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this Publisher.
+        A description of the publisher.
+
+
+        :param description: The description of this Publisher.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def year_founded(self):
+        """
+        Gets the year_founded of this Publisher.
+        The year the publisher's company or organization was founded.
+
+
+        :return: The year_founded of this Publisher.
+        :rtype: int
+        """
+        return self._year_founded
+
+    @year_founded.setter
+    def year_founded(self, year_founded):
+        """
+        Sets the year_founded of this Publisher.
+        The year the publisher's company or organization was founded.
+
+
+        :param year_founded: The year_founded of this Publisher.
+        :type: int
+        """
+        self._year_founded = year_founded
+
+    @property
+    def website_url(self):
+        """
+        Gets the website_url of this Publisher.
+        The publisher's website.
+
+
+        :return: The website_url of this Publisher.
+        :rtype: str
+        """
+        return self._website_url
+
+    @website_url.setter
+    def website_url(self, website_url):
+        """
+        Sets the website_url of this Publisher.
+        The publisher's website.
+
+
+        :param website_url: The website_url of this Publisher.
+        :type: str
+        """
+        self._website_url = website_url
+
+    @property
+    def contact_email(self):
+        """
+        Gets the contact_email of this Publisher.
+        The email address of the publisher.
+
+
+        :return: The contact_email of this Publisher.
+        :rtype: str
+        """
+        return self._contact_email
+
+    @contact_email.setter
+    def contact_email(self, contact_email):
+        """
+        Sets the contact_email of this Publisher.
+        The email address of the publisher.
+
+
+        :param contact_email: The contact_email of this Publisher.
+        :type: str
+        """
+        self._contact_email = contact_email
+
+    @property
+    def contact_phone(self):
+        """
+        Gets the contact_phone of this Publisher.
+        The phone number of the publisher.
+
+
+        :return: The contact_phone of this Publisher.
+        :rtype: str
+        """
+        return self._contact_phone
+
+    @contact_phone.setter
+    def contact_phone(self, contact_phone):
+        """
+        Sets the contact_phone of this Publisher.
+        The phone number of the publisher.
+
+
+        :param contact_phone: The contact_phone of this Publisher.
+        :type: str
+        """
+        self._contact_phone = contact_phone
+
+    @property
+    def hq_address(self):
+        """
+        Gets the hq_address of this Publisher.
+        The address of the publisher's headquarters.
+
+
+        :return: The hq_address of this Publisher.
+        :rtype: str
+        """
+        return self._hq_address
+
+    @hq_address.setter
+    def hq_address(self, hq_address):
+        """
+        Sets the hq_address of this Publisher.
+        The address of the publisher's headquarters.
+
+
+        :param hq_address: The hq_address of this Publisher.
+        :type: str
+        """
+        self._hq_address = hq_address
+
+    @property
+    def logo(self):
+        """
+        Gets the logo of this Publisher.
+
+        :return: The logo of this Publisher.
+        :rtype: UploadData
+        """
+        return self._logo
+
+    @logo.setter
+    def logo(self, logo):
+        """
+        Sets the logo of this Publisher.
+
+        :param logo: The logo of this Publisher.
+        :type: UploadData
+        """
+        self._logo = logo
+
+    @property
+    def links(self):
+        """
+        Gets the links of this Publisher.
+        Reference links.
+
+
+        :return: The links of this Publisher.
+        :rtype: list[Link]
+        """
+        return self._links
+
+    @links.setter
+    def links(self, links):
+        """
+        Sets the links of this Publisher.
+        Reference links.
+
+
+        :param links: The links of this Publisher.
+        :type: list[Link]
+        """
+        self._links = links
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/publisher_summary.py
+++ b/src/oci/marketplace/models/publisher_summary.py
@@ -1,0 +1,131 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PublisherSummary(object):
+    """
+    Summary details about the publisher of the listing.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PublisherSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this PublisherSummary.
+        :type id: str
+
+        :param name:
+            The value to assign to the name property of this PublisherSummary.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this PublisherSummary.
+        :type description: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'name': 'str',
+            'description': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'name': 'name',
+            'description': 'description'
+        }
+
+        self._id = None
+        self._name = None
+        self._description = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this PublisherSummary.
+        Unique identifier for the publisher.
+
+
+        :return: The id of this PublisherSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this PublisherSummary.
+        Unique identifier for the publisher.
+
+
+        :param id: The id of this PublisherSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def name(self):
+        """
+        Gets the name of this PublisherSummary.
+        The name of the publisher.
+
+
+        :return: The name of this PublisherSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this PublisherSummary.
+        The name of the publisher.
+
+
+        :param name: The name of this PublisherSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this PublisherSummary.
+        A description of the publisher.
+
+
+        :return: The description of this PublisherSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this PublisherSummary.
+        A description of the publisher.
+
+
+        :param description: The description of this PublisherSummary.
+        :type: str
+        """
+        self._description = description
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/region.py
+++ b/src/oci/marketplace/models/region.py
@@ -1,0 +1,131 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Region(object):
+    """
+    The model for regions supported by a listing.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Region object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this Region.
+        :type name: str
+
+        :param code:
+            The value to assign to the code property of this Region.
+        :type code: str
+
+        :param countries:
+            The value to assign to the countries property of this Region.
+        :type countries: list[Item]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'code': 'str',
+            'countries': 'list[Item]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'code': 'code',
+            'countries': 'countries'
+        }
+
+        self._name = None
+        self._code = None
+        self._countries = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this Region.
+        The name of the region.
+
+
+        :return: The name of this Region.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this Region.
+        The name of the region.
+
+
+        :param name: The name of this Region.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def code(self):
+        """
+        Gets the code of this Region.
+        The code of the region.
+
+
+        :return: The code of this Region.
+        :rtype: str
+        """
+        return self._code
+
+    @code.setter
+    def code(self, code):
+        """
+        Sets the code of this Region.
+        The code of the region.
+
+
+        :param code: The code of this Region.
+        :type: str
+        """
+        self._code = code
+
+    @property
+    def countries(self):
+        """
+        Gets the countries of this Region.
+        Countries in the region.
+
+
+        :return: The countries of this Region.
+        :rtype: list[Item]
+        """
+        return self._countries
+
+    @countries.setter
+    def countries(self, countries):
+        """
+        Sets the countries of this Region.
+        Countries in the region.
+
+
+        :param countries: The countries of this Region.
+        :type: list[Item]
+        """
+        self._countries = countries
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/screenshot.py
+++ b/src/oci/marketplace/models/screenshot.py
@@ -1,0 +1,193 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Screenshot(object):
+    """
+    The model for a listing's screenshot.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Screenshot object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this Screenshot.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this Screenshot.
+        :type description: str
+
+        :param content_url:
+            The value to assign to the content_url property of this Screenshot.
+        :type content_url: str
+
+        :param mime_type:
+            The value to assign to the mime_type property of this Screenshot.
+        :type mime_type: str
+
+        :param file_extension:
+            The value to assign to the file_extension property of this Screenshot.
+        :type file_extension: str
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'description': 'str',
+            'content_url': 'str',
+            'mime_type': 'str',
+            'file_extension': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'description': 'description',
+            'content_url': 'contentUrl',
+            'mime_type': 'mimeType',
+            'file_extension': 'fileExtension'
+        }
+
+        self._name = None
+        self._description = None
+        self._content_url = None
+        self._mime_type = None
+        self._file_extension = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this Screenshot.
+        The name of the screenshot.
+
+
+        :return: The name of this Screenshot.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this Screenshot.
+        The name of the screenshot.
+
+
+        :param name: The name of this Screenshot.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this Screenshot.
+        A description of the screenshot.
+
+
+        :return: The description of this Screenshot.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this Screenshot.
+        A description of the screenshot.
+
+
+        :param description: The description of this Screenshot.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def content_url(self):
+        """
+        Gets the content_url of this Screenshot.
+        The content URL of the screenshot.
+
+
+        :return: The content_url of this Screenshot.
+        :rtype: str
+        """
+        return self._content_url
+
+    @content_url.setter
+    def content_url(self, content_url):
+        """
+        Sets the content_url of this Screenshot.
+        The content URL of the screenshot.
+
+
+        :param content_url: The content_url of this Screenshot.
+        :type: str
+        """
+        self._content_url = content_url
+
+    @property
+    def mime_type(self):
+        """
+        Gets the mime_type of this Screenshot.
+        The MIME type of the screenshot.
+
+
+        :return: The mime_type of this Screenshot.
+        :rtype: str
+        """
+        return self._mime_type
+
+    @mime_type.setter
+    def mime_type(self, mime_type):
+        """
+        Sets the mime_type of this Screenshot.
+        The MIME type of the screenshot.
+
+
+        :param mime_type: The mime_type of this Screenshot.
+        :type: str
+        """
+        self._mime_type = mime_type
+
+    @property
+    def file_extension(self):
+        """
+        Gets the file_extension of this Screenshot.
+        The file extension of the screenshot.
+
+
+        :return: The file_extension of this Screenshot.
+        :rtype: str
+        """
+        return self._file_extension
+
+    @file_extension.setter
+    def file_extension(self, file_extension):
+        """
+        Sets the file_extension of this Screenshot.
+        The file extension of the screenshot.
+
+
+        :param file_extension: The file_extension of this Screenshot.
+        :type: str
+        """
+        self._file_extension = file_extension
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/support_contact.py
+++ b/src/oci/marketplace/models/support_contact.py
@@ -1,0 +1,162 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SupportContact(object):
+    """
+    Contact information to use to get support.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SupportContact object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this SupportContact.
+        :type name: str
+
+        :param phone:
+            The value to assign to the phone property of this SupportContact.
+        :type phone: str
+
+        :param email:
+            The value to assign to the email property of this SupportContact.
+        :type email: str
+
+        :param subject:
+            The value to assign to the subject property of this SupportContact.
+        :type subject: str
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'phone': 'str',
+            'email': 'str',
+            'subject': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'phone': 'phone',
+            'email': 'email',
+            'subject': 'subject'
+        }
+
+        self._name = None
+        self._phone = None
+        self._email = None
+        self._subject = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this SupportContact.
+        The name of the contact.
+
+
+        :return: The name of this SupportContact.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this SupportContact.
+        The name of the contact.
+
+
+        :param name: The name of this SupportContact.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def phone(self):
+        """
+        Gets the phone of this SupportContact.
+        The phone number of the contact.
+
+
+        :return: The phone of this SupportContact.
+        :rtype: str
+        """
+        return self._phone
+
+    @phone.setter
+    def phone(self, phone):
+        """
+        Sets the phone of this SupportContact.
+        The phone number of the contact.
+
+
+        :param phone: The phone of this SupportContact.
+        :type: str
+        """
+        self._phone = phone
+
+    @property
+    def email(self):
+        """
+        Gets the email of this SupportContact.
+        The email of the contact.
+
+
+        :return: The email of this SupportContact.
+        :rtype: str
+        """
+        return self._email
+
+    @email.setter
+    def email(self, email):
+        """
+        Sets the email of this SupportContact.
+        The email of the contact.
+
+
+        :param email: The email of this SupportContact.
+        :type: str
+        """
+        self._email = email
+
+    @property
+    def subject(self):
+        """
+        Gets the subject of this SupportContact.
+        The email subject line to use when contacting support.
+
+
+        :return: The subject of this SupportContact.
+        :rtype: str
+        """
+        return self._subject
+
+    @subject.setter
+    def subject(self, subject):
+        """
+        Sets the subject of this SupportContact.
+        The email subject line to use when contacting support.
+
+
+        :param subject: The subject of this SupportContact.
+        :type: str
+        """
+        self._subject = subject
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/update_accepted_agreement_details.py
+++ b/src/oci/marketplace/models/update_accepted_agreement_details.py
@@ -1,0 +1,153 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateAcceptedAgreementDetails(object):
+    """
+    The model for the parameters needed to update an accepted terms of use agreement.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateAcceptedAgreementDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateAcceptedAgreementDetails.
+        :type display_name: str
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateAcceptedAgreementDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateAcceptedAgreementDetails.
+        :type freeform_tags: dict(str, str)
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'freeform_tags': 'dict(str, str)'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'defined_tags': 'definedTags',
+            'freeform_tags': 'freeformTags'
+        }
+
+        self._display_name = None
+        self._defined_tags = None
+        self._freeform_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateAcceptedAgreementDetails.
+        A display name for the accepted agreement.
+
+
+        :return: The display_name of this UpdateAcceptedAgreementDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateAcceptedAgreementDetails.
+        A display name for the accepted agreement.
+
+
+        :param display_name: The display_name of this UpdateAcceptedAgreementDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateAcceptedAgreementDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateAcceptedAgreementDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateAcceptedAgreementDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateAcceptedAgreementDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateAcceptedAgreementDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateAcceptedAgreementDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateAcceptedAgreementDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see
+        `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateAcceptedAgreementDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/marketplace/models/upload_data.py
+++ b/src/oci/marketplace/models/upload_data.py
@@ -1,0 +1,162 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UploadData(object):
+    """
+    The model for upload data for images and icons.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UploadData object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this UploadData.
+        :type name: str
+
+        :param content_url:
+            The value to assign to the content_url property of this UploadData.
+        :type content_url: str
+
+        :param mime_type:
+            The value to assign to the mime_type property of this UploadData.
+        :type mime_type: str
+
+        :param file_extension:
+            The value to assign to the file_extension property of this UploadData.
+        :type file_extension: str
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'content_url': 'str',
+            'mime_type': 'str',
+            'file_extension': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'content_url': 'contentUrl',
+            'mime_type': 'mimeType',
+            'file_extension': 'fileExtension'
+        }
+
+        self._name = None
+        self._content_url = None
+        self._mime_type = None
+        self._file_extension = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this UploadData.
+        The name used to refer to the upload data.
+
+
+        :return: The name of this UploadData.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this UploadData.
+        The name used to refer to the upload data.
+
+
+        :param name: The name of this UploadData.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def content_url(self):
+        """
+        Gets the content_url of this UploadData.
+        The content URL of the upload data.
+
+
+        :return: The content_url of this UploadData.
+        :rtype: str
+        """
+        return self._content_url
+
+    @content_url.setter
+    def content_url(self, content_url):
+        """
+        Sets the content_url of this UploadData.
+        The content URL of the upload data.
+
+
+        :param content_url: The content_url of this UploadData.
+        :type: str
+        """
+        self._content_url = content_url
+
+    @property
+    def mime_type(self):
+        """
+        Gets the mime_type of this UploadData.
+        The MIME type of the upload data.
+
+
+        :return: The mime_type of this UploadData.
+        :rtype: str
+        """
+        return self._mime_type
+
+    @mime_type.setter
+    def mime_type(self, mime_type):
+        """
+        Sets the mime_type of this UploadData.
+        The MIME type of the upload data.
+
+
+        :param mime_type: The mime_type of this UploadData.
+        :type: str
+        """
+        self._mime_type = mime_type
+
+    @property
+    def file_extension(self):
+        """
+        Gets the file_extension of this UploadData.
+        The file extension of the upload data.
+
+
+        :return: The file_extension of this UploadData.
+        :rtype: str
+        """
+        return self._file_extension
+
+    @file_extension.setter
+    def file_extension(self, file_extension):
+        """
+        Sets the file_extension of this UploadData.
+        The file extension of the upload data.
+
+
+        :param file_extension: The file_extension of this UploadData.
+        :type: str
+        """
+        self._file_extension = file_extension
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/__init__.py
+++ b/src/oci/os_management/__init__.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+
+from .os_management_client import OsManagementClient
+from .os_management_client_composite_operations import OsManagementClientCompositeOperations
+from . import models
+
+__all__ = ["OsManagementClient", "OsManagementClientCompositeOperations", "models"]

--- a/src/oci/os_management/models/__init__.py
+++ b/src/oci/os_management/models/__init__.py
@@ -1,0 +1,103 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from .add_packages_to_software_source_details import AddPackagesToSoftwareSourceDetails
+from .api_error import ApiError
+from .attach_child_software_source_to_managed_instance_details import AttachChildSoftwareSourceToManagedInstanceDetails
+from .attach_parent_software_source_to_managed_instance_details import AttachParentSoftwareSourceToManagedInstanceDetails
+from .available_software_source_summary import AvailableSoftwareSourceSummary
+from .available_update_summary import AvailableUpdateSummary
+from .change_managed_instance_group_compartment_details import ChangeManagedInstanceGroupCompartmentDetails
+from .change_scheduled_job_compartment_details import ChangeScheduledJobCompartmentDetails
+from .change_software_source_compartment_details import ChangeSoftwareSourceCompartmentDetails
+from .create_managed_instance_group_details import CreateManagedInstanceGroupDetails
+from .create_scheduled_job_details import CreateScheduledJobDetails
+from .create_software_source_details import CreateSoftwareSourceDetails
+from .detach_child_software_source_from_managed_instance_details import DetachChildSoftwareSourceFromManagedInstanceDetails
+from .detach_parent_software_source_from_managed_instance_details import DetachParentSoftwareSourceFromManagedInstanceDetails
+from .errata_id import ErrataId
+from .erratum import Erratum
+from .erratum_summary import ErratumSummary
+from .id import Id
+from .installable_package_summary import InstallablePackageSummary
+from .installed_package_summary import InstalledPackageSummary
+from .managed_instance import ManagedInstance
+from .managed_instance_group import ManagedInstanceGroup
+from .managed_instance_group_summary import ManagedInstanceGroupSummary
+from .managed_instance_summary import ManagedInstanceSummary
+from .managed_instance_update_details import ManagedInstanceUpdateDetails
+from .package_name import PackageName
+from .recurrence import Recurrence
+from .remove_packages_from_software_source_details import RemovePackagesFromSoftwareSourceDetails
+from .scheduled_job import ScheduledJob
+from .scheduled_job_summary import ScheduledJobSummary
+from .software_package import SoftwarePackage
+from .software_package_dependency import SoftwarePackageDependency
+from .software_package_file import SoftwarePackageFile
+from .software_package_search_summary import SoftwarePackageSearchSummary
+from .software_package_summary import SoftwarePackageSummary
+from .software_source import SoftwareSource
+from .software_source_id import SoftwareSourceId
+from .software_source_summary import SoftwareSourceSummary
+from .updatable_package_summary import UpdatablePackageSummary
+from .update_managed_instance_group_details import UpdateManagedInstanceGroupDetails
+from .update_scheduled_job_details import UpdateScheduledJobDetails
+from .update_software_source_details import UpdateSoftwareSourceDetails
+from .work_request import WorkRequest
+from .work_request_error import WorkRequestError
+from .work_request_log_entry import WorkRequestLogEntry
+from .work_request_resource import WorkRequestResource
+from .work_request_summary import WorkRequestSummary
+
+# Maps type names to classes for os_management services.
+os_management_type_mapping = {
+    "AddPackagesToSoftwareSourceDetails": AddPackagesToSoftwareSourceDetails,
+    "ApiError": ApiError,
+    "AttachChildSoftwareSourceToManagedInstanceDetails": AttachChildSoftwareSourceToManagedInstanceDetails,
+    "AttachParentSoftwareSourceToManagedInstanceDetails": AttachParentSoftwareSourceToManagedInstanceDetails,
+    "AvailableSoftwareSourceSummary": AvailableSoftwareSourceSummary,
+    "AvailableUpdateSummary": AvailableUpdateSummary,
+    "ChangeManagedInstanceGroupCompartmentDetails": ChangeManagedInstanceGroupCompartmentDetails,
+    "ChangeScheduledJobCompartmentDetails": ChangeScheduledJobCompartmentDetails,
+    "ChangeSoftwareSourceCompartmentDetails": ChangeSoftwareSourceCompartmentDetails,
+    "CreateManagedInstanceGroupDetails": CreateManagedInstanceGroupDetails,
+    "CreateScheduledJobDetails": CreateScheduledJobDetails,
+    "CreateSoftwareSourceDetails": CreateSoftwareSourceDetails,
+    "DetachChildSoftwareSourceFromManagedInstanceDetails": DetachChildSoftwareSourceFromManagedInstanceDetails,
+    "DetachParentSoftwareSourceFromManagedInstanceDetails": DetachParentSoftwareSourceFromManagedInstanceDetails,
+    "ErrataId": ErrataId,
+    "Erratum": Erratum,
+    "ErratumSummary": ErratumSummary,
+    "Id": Id,
+    "InstallablePackageSummary": InstallablePackageSummary,
+    "InstalledPackageSummary": InstalledPackageSummary,
+    "ManagedInstance": ManagedInstance,
+    "ManagedInstanceGroup": ManagedInstanceGroup,
+    "ManagedInstanceGroupSummary": ManagedInstanceGroupSummary,
+    "ManagedInstanceSummary": ManagedInstanceSummary,
+    "ManagedInstanceUpdateDetails": ManagedInstanceUpdateDetails,
+    "PackageName": PackageName,
+    "Recurrence": Recurrence,
+    "RemovePackagesFromSoftwareSourceDetails": RemovePackagesFromSoftwareSourceDetails,
+    "ScheduledJob": ScheduledJob,
+    "ScheduledJobSummary": ScheduledJobSummary,
+    "SoftwarePackage": SoftwarePackage,
+    "SoftwarePackageDependency": SoftwarePackageDependency,
+    "SoftwarePackageFile": SoftwarePackageFile,
+    "SoftwarePackageSearchSummary": SoftwarePackageSearchSummary,
+    "SoftwarePackageSummary": SoftwarePackageSummary,
+    "SoftwareSource": SoftwareSource,
+    "SoftwareSourceId": SoftwareSourceId,
+    "SoftwareSourceSummary": SoftwareSourceSummary,
+    "UpdatablePackageSummary": UpdatablePackageSummary,
+    "UpdateManagedInstanceGroupDetails": UpdateManagedInstanceGroupDetails,
+    "UpdateScheduledJobDetails": UpdateScheduledJobDetails,
+    "UpdateSoftwareSourceDetails": UpdateSoftwareSourceDetails,
+    "WorkRequest": WorkRequest,
+    "WorkRequestError": WorkRequestError,
+    "WorkRequestLogEntry": WorkRequestLogEntry,
+    "WorkRequestResource": WorkRequestResource,
+    "WorkRequestSummary": WorkRequestSummary
+}

--- a/src/oci/os_management/models/add_packages_to_software_source_details.py
+++ b/src/oci/os_management/models/add_packages_to_software_source_details.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AddPackagesToSoftwareSourceDetails(object):
+    """
+    List of software package names
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AddPackagesToSoftwareSourceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param package_names:
+            The value to assign to the package_names property of this AddPackagesToSoftwareSourceDetails.
+        :type package_names: list[str]
+
+        """
+        self.swagger_types = {
+            'package_names': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'package_names': 'packageNames'
+        }
+
+        self._package_names = None
+
+    @property
+    def package_names(self):
+        """
+        **[Required]** Gets the package_names of this AddPackagesToSoftwareSourceDetails.
+        the list of package names
+
+
+        :return: The package_names of this AddPackagesToSoftwareSourceDetails.
+        :rtype: list[str]
+        """
+        return self._package_names
+
+    @package_names.setter
+    def package_names(self, package_names):
+        """
+        Sets the package_names of this AddPackagesToSoftwareSourceDetails.
+        the list of package names
+
+
+        :param package_names: The package_names of this AddPackagesToSoftwareSourceDetails.
+        :type: list[str]
+        """
+        self._package_names = package_names
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/api_error.py
+++ b/src/oci/os_management/models/api_error.py
@@ -1,0 +1,102 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ApiError(object):
+    """
+    Error Information
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ApiError object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param code:
+            The value to assign to the code property of this ApiError.
+        :type code: str
+
+        :param message:
+            The value to assign to the message property of this ApiError.
+        :type message: str
+
+        """
+        self.swagger_types = {
+            'code': 'str',
+            'message': 'str'
+        }
+
+        self.attribute_map = {
+            'code': 'code',
+            'message': 'message'
+        }
+
+        self._code = None
+        self._message = None
+
+    @property
+    def code(self):
+        """
+        **[Required]** Gets the code of this ApiError.
+        A short error code that defines the error, meant for programmatic
+        parsing.
+
+
+        :return: The code of this ApiError.
+        :rtype: str
+        """
+        return self._code
+
+    @code.setter
+    def code(self, code):
+        """
+        Sets the code of this ApiError.
+        A short error code that defines the error, meant for programmatic
+        parsing.
+
+
+        :param code: The code of this ApiError.
+        :type: str
+        """
+        self._code = code
+
+    @property
+    def message(self):
+        """
+        **[Required]** Gets the message of this ApiError.
+        A human-readable error string.
+
+
+        :return: The message of this ApiError.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this ApiError.
+        A human-readable error string.
+
+
+        :param message: The message of this ApiError.
+        :type: str
+        """
+        self._message = message
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/attach_child_software_source_to_managed_instance_details.py
+++ b/src/oci/os_management/models/attach_child_software_source_to_managed_instance_details.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AttachChildSoftwareSourceToManagedInstanceDetails(object):
+    """
+    Information for attaching a software source to a managed instance
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AttachChildSoftwareSourceToManagedInstanceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param software_source_id:
+            The value to assign to the software_source_id property of this AttachChildSoftwareSourceToManagedInstanceDetails.
+        :type software_source_id: str
+
+        """
+        self.swagger_types = {
+            'software_source_id': 'str'
+        }
+
+        self.attribute_map = {
+            'software_source_id': 'softwareSourceId'
+        }
+
+        self._software_source_id = None
+
+    @property
+    def software_source_id(self):
+        """
+        **[Required]** Gets the software_source_id of this AttachChildSoftwareSourceToManagedInstanceDetails.
+        OCID for the Software Source
+
+
+        :return: The software_source_id of this AttachChildSoftwareSourceToManagedInstanceDetails.
+        :rtype: str
+        """
+        return self._software_source_id
+
+    @software_source_id.setter
+    def software_source_id(self, software_source_id):
+        """
+        Sets the software_source_id of this AttachChildSoftwareSourceToManagedInstanceDetails.
+        OCID for the Software Source
+
+
+        :param software_source_id: The software_source_id of this AttachChildSoftwareSourceToManagedInstanceDetails.
+        :type: str
+        """
+        self._software_source_id = software_source_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/attach_parent_software_source_to_managed_instance_details.py
+++ b/src/oci/os_management/models/attach_parent_software_source_to_managed_instance_details.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AttachParentSoftwareSourceToManagedInstanceDetails(object):
+    """
+    Information for attaching a software source to a managed instance
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AttachParentSoftwareSourceToManagedInstanceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param software_source_id:
+            The value to assign to the software_source_id property of this AttachParentSoftwareSourceToManagedInstanceDetails.
+        :type software_source_id: str
+
+        """
+        self.swagger_types = {
+            'software_source_id': 'str'
+        }
+
+        self.attribute_map = {
+            'software_source_id': 'softwareSourceId'
+        }
+
+        self._software_source_id = None
+
+    @property
+    def software_source_id(self):
+        """
+        **[Required]** Gets the software_source_id of this AttachParentSoftwareSourceToManagedInstanceDetails.
+        OCID for the Software Source
+
+
+        :return: The software_source_id of this AttachParentSoftwareSourceToManagedInstanceDetails.
+        :rtype: str
+        """
+        return self._software_source_id
+
+    @software_source_id.setter
+    def software_source_id(self, software_source_id):
+        """
+        Sets the software_source_id of this AttachParentSoftwareSourceToManagedInstanceDetails.
+        OCID for the Software Source
+
+
+        :param software_source_id: The software_source_id of this AttachParentSoftwareSourceToManagedInstanceDetails.
+        :type: str
+        """
+        self._software_source_id = software_source_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/available_software_source_summary.py
+++ b/src/oci/os_management/models/available_software_source_summary.py
@@ -1,0 +1,193 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AvailableSoftwareSourceSummary(object):
+    """
+    A software source which can be added to a managed instance. Once a software source is added, packages from that software source can be installed on that managed instance.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AvailableSoftwareSourceSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this AvailableSoftwareSourceSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this AvailableSoftwareSourceSummary.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this AvailableSoftwareSourceSummary.
+        :type display_name: str
+
+        :param parent_id:
+            The value to assign to the parent_id property of this AvailableSoftwareSourceSummary.
+        :type parent_id: str
+
+        :param parent_name:
+            The value to assign to the parent_name property of this AvailableSoftwareSourceSummary.
+        :type parent_name: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'parent_id': 'str',
+            'parent_name': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'parent_id': 'parentId',
+            'parent_name': 'parentName'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._display_name = None
+        self._parent_id = None
+        self._parent_name = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this AvailableSoftwareSourceSummary.
+        unique identifier that is immutable on creation
+
+
+        :return: The id of this AvailableSoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this AvailableSoftwareSourceSummary.
+        unique identifier that is immutable on creation
+
+
+        :param id: The id of this AvailableSoftwareSourceSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this AvailableSoftwareSourceSummary.
+        OCID for the Compartment
+
+
+        :return: The compartment_id of this AvailableSoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this AvailableSoftwareSourceSummary.
+        OCID for the Compartment
+
+
+        :param compartment_id: The compartment_id of this AvailableSoftwareSourceSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this AvailableSoftwareSourceSummary.
+        User friendly name for the software source
+
+
+        :return: The display_name of this AvailableSoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this AvailableSoftwareSourceSummary.
+        User friendly name for the software source
+
+
+        :param display_name: The display_name of this AvailableSoftwareSourceSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def parent_id(self):
+        """
+        Gets the parent_id of this AvailableSoftwareSourceSummary.
+        OCID for the parent software source, if there is one
+
+
+        :return: The parent_id of this AvailableSoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._parent_id
+
+    @parent_id.setter
+    def parent_id(self, parent_id):
+        """
+        Sets the parent_id of this AvailableSoftwareSourceSummary.
+        OCID for the parent software source, if there is one
+
+
+        :param parent_id: The parent_id of this AvailableSoftwareSourceSummary.
+        :type: str
+        """
+        self._parent_id = parent_id
+
+    @property
+    def parent_name(self):
+        """
+        Gets the parent_name of this AvailableSoftwareSourceSummary.
+        Display name of the parent software source, if there is one
+
+
+        :return: The parent_name of this AvailableSoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._parent_name
+
+    @parent_name.setter
+    def parent_name(self, parent_name):
+        """
+        Sets the parent_name of this AvailableSoftwareSourceSummary.
+        Display name of the parent software source, if there is one
+
+
+        :param parent_name: The parent_name of this AvailableSoftwareSourceSummary.
+        :type: str
+        """
+        self._parent_name = parent_name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/available_update_summary.py
+++ b/src/oci/os_management/models/available_update_summary.py
@@ -1,0 +1,368 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AvailableUpdateSummary(object):
+    """
+    An update available for a managed instance
+    """
+
+    #: A constant which can be used with the update_type property of a AvailableUpdateSummary.
+    #: This constant has a value of "SECURITY"
+    UPDATE_TYPE_SECURITY = "SECURITY"
+
+    #: A constant which can be used with the update_type property of a AvailableUpdateSummary.
+    #: This constant has a value of "BUG"
+    UPDATE_TYPE_BUG = "BUG"
+
+    #: A constant which can be used with the update_type property of a AvailableUpdateSummary.
+    #: This constant has a value of "ENHANCEMENT"
+    UPDATE_TYPE_ENHANCEMENT = "ENHANCEMENT"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AvailableUpdateSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this AvailableUpdateSummary.
+        :type display_name: str
+
+        :param name:
+            The value to assign to the name property of this AvailableUpdateSummary.
+        :type name: str
+
+        :param update_type:
+            The value to assign to the update_type property of this AvailableUpdateSummary.
+            Allowed values for this property are: "SECURITY", "BUG", "ENHANCEMENT", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type update_type: str
+
+        :param type:
+            The value to assign to the type property of this AvailableUpdateSummary.
+        :type type: str
+
+        :param installed_version:
+            The value to assign to the installed_version property of this AvailableUpdateSummary.
+        :type installed_version: str
+
+        :param available_version:
+            The value to assign to the available_version property of this AvailableUpdateSummary.
+        :type available_version: str
+
+        :param architecture:
+            The value to assign to the architecture property of this AvailableUpdateSummary.
+        :type architecture: str
+
+        :param errata:
+            The value to assign to the errata property of this AvailableUpdateSummary.
+        :type errata: list[Id]
+
+        :param related_cves:
+            The value to assign to the related_cves property of this AvailableUpdateSummary.
+        :type related_cves: list[str]
+
+        :param software_sources:
+            The value to assign to the software_sources property of this AvailableUpdateSummary.
+        :type software_sources: list[SoftwareSourceId]
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'name': 'str',
+            'update_type': 'str',
+            'type': 'str',
+            'installed_version': 'str',
+            'available_version': 'str',
+            'architecture': 'str',
+            'errata': 'list[Id]',
+            'related_cves': 'list[str]',
+            'software_sources': 'list[SoftwareSourceId]'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'name': 'name',
+            'update_type': 'updateType',
+            'type': 'type',
+            'installed_version': 'installedVersion',
+            'available_version': 'availableVersion',
+            'architecture': 'architecture',
+            'errata': 'errata',
+            'related_cves': 'relatedCves',
+            'software_sources': 'softwareSources'
+        }
+
+        self._display_name = None
+        self._name = None
+        self._update_type = None
+        self._type = None
+        self._installed_version = None
+        self._available_version = None
+        self._architecture = None
+        self._errata = None
+        self._related_cves = None
+        self._software_sources = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this AvailableUpdateSummary.
+        Package name
+
+
+        :return: The display_name of this AvailableUpdateSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this AvailableUpdateSummary.
+        Package name
+
+
+        :param display_name: The display_name of this AvailableUpdateSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this AvailableUpdateSummary.
+        Unique identifier for the package available for update. NOTE - This is not an OCID
+
+
+        :return: The name of this AvailableUpdateSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this AvailableUpdateSummary.
+        Unique identifier for the package available for update. NOTE - This is not an OCID
+
+
+        :param name: The name of this AvailableUpdateSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def update_type(self):
+        """
+        Gets the update_type of this AvailableUpdateSummary.
+        The purpose of this update.
+
+        Allowed values for this property are: "SECURITY", "BUG", "ENHANCEMENT", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The update_type of this AvailableUpdateSummary.
+        :rtype: str
+        """
+        return self._update_type
+
+    @update_type.setter
+    def update_type(self, update_type):
+        """
+        Sets the update_type of this AvailableUpdateSummary.
+        The purpose of this update.
+
+
+        :param update_type: The update_type of this AvailableUpdateSummary.
+        :type: str
+        """
+        allowed_values = ["SECURITY", "BUG", "ENHANCEMENT"]
+        if not value_allowed_none_or_none_sentinel(update_type, allowed_values):
+            update_type = 'UNKNOWN_ENUM_VALUE'
+        self._update_type = update_type
+
+    @property
+    def type(self):
+        """
+        **[Required]** Gets the type of this AvailableUpdateSummary.
+        Type of the package
+
+
+        :return: The type of this AvailableUpdateSummary.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this AvailableUpdateSummary.
+        Type of the package
+
+
+        :param type: The type of this AvailableUpdateSummary.
+        :type: str
+        """
+        self._type = type
+
+    @property
+    def installed_version(self):
+        """
+        **[Required]** Gets the installed_version of this AvailableUpdateSummary.
+        Version of the installed package
+
+
+        :return: The installed_version of this AvailableUpdateSummary.
+        :rtype: str
+        """
+        return self._installed_version
+
+    @installed_version.setter
+    def installed_version(self, installed_version):
+        """
+        Sets the installed_version of this AvailableUpdateSummary.
+        Version of the installed package
+
+
+        :param installed_version: The installed_version of this AvailableUpdateSummary.
+        :type: str
+        """
+        self._installed_version = installed_version
+
+    @property
+    def available_version(self):
+        """
+        **[Required]** Gets the available_version of this AvailableUpdateSummary.
+        Version of the package available for update
+
+
+        :return: The available_version of this AvailableUpdateSummary.
+        :rtype: str
+        """
+        return self._available_version
+
+    @available_version.setter
+    def available_version(self, available_version):
+        """
+        Sets the available_version of this AvailableUpdateSummary.
+        Version of the package available for update
+
+
+        :param available_version: The available_version of this AvailableUpdateSummary.
+        :type: str
+        """
+        self._available_version = available_version
+
+    @property
+    def architecture(self):
+        """
+        Gets the architecture of this AvailableUpdateSummary.
+        The architecture for which this package was built
+
+
+        :return: The architecture of this AvailableUpdateSummary.
+        :rtype: str
+        """
+        return self._architecture
+
+    @architecture.setter
+    def architecture(self, architecture):
+        """
+        Sets the architecture of this AvailableUpdateSummary.
+        The architecture for which this package was built
+
+
+        :param architecture: The architecture of this AvailableUpdateSummary.
+        :type: str
+        """
+        self._architecture = architecture
+
+    @property
+    def errata(self):
+        """
+        Gets the errata of this AvailableUpdateSummary.
+        List of errata containing this update
+
+
+        :return: The errata of this AvailableUpdateSummary.
+        :rtype: list[Id]
+        """
+        return self._errata
+
+    @errata.setter
+    def errata(self, errata):
+        """
+        Sets the errata of this AvailableUpdateSummary.
+        List of errata containing this update
+
+
+        :param errata: The errata of this AvailableUpdateSummary.
+        :type: list[Id]
+        """
+        self._errata = errata
+
+    @property
+    def related_cves(self):
+        """
+        Gets the related_cves of this AvailableUpdateSummary.
+        List of CVEs applicable to this erratum
+
+
+        :return: The related_cves of this AvailableUpdateSummary.
+        :rtype: list[str]
+        """
+        return self._related_cves
+
+    @related_cves.setter
+    def related_cves(self, related_cves):
+        """
+        Sets the related_cves of this AvailableUpdateSummary.
+        List of CVEs applicable to this erratum
+
+
+        :param related_cves: The related_cves of this AvailableUpdateSummary.
+        :type: list[str]
+        """
+        self._related_cves = related_cves
+
+    @property
+    def software_sources(self):
+        """
+        Gets the software_sources of this AvailableUpdateSummary.
+        list of software sources that provide the software package
+
+
+        :return: The software_sources of this AvailableUpdateSummary.
+        :rtype: list[SoftwareSourceId]
+        """
+        return self._software_sources
+
+    @software_sources.setter
+    def software_sources(self, software_sources):
+        """
+        Sets the software_sources of this AvailableUpdateSummary.
+        list of software sources that provide the software package
+
+
+        :param software_sources: The software_sources of this AvailableUpdateSummary.
+        :type: list[SoftwareSourceId]
+        """
+        self._software_sources = software_sources
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/change_managed_instance_group_compartment_details.py
+++ b/src/oci/os_management/models/change_managed_instance_group_compartment_details.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeManagedInstanceGroupCompartmentDetails(object):
+    """
+    Compartment id for a managed instance group
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeManagedInstanceGroupCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeManagedInstanceGroupCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this ChangeManagedInstanceGroupCompartmentDetails.
+        The `OCID`__ of the
+        compartment into which the resource should be moved.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeManagedInstanceGroupCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeManagedInstanceGroupCompartmentDetails.
+        The `OCID`__ of the
+        compartment into which the resource should be moved.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeManagedInstanceGroupCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/change_scheduled_job_compartment_details.py
+++ b/src/oci/os_management/models/change_scheduled_job_compartment_details.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeScheduledJobCompartmentDetails(object):
+    """
+    Compartment id for a scheduled job
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeScheduledJobCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeScheduledJobCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this ChangeScheduledJobCompartmentDetails.
+        The `OCID`__ of the
+        compartment into which the resource should be moved.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeScheduledJobCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeScheduledJobCompartmentDetails.
+        The `OCID`__ of the
+        compartment into which the resource should be moved.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeScheduledJobCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/change_software_source_compartment_details.py
+++ b/src/oci/os_management/models/change_software_source_compartment_details.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeSoftwareSourceCompartmentDetails(object):
+    """
+    Compartment id for a software source
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeSoftwareSourceCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeSoftwareSourceCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this ChangeSoftwareSourceCompartmentDetails.
+        The `OCID`__ of the
+        compartment into which the resource should be moved.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeSoftwareSourceCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeSoftwareSourceCompartmentDetails.
+        The `OCID`__ of the
+        compartment into which the resource should be moved.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeSoftwareSourceCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/create_managed_instance_group_details.py
+++ b/src/oci/os_management/models/create_managed_instance_group_details.py
@@ -1,0 +1,197 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateManagedInstanceGroupDetails(object):
+    """
+    Detail information for creating a managed instance group
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateManagedInstanceGroupDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateManagedInstanceGroupDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this CreateManagedInstanceGroupDetails.
+        :type description: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateManagedInstanceGroupDetails.
+        :type compartment_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateManagedInstanceGroupDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateManagedInstanceGroupDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'description': 'str',
+            'compartment_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'description': 'description',
+            'compartment_id': 'compartmentId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._description = None
+        self._compartment_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateManagedInstanceGroupDetails.
+        Managed Instance Group identifier
+
+
+        :return: The display_name of this CreateManagedInstanceGroupDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateManagedInstanceGroupDetails.
+        Managed Instance Group identifier
+
+
+        :param display_name: The display_name of this CreateManagedInstanceGroupDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this CreateManagedInstanceGroupDetails.
+        Information specified by the user about the managed instance group
+
+
+        :return: The description of this CreateManagedInstanceGroupDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this CreateManagedInstanceGroupDetails.
+        Information specified by the user about the managed instance group
+
+
+        :param description: The description of this CreateManagedInstanceGroupDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateManagedInstanceGroupDetails.
+        OCID for the Compartment
+
+
+        :return: The compartment_id of this CreateManagedInstanceGroupDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateManagedInstanceGroupDetails.
+        OCID for the Compartment
+
+
+        :param compartment_id: The compartment_id of this CreateManagedInstanceGroupDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateManagedInstanceGroupDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this CreateManagedInstanceGroupDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateManagedInstanceGroupDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this CreateManagedInstanceGroupDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateManagedInstanceGroupDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this CreateManagedInstanceGroupDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateManagedInstanceGroupDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this CreateManagedInstanceGroupDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/create_scheduled_job_details.py
+++ b/src/oci/os_management/models/create_scheduled_job_details.py
@@ -1,0 +1,576 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateScheduledJobDetails(object):
+    """
+    Information for creating a Scheduled Job
+    """
+
+    #: A constant which can be used with the schedule_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "ONETIME"
+    SCHEDULE_TYPE_ONETIME = "ONETIME"
+
+    #: A constant which can be used with the schedule_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "RECURRING"
+    SCHEDULE_TYPE_RECURRING = "RECURRING"
+
+    #: A constant which can be used with the interval_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "HOUR"
+    INTERVAL_TYPE_HOUR = "HOUR"
+
+    #: A constant which can be used with the interval_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "DAY"
+    INTERVAL_TYPE_DAY = "DAY"
+
+    #: A constant which can be used with the interval_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "WEEK"
+    INTERVAL_TYPE_WEEK = "WEEK"
+
+    #: A constant which can be used with the interval_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "MONTH"
+    INTERVAL_TYPE_MONTH = "MONTH"
+
+    #: A constant which can be used with the operation_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "INSTALL"
+    OPERATION_TYPE_INSTALL = "INSTALL"
+
+    #: A constant which can be used with the operation_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "UPDATE"
+    OPERATION_TYPE_UPDATE = "UPDATE"
+
+    #: A constant which can be used with the operation_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "REMOVE"
+    OPERATION_TYPE_REMOVE = "REMOVE"
+
+    #: A constant which can be used with the operation_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "UPDATEALL"
+    OPERATION_TYPE_UPDATEALL = "UPDATEALL"
+
+    #: A constant which can be used with the update_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "SECURITY"
+    UPDATE_TYPE_SECURITY = "SECURITY"
+
+    #: A constant which can be used with the update_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "BUGFIX"
+    UPDATE_TYPE_BUGFIX = "BUGFIX"
+
+    #: A constant which can be used with the update_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "ENHANCEMENT"
+    UPDATE_TYPE_ENHANCEMENT = "ENHANCEMENT"
+
+    #: A constant which can be used with the update_type property of a CreateScheduledJobDetails.
+    #: This constant has a value of "ALL"
+    UPDATE_TYPE_ALL = "ALL"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateScheduledJobDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateScheduledJobDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateScheduledJobDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this CreateScheduledJobDetails.
+        :type description: str
+
+        :param schedule_type:
+            The value to assign to the schedule_type property of this CreateScheduledJobDetails.
+            Allowed values for this property are: "ONETIME", "RECURRING"
+        :type schedule_type: str
+
+        :param time_next_execution:
+            The value to assign to the time_next_execution property of this CreateScheduledJobDetails.
+        :type time_next_execution: datetime
+
+        :param interval_type:
+            The value to assign to the interval_type property of this CreateScheduledJobDetails.
+            Allowed values for this property are: "HOUR", "DAY", "WEEK", "MONTH"
+        :type interval_type: str
+
+        :param interval_value:
+            The value to assign to the interval_value property of this CreateScheduledJobDetails.
+        :type interval_value: str
+
+        :param managed_instances:
+            The value to assign to the managed_instances property of this CreateScheduledJobDetails.
+        :type managed_instances: list[Id]
+
+        :param managed_instance_groups:
+            The value to assign to the managed_instance_groups property of this CreateScheduledJobDetails.
+        :type managed_instance_groups: list[Id]
+
+        :param operation_type:
+            The value to assign to the operation_type property of this CreateScheduledJobDetails.
+            Allowed values for this property are: "INSTALL", "UPDATE", "REMOVE", "UPDATEALL"
+        :type operation_type: str
+
+        :param update_type:
+            The value to assign to the update_type property of this CreateScheduledJobDetails.
+            Allowed values for this property are: "SECURITY", "BUGFIX", "ENHANCEMENT", "ALL"
+        :type update_type: str
+
+        :param package_names:
+            The value to assign to the package_names property of this CreateScheduledJobDetails.
+        :type package_names: list[PackageName]
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateScheduledJobDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateScheduledJobDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'description': 'str',
+            'schedule_type': 'str',
+            'time_next_execution': 'datetime',
+            'interval_type': 'str',
+            'interval_value': 'str',
+            'managed_instances': 'list[Id]',
+            'managed_instance_groups': 'list[Id]',
+            'operation_type': 'str',
+            'update_type': 'str',
+            'package_names': 'list[PackageName]',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'description': 'description',
+            'schedule_type': 'scheduleType',
+            'time_next_execution': 'timeNextExecution',
+            'interval_type': 'intervalType',
+            'interval_value': 'intervalValue',
+            'managed_instances': 'managedInstances',
+            'managed_instance_groups': 'managedInstanceGroups',
+            'operation_type': 'operationType',
+            'update_type': 'updateType',
+            'package_names': 'packageNames',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._display_name = None
+        self._description = None
+        self._schedule_type = None
+        self._time_next_execution = None
+        self._interval_type = None
+        self._interval_value = None
+        self._managed_instances = None
+        self._managed_instance_groups = None
+        self._operation_type = None
+        self._update_type = None
+        self._package_names = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateScheduledJobDetails.
+        OCID for the Compartment
+
+
+        :return: The compartment_id of this CreateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateScheduledJobDetails.
+        OCID for the Compartment
+
+
+        :param compartment_id: The compartment_id of this CreateScheduledJobDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateScheduledJobDetails.
+        Scheduled Job name
+
+
+        :return: The display_name of this CreateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateScheduledJobDetails.
+        Scheduled Job name
+
+
+        :param display_name: The display_name of this CreateScheduledJobDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this CreateScheduledJobDetails.
+        Details describing the Scheduled Job.
+
+
+        :return: The description of this CreateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this CreateScheduledJobDetails.
+        Details describing the Scheduled Job.
+
+
+        :param description: The description of this CreateScheduledJobDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def schedule_type(self):
+        """
+        **[Required]** Gets the schedule_type of this CreateScheduledJobDetails.
+        the type of scheduling this Scheduled Job follows
+
+        Allowed values for this property are: "ONETIME", "RECURRING"
+
+
+        :return: The schedule_type of this CreateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._schedule_type
+
+    @schedule_type.setter
+    def schedule_type(self, schedule_type):
+        """
+        Sets the schedule_type of this CreateScheduledJobDetails.
+        the type of scheduling this Scheduled Job follows
+
+
+        :param schedule_type: The schedule_type of this CreateScheduledJobDetails.
+        :type: str
+        """
+        allowed_values = ["ONETIME", "RECURRING"]
+        if not value_allowed_none_or_none_sentinel(schedule_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `schedule_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._schedule_type = schedule_type
+
+    @property
+    def time_next_execution(self):
+        """
+        **[Required]** Gets the time_next_execution of this CreateScheduledJobDetails.
+        the desired time for the next execution of this Scheduled Job
+
+
+        :return: The time_next_execution of this CreateScheduledJobDetails.
+        :rtype: datetime
+        """
+        return self._time_next_execution
+
+    @time_next_execution.setter
+    def time_next_execution(self, time_next_execution):
+        """
+        Sets the time_next_execution of this CreateScheduledJobDetails.
+        the desired time for the next execution of this Scheduled Job
+
+
+        :param time_next_execution: The time_next_execution of this CreateScheduledJobDetails.
+        :type: datetime
+        """
+        self._time_next_execution = time_next_execution
+
+    @property
+    def interval_type(self):
+        """
+        Gets the interval_type of this CreateScheduledJobDetails.
+        the interval period for a recurring Scheduled Job (only if schedule type is RECURRING)
+
+        Allowed values for this property are: "HOUR", "DAY", "WEEK", "MONTH"
+
+
+        :return: The interval_type of this CreateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._interval_type
+
+    @interval_type.setter
+    def interval_type(self, interval_type):
+        """
+        Sets the interval_type of this CreateScheduledJobDetails.
+        the interval period for a recurring Scheduled Job (only if schedule type is RECURRING)
+
+
+        :param interval_type: The interval_type of this CreateScheduledJobDetails.
+        :type: str
+        """
+        allowed_values = ["HOUR", "DAY", "WEEK", "MONTH"]
+        if not value_allowed_none_or_none_sentinel(interval_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `interval_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._interval_type = interval_type
+
+    @property
+    def interval_value(self):
+        """
+        Gets the interval_value of this CreateScheduledJobDetails.
+        the value for the interval period for a recurring Scheduled Job (only if schedule type is RECURRING)
+
+
+        :return: The interval_value of this CreateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._interval_value
+
+    @interval_value.setter
+    def interval_value(self, interval_value):
+        """
+        Sets the interval_value of this CreateScheduledJobDetails.
+        the value for the interval period for a recurring Scheduled Job (only if schedule type is RECURRING)
+
+
+        :param interval_value: The interval_value of this CreateScheduledJobDetails.
+        :type: str
+        """
+        self._interval_value = interval_value
+
+    @property
+    def managed_instances(self):
+        """
+        Gets the managed_instances of this CreateScheduledJobDetails.
+        The list of managed instances this scheduled job operates on
+        (mutually exclusive with managedInstanceGroups). Either this or the
+        managedInstanceGroups must be supplied.
+
+
+        :return: The managed_instances of this CreateScheduledJobDetails.
+        :rtype: list[Id]
+        """
+        return self._managed_instances
+
+    @managed_instances.setter
+    def managed_instances(self, managed_instances):
+        """
+        Sets the managed_instances of this CreateScheduledJobDetails.
+        The list of managed instances this scheduled job operates on
+        (mutually exclusive with managedInstanceGroups). Either this or the
+        managedInstanceGroups must be supplied.
+
+
+        :param managed_instances: The managed_instances of this CreateScheduledJobDetails.
+        :type: list[Id]
+        """
+        self._managed_instances = managed_instances
+
+    @property
+    def managed_instance_groups(self):
+        """
+        Gets the managed_instance_groups of this CreateScheduledJobDetails.
+        The list of managed instance groups this scheduled job operates on
+        (mutually exclusive with managedInstances). Either this or
+        managedInstances must be supplied.
+
+
+        :return: The managed_instance_groups of this CreateScheduledJobDetails.
+        :rtype: list[Id]
+        """
+        return self._managed_instance_groups
+
+    @managed_instance_groups.setter
+    def managed_instance_groups(self, managed_instance_groups):
+        """
+        Sets the managed_instance_groups of this CreateScheduledJobDetails.
+        The list of managed instance groups this scheduled job operates on
+        (mutually exclusive with managedInstances). Either this or
+        managedInstances must be supplied.
+
+
+        :param managed_instance_groups: The managed_instance_groups of this CreateScheduledJobDetails.
+        :type: list[Id]
+        """
+        self._managed_instance_groups = managed_instance_groups
+
+    @property
+    def operation_type(self):
+        """
+        **[Required]** Gets the operation_type of this CreateScheduledJobDetails.
+        the type of operation this Scheduled Job performs
+
+        Allowed values for this property are: "INSTALL", "UPDATE", "REMOVE", "UPDATEALL"
+
+
+        :return: The operation_type of this CreateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._operation_type
+
+    @operation_type.setter
+    def operation_type(self, operation_type):
+        """
+        Sets the operation_type of this CreateScheduledJobDetails.
+        the type of operation this Scheduled Job performs
+
+
+        :param operation_type: The operation_type of this CreateScheduledJobDetails.
+        :type: str
+        """
+        allowed_values = ["INSTALL", "UPDATE", "REMOVE", "UPDATEALL"]
+        if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `operation_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._operation_type = operation_type
+
+    @property
+    def update_type(self):
+        """
+        Gets the update_type of this CreateScheduledJobDetails.
+        Type of the update (only if operation type is UPDATE_ALL_PACKAGES)
+
+        Allowed values for this property are: "SECURITY", "BUGFIX", "ENHANCEMENT", "ALL"
+
+
+        :return: The update_type of this CreateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._update_type
+
+    @update_type.setter
+    def update_type(self, update_type):
+        """
+        Sets the update_type of this CreateScheduledJobDetails.
+        Type of the update (only if operation type is UPDATE_ALL_PACKAGES)
+
+
+        :param update_type: The update_type of this CreateScheduledJobDetails.
+        :type: str
+        """
+        allowed_values = ["SECURITY", "BUGFIX", "ENHANCEMENT", "ALL"]
+        if not value_allowed_none_or_none_sentinel(update_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `update_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._update_type = update_type
+
+    @property
+    def package_names(self):
+        """
+        Gets the package_names of this CreateScheduledJobDetails.
+        the id of the package (only if operation type is INSTALL/UPDATE/REMOVE_PACKAGE)
+
+
+        :return: The package_names of this CreateScheduledJobDetails.
+        :rtype: list[PackageName]
+        """
+        return self._package_names
+
+    @package_names.setter
+    def package_names(self, package_names):
+        """
+        Sets the package_names of this CreateScheduledJobDetails.
+        the id of the package (only if operation type is INSTALL/UPDATE/REMOVE_PACKAGE)
+
+
+        :param package_names: The package_names of this CreateScheduledJobDetails.
+        :type: list[PackageName]
+        """
+        self._package_names = package_names
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateScheduledJobDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this CreateScheduledJobDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateScheduledJobDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this CreateScheduledJobDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateScheduledJobDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this CreateScheduledJobDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateScheduledJobDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this CreateScheduledJobDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/create_software_source_details.py
+++ b/src/oci/os_management/models/create_software_source_details.py
@@ -1,0 +1,437 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateSoftwareSourceDetails(object):
+    """
+    Description of a software source to be created on the management system
+    """
+
+    #: A constant which can be used with the arch_type property of a CreateSoftwareSourceDetails.
+    #: This constant has a value of "IA_32"
+    ARCH_TYPE_IA_32 = "IA_32"
+
+    #: A constant which can be used with the arch_type property of a CreateSoftwareSourceDetails.
+    #: This constant has a value of "X86_64"
+    ARCH_TYPE_X86_64 = "X86_64"
+
+    #: A constant which can be used with the arch_type property of a CreateSoftwareSourceDetails.
+    #: This constant has a value of "AARCH64"
+    ARCH_TYPE_AARCH64 = "AARCH64"
+
+    #: A constant which can be used with the arch_type property of a CreateSoftwareSourceDetails.
+    #: This constant has a value of "SPARC"
+    ARCH_TYPE_SPARC = "SPARC"
+
+    #: A constant which can be used with the arch_type property of a CreateSoftwareSourceDetails.
+    #: This constant has a value of "AMD64_DEBIAN"
+    ARCH_TYPE_AMD64_DEBIAN = "AMD64_DEBIAN"
+
+    #: A constant which can be used with the checksum_type property of a CreateSoftwareSourceDetails.
+    #: This constant has a value of "SHA1"
+    CHECKSUM_TYPE_SHA1 = "SHA1"
+
+    #: A constant which can be used with the checksum_type property of a CreateSoftwareSourceDetails.
+    #: This constant has a value of "SHA256"
+    CHECKSUM_TYPE_SHA256 = "SHA256"
+
+    #: A constant which can be used with the checksum_type property of a CreateSoftwareSourceDetails.
+    #: This constant has a value of "SHA384"
+    CHECKSUM_TYPE_SHA384 = "SHA384"
+
+    #: A constant which can be used with the checksum_type property of a CreateSoftwareSourceDetails.
+    #: This constant has a value of "SHA512"
+    CHECKSUM_TYPE_SHA512 = "SHA512"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateSoftwareSourceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateSoftwareSourceDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateSoftwareSourceDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this CreateSoftwareSourceDetails.
+        :type description: str
+
+        :param arch_type:
+            The value to assign to the arch_type property of this CreateSoftwareSourceDetails.
+            Allowed values for this property are: "IA_32", "X86_64", "AARCH64", "SPARC", "AMD64_DEBIAN"
+        :type arch_type: str
+
+        :param maintainer_name:
+            The value to assign to the maintainer_name property of this CreateSoftwareSourceDetails.
+        :type maintainer_name: str
+
+        :param maintainer_email:
+            The value to assign to the maintainer_email property of this CreateSoftwareSourceDetails.
+        :type maintainer_email: str
+
+        :param maintainer_phone:
+            The value to assign to the maintainer_phone property of this CreateSoftwareSourceDetails.
+        :type maintainer_phone: str
+
+        :param checksum_type:
+            The value to assign to the checksum_type property of this CreateSoftwareSourceDetails.
+            Allowed values for this property are: "SHA1", "SHA256", "SHA384", "SHA512"
+        :type checksum_type: str
+
+        :param parent_id:
+            The value to assign to the parent_id property of this CreateSoftwareSourceDetails.
+        :type parent_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateSoftwareSourceDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateSoftwareSourceDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'description': 'str',
+            'arch_type': 'str',
+            'maintainer_name': 'str',
+            'maintainer_email': 'str',
+            'maintainer_phone': 'str',
+            'checksum_type': 'str',
+            'parent_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'description': 'description',
+            'arch_type': 'archType',
+            'maintainer_name': 'maintainerName',
+            'maintainer_email': 'maintainerEmail',
+            'maintainer_phone': 'maintainerPhone',
+            'checksum_type': 'checksumType',
+            'parent_id': 'parentId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._display_name = None
+        self._description = None
+        self._arch_type = None
+        self._maintainer_name = None
+        self._maintainer_email = None
+        self._maintainer_phone = None
+        self._checksum_type = None
+        self._parent_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateSoftwareSourceDetails.
+        OCID for the Compartment
+
+
+        :return: The compartment_id of this CreateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateSoftwareSourceDetails.
+        OCID for the Compartment
+
+
+        :param compartment_id: The compartment_id of this CreateSoftwareSourceDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateSoftwareSourceDetails.
+        User friendly name for the software source
+
+
+        :return: The display_name of this CreateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateSoftwareSourceDetails.
+        User friendly name for the software source
+
+
+        :param display_name: The display_name of this CreateSoftwareSourceDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this CreateSoftwareSourceDetails.
+        Information specified by the user about the software source
+
+
+        :return: The description of this CreateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this CreateSoftwareSourceDetails.
+        Information specified by the user about the software source
+
+
+        :param description: The description of this CreateSoftwareSourceDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def arch_type(self):
+        """
+        **[Required]** Gets the arch_type of this CreateSoftwareSourceDetails.
+        The architecture type supported by the Software Source
+
+        Allowed values for this property are: "IA_32", "X86_64", "AARCH64", "SPARC", "AMD64_DEBIAN"
+
+
+        :return: The arch_type of this CreateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._arch_type
+
+    @arch_type.setter
+    def arch_type(self, arch_type):
+        """
+        Sets the arch_type of this CreateSoftwareSourceDetails.
+        The architecture type supported by the Software Source
+
+
+        :param arch_type: The arch_type of this CreateSoftwareSourceDetails.
+        :type: str
+        """
+        allowed_values = ["IA_32", "X86_64", "AARCH64", "SPARC", "AMD64_DEBIAN"]
+        if not value_allowed_none_or_none_sentinel(arch_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `arch_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._arch_type = arch_type
+
+    @property
+    def maintainer_name(self):
+        """
+        Gets the maintainer_name of this CreateSoftwareSourceDetails.
+        Name of the person maintaining this software source
+
+
+        :return: The maintainer_name of this CreateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._maintainer_name
+
+    @maintainer_name.setter
+    def maintainer_name(self, maintainer_name):
+        """
+        Sets the maintainer_name of this CreateSoftwareSourceDetails.
+        Name of the person maintaining this software source
+
+
+        :param maintainer_name: The maintainer_name of this CreateSoftwareSourceDetails.
+        :type: str
+        """
+        self._maintainer_name = maintainer_name
+
+    @property
+    def maintainer_email(self):
+        """
+        Gets the maintainer_email of this CreateSoftwareSourceDetails.
+        Email address of the person maintaining this software source
+
+
+        :return: The maintainer_email of this CreateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._maintainer_email
+
+    @maintainer_email.setter
+    def maintainer_email(self, maintainer_email):
+        """
+        Sets the maintainer_email of this CreateSoftwareSourceDetails.
+        Email address of the person maintaining this software source
+
+
+        :param maintainer_email: The maintainer_email of this CreateSoftwareSourceDetails.
+        :type: str
+        """
+        self._maintainer_email = maintainer_email
+
+    @property
+    def maintainer_phone(self):
+        """
+        Gets the maintainer_phone of this CreateSoftwareSourceDetails.
+        Phone number of the person maintaining this software source
+
+
+        :return: The maintainer_phone of this CreateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._maintainer_phone
+
+    @maintainer_phone.setter
+    def maintainer_phone(self, maintainer_phone):
+        """
+        Sets the maintainer_phone of this CreateSoftwareSourceDetails.
+        Phone number of the person maintaining this software source
+
+
+        :param maintainer_phone: The maintainer_phone of this CreateSoftwareSourceDetails.
+        :type: str
+        """
+        self._maintainer_phone = maintainer_phone
+
+    @property
+    def checksum_type(self):
+        """
+        Gets the checksum_type of this CreateSoftwareSourceDetails.
+        The yum repository checksum type used by this software source
+
+        Allowed values for this property are: "SHA1", "SHA256", "SHA384", "SHA512"
+
+
+        :return: The checksum_type of this CreateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._checksum_type
+
+    @checksum_type.setter
+    def checksum_type(self, checksum_type):
+        """
+        Sets the checksum_type of this CreateSoftwareSourceDetails.
+        The yum repository checksum type used by this software source
+
+
+        :param checksum_type: The checksum_type of this CreateSoftwareSourceDetails.
+        :type: str
+        """
+        allowed_values = ["SHA1", "SHA256", "SHA384", "SHA512"]
+        if not value_allowed_none_or_none_sentinel(checksum_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `checksum_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._checksum_type = checksum_type
+
+    @property
+    def parent_id(self):
+        """
+        Gets the parent_id of this CreateSoftwareSourceDetails.
+        OCID for the parent software source, if there is one
+
+
+        :return: The parent_id of this CreateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._parent_id
+
+    @parent_id.setter
+    def parent_id(self, parent_id):
+        """
+        Sets the parent_id of this CreateSoftwareSourceDetails.
+        OCID for the parent software source, if there is one
+
+
+        :param parent_id: The parent_id of this CreateSoftwareSourceDetails.
+        :type: str
+        """
+        self._parent_id = parent_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateSoftwareSourceDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this CreateSoftwareSourceDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateSoftwareSourceDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this CreateSoftwareSourceDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateSoftwareSourceDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this CreateSoftwareSourceDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateSoftwareSourceDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this CreateSoftwareSourceDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/detach_child_software_source_from_managed_instance_details.py
+++ b/src/oci/os_management/models/detach_child_software_source_from_managed_instance_details.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DetachChildSoftwareSourceFromManagedInstanceDetails(object):
+    """
+    Information for detaching a software source from a managed instance
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DetachChildSoftwareSourceFromManagedInstanceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param software_source_id:
+            The value to assign to the software_source_id property of this DetachChildSoftwareSourceFromManagedInstanceDetails.
+        :type software_source_id: str
+
+        """
+        self.swagger_types = {
+            'software_source_id': 'str'
+        }
+
+        self.attribute_map = {
+            'software_source_id': 'softwareSourceId'
+        }
+
+        self._software_source_id = None
+
+    @property
+    def software_source_id(self):
+        """
+        **[Required]** Gets the software_source_id of this DetachChildSoftwareSourceFromManagedInstanceDetails.
+        OCID for the Software Source
+
+
+        :return: The software_source_id of this DetachChildSoftwareSourceFromManagedInstanceDetails.
+        :rtype: str
+        """
+        return self._software_source_id
+
+    @software_source_id.setter
+    def software_source_id(self, software_source_id):
+        """
+        Sets the software_source_id of this DetachChildSoftwareSourceFromManagedInstanceDetails.
+        OCID for the Software Source
+
+
+        :param software_source_id: The software_source_id of this DetachChildSoftwareSourceFromManagedInstanceDetails.
+        :type: str
+        """
+        self._software_source_id = software_source_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/detach_parent_software_source_from_managed_instance_details.py
+++ b/src/oci/os_management/models/detach_parent_software_source_from_managed_instance_details.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DetachParentSoftwareSourceFromManagedInstanceDetails(object):
+    """
+    Information for detaching a software source from a managed instance
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DetachParentSoftwareSourceFromManagedInstanceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param software_source_id:
+            The value to assign to the software_source_id property of this DetachParentSoftwareSourceFromManagedInstanceDetails.
+        :type software_source_id: str
+
+        """
+        self.swagger_types = {
+            'software_source_id': 'str'
+        }
+
+        self.attribute_map = {
+            'software_source_id': 'softwareSourceId'
+        }
+
+        self._software_source_id = None
+
+    @property
+    def software_source_id(self):
+        """
+        **[Required]** Gets the software_source_id of this DetachParentSoftwareSourceFromManagedInstanceDetails.
+        OCID for the Software Source
+
+
+        :return: The software_source_id of this DetachParentSoftwareSourceFromManagedInstanceDetails.
+        :rtype: str
+        """
+        return self._software_source_id
+
+    @software_source_id.setter
+    def software_source_id(self, software_source_id):
+        """
+        Sets the software_source_id of this DetachParentSoftwareSourceFromManagedInstanceDetails.
+        OCID for the Software Source
+
+
+        :param software_source_id: The software_source_id of this DetachParentSoftwareSourceFromManagedInstanceDetails.
+        :type: str
+        """
+        self._software_source_id = software_source_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/errata_id.py
+++ b/src/oci/os_management/models/errata_id.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ErrataId(object):
+    """
+    Identifying information for an errata
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ErrataId object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this ErrataId.
+        :type name: str
+
+        :param id:
+            The value to assign to the id property of this ErrataId.
+        :type id: str
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'id': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'id': 'id'
+        }
+
+        self._name = None
+        self._id = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this ErrataId.
+        errata name
+
+
+        :return: The name of this ErrataId.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this ErrataId.
+        errata name
+
+
+        :param name: The name of this ErrataId.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ErrataId.
+        errata identifier
+
+
+        :return: The id of this ErrataId.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ErrataId.
+        errata identifier
+
+
+        :param id: The id of this ErrataId.
+        :type: str
+        """
+        self._id = id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/erratum.py
+++ b/src/oci/os_management/models/erratum.py
@@ -1,0 +1,523 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Erratum(object):
+    """
+    Details about the erratum.
+    """
+
+    #: A constant which can be used with the advisory_type property of a Erratum.
+    #: This constant has a value of "SECURITY"
+    ADVISORY_TYPE_SECURITY = "SECURITY"
+
+    #: A constant which can be used with the advisory_type property of a Erratum.
+    #: This constant has a value of "BUG"
+    ADVISORY_TYPE_BUG = "BUG"
+
+    #: A constant which can be used with the advisory_type property of a Erratum.
+    #: This constant has a value of "ENHANCEMENT"
+    ADVISORY_TYPE_ENHANCEMENT = "ENHANCEMENT"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Erratum object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this Erratum.
+        :type name: str
+
+        :param id:
+            The value to assign to the id property of this Erratum.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this Erratum.
+        :type compartment_id: str
+
+        :param synopsis:
+            The value to assign to the synopsis property of this Erratum.
+        :type synopsis: str
+
+        :param issued:
+            The value to assign to the issued property of this Erratum.
+        :type issued: str
+
+        :param description:
+            The value to assign to the description property of this Erratum.
+        :type description: str
+
+        :param updated:
+            The value to assign to the updated property of this Erratum.
+        :type updated: str
+
+        :param advisory_type:
+            The value to assign to the advisory_type property of this Erratum.
+            Allowed values for this property are: "SECURITY", "BUG", "ENHANCEMENT", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type advisory_type: str
+
+        :param _from:
+            The value to assign to the _from property of this Erratum.
+        :type _from: str
+
+        :param solution:
+            The value to assign to the solution property of this Erratum.
+        :type solution: str
+
+        :param references:
+            The value to assign to the references property of this Erratum.
+        :type references: str
+
+        :param affected_instances:
+            The value to assign to the affected_instances property of this Erratum.
+        :type affected_instances: list[Id]
+
+        :param related_cves:
+            The value to assign to the related_cves property of this Erratum.
+        :type related_cves: list[str]
+
+        :param software_sources:
+            The value to assign to the software_sources property of this Erratum.
+        :type software_sources: list[Id]
+
+        :param packages:
+            The value to assign to the packages property of this Erratum.
+        :type packages: list[SoftwarePackageSummary]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'id': 'str',
+            'compartment_id': 'str',
+            'synopsis': 'str',
+            'issued': 'str',
+            'description': 'str',
+            'updated': 'str',
+            'advisory_type': 'str',
+            '_from': 'str',
+            'solution': 'str',
+            'references': 'str',
+            'affected_instances': 'list[Id]',
+            'related_cves': 'list[str]',
+            'software_sources': 'list[Id]',
+            'packages': 'list[SoftwarePackageSummary]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'synopsis': 'synopsis',
+            'issued': 'issued',
+            'description': 'description',
+            'updated': 'updated',
+            'advisory_type': 'advisoryType',
+            '_from': 'from',
+            'solution': 'solution',
+            'references': 'references',
+            'affected_instances': 'affectedInstances',
+            'related_cves': 'relatedCves',
+            'software_sources': 'softwareSources',
+            'packages': 'packages'
+        }
+
+        self._name = None
+        self._id = None
+        self._compartment_id = None
+        self._synopsis = None
+        self._issued = None
+        self._description = None
+        self._updated = None
+        self._advisory_type = None
+        self.__from = None
+        self._solution = None
+        self._references = None
+        self._affected_instances = None
+        self._related_cves = None
+        self._software_sources = None
+        self._packages = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this Erratum.
+        Advisory name
+
+
+        :return: The name of this Erratum.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this Erratum.
+        Advisory name
+
+
+        :param name: The name of this Erratum.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this Erratum.
+        OCID for the Erratum.
+
+
+        :return: The id of this Erratum.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this Erratum.
+        OCID for the Erratum.
+
+
+        :param id: The id of this Erratum.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this Erratum.
+        OCID for the Compartment.
+
+
+        :return: The compartment_id of this Erratum.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this Erratum.
+        OCID for the Compartment.
+
+
+        :param compartment_id: The compartment_id of this Erratum.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def synopsis(self):
+        """
+        Gets the synopsis of this Erratum.
+        Summary description of the erratum.
+
+
+        :return: The synopsis of this Erratum.
+        :rtype: str
+        """
+        return self._synopsis
+
+    @synopsis.setter
+    def synopsis(self, synopsis):
+        """
+        Sets the synopsis of this Erratum.
+        Summary description of the erratum.
+
+
+        :param synopsis: The synopsis of this Erratum.
+        :type: str
+        """
+        self._synopsis = synopsis
+
+    @property
+    def issued(self):
+        """
+        Gets the issued of this Erratum.
+        date the erratum was issued
+
+
+        :return: The issued of this Erratum.
+        :rtype: str
+        """
+        return self._issued
+
+    @issued.setter
+    def issued(self, issued):
+        """
+        Sets the issued of this Erratum.
+        date the erratum was issued
+
+
+        :param issued: The issued of this Erratum.
+        :type: str
+        """
+        self._issued = issued
+
+    @property
+    def description(self):
+        """
+        Gets the description of this Erratum.
+        Details describing the erratum.
+
+
+        :return: The description of this Erratum.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this Erratum.
+        Details describing the erratum.
+
+
+        :param description: The description of this Erratum.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def updated(self):
+        """
+        Gets the updated of this Erratum.
+        most recent date the erratum was updated
+
+
+        :return: The updated of this Erratum.
+        :rtype: str
+        """
+        return self._updated
+
+    @updated.setter
+    def updated(self, updated):
+        """
+        Sets the updated of this Erratum.
+        most recent date the erratum was updated
+
+
+        :param updated: The updated of this Erratum.
+        :type: str
+        """
+        self._updated = updated
+
+    @property
+    def advisory_type(self):
+        """
+        Gets the advisory_type of this Erratum.
+        Type of the erratum.
+
+        Allowed values for this property are: "SECURITY", "BUG", "ENHANCEMENT", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The advisory_type of this Erratum.
+        :rtype: str
+        """
+        return self._advisory_type
+
+    @advisory_type.setter
+    def advisory_type(self, advisory_type):
+        """
+        Sets the advisory_type of this Erratum.
+        Type of the erratum.
+
+
+        :param advisory_type: The advisory_type of this Erratum.
+        :type: str
+        """
+        allowed_values = ["SECURITY", "BUG", "ENHANCEMENT"]
+        if not value_allowed_none_or_none_sentinel(advisory_type, allowed_values):
+            advisory_type = 'UNKNOWN_ENUM_VALUE'
+        self._advisory_type = advisory_type
+
+    @property
+    def _from(self):
+        """
+        Gets the _from of this Erratum.
+        Information specifying from where the erratum was release.
+
+
+        :return: The _from of this Erratum.
+        :rtype: str
+        """
+        return self.__from
+
+    @_from.setter
+    def _from(self, _from):
+        """
+        Sets the _from of this Erratum.
+        Information specifying from where the erratum was release.
+
+
+        :param _from: The _from of this Erratum.
+        :type: str
+        """
+        self.__from = _from
+
+    @property
+    def solution(self):
+        """
+        Gets the solution of this Erratum.
+        Information describing how the erratum can be resolved.
+
+
+        :return: The solution of this Erratum.
+        :rtype: str
+        """
+        return self._solution
+
+    @solution.setter
+    def solution(self, solution):
+        """
+        Sets the solution of this Erratum.
+        Information describing how the erratum can be resolved.
+
+
+        :param solution: The solution of this Erratum.
+        :type: str
+        """
+        self._solution = solution
+
+    @property
+    def references(self):
+        """
+        Gets the references of this Erratum.
+        Information describing how to find more information about the erratum.
+
+
+        :return: The references of this Erratum.
+        :rtype: str
+        """
+        return self._references
+
+    @references.setter
+    def references(self, references):
+        """
+        Sets the references of this Erratum.
+        Information describing how to find more information about the erratum.
+
+
+        :param references: The references of this Erratum.
+        :type: str
+        """
+        self._references = references
+
+    @property
+    def affected_instances(self):
+        """
+        Gets the affected_instances of this Erratum.
+        list of managed instances  to this erratum
+
+
+        :return: The affected_instances of this Erratum.
+        :rtype: list[Id]
+        """
+        return self._affected_instances
+
+    @affected_instances.setter
+    def affected_instances(self, affected_instances):
+        """
+        Sets the affected_instances of this Erratum.
+        list of managed instances  to this erratum
+
+
+        :param affected_instances: The affected_instances of this Erratum.
+        :type: list[Id]
+        """
+        self._affected_instances = affected_instances
+
+    @property
+    def related_cves(self):
+        """
+        Gets the related_cves of this Erratum.
+        list of CVEs applicable to this erratum
+
+
+        :return: The related_cves of this Erratum.
+        :rtype: list[str]
+        """
+        return self._related_cves
+
+    @related_cves.setter
+    def related_cves(self, related_cves):
+        """
+        Sets the related_cves of this Erratum.
+        list of CVEs applicable to this erratum
+
+
+        :param related_cves: The related_cves of this Erratum.
+        :type: list[str]
+        """
+        self._related_cves = related_cves
+
+    @property
+    def software_sources(self):
+        """
+        Gets the software_sources of this Erratum.
+        list of Software Sources
+
+
+        :return: The software_sources of this Erratum.
+        :rtype: list[Id]
+        """
+        return self._software_sources
+
+    @software_sources.setter
+    def software_sources(self, software_sources):
+        """
+        Sets the software_sources of this Erratum.
+        list of Software Sources
+
+
+        :param software_sources: The software_sources of this Erratum.
+        :type: list[Id]
+        """
+        self._software_sources = software_sources
+
+    @property
+    def packages(self):
+        """
+        Gets the packages of this Erratum.
+        list of Packages affected by this erratum
+
+
+        :return: The packages of this Erratum.
+        :rtype: list[SoftwarePackageSummary]
+        """
+        return self._packages
+
+    @packages.setter
+    def packages(self, packages):
+        """
+        Sets the packages of this Erratum.
+        list of Packages affected by this erratum
+
+
+        :param packages: The packages of this Erratum.
+        :type: list[SoftwarePackageSummary]
+        """
+        self._packages = packages
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/erratum_summary.py
+++ b/src/oci/os_management/models/erratum_summary.py
@@ -1,0 +1,307 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ErratumSummary(object):
+    """
+    Important changes for software. This can include security advisories, bug fixes, or enhancements.
+    """
+
+    #: A constant which can be used with the advisory_type property of a ErratumSummary.
+    #: This constant has a value of "SECURITY"
+    ADVISORY_TYPE_SECURITY = "SECURITY"
+
+    #: A constant which can be used with the advisory_type property of a ErratumSummary.
+    #: This constant has a value of "BUG"
+    ADVISORY_TYPE_BUG = "BUG"
+
+    #: A constant which can be used with the advisory_type property of a ErratumSummary.
+    #: This constant has a value of "ENHANCEMENT"
+    ADVISORY_TYPE_ENHANCEMENT = "ENHANCEMENT"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ErratumSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this ErratumSummary.
+        :type name: str
+
+        :param id:
+            The value to assign to the id property of this ErratumSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ErratumSummary.
+        :type compartment_id: str
+
+        :param synopsis:
+            The value to assign to the synopsis property of this ErratumSummary.
+        :type synopsis: str
+
+        :param issued:
+            The value to assign to the issued property of this ErratumSummary.
+        :type issued: str
+
+        :param updated:
+            The value to assign to the updated property of this ErratumSummary.
+        :type updated: str
+
+        :param advisory_type:
+            The value to assign to the advisory_type property of this ErratumSummary.
+            Allowed values for this property are: "SECURITY", "BUG", "ENHANCEMENT"
+        :type advisory_type: str
+
+        :param related_cves:
+            The value to assign to the related_cves property of this ErratumSummary.
+        :type related_cves: list[str]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'id': 'str',
+            'compartment_id': 'str',
+            'synopsis': 'str',
+            'issued': 'str',
+            'updated': 'str',
+            'advisory_type': 'str',
+            'related_cves': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'synopsis': 'synopsis',
+            'issued': 'issued',
+            'updated': 'updated',
+            'advisory_type': 'advisoryType',
+            'related_cves': 'relatedCves'
+        }
+
+        self._name = None
+        self._id = None
+        self._compartment_id = None
+        self._synopsis = None
+        self._issued = None
+        self._updated = None
+        self._advisory_type = None
+        self._related_cves = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this ErratumSummary.
+        Advisory name
+
+
+        :return: The name of this ErratumSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this ErratumSummary.
+        Advisory name
+
+
+        :param name: The name of this ErratumSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ErratumSummary.
+        OCID for the Erratum.
+
+
+        :return: The id of this ErratumSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ErratumSummary.
+        OCID for the Erratum.
+
+
+        :param id: The id of this ErratumSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ErratumSummary.
+        OCID for the Compartment.
+
+
+        :return: The compartment_id of this ErratumSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ErratumSummary.
+        OCID for the Compartment.
+
+
+        :param compartment_id: The compartment_id of this ErratumSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def synopsis(self):
+        """
+        Gets the synopsis of this ErratumSummary.
+        Summary description of the erratum.
+
+
+        :return: The synopsis of this ErratumSummary.
+        :rtype: str
+        """
+        return self._synopsis
+
+    @synopsis.setter
+    def synopsis(self, synopsis):
+        """
+        Sets the synopsis of this ErratumSummary.
+        Summary description of the erratum.
+
+
+        :param synopsis: The synopsis of this ErratumSummary.
+        :type: str
+        """
+        self._synopsis = synopsis
+
+    @property
+    def issued(self):
+        """
+        Gets the issued of this ErratumSummary.
+        date the erratum was issued
+
+
+        :return: The issued of this ErratumSummary.
+        :rtype: str
+        """
+        return self._issued
+
+    @issued.setter
+    def issued(self, issued):
+        """
+        Sets the issued of this ErratumSummary.
+        date the erratum was issued
+
+
+        :param issued: The issued of this ErratumSummary.
+        :type: str
+        """
+        self._issued = issued
+
+    @property
+    def updated(self):
+        """
+        Gets the updated of this ErratumSummary.
+        most recent date the erratum was updated
+
+
+        :return: The updated of this ErratumSummary.
+        :rtype: str
+        """
+        return self._updated
+
+    @updated.setter
+    def updated(self, updated):
+        """
+        Sets the updated of this ErratumSummary.
+        most recent date the erratum was updated
+
+
+        :param updated: The updated of this ErratumSummary.
+        :type: str
+        """
+        self._updated = updated
+
+    @property
+    def advisory_type(self):
+        """
+        Gets the advisory_type of this ErratumSummary.
+        Type of the erratum.
+
+        Allowed values for this property are: "SECURITY", "BUG", "ENHANCEMENT"
+
+
+        :return: The advisory_type of this ErratumSummary.
+        :rtype: str
+        """
+        return self._advisory_type
+
+    @advisory_type.setter
+    def advisory_type(self, advisory_type):
+        """
+        Sets the advisory_type of this ErratumSummary.
+        Type of the erratum.
+
+
+        :param advisory_type: The advisory_type of this ErratumSummary.
+        :type: str
+        """
+        allowed_values = ["SECURITY", "BUG", "ENHANCEMENT"]
+        if not value_allowed_none_or_none_sentinel(advisory_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `advisory_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._advisory_type = advisory_type
+
+    @property
+    def related_cves(self):
+        """
+        Gets the related_cves of this ErratumSummary.
+        list of CVEs applicable to this erratum
+
+
+        :return: The related_cves of this ErratumSummary.
+        :rtype: list[str]
+        """
+        return self._related_cves
+
+    @related_cves.setter
+    def related_cves(self, related_cves):
+        """
+        Sets the related_cves of this ErratumSummary.
+        list of CVEs applicable to this erratum
+
+
+        :param related_cves: The related_cves of this ErratumSummary.
+        :type: list[str]
+        """
+        self._related_cves = related_cves
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/id.py
+++ b/src/oci/os_management/models/id.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Id(object):
+    """
+    An id along with a name to simplify display for a user
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Id object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this Id.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this Id.
+        :type display_name: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName'
+        }
+
+        self._id = None
+        self._display_name = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this Id.
+        unique identifier that is immutable on creation
+
+
+        :return: The id of this Id.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this Id.
+        unique identifier that is immutable on creation
+
+
+        :param id: The id of this Id.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this Id.
+        User friendly name
+
+
+        :return: The display_name of this Id.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this Id.
+        User friendly name
+
+
+        :param display_name: The display_name of this Id.
+        :type: str
+        """
+        self._display_name = display_name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/installable_package_summary.py
+++ b/src/oci/os_management/models/installable_package_summary.py
@@ -1,0 +1,224 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class InstallablePackageSummary(object):
+    """
+    A software package available for install on a managed instance
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new InstallablePackageSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this InstallablePackageSummary.
+        :type display_name: str
+
+        :param name:
+            The value to assign to the name property of this InstallablePackageSummary.
+        :type name: str
+
+        :param type:
+            The value to assign to the type property of this InstallablePackageSummary.
+        :type type: str
+
+        :param version:
+            The value to assign to the version property of this InstallablePackageSummary.
+        :type version: str
+
+        :param architecture:
+            The value to assign to the architecture property of this InstallablePackageSummary.
+        :type architecture: str
+
+        :param software_sources:
+            The value to assign to the software_sources property of this InstallablePackageSummary.
+        :type software_sources: list[SoftwareSourceId]
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'name': 'str',
+            'type': 'str',
+            'version': 'str',
+            'architecture': 'str',
+            'software_sources': 'list[SoftwareSourceId]'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'name': 'name',
+            'type': 'type',
+            'version': 'version',
+            'architecture': 'architecture',
+            'software_sources': 'softwareSources'
+        }
+
+        self._display_name = None
+        self._name = None
+        self._type = None
+        self._version = None
+        self._architecture = None
+        self._software_sources = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this InstallablePackageSummary.
+        Package name
+
+
+        :return: The display_name of this InstallablePackageSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this InstallablePackageSummary.
+        Package name
+
+
+        :param display_name: The display_name of this InstallablePackageSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this InstallablePackageSummary.
+        Unique identifier for the package. NOTE - This is not an OCID
+
+
+        :return: The name of this InstallablePackageSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this InstallablePackageSummary.
+        Unique identifier for the package. NOTE - This is not an OCID
+
+
+        :param name: The name of this InstallablePackageSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def type(self):
+        """
+        **[Required]** Gets the type of this InstallablePackageSummary.
+        Type of the package
+
+
+        :return: The type of this InstallablePackageSummary.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this InstallablePackageSummary.
+        Type of the package
+
+
+        :param type: The type of this InstallablePackageSummary.
+        :type: str
+        """
+        self._type = type
+
+    @property
+    def version(self):
+        """
+        **[Required]** Gets the version of this InstallablePackageSummary.
+        Version of the package
+
+
+        :return: The version of this InstallablePackageSummary.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this InstallablePackageSummary.
+        Version of the package
+
+
+        :param version: The version of this InstallablePackageSummary.
+        :type: str
+        """
+        self._version = version
+
+    @property
+    def architecture(self):
+        """
+        Gets the architecture of this InstallablePackageSummary.
+        The architecture for which this package was built
+
+
+        :return: The architecture of this InstallablePackageSummary.
+        :rtype: str
+        """
+        return self._architecture
+
+    @architecture.setter
+    def architecture(self, architecture):
+        """
+        Sets the architecture of this InstallablePackageSummary.
+        The architecture for which this package was built
+
+
+        :param architecture: The architecture of this InstallablePackageSummary.
+        :type: str
+        """
+        self._architecture = architecture
+
+    @property
+    def software_sources(self):
+        """
+        Gets the software_sources of this InstallablePackageSummary.
+        list of software sources that provide the software package
+
+
+        :return: The software_sources of this InstallablePackageSummary.
+        :rtype: list[SoftwareSourceId]
+        """
+        return self._software_sources
+
+    @software_sources.setter
+    def software_sources(self, software_sources):
+        """
+        Sets the software_sources of this InstallablePackageSummary.
+        list of software sources that provide the software package
+
+
+        :param software_sources: The software_sources of this InstallablePackageSummary.
+        :type: list[SoftwareSourceId]
+        """
+        self._software_sources = software_sources
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/installed_package_summary.py
+++ b/src/oci/os_management/models/installed_package_summary.py
@@ -1,0 +1,255 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class InstalledPackageSummary(object):
+    """
+    A software package installed on a managed instance
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new InstalledPackageSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this InstalledPackageSummary.
+        :type display_name: str
+
+        :param name:
+            The value to assign to the name property of this InstalledPackageSummary.
+        :type name: str
+
+        :param type:
+            The value to assign to the type property of this InstalledPackageSummary.
+        :type type: str
+
+        :param version:
+            The value to assign to the version property of this InstalledPackageSummary.
+        :type version: str
+
+        :param architecture:
+            The value to assign to the architecture property of this InstalledPackageSummary.
+        :type architecture: str
+
+        :param install_time:
+            The value to assign to the install_time property of this InstalledPackageSummary.
+        :type install_time: str
+
+        :param software_sources:
+            The value to assign to the software_sources property of this InstalledPackageSummary.
+        :type software_sources: list[SoftwareSourceId]
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'name': 'str',
+            'type': 'str',
+            'version': 'str',
+            'architecture': 'str',
+            'install_time': 'str',
+            'software_sources': 'list[SoftwareSourceId]'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'name': 'name',
+            'type': 'type',
+            'version': 'version',
+            'architecture': 'architecture',
+            'install_time': 'installTime',
+            'software_sources': 'softwareSources'
+        }
+
+        self._display_name = None
+        self._name = None
+        self._type = None
+        self._version = None
+        self._architecture = None
+        self._install_time = None
+        self._software_sources = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this InstalledPackageSummary.
+        Package name
+
+
+        :return: The display_name of this InstalledPackageSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this InstalledPackageSummary.
+        Package name
+
+
+        :param display_name: The display_name of this InstalledPackageSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this InstalledPackageSummary.
+        Unique identifier for the package. NOTE - This is not an OCID
+
+
+        :return: The name of this InstalledPackageSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this InstalledPackageSummary.
+        Unique identifier for the package. NOTE - This is not an OCID
+
+
+        :param name: The name of this InstalledPackageSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def type(self):
+        """
+        **[Required]** Gets the type of this InstalledPackageSummary.
+        Type of the package
+
+
+        :return: The type of this InstalledPackageSummary.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this InstalledPackageSummary.
+        Type of the package
+
+
+        :param type: The type of this InstalledPackageSummary.
+        :type: str
+        """
+        self._type = type
+
+    @property
+    def version(self):
+        """
+        **[Required]** Gets the version of this InstalledPackageSummary.
+        Version of the installed package
+
+
+        :return: The version of this InstalledPackageSummary.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this InstalledPackageSummary.
+        Version of the installed package
+
+
+        :param version: The version of this InstalledPackageSummary.
+        :type: str
+        """
+        self._version = version
+
+    @property
+    def architecture(self):
+        """
+        Gets the architecture of this InstalledPackageSummary.
+        The architecture for which this package was built
+
+
+        :return: The architecture of this InstalledPackageSummary.
+        :rtype: str
+        """
+        return self._architecture
+
+    @architecture.setter
+    def architecture(self, architecture):
+        """
+        Sets the architecture of this InstalledPackageSummary.
+        The architecture for which this package was built
+
+
+        :param architecture: The architecture of this InstalledPackageSummary.
+        :type: str
+        """
+        self._architecture = architecture
+
+    @property
+    def install_time(self):
+        """
+        Gets the install_time of this InstalledPackageSummary.
+        Install time of the package
+
+
+        :return: The install_time of this InstalledPackageSummary.
+        :rtype: str
+        """
+        return self._install_time
+
+    @install_time.setter
+    def install_time(self, install_time):
+        """
+        Sets the install_time of this InstalledPackageSummary.
+        Install time of the package
+
+
+        :param install_time: The install_time of this InstalledPackageSummary.
+        :type: str
+        """
+        self._install_time = install_time
+
+    @property
+    def software_sources(self):
+        """
+        Gets the software_sources of this InstalledPackageSummary.
+        list of software sources that provide the software package
+
+
+        :return: The software_sources of this InstalledPackageSummary.
+        :rtype: list[SoftwareSourceId]
+        """
+        return self._software_sources
+
+    @software_sources.setter
+    def software_sources(self, software_sources):
+        """
+        Sets the software_sources of this InstalledPackageSummary.
+        list of software sources that provide the software package
+
+
+        :param software_sources: The software_sources of this InstalledPackageSummary.
+        :type: list[SoftwareSourceId]
+        """
+        self._software_sources = software_sources
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/managed_instance.py
+++ b/src/oci/os_management/models/managed_instance.py
@@ -1,0 +1,498 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ManagedInstance(object):
+    """
+    Detail information for an OCI Compute instance that is being managed
+    """
+
+    #: A constant which can be used with the status property of a ManagedInstance.
+    #: This constant has a value of "NORMAL"
+    STATUS_NORMAL = "NORMAL"
+
+    #: A constant which can be used with the status property of a ManagedInstance.
+    #: This constant has a value of "UNREACHABLE"
+    STATUS_UNREACHABLE = "UNREACHABLE"
+
+    #: A constant which can be used with the status property of a ManagedInstance.
+    #: This constant has a value of "ERROR"
+    STATUS_ERROR = "ERROR"
+
+    #: A constant which can be used with the status property of a ManagedInstance.
+    #: This constant has a value of "WARNING"
+    STATUS_WARNING = "WARNING"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ManagedInstance object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this ManagedInstance.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ManagedInstance.
+        :type id: str
+
+        :param description:
+            The value to assign to the description property of this ManagedInstance.
+        :type description: str
+
+        :param last_checkin:
+            The value to assign to the last_checkin property of this ManagedInstance.
+        :type last_checkin: str
+
+        :param last_boot:
+            The value to assign to the last_boot property of this ManagedInstance.
+        :type last_boot: str
+
+        :param updates_available:
+            The value to assign to the updates_available property of this ManagedInstance.
+        :type updates_available: int
+
+        :param os_name:
+            The value to assign to the os_name property of this ManagedInstance.
+        :type os_name: str
+
+        :param os_version:
+            The value to assign to the os_version property of this ManagedInstance.
+        :type os_version: str
+
+        :param os_kernel_version:
+            The value to assign to the os_kernel_version property of this ManagedInstance.
+        :type os_kernel_version: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ManagedInstance.
+        :type compartment_id: str
+
+        :param status:
+            The value to assign to the status property of this ManagedInstance.
+            Allowed values for this property are: "NORMAL", "UNREACHABLE", "ERROR", "WARNING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param parent_software_source:
+            The value to assign to the parent_software_source property of this ManagedInstance.
+        :type parent_software_source: SoftwareSourceId
+
+        :param child_software_sources:
+            The value to assign to the child_software_sources property of this ManagedInstance.
+        :type child_software_sources: list[SoftwareSourceId]
+
+        :param managed_instance_groups:
+            The value to assign to the managed_instance_groups property of this ManagedInstance.
+        :type managed_instance_groups: list[Id]
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'id': 'str',
+            'description': 'str',
+            'last_checkin': 'str',
+            'last_boot': 'str',
+            'updates_available': 'int',
+            'os_name': 'str',
+            'os_version': 'str',
+            'os_kernel_version': 'str',
+            'compartment_id': 'str',
+            'status': 'str',
+            'parent_software_source': 'SoftwareSourceId',
+            'child_software_sources': 'list[SoftwareSourceId]',
+            'managed_instance_groups': 'list[Id]'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'id': 'id',
+            'description': 'description',
+            'last_checkin': 'lastCheckin',
+            'last_boot': 'lastBoot',
+            'updates_available': 'updatesAvailable',
+            'os_name': 'osName',
+            'os_version': 'osVersion',
+            'os_kernel_version': 'osKernelVersion',
+            'compartment_id': 'compartmentId',
+            'status': 'status',
+            'parent_software_source': 'parentSoftwareSource',
+            'child_software_sources': 'childSoftwareSources',
+            'managed_instance_groups': 'managedInstanceGroups'
+        }
+
+        self._display_name = None
+        self._id = None
+        self._description = None
+        self._last_checkin = None
+        self._last_boot = None
+        self._updates_available = None
+        self._os_name = None
+        self._os_version = None
+        self._os_kernel_version = None
+        self._compartment_id = None
+        self._status = None
+        self._parent_software_source = None
+        self._child_software_sources = None
+        self._managed_instance_groups = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ManagedInstance.
+        Managed Instance identifier
+
+
+        :return: The display_name of this ManagedInstance.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ManagedInstance.
+        Managed Instance identifier
+
+
+        :param display_name: The display_name of this ManagedInstance.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ManagedInstance.
+        OCID for the managed instance
+
+
+        :return: The id of this ManagedInstance.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ManagedInstance.
+        OCID for the managed instance
+
+
+        :param id: The id of this ManagedInstance.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this ManagedInstance.
+        Information specified by the user about the managed instance
+
+
+        :return: The description of this ManagedInstance.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this ManagedInstance.
+        Information specified by the user about the managed instance
+
+
+        :param description: The description of this ManagedInstance.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def last_checkin(self):
+        """
+        Gets the last_checkin of this ManagedInstance.
+        Time at which the instance last checked in
+
+
+        :return: The last_checkin of this ManagedInstance.
+        :rtype: str
+        """
+        return self._last_checkin
+
+    @last_checkin.setter
+    def last_checkin(self, last_checkin):
+        """
+        Sets the last_checkin of this ManagedInstance.
+        Time at which the instance last checked in
+
+
+        :param last_checkin: The last_checkin of this ManagedInstance.
+        :type: str
+        """
+        self._last_checkin = last_checkin
+
+    @property
+    def last_boot(self):
+        """
+        Gets the last_boot of this ManagedInstance.
+        Time at which the instance last booted
+
+
+        :return: The last_boot of this ManagedInstance.
+        :rtype: str
+        """
+        return self._last_boot
+
+    @last_boot.setter
+    def last_boot(self, last_boot):
+        """
+        Sets the last_boot of this ManagedInstance.
+        Time at which the instance last booted
+
+
+        :param last_boot: The last_boot of this ManagedInstance.
+        :type: str
+        """
+        self._last_boot = last_boot
+
+    @property
+    def updates_available(self):
+        """
+        Gets the updates_available of this ManagedInstance.
+        Number of updates available to be installed
+
+
+        :return: The updates_available of this ManagedInstance.
+        :rtype: int
+        """
+        return self._updates_available
+
+    @updates_available.setter
+    def updates_available(self, updates_available):
+        """
+        Sets the updates_available of this ManagedInstance.
+        Number of updates available to be installed
+
+
+        :param updates_available: The updates_available of this ManagedInstance.
+        :type: int
+        """
+        self._updates_available = updates_available
+
+    @property
+    def os_name(self):
+        """
+        Gets the os_name of this ManagedInstance.
+        Operating System Name
+
+
+        :return: The os_name of this ManagedInstance.
+        :rtype: str
+        """
+        return self._os_name
+
+    @os_name.setter
+    def os_name(self, os_name):
+        """
+        Sets the os_name of this ManagedInstance.
+        Operating System Name
+
+
+        :param os_name: The os_name of this ManagedInstance.
+        :type: str
+        """
+        self._os_name = os_name
+
+    @property
+    def os_version(self):
+        """
+        Gets the os_version of this ManagedInstance.
+        Operating System Version
+
+
+        :return: The os_version of this ManagedInstance.
+        :rtype: str
+        """
+        return self._os_version
+
+    @os_version.setter
+    def os_version(self, os_version):
+        """
+        Sets the os_version of this ManagedInstance.
+        Operating System Version
+
+
+        :param os_version: The os_version of this ManagedInstance.
+        :type: str
+        """
+        self._os_version = os_version
+
+    @property
+    def os_kernel_version(self):
+        """
+        Gets the os_kernel_version of this ManagedInstance.
+        Operating System Kernel Version
+
+
+        :return: The os_kernel_version of this ManagedInstance.
+        :rtype: str
+        """
+        return self._os_kernel_version
+
+    @os_kernel_version.setter
+    def os_kernel_version(self, os_kernel_version):
+        """
+        Sets the os_kernel_version of this ManagedInstance.
+        Operating System Kernel Version
+
+
+        :param os_kernel_version: The os_kernel_version of this ManagedInstance.
+        :type: str
+        """
+        self._os_kernel_version = os_kernel_version
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ManagedInstance.
+        OCID for the Compartment
+
+
+        :return: The compartment_id of this ManagedInstance.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ManagedInstance.
+        OCID for the Compartment
+
+
+        :param compartment_id: The compartment_id of this ManagedInstance.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def status(self):
+        """
+        Gets the status of this ManagedInstance.
+        status of the managed instance.
+
+        Allowed values for this property are: "NORMAL", "UNREACHABLE", "ERROR", "WARNING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this ManagedInstance.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this ManagedInstance.
+        status of the managed instance.
+
+
+        :param status: The status of this ManagedInstance.
+        :type: str
+        """
+        allowed_values = ["NORMAL", "UNREACHABLE", "ERROR", "WARNING"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def parent_software_source(self):
+        """
+        Gets the parent_software_source of this ManagedInstance.
+        the parent (base) Software Source attached to the Managed Instance
+
+
+        :return: The parent_software_source of this ManagedInstance.
+        :rtype: SoftwareSourceId
+        """
+        return self._parent_software_source
+
+    @parent_software_source.setter
+    def parent_software_source(self, parent_software_source):
+        """
+        Sets the parent_software_source of this ManagedInstance.
+        the parent (base) Software Source attached to the Managed Instance
+
+
+        :param parent_software_source: The parent_software_source of this ManagedInstance.
+        :type: SoftwareSourceId
+        """
+        self._parent_software_source = parent_software_source
+
+    @property
+    def child_software_sources(self):
+        """
+        Gets the child_software_sources of this ManagedInstance.
+        list of child Software Sources attached to the Managed Instance
+
+
+        :return: The child_software_sources of this ManagedInstance.
+        :rtype: list[SoftwareSourceId]
+        """
+        return self._child_software_sources
+
+    @child_software_sources.setter
+    def child_software_sources(self, child_software_sources):
+        """
+        Sets the child_software_sources of this ManagedInstance.
+        list of child Software Sources attached to the Managed Instance
+
+
+        :param child_software_sources: The child_software_sources of this ManagedInstance.
+        :type: list[SoftwareSourceId]
+        """
+        self._child_software_sources = child_software_sources
+
+    @property
+    def managed_instance_groups(self):
+        """
+        Gets the managed_instance_groups of this ManagedInstance.
+        The ids of the managed instance groups of which this instance is a
+        member.
+
+
+        :return: The managed_instance_groups of this ManagedInstance.
+        :rtype: list[Id]
+        """
+        return self._managed_instance_groups
+
+    @managed_instance_groups.setter
+    def managed_instance_groups(self, managed_instance_groups):
+        """
+        Sets the managed_instance_groups of this ManagedInstance.
+        The ids of the managed instance groups of which this instance is a
+        member.
+
+
+        :param managed_instance_groups: The managed_instance_groups of this ManagedInstance.
+        :type: list[Id]
+        """
+        self._managed_instance_groups = managed_instance_groups
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/managed_instance_group.py
+++ b/src/oci/os_management/models/managed_instance_group.py
@@ -1,0 +1,322 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ManagedInstanceGroup(object):
+    """
+    Detail information for a managed instance group
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ManagedInstanceGroup.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ManagedInstanceGroup.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ManagedInstanceGroup.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a ManagedInstanceGroup.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a ManagedInstanceGroup.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a ManagedInstanceGroup.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ManagedInstanceGroup object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this ManagedInstanceGroup.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ManagedInstanceGroup.
+        :type id: str
+
+        :param description:
+            The value to assign to the description property of this ManagedInstanceGroup.
+        :type description: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ManagedInstanceGroup.
+        :type compartment_id: str
+
+        :param managed_instances:
+            The value to assign to the managed_instances property of this ManagedInstanceGroup.
+        :type managed_instances: list[Id]
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ManagedInstanceGroup.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ManagedInstanceGroup.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ManagedInstanceGroup.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'id': 'str',
+            'description': 'str',
+            'compartment_id': 'str',
+            'managed_instances': 'list[Id]',
+            'lifecycle_state': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'id': 'id',
+            'description': 'description',
+            'compartment_id': 'compartmentId',
+            'managed_instances': 'managedInstances',
+            'lifecycle_state': 'lifecycleState',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._id = None
+        self._description = None
+        self._compartment_id = None
+        self._managed_instances = None
+        self._lifecycle_state = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ManagedInstanceGroup.
+        Managed Instance Group identifier
+
+
+        :return: The display_name of this ManagedInstanceGroup.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ManagedInstanceGroup.
+        Managed Instance Group identifier
+
+
+        :param display_name: The display_name of this ManagedInstanceGroup.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ManagedInstanceGroup.
+        OCID for the managed instance group
+
+
+        :return: The id of this ManagedInstanceGroup.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ManagedInstanceGroup.
+        OCID for the managed instance group
+
+
+        :param id: The id of this ManagedInstanceGroup.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this ManagedInstanceGroup.
+        Information specified by the user about the managed instance group
+
+
+        :return: The description of this ManagedInstanceGroup.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this ManagedInstanceGroup.
+        Information specified by the user about the managed instance group
+
+
+        :param description: The description of this ManagedInstanceGroup.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ManagedInstanceGroup.
+        OCID for the Compartment
+
+
+        :return: The compartment_id of this ManagedInstanceGroup.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ManagedInstanceGroup.
+        OCID for the Compartment
+
+
+        :param compartment_id: The compartment_id of this ManagedInstanceGroup.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def managed_instances(self):
+        """
+        Gets the managed_instances of this ManagedInstanceGroup.
+        list of Managed Instances in the group
+
+
+        :return: The managed_instances of this ManagedInstanceGroup.
+        :rtype: list[Id]
+        """
+        return self._managed_instances
+
+    @managed_instances.setter
+    def managed_instances(self, managed_instances):
+        """
+        Sets the managed_instances of this ManagedInstanceGroup.
+        list of Managed Instances in the group
+
+
+        :param managed_instances: The managed_instances of this ManagedInstanceGroup.
+        :type: list[Id]
+        """
+        self._managed_instances = managed_instances
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this ManagedInstanceGroup.
+        The current state of the Software Source.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ManagedInstanceGroup.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ManagedInstanceGroup.
+        The current state of the Software Source.
+
+
+        :param lifecycle_state: The lifecycle_state of this ManagedInstanceGroup.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ManagedInstanceGroup.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this ManagedInstanceGroup.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ManagedInstanceGroup.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this ManagedInstanceGroup.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ManagedInstanceGroup.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this ManagedInstanceGroup.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ManagedInstanceGroup.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this ManagedInstanceGroup.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/managed_instance_group_summary.py
+++ b/src/oci/os_management/models/managed_instance_group_summary.py
@@ -1,0 +1,322 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ManagedInstanceGroupSummary(object):
+    """
+    An group of managed instances that will be managed together
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ManagedInstanceGroupSummary.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ManagedInstanceGroupSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ManagedInstanceGroupSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a ManagedInstanceGroupSummary.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a ManagedInstanceGroupSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a ManagedInstanceGroupSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ManagedInstanceGroupSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this ManagedInstanceGroupSummary.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ManagedInstanceGroupSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ManagedInstanceGroupSummary.
+        :type compartment_id: str
+
+        :param description:
+            The value to assign to the description property of this ManagedInstanceGroupSummary.
+        :type description: str
+
+        :param managed_instance_count:
+            The value to assign to the managed_instance_count property of this ManagedInstanceGroupSummary.
+        :type managed_instance_count: int
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ManagedInstanceGroupSummary.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ManagedInstanceGroupSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ManagedInstanceGroupSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'id': 'str',
+            'compartment_id': 'str',
+            'description': 'str',
+            'managed_instance_count': 'int',
+            'lifecycle_state': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'description': 'description',
+            'managed_instance_count': 'managedInstanceCount',
+            'lifecycle_state': 'lifecycleState',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._id = None
+        self._compartment_id = None
+        self._description = None
+        self._managed_instance_count = None
+        self._lifecycle_state = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ManagedInstanceGroupSummary.
+        user settable name
+
+
+        :return: The display_name of this ManagedInstanceGroupSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ManagedInstanceGroupSummary.
+        user settable name
+
+
+        :param display_name: The display_name of this ManagedInstanceGroupSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ManagedInstanceGroupSummary.
+        OCID for the managed instance group
+
+
+        :return: The id of this ManagedInstanceGroupSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ManagedInstanceGroupSummary.
+        OCID for the managed instance group
+
+
+        :param id: The id of this ManagedInstanceGroupSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ManagedInstanceGroupSummary.
+        OCID for the Compartment
+
+
+        :return: The compartment_id of this ManagedInstanceGroupSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ManagedInstanceGroupSummary.
+        OCID for the Compartment
+
+
+        :param compartment_id: The compartment_id of this ManagedInstanceGroupSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this ManagedInstanceGroupSummary.
+        Information specified by the user about the managed instance group
+
+
+        :return: The description of this ManagedInstanceGroupSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this ManagedInstanceGroupSummary.
+        Information specified by the user about the managed instance group
+
+
+        :param description: The description of this ManagedInstanceGroupSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def managed_instance_count(self):
+        """
+        Gets the managed_instance_count of this ManagedInstanceGroupSummary.
+        Number of managed instances in this managed instance group
+
+
+        :return: The managed_instance_count of this ManagedInstanceGroupSummary.
+        :rtype: int
+        """
+        return self._managed_instance_count
+
+    @managed_instance_count.setter
+    def managed_instance_count(self, managed_instance_count):
+        """
+        Sets the managed_instance_count of this ManagedInstanceGroupSummary.
+        Number of managed instances in this managed instance group
+
+
+        :param managed_instance_count: The managed_instance_count of this ManagedInstanceGroupSummary.
+        :type: int
+        """
+        self._managed_instance_count = managed_instance_count
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this ManagedInstanceGroupSummary.
+        The current state of the Software Source.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ManagedInstanceGroupSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ManagedInstanceGroupSummary.
+        The current state of the Software Source.
+
+
+        :param lifecycle_state: The lifecycle_state of this ManagedInstanceGroupSummary.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ManagedInstanceGroupSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this ManagedInstanceGroupSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ManagedInstanceGroupSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this ManagedInstanceGroupSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ManagedInstanceGroupSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this ManagedInstanceGroupSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ManagedInstanceGroupSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this ManagedInstanceGroupSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/managed_instance_summary.py
+++ b/src/oci/os_management/models/managed_instance_summary.py
@@ -1,0 +1,310 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ManagedInstanceSummary(object):
+    """
+    An OCI Compute instance that is being managed
+    """
+
+    #: A constant which can be used with the status property of a ManagedInstanceSummary.
+    #: This constant has a value of "NORMAL"
+    STATUS_NORMAL = "NORMAL"
+
+    #: A constant which can be used with the status property of a ManagedInstanceSummary.
+    #: This constant has a value of "UNREACHABLE"
+    STATUS_UNREACHABLE = "UNREACHABLE"
+
+    #: A constant which can be used with the status property of a ManagedInstanceSummary.
+    #: This constant has a value of "ERROR"
+    STATUS_ERROR = "ERROR"
+
+    #: A constant which can be used with the status property of a ManagedInstanceSummary.
+    #: This constant has a value of "WARNING"
+    STATUS_WARNING = "WARNING"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ManagedInstanceSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this ManagedInstanceSummary.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ManagedInstanceSummary.
+        :type id: str
+
+        :param last_checkin:
+            The value to assign to the last_checkin property of this ManagedInstanceSummary.
+        :type last_checkin: str
+
+        :param last_boot:
+            The value to assign to the last_boot property of this ManagedInstanceSummary.
+        :type last_boot: str
+
+        :param updates_available:
+            The value to assign to the updates_available property of this ManagedInstanceSummary.
+        :type updates_available: int
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ManagedInstanceSummary.
+        :type compartment_id: str
+
+        :param description:
+            The value to assign to the description property of this ManagedInstanceSummary.
+        :type description: str
+
+        :param status:
+            The value to assign to the status property of this ManagedInstanceSummary.
+            Allowed values for this property are: "NORMAL", "UNREACHABLE", "ERROR", "WARNING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'id': 'str',
+            'last_checkin': 'str',
+            'last_boot': 'str',
+            'updates_available': 'int',
+            'compartment_id': 'str',
+            'description': 'str',
+            'status': 'str'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'id': 'id',
+            'last_checkin': 'lastCheckin',
+            'last_boot': 'lastBoot',
+            'updates_available': 'updatesAvailable',
+            'compartment_id': 'compartmentId',
+            'description': 'description',
+            'status': 'status'
+        }
+
+        self._display_name = None
+        self._id = None
+        self._last_checkin = None
+        self._last_boot = None
+        self._updates_available = None
+        self._compartment_id = None
+        self._description = None
+        self._status = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ManagedInstanceSummary.
+        user settable name
+
+
+        :return: The display_name of this ManagedInstanceSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ManagedInstanceSummary.
+        user settable name
+
+
+        :param display_name: The display_name of this ManagedInstanceSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ManagedInstanceSummary.
+        OCID for the managed instance
+
+
+        :return: The id of this ManagedInstanceSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ManagedInstanceSummary.
+        OCID for the managed instance
+
+
+        :param id: The id of this ManagedInstanceSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def last_checkin(self):
+        """
+        Gets the last_checkin of this ManagedInstanceSummary.
+        Time at which the instance last checked in
+
+
+        :return: The last_checkin of this ManagedInstanceSummary.
+        :rtype: str
+        """
+        return self._last_checkin
+
+    @last_checkin.setter
+    def last_checkin(self, last_checkin):
+        """
+        Sets the last_checkin of this ManagedInstanceSummary.
+        Time at which the instance last checked in
+
+
+        :param last_checkin: The last_checkin of this ManagedInstanceSummary.
+        :type: str
+        """
+        self._last_checkin = last_checkin
+
+    @property
+    def last_boot(self):
+        """
+        Gets the last_boot of this ManagedInstanceSummary.
+        Time at which the instance last booted
+
+
+        :return: The last_boot of this ManagedInstanceSummary.
+        :rtype: str
+        """
+        return self._last_boot
+
+    @last_boot.setter
+    def last_boot(self, last_boot):
+        """
+        Sets the last_boot of this ManagedInstanceSummary.
+        Time at which the instance last booted
+
+
+        :param last_boot: The last_boot of this ManagedInstanceSummary.
+        :type: str
+        """
+        self._last_boot = last_boot
+
+    @property
+    def updates_available(self):
+        """
+        Gets the updates_available of this ManagedInstanceSummary.
+        Number of updates available to be installed
+
+
+        :return: The updates_available of this ManagedInstanceSummary.
+        :rtype: int
+        """
+        return self._updates_available
+
+    @updates_available.setter
+    def updates_available(self, updates_available):
+        """
+        Sets the updates_available of this ManagedInstanceSummary.
+        Number of updates available to be installed
+
+
+        :param updates_available: The updates_available of this ManagedInstanceSummary.
+        :type: int
+        """
+        self._updates_available = updates_available
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ManagedInstanceSummary.
+        OCID for the Compartment
+
+
+        :return: The compartment_id of this ManagedInstanceSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ManagedInstanceSummary.
+        OCID for the Compartment
+
+
+        :param compartment_id: The compartment_id of this ManagedInstanceSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this ManagedInstanceSummary.
+        Information specified by the user about the managed instance
+
+
+        :return: The description of this ManagedInstanceSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this ManagedInstanceSummary.
+        Information specified by the user about the managed instance
+
+
+        :param description: The description of this ManagedInstanceSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def status(self):
+        """
+        Gets the status of this ManagedInstanceSummary.
+        status of the managed instance.
+
+        Allowed values for this property are: "NORMAL", "UNREACHABLE", "ERROR", "WARNING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this ManagedInstanceSummary.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this ManagedInstanceSummary.
+        status of the managed instance.
+
+
+        :param status: The status of this ManagedInstanceSummary.
+        :type: str
+        """
+        allowed_values = ["NORMAL", "UNREACHABLE", "ERROR", "WARNING"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/managed_instance_update_details.py
+++ b/src/oci/os_management/models/managed_instance_update_details.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ManagedInstanceUpdateDetails(object):
+    """
+    Updated information for the managed instance
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ManagedInstanceUpdateDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this ManagedInstanceUpdateDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this ManagedInstanceUpdateDetails.
+        :type description: str
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'description': 'str'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'description': 'description'
+        }
+
+        self._display_name = None
+        self._description = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ManagedInstanceUpdateDetails.
+        Managed Instance identifier
+
+
+        :return: The display_name of this ManagedInstanceUpdateDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ManagedInstanceUpdateDetails.
+        Managed Instance identifier
+
+
+        :param display_name: The display_name of this ManagedInstanceUpdateDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this ManagedInstanceUpdateDetails.
+        Information specified by the user about the managed instance
+
+
+        :return: The description of this ManagedInstanceUpdateDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this ManagedInstanceUpdateDetails.
+        Information specified by the user about the managed instance
+
+
+        :param description: The description of this ManagedInstanceUpdateDetails.
+        :type: str
+        """
+        self._description = description
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/package_name.py
+++ b/src/oci/os_management/models/package_name.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PackageName(object):
+    """
+    Identifying information for the specified package
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PackageName object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this PackageName.
+        :type name: str
+
+        """
+        self.swagger_types = {
+            'name': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name'
+        }
+
+        self._name = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this PackageName.
+        package identifier
+
+
+        :return: The name of this PackageName.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this PackageName.
+        package identifier
+
+
+        :param name: The name of this PackageName.
+        :type: str
+        """
+        self._name = name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/recurrence.py
+++ b/src/oci/os_management/models/recurrence.py
@@ -1,0 +1,125 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Recurrence(object):
+    """
+    An object for representing a recurrence time interval
+    """
+
+    #: A constant which can be used with the interval_type property of a Recurrence.
+    #: This constant has a value of "MINUTES"
+    INTERVAL_TYPE_MINUTES = "MINUTES"
+
+    #: A constant which can be used with the interval_type property of a Recurrence.
+    #: This constant has a value of "HOURS"
+    INTERVAL_TYPE_HOURS = "HOURS"
+
+    #: A constant which can be used with the interval_type property of a Recurrence.
+    #: This constant has a value of "DAYS"
+    INTERVAL_TYPE_DAYS = "DAYS"
+
+    #: A constant which can be used with the interval_type property of a Recurrence.
+    #: This constant has a value of "WEEKS"
+    INTERVAL_TYPE_WEEKS = "WEEKS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Recurrence object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param interval_type:
+            The value to assign to the interval_type property of this Recurrence.
+            Allowed values for this property are: "MINUTES", "HOURS", "DAYS", "WEEKS"
+        :type interval_type: str
+
+        :param interval_value:
+            The value to assign to the interval_value property of this Recurrence.
+        :type interval_value: str
+
+        """
+        self.swagger_types = {
+            'interval_type': 'str',
+            'interval_value': 'str'
+        }
+
+        self.attribute_map = {
+            'interval_type': 'intervalType',
+            'interval_value': 'intervalValue'
+        }
+
+        self._interval_type = None
+        self._interval_value = None
+
+    @property
+    def interval_type(self):
+        """
+        **[Required]** Gets the interval_type of this Recurrence.
+        the interval period for the recurrence
+
+        Allowed values for this property are: "MINUTES", "HOURS", "DAYS", "WEEKS"
+
+
+        :return: The interval_type of this Recurrence.
+        :rtype: str
+        """
+        return self._interval_type
+
+    @interval_type.setter
+    def interval_type(self, interval_type):
+        """
+        Sets the interval_type of this Recurrence.
+        the interval period for the recurrence
+
+
+        :param interval_type: The interval_type of this Recurrence.
+        :type: str
+        """
+        allowed_values = ["MINUTES", "HOURS", "DAYS", "WEEKS"]
+        if not value_allowed_none_or_none_sentinel(interval_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `interval_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._interval_type = interval_type
+
+    @property
+    def interval_value(self):
+        """
+        **[Required]** Gets the interval_value of this Recurrence.
+        the value for the interval period for the recurrence
+
+
+        :return: The interval_value of this Recurrence.
+        :rtype: str
+        """
+        return self._interval_value
+
+    @interval_value.setter
+    def interval_value(self, interval_value):
+        """
+        Sets the interval_value of this Recurrence.
+        the value for the interval period for the recurrence
+
+
+        :param interval_value: The interval_value of this Recurrence.
+        :type: str
+        """
+        self._interval_value = interval_value
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/remove_packages_from_software_source_details.py
+++ b/src/oci/os_management/models/remove_packages_from_software_source_details.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class RemovePackagesFromSoftwareSourceDetails(object):
+    """
+    List of software package names
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new RemovePackagesFromSoftwareSourceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param package_names:
+            The value to assign to the package_names property of this RemovePackagesFromSoftwareSourceDetails.
+        :type package_names: list[str]
+
+        """
+        self.swagger_types = {
+            'package_names': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'package_names': 'packageNames'
+        }
+
+        self._package_names = None
+
+    @property
+    def package_names(self):
+        """
+        **[Required]** Gets the package_names of this RemovePackagesFromSoftwareSourceDetails.
+        the list of package names
+
+
+        :return: The package_names of this RemovePackagesFromSoftwareSourceDetails.
+        :rtype: list[str]
+        """
+        return self._package_names
+
+    @package_names.setter
+    def package_names(self, package_names):
+        """
+        Sets the package_names of this RemovePackagesFromSoftwareSourceDetails.
+        the list of package names
+
+
+        :param package_names: The package_names of this RemovePackagesFromSoftwareSourceDetails.
+        :type: list[str]
+        """
+        self._package_names = package_names
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/scheduled_job.py
+++ b/src/oci/os_management/models/scheduled_job.py
@@ -1,0 +1,720 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ScheduledJob(object):
+    """
+    Detailed information about a Scheduled Job
+    """
+
+    #: A constant which can be used with the schedule_type property of a ScheduledJob.
+    #: This constant has a value of "ONETIME"
+    SCHEDULE_TYPE_ONETIME = "ONETIME"
+
+    #: A constant which can be used with the schedule_type property of a ScheduledJob.
+    #: This constant has a value of "RECURRING"
+    SCHEDULE_TYPE_RECURRING = "RECURRING"
+
+    #: A constant which can be used with the interval_type property of a ScheduledJob.
+    #: This constant has a value of "HOUR"
+    INTERVAL_TYPE_HOUR = "HOUR"
+
+    #: A constant which can be used with the interval_type property of a ScheduledJob.
+    #: This constant has a value of "DAY"
+    INTERVAL_TYPE_DAY = "DAY"
+
+    #: A constant which can be used with the interval_type property of a ScheduledJob.
+    #: This constant has a value of "WEEK"
+    INTERVAL_TYPE_WEEK = "WEEK"
+
+    #: A constant which can be used with the interval_type property of a ScheduledJob.
+    #: This constant has a value of "MONTH"
+    INTERVAL_TYPE_MONTH = "MONTH"
+
+    #: A constant which can be used with the operation_type property of a ScheduledJob.
+    #: This constant has a value of "INSTALL"
+    OPERATION_TYPE_INSTALL = "INSTALL"
+
+    #: A constant which can be used with the operation_type property of a ScheduledJob.
+    #: This constant has a value of "UPDATE"
+    OPERATION_TYPE_UPDATE = "UPDATE"
+
+    #: A constant which can be used with the operation_type property of a ScheduledJob.
+    #: This constant has a value of "REMOVE"
+    OPERATION_TYPE_REMOVE = "REMOVE"
+
+    #: A constant which can be used with the operation_type property of a ScheduledJob.
+    #: This constant has a value of "UPDATEALL"
+    OPERATION_TYPE_UPDATEALL = "UPDATEALL"
+
+    #: A constant which can be used with the update_type property of a ScheduledJob.
+    #: This constant has a value of "SECURITY"
+    UPDATE_TYPE_SECURITY = "SECURITY"
+
+    #: A constant which can be used with the update_type property of a ScheduledJob.
+    #: This constant has a value of "BUGFIX"
+    UPDATE_TYPE_BUGFIX = "BUGFIX"
+
+    #: A constant which can be used with the update_type property of a ScheduledJob.
+    #: This constant has a value of "ENHANCEMENT"
+    UPDATE_TYPE_ENHANCEMENT = "ENHANCEMENT"
+
+    #: A constant which can be used with the update_type property of a ScheduledJob.
+    #: This constant has a value of "ALL"
+    UPDATE_TYPE_ALL = "ALL"
+
+    #: A constant which can be used with the lifecycle_state property of a ScheduledJob.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ScheduledJob.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ScheduledJob.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a ScheduledJob.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a ScheduledJob.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a ScheduledJob.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ScheduledJob object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this ScheduledJob.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ScheduledJob.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this ScheduledJob.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this ScheduledJob.
+        :type description: str
+
+        :param schedule_type:
+            The value to assign to the schedule_type property of this ScheduledJob.
+            Allowed values for this property are: "ONETIME", "RECURRING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type schedule_type: str
+
+        :param time_next_execution:
+            The value to assign to the time_next_execution property of this ScheduledJob.
+        :type time_next_execution: datetime
+
+        :param time_last_execution:
+            The value to assign to the time_last_execution property of this ScheduledJob.
+        :type time_last_execution: datetime
+
+        :param interval_type:
+            The value to assign to the interval_type property of this ScheduledJob.
+            Allowed values for this property are: "HOUR", "DAY", "WEEK", "MONTH", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type interval_type: str
+
+        :param interval_value:
+            The value to assign to the interval_value property of this ScheduledJob.
+        :type interval_value: str
+
+        :param managed_instances:
+            The value to assign to the managed_instances property of this ScheduledJob.
+        :type managed_instances: list[Id]
+
+        :param managed_instance_groups:
+            The value to assign to the managed_instance_groups property of this ScheduledJob.
+        :type managed_instance_groups: list[Id]
+
+        :param operation_type:
+            The value to assign to the operation_type property of this ScheduledJob.
+            Allowed values for this property are: "INSTALL", "UPDATE", "REMOVE", "UPDATEALL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type operation_type: str
+
+        :param update_type:
+            The value to assign to the update_type property of this ScheduledJob.
+            Allowed values for this property are: "SECURITY", "BUGFIX", "ENHANCEMENT", "ALL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type update_type: str
+
+        :param package_names:
+            The value to assign to the package_names property of this ScheduledJob.
+        :type package_names: list[PackageName]
+
+        :param work_requests:
+            The value to assign to the work_requests property of this ScheduledJob.
+        :type work_requests: list[Id]
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ScheduledJob.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ScheduledJob.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ScheduledJob.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'description': 'str',
+            'schedule_type': 'str',
+            'time_next_execution': 'datetime',
+            'time_last_execution': 'datetime',
+            'interval_type': 'str',
+            'interval_value': 'str',
+            'managed_instances': 'list[Id]',
+            'managed_instance_groups': 'list[Id]',
+            'operation_type': 'str',
+            'update_type': 'str',
+            'package_names': 'list[PackageName]',
+            'work_requests': 'list[Id]',
+            'lifecycle_state': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'description': 'description',
+            'schedule_type': 'scheduleType',
+            'time_next_execution': 'timeNextExecution',
+            'time_last_execution': 'timeLastExecution',
+            'interval_type': 'intervalType',
+            'interval_value': 'intervalValue',
+            'managed_instances': 'managedInstances',
+            'managed_instance_groups': 'managedInstanceGroups',
+            'operation_type': 'operationType',
+            'update_type': 'updateType',
+            'package_names': 'packageNames',
+            'work_requests': 'workRequests',
+            'lifecycle_state': 'lifecycleState',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._display_name = None
+        self._description = None
+        self._schedule_type = None
+        self._time_next_execution = None
+        self._time_last_execution = None
+        self._interval_type = None
+        self._interval_value = None
+        self._managed_instances = None
+        self._managed_instance_groups = None
+        self._operation_type = None
+        self._update_type = None
+        self._package_names = None
+        self._work_requests = None
+        self._lifecycle_state = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ScheduledJob.
+        OCID for the Scheduled Job
+
+
+        :return: The id of this ScheduledJob.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ScheduledJob.
+        OCID for the Scheduled Job
+
+
+        :param id: The id of this ScheduledJob.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this ScheduledJob.
+        OCID for the Compartment
+
+
+        :return: The compartment_id of this ScheduledJob.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ScheduledJob.
+        OCID for the Compartment
+
+
+        :param compartment_id: The compartment_id of this ScheduledJob.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ScheduledJob.
+        Scheduled Job name
+
+
+        :return: The display_name of this ScheduledJob.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ScheduledJob.
+        Scheduled Job name
+
+
+        :param display_name: The display_name of this ScheduledJob.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this ScheduledJob.
+        Details describing the Scheduled Job.
+
+
+        :return: The description of this ScheduledJob.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this ScheduledJob.
+        Details describing the Scheduled Job.
+
+
+        :param description: The description of this ScheduledJob.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def schedule_type(self):
+        """
+        Gets the schedule_type of this ScheduledJob.
+        the type of scheduling this Scheduled Job follows
+
+        Allowed values for this property are: "ONETIME", "RECURRING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The schedule_type of this ScheduledJob.
+        :rtype: str
+        """
+        return self._schedule_type
+
+    @schedule_type.setter
+    def schedule_type(self, schedule_type):
+        """
+        Sets the schedule_type of this ScheduledJob.
+        the type of scheduling this Scheduled Job follows
+
+
+        :param schedule_type: The schedule_type of this ScheduledJob.
+        :type: str
+        """
+        allowed_values = ["ONETIME", "RECURRING"]
+        if not value_allowed_none_or_none_sentinel(schedule_type, allowed_values):
+            schedule_type = 'UNKNOWN_ENUM_VALUE'
+        self._schedule_type = schedule_type
+
+    @property
+    def time_next_execution(self):
+        """
+        Gets the time_next_execution of this ScheduledJob.
+        the time of the next execution of this Scheduled Job
+
+
+        :return: The time_next_execution of this ScheduledJob.
+        :rtype: datetime
+        """
+        return self._time_next_execution
+
+    @time_next_execution.setter
+    def time_next_execution(self, time_next_execution):
+        """
+        Sets the time_next_execution of this ScheduledJob.
+        the time of the next execution of this Scheduled Job
+
+
+        :param time_next_execution: The time_next_execution of this ScheduledJob.
+        :type: datetime
+        """
+        self._time_next_execution = time_next_execution
+
+    @property
+    def time_last_execution(self):
+        """
+        Gets the time_last_execution of this ScheduledJob.
+        the time of the last execution of this Scheduled Job
+
+
+        :return: The time_last_execution of this ScheduledJob.
+        :rtype: datetime
+        """
+        return self._time_last_execution
+
+    @time_last_execution.setter
+    def time_last_execution(self, time_last_execution):
+        """
+        Sets the time_last_execution of this ScheduledJob.
+        the time of the last execution of this Scheduled Job
+
+
+        :param time_last_execution: The time_last_execution of this ScheduledJob.
+        :type: datetime
+        """
+        self._time_last_execution = time_last_execution
+
+    @property
+    def interval_type(self):
+        """
+        Gets the interval_type of this ScheduledJob.
+        the interval period for a recurring Scheduled Job (only if schedule type is RECURRING)
+
+        Allowed values for this property are: "HOUR", "DAY", "WEEK", "MONTH", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The interval_type of this ScheduledJob.
+        :rtype: str
+        """
+        return self._interval_type
+
+    @interval_type.setter
+    def interval_type(self, interval_type):
+        """
+        Sets the interval_type of this ScheduledJob.
+        the interval period for a recurring Scheduled Job (only if schedule type is RECURRING)
+
+
+        :param interval_type: The interval_type of this ScheduledJob.
+        :type: str
+        """
+        allowed_values = ["HOUR", "DAY", "WEEK", "MONTH"]
+        if not value_allowed_none_or_none_sentinel(interval_type, allowed_values):
+            interval_type = 'UNKNOWN_ENUM_VALUE'
+        self._interval_type = interval_type
+
+    @property
+    def interval_value(self):
+        """
+        Gets the interval_value of this ScheduledJob.
+        the value for the interval period for a recurring Scheduled Job (only if schedule type is RECURRING)
+
+
+        :return: The interval_value of this ScheduledJob.
+        :rtype: str
+        """
+        return self._interval_value
+
+    @interval_value.setter
+    def interval_value(self, interval_value):
+        """
+        Sets the interval_value of this ScheduledJob.
+        the value for the interval period for a recurring Scheduled Job (only if schedule type is RECURRING)
+
+
+        :param interval_value: The interval_value of this ScheduledJob.
+        :type: str
+        """
+        self._interval_value = interval_value
+
+    @property
+    def managed_instances(self):
+        """
+        Gets the managed_instances of this ScheduledJob.
+        the list of managed instances this scheduled job operates on (mutually exclusive with managedInstanceGroups)
+
+
+        :return: The managed_instances of this ScheduledJob.
+        :rtype: list[Id]
+        """
+        return self._managed_instances
+
+    @managed_instances.setter
+    def managed_instances(self, managed_instances):
+        """
+        Sets the managed_instances of this ScheduledJob.
+        the list of managed instances this scheduled job operates on (mutually exclusive with managedInstanceGroups)
+
+
+        :param managed_instances: The managed_instances of this ScheduledJob.
+        :type: list[Id]
+        """
+        self._managed_instances = managed_instances
+
+    @property
+    def managed_instance_groups(self):
+        """
+        Gets the managed_instance_groups of this ScheduledJob.
+        the list of managed instance groups this scheduled job operates on (mutually exclusive with managedInstances)
+
+
+        :return: The managed_instance_groups of this ScheduledJob.
+        :rtype: list[Id]
+        """
+        return self._managed_instance_groups
+
+    @managed_instance_groups.setter
+    def managed_instance_groups(self, managed_instance_groups):
+        """
+        Sets the managed_instance_groups of this ScheduledJob.
+        the list of managed instance groups this scheduled job operates on (mutually exclusive with managedInstances)
+
+
+        :param managed_instance_groups: The managed_instance_groups of this ScheduledJob.
+        :type: list[Id]
+        """
+        self._managed_instance_groups = managed_instance_groups
+
+    @property
+    def operation_type(self):
+        """
+        Gets the operation_type of this ScheduledJob.
+        the type of operation this Scheduled Job performs
+
+        Allowed values for this property are: "INSTALL", "UPDATE", "REMOVE", "UPDATEALL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The operation_type of this ScheduledJob.
+        :rtype: str
+        """
+        return self._operation_type
+
+    @operation_type.setter
+    def operation_type(self, operation_type):
+        """
+        Sets the operation_type of this ScheduledJob.
+        the type of operation this Scheduled Job performs
+
+
+        :param operation_type: The operation_type of this ScheduledJob.
+        :type: str
+        """
+        allowed_values = ["INSTALL", "UPDATE", "REMOVE", "UPDATEALL"]
+        if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
+            operation_type = 'UNKNOWN_ENUM_VALUE'
+        self._operation_type = operation_type
+
+    @property
+    def update_type(self):
+        """
+        Gets the update_type of this ScheduledJob.
+        Type of the update (only if operation type is UPDATE_ALL_PACKAGES)
+
+        Allowed values for this property are: "SECURITY", "BUGFIX", "ENHANCEMENT", "ALL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The update_type of this ScheduledJob.
+        :rtype: str
+        """
+        return self._update_type
+
+    @update_type.setter
+    def update_type(self, update_type):
+        """
+        Sets the update_type of this ScheduledJob.
+        Type of the update (only if operation type is UPDATE_ALL_PACKAGES)
+
+
+        :param update_type: The update_type of this ScheduledJob.
+        :type: str
+        """
+        allowed_values = ["SECURITY", "BUGFIX", "ENHANCEMENT", "ALL"]
+        if not value_allowed_none_or_none_sentinel(update_type, allowed_values):
+            update_type = 'UNKNOWN_ENUM_VALUE'
+        self._update_type = update_type
+
+    @property
+    def package_names(self):
+        """
+        Gets the package_names of this ScheduledJob.
+        the names of the packages (only if operation type is INSTALL/UPDATE/REMOVE_PACKAGE)
+
+
+        :return: The package_names of this ScheduledJob.
+        :rtype: list[PackageName]
+        """
+        return self._package_names
+
+    @package_names.setter
+    def package_names(self, package_names):
+        """
+        Sets the package_names of this ScheduledJob.
+        the names of the packages (only if operation type is INSTALL/UPDATE/REMOVE_PACKAGE)
+
+
+        :param package_names: The package_names of this ScheduledJob.
+        :type: list[PackageName]
+        """
+        self._package_names = package_names
+
+    @property
+    def work_requests(self):
+        """
+        Gets the work_requests of this ScheduledJob.
+        list of Work Requests associated with this Scheduled Job
+
+
+        :return: The work_requests of this ScheduledJob.
+        :rtype: list[Id]
+        """
+        return self._work_requests
+
+    @work_requests.setter
+    def work_requests(self, work_requests):
+        """
+        Sets the work_requests of this ScheduledJob.
+        list of Work Requests associated with this Scheduled Job
+
+
+        :param work_requests: The work_requests of this ScheduledJob.
+        :type: list[Id]
+        """
+        self._work_requests = work_requests
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this ScheduledJob.
+        The current state of the Scheduled Job.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ScheduledJob.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ScheduledJob.
+        The current state of the Scheduled Job.
+
+
+        :param lifecycle_state: The lifecycle_state of this ScheduledJob.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ScheduledJob.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this ScheduledJob.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ScheduledJob.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this ScheduledJob.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ScheduledJob.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this ScheduledJob.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ScheduledJob.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this ScheduledJob.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/scheduled_job_summary.py
+++ b/src/oci/os_management/models/scheduled_job_summary.py
@@ -1,0 +1,486 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ScheduledJobSummary(object):
+    """
+    Basic information about a Scheduled Job
+    """
+
+    #: A constant which can be used with the schedule_type property of a ScheduledJobSummary.
+    #: This constant has a value of "ONETIME"
+    SCHEDULE_TYPE_ONETIME = "ONETIME"
+
+    #: A constant which can be used with the schedule_type property of a ScheduledJobSummary.
+    #: This constant has a value of "RECURRING"
+    SCHEDULE_TYPE_RECURRING = "RECURRING"
+
+    #: A constant which can be used with the operation_type property of a ScheduledJobSummary.
+    #: This constant has a value of "INSTALL"
+    OPERATION_TYPE_INSTALL = "INSTALL"
+
+    #: A constant which can be used with the operation_type property of a ScheduledJobSummary.
+    #: This constant has a value of "UPDATE"
+    OPERATION_TYPE_UPDATE = "UPDATE"
+
+    #: A constant which can be used with the operation_type property of a ScheduledJobSummary.
+    #: This constant has a value of "REMOVE"
+    OPERATION_TYPE_REMOVE = "REMOVE"
+
+    #: A constant which can be used with the operation_type property of a ScheduledJobSummary.
+    #: This constant has a value of "UPDATEALL"
+    OPERATION_TYPE_UPDATEALL = "UPDATEALL"
+
+    #: A constant which can be used with the lifecycle_state property of a ScheduledJobSummary.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ScheduledJobSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ScheduledJobSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a ScheduledJobSummary.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a ScheduledJobSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a ScheduledJobSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ScheduledJobSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this ScheduledJobSummary.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this ScheduledJobSummary.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ScheduledJobSummary.
+        :type compartment_id: str
+
+        :param schedule_type:
+            The value to assign to the schedule_type property of this ScheduledJobSummary.
+            Allowed values for this property are: "ONETIME", "RECURRING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type schedule_type: str
+
+        :param time_next_execution:
+            The value to assign to the time_next_execution property of this ScheduledJobSummary.
+        :type time_next_execution: datetime
+
+        :param time_last_execution:
+            The value to assign to the time_last_execution property of this ScheduledJobSummary.
+        :type time_last_execution: datetime
+
+        :param managed_instances:
+            The value to assign to the managed_instances property of this ScheduledJobSummary.
+        :type managed_instances: list[Id]
+
+        :param managed_instance_groups:
+            The value to assign to the managed_instance_groups property of this ScheduledJobSummary.
+        :type managed_instance_groups: list[Id]
+
+        :param operation_type:
+            The value to assign to the operation_type property of this ScheduledJobSummary.
+            Allowed values for this property are: "INSTALL", "UPDATE", "REMOVE", "UPDATEALL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type operation_type: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ScheduledJobSummary.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ScheduledJobSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ScheduledJobSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'schedule_type': 'str',
+            'time_next_execution': 'datetime',
+            'time_last_execution': 'datetime',
+            'managed_instances': 'list[Id]',
+            'managed_instance_groups': 'list[Id]',
+            'operation_type': 'str',
+            'lifecycle_state': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'schedule_type': 'scheduleType',
+            'time_next_execution': 'timeNextExecution',
+            'time_last_execution': 'timeLastExecution',
+            'managed_instances': 'managedInstances',
+            'managed_instance_groups': 'managedInstanceGroups',
+            'operation_type': 'operationType',
+            'lifecycle_state': 'lifecycleState',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._schedule_type = None
+        self._time_next_execution = None
+        self._time_last_execution = None
+        self._managed_instances = None
+        self._managed_instance_groups = None
+        self._operation_type = None
+        self._lifecycle_state = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ScheduledJobSummary.
+        OCID for the Scheduled Job
+
+
+        :return: The id of this ScheduledJobSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ScheduledJobSummary.
+        OCID for the Scheduled Job
+
+
+        :param id: The id of this ScheduledJobSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ScheduledJobSummary.
+        Scheduled Job name
+
+
+        :return: The display_name of this ScheduledJobSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ScheduledJobSummary.
+        Scheduled Job name
+
+
+        :param display_name: The display_name of this ScheduledJobSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this ScheduledJobSummary.
+        OCID for the Compartment
+
+
+        :return: The compartment_id of this ScheduledJobSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ScheduledJobSummary.
+        OCID for the Compartment
+
+
+        :param compartment_id: The compartment_id of this ScheduledJobSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def schedule_type(self):
+        """
+        Gets the schedule_type of this ScheduledJobSummary.
+        the type of scheduling this Scheduled Job follows
+
+        Allowed values for this property are: "ONETIME", "RECURRING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The schedule_type of this ScheduledJobSummary.
+        :rtype: str
+        """
+        return self._schedule_type
+
+    @schedule_type.setter
+    def schedule_type(self, schedule_type):
+        """
+        Sets the schedule_type of this ScheduledJobSummary.
+        the type of scheduling this Scheduled Job follows
+
+
+        :param schedule_type: The schedule_type of this ScheduledJobSummary.
+        :type: str
+        """
+        allowed_values = ["ONETIME", "RECURRING"]
+        if not value_allowed_none_or_none_sentinel(schedule_type, allowed_values):
+            schedule_type = 'UNKNOWN_ENUM_VALUE'
+        self._schedule_type = schedule_type
+
+    @property
+    def time_next_execution(self):
+        """
+        Gets the time_next_execution of this ScheduledJobSummary.
+        the time/date of the next scheduled execution of this Scheduled Job
+
+
+        :return: The time_next_execution of this ScheduledJobSummary.
+        :rtype: datetime
+        """
+        return self._time_next_execution
+
+    @time_next_execution.setter
+    def time_next_execution(self, time_next_execution):
+        """
+        Sets the time_next_execution of this ScheduledJobSummary.
+        the time/date of the next scheduled execution of this Scheduled Job
+
+
+        :param time_next_execution: The time_next_execution of this ScheduledJobSummary.
+        :type: datetime
+        """
+        self._time_next_execution = time_next_execution
+
+    @property
+    def time_last_execution(self):
+        """
+        Gets the time_last_execution of this ScheduledJobSummary.
+        the time/date of the last execution of this Scheduled Job
+
+
+        :return: The time_last_execution of this ScheduledJobSummary.
+        :rtype: datetime
+        """
+        return self._time_last_execution
+
+    @time_last_execution.setter
+    def time_last_execution(self, time_last_execution):
+        """
+        Sets the time_last_execution of this ScheduledJobSummary.
+        the time/date of the last execution of this Scheduled Job
+
+
+        :param time_last_execution: The time_last_execution of this ScheduledJobSummary.
+        :type: datetime
+        """
+        self._time_last_execution = time_last_execution
+
+    @property
+    def managed_instances(self):
+        """
+        Gets the managed_instances of this ScheduledJobSummary.
+        the list of managed instances this scheduled job operates on (mutually exclusive with managedInstanceGroups)
+
+
+        :return: The managed_instances of this ScheduledJobSummary.
+        :rtype: list[Id]
+        """
+        return self._managed_instances
+
+    @managed_instances.setter
+    def managed_instances(self, managed_instances):
+        """
+        Sets the managed_instances of this ScheduledJobSummary.
+        the list of managed instances this scheduled job operates on (mutually exclusive with managedInstanceGroups)
+
+
+        :param managed_instances: The managed_instances of this ScheduledJobSummary.
+        :type: list[Id]
+        """
+        self._managed_instances = managed_instances
+
+    @property
+    def managed_instance_groups(self):
+        """
+        Gets the managed_instance_groups of this ScheduledJobSummary.
+        the list of managed instance groups this scheduled job operates on (mutually exclusive with managedInstances)
+
+
+        :return: The managed_instance_groups of this ScheduledJobSummary.
+        :rtype: list[Id]
+        """
+        return self._managed_instance_groups
+
+    @managed_instance_groups.setter
+    def managed_instance_groups(self, managed_instance_groups):
+        """
+        Sets the managed_instance_groups of this ScheduledJobSummary.
+        the list of managed instance groups this scheduled job operates on (mutually exclusive with managedInstances)
+
+
+        :param managed_instance_groups: The managed_instance_groups of this ScheduledJobSummary.
+        :type: list[Id]
+        """
+        self._managed_instance_groups = managed_instance_groups
+
+    @property
+    def operation_type(self):
+        """
+        Gets the operation_type of this ScheduledJobSummary.
+        the type of operation this Scheduled Job performs
+
+        Allowed values for this property are: "INSTALL", "UPDATE", "REMOVE", "UPDATEALL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The operation_type of this ScheduledJobSummary.
+        :rtype: str
+        """
+        return self._operation_type
+
+    @operation_type.setter
+    def operation_type(self, operation_type):
+        """
+        Sets the operation_type of this ScheduledJobSummary.
+        the type of operation this Scheduled Job performs
+
+
+        :param operation_type: The operation_type of this ScheduledJobSummary.
+        :type: str
+        """
+        allowed_values = ["INSTALL", "UPDATE", "REMOVE", "UPDATEALL"]
+        if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
+            operation_type = 'UNKNOWN_ENUM_VALUE'
+        self._operation_type = operation_type
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this ScheduledJobSummary.
+        The current state of the Scheduled Job.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ScheduledJobSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ScheduledJobSummary.
+        The current state of the Scheduled Job.
+
+
+        :param lifecycle_state: The lifecycle_state of this ScheduledJobSummary.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ScheduledJobSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this ScheduledJobSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ScheduledJobSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this ScheduledJobSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ScheduledJobSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this ScheduledJobSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ScheduledJobSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this ScheduledJobSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/software_package.py
+++ b/src/oci/os_management/models/software_package.py
@@ -1,0 +1,441 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SoftwarePackage(object):
+    """
+    The details for a software package
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SoftwarePackage object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this SoftwarePackage.
+        :type display_name: str
+
+        :param name:
+            The value to assign to the name property of this SoftwarePackage.
+        :type name: str
+
+        :param type:
+            The value to assign to the type property of this SoftwarePackage.
+        :type type: str
+
+        :param version:
+            The value to assign to the version property of this SoftwarePackage.
+        :type version: str
+
+        :param architecture:
+            The value to assign to the architecture property of this SoftwarePackage.
+        :type architecture: str
+
+        :param last_modified_date:
+            The value to assign to the last_modified_date property of this SoftwarePackage.
+        :type last_modified_date: str
+
+        :param checksum:
+            The value to assign to the checksum property of this SoftwarePackage.
+        :type checksum: str
+
+        :param checksum_type:
+            The value to assign to the checksum_type property of this SoftwarePackage.
+        :type checksum_type: str
+
+        :param description:
+            The value to assign to the description property of this SoftwarePackage.
+        :type description: str
+
+        :param size_in_bytes:
+            The value to assign to the size_in_bytes property of this SoftwarePackage.
+        :type size_in_bytes: int
+
+        :param dependencies:
+            The value to assign to the dependencies property of this SoftwarePackage.
+        :type dependencies: list[SoftwarePackageDependency]
+
+        :param files:
+            The value to assign to the files property of this SoftwarePackage.
+        :type files: list[SoftwarePackageFile]
+
+        :param software_sources:
+            The value to assign to the software_sources property of this SoftwarePackage.
+        :type software_sources: list[SoftwareSourceId]
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'name': 'str',
+            'type': 'str',
+            'version': 'str',
+            'architecture': 'str',
+            'last_modified_date': 'str',
+            'checksum': 'str',
+            'checksum_type': 'str',
+            'description': 'str',
+            'size_in_bytes': 'int',
+            'dependencies': 'list[SoftwarePackageDependency]',
+            'files': 'list[SoftwarePackageFile]',
+            'software_sources': 'list[SoftwareSourceId]'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'name': 'name',
+            'type': 'type',
+            'version': 'version',
+            'architecture': 'architecture',
+            'last_modified_date': 'lastModifiedDate',
+            'checksum': 'checksum',
+            'checksum_type': 'checksumType',
+            'description': 'description',
+            'size_in_bytes': 'sizeInBytes',
+            'dependencies': 'dependencies',
+            'files': 'files',
+            'software_sources': 'softwareSources'
+        }
+
+        self._display_name = None
+        self._name = None
+        self._type = None
+        self._version = None
+        self._architecture = None
+        self._last_modified_date = None
+        self._checksum = None
+        self._checksum_type = None
+        self._description = None
+        self._size_in_bytes = None
+        self._dependencies = None
+        self._files = None
+        self._software_sources = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this SoftwarePackage.
+        Package name
+
+
+        :return: The display_name of this SoftwarePackage.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this SoftwarePackage.
+        Package name
+
+
+        :param display_name: The display_name of this SoftwarePackage.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this SoftwarePackage.
+        Unique identifier for the package. NOTE - This is not an OCID
+
+
+        :return: The name of this SoftwarePackage.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this SoftwarePackage.
+        Unique identifier for the package. NOTE - This is not an OCID
+
+
+        :param name: The name of this SoftwarePackage.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def type(self):
+        """
+        **[Required]** Gets the type of this SoftwarePackage.
+        Type of the package
+
+
+        :return: The type of this SoftwarePackage.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this SoftwarePackage.
+        Type of the package
+
+
+        :param type: The type of this SoftwarePackage.
+        :type: str
+        """
+        self._type = type
+
+    @property
+    def version(self):
+        """
+        **[Required]** Gets the version of this SoftwarePackage.
+        Version of the package
+
+
+        :return: The version of this SoftwarePackage.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this SoftwarePackage.
+        Version of the package
+
+
+        :param version: The version of this SoftwarePackage.
+        :type: str
+        """
+        self._version = version
+
+    @property
+    def architecture(self):
+        """
+        Gets the architecture of this SoftwarePackage.
+        the architecture for which this software was built
+
+
+        :return: The architecture of this SoftwarePackage.
+        :rtype: str
+        """
+        return self._architecture
+
+    @architecture.setter
+    def architecture(self, architecture):
+        """
+        Sets the architecture of this SoftwarePackage.
+        the architecture for which this software was built
+
+
+        :param architecture: The architecture of this SoftwarePackage.
+        :type: str
+        """
+        self._architecture = architecture
+
+    @property
+    def last_modified_date(self):
+        """
+        Gets the last_modified_date of this SoftwarePackage.
+        date of the last update to the package
+
+
+        :return: The last_modified_date of this SoftwarePackage.
+        :rtype: str
+        """
+        return self._last_modified_date
+
+    @last_modified_date.setter
+    def last_modified_date(self, last_modified_date):
+        """
+        Sets the last_modified_date of this SoftwarePackage.
+        date of the last update to the package
+
+
+        :param last_modified_date: The last_modified_date of this SoftwarePackage.
+        :type: str
+        """
+        self._last_modified_date = last_modified_date
+
+    @property
+    def checksum(self):
+        """
+        Gets the checksum of this SoftwarePackage.
+        checksum of the package
+
+
+        :return: The checksum of this SoftwarePackage.
+        :rtype: str
+        """
+        return self._checksum
+
+    @checksum.setter
+    def checksum(self, checksum):
+        """
+        Sets the checksum of this SoftwarePackage.
+        checksum of the package
+
+
+        :param checksum: The checksum of this SoftwarePackage.
+        :type: str
+        """
+        self._checksum = checksum
+
+    @property
+    def checksum_type(self):
+        """
+        Gets the checksum_type of this SoftwarePackage.
+        type of the checksum
+
+
+        :return: The checksum_type of this SoftwarePackage.
+        :rtype: str
+        """
+        return self._checksum_type
+
+    @checksum_type.setter
+    def checksum_type(self, checksum_type):
+        """
+        Sets the checksum_type of this SoftwarePackage.
+        type of the checksum
+
+
+        :param checksum_type: The checksum_type of this SoftwarePackage.
+        :type: str
+        """
+        self._checksum_type = checksum_type
+
+    @property
+    def description(self):
+        """
+        Gets the description of this SoftwarePackage.
+        description of the package
+
+
+        :return: The description of this SoftwarePackage.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this SoftwarePackage.
+        description of the package
+
+
+        :param description: The description of this SoftwarePackage.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def size_in_bytes(self):
+        """
+        Gets the size_in_bytes of this SoftwarePackage.
+        size of the package in bytes
+
+
+        :return: The size_in_bytes of this SoftwarePackage.
+        :rtype: int
+        """
+        return self._size_in_bytes
+
+    @size_in_bytes.setter
+    def size_in_bytes(self, size_in_bytes):
+        """
+        Sets the size_in_bytes of this SoftwarePackage.
+        size of the package in bytes
+
+
+        :param size_in_bytes: The size_in_bytes of this SoftwarePackage.
+        :type: int
+        """
+        self._size_in_bytes = size_in_bytes
+
+    @property
+    def dependencies(self):
+        """
+        Gets the dependencies of this SoftwarePackage.
+        list of dependencies for the software package
+
+
+        :return: The dependencies of this SoftwarePackage.
+        :rtype: list[SoftwarePackageDependency]
+        """
+        return self._dependencies
+
+    @dependencies.setter
+    def dependencies(self, dependencies):
+        """
+        Sets the dependencies of this SoftwarePackage.
+        list of dependencies for the software package
+
+
+        :param dependencies: The dependencies of this SoftwarePackage.
+        :type: list[SoftwarePackageDependency]
+        """
+        self._dependencies = dependencies
+
+    @property
+    def files(self):
+        """
+        Gets the files of this SoftwarePackage.
+        list of files for the software package
+
+
+        :return: The files of this SoftwarePackage.
+        :rtype: list[SoftwarePackageFile]
+        """
+        return self._files
+
+    @files.setter
+    def files(self, files):
+        """
+        Sets the files of this SoftwarePackage.
+        list of files for the software package
+
+
+        :param files: The files of this SoftwarePackage.
+        :type: list[SoftwarePackageFile]
+        """
+        self._files = files
+
+    @property
+    def software_sources(self):
+        """
+        Gets the software_sources of this SoftwarePackage.
+        list of software sources that provide the software package
+
+
+        :return: The software_sources of this SoftwarePackage.
+        :rtype: list[SoftwareSourceId]
+        """
+        return self._software_sources
+
+    @software_sources.setter
+    def software_sources(self, software_sources):
+        """
+        Sets the software_sources of this SoftwarePackage.
+        list of software sources that provide the software package
+
+
+        :param software_sources: The software_sources of this SoftwarePackage.
+        :type: list[SoftwareSourceId]
+        """
+        self._software_sources = software_sources
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/software_package_dependency.py
+++ b/src/oci/os_management/models/software_package_dependency.py
@@ -1,0 +1,131 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SoftwarePackageDependency(object):
+    """
+    A dependecy for a software package
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SoftwarePackageDependency object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param dependency:
+            The value to assign to the dependency property of this SoftwarePackageDependency.
+        :type dependency: str
+
+        :param dependency_type:
+            The value to assign to the dependency_type property of this SoftwarePackageDependency.
+        :type dependency_type: str
+
+        :param dependency_modifier:
+            The value to assign to the dependency_modifier property of this SoftwarePackageDependency.
+        :type dependency_modifier: str
+
+        """
+        self.swagger_types = {
+            'dependency': 'str',
+            'dependency_type': 'str',
+            'dependency_modifier': 'str'
+        }
+
+        self.attribute_map = {
+            'dependency': 'dependency',
+            'dependency_type': 'dependencyType',
+            'dependency_modifier': 'dependencyModifier'
+        }
+
+        self._dependency = None
+        self._dependency_type = None
+        self._dependency_modifier = None
+
+    @property
+    def dependency(self):
+        """
+        Gets the dependency of this SoftwarePackageDependency.
+        the software package's dependency
+
+
+        :return: The dependency of this SoftwarePackageDependency.
+        :rtype: str
+        """
+        return self._dependency
+
+    @dependency.setter
+    def dependency(self, dependency):
+        """
+        Sets the dependency of this SoftwarePackageDependency.
+        the software package's dependency
+
+
+        :param dependency: The dependency of this SoftwarePackageDependency.
+        :type: str
+        """
+        self._dependency = dependency
+
+    @property
+    def dependency_type(self):
+        """
+        Gets the dependency_type of this SoftwarePackageDependency.
+        the type of the dependency
+
+
+        :return: The dependency_type of this SoftwarePackageDependency.
+        :rtype: str
+        """
+        return self._dependency_type
+
+    @dependency_type.setter
+    def dependency_type(self, dependency_type):
+        """
+        Sets the dependency_type of this SoftwarePackageDependency.
+        the type of the dependency
+
+
+        :param dependency_type: The dependency_type of this SoftwarePackageDependency.
+        :type: str
+        """
+        self._dependency_type = dependency_type
+
+    @property
+    def dependency_modifier(self):
+        """
+        Gets the dependency_modifier of this SoftwarePackageDependency.
+        the modifier for the dependency
+
+
+        :return: The dependency_modifier of this SoftwarePackageDependency.
+        :rtype: str
+        """
+        return self._dependency_modifier
+
+    @dependency_modifier.setter
+    def dependency_modifier(self, dependency_modifier):
+        """
+        Sets the dependency_modifier of this SoftwarePackageDependency.
+        the modifier for the dependency
+
+
+        :param dependency_modifier: The dependency_modifier of this SoftwarePackageDependency.
+        :type: str
+        """
+        self._dependency_modifier = dependency_modifier
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/software_package_file.py
+++ b/src/oci/os_management/models/software_package_file.py
@@ -1,0 +1,230 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SoftwarePackageFile(object):
+    """
+    A file associated with a package
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SoftwarePackageFile object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param path:
+            The value to assign to the path property of this SoftwarePackageFile.
+        :type path: str
+
+        :param type:
+            The value to assign to the type property of this SoftwarePackageFile.
+        :type type: str
+
+        :param time_modified:
+            The value to assign to the time_modified property of this SoftwarePackageFile.
+        :type time_modified: datetime
+
+        :param checksum:
+            The value to assign to the checksum property of this SoftwarePackageFile.
+        :type checksum: str
+
+        :param checksum_type:
+            The value to assign to the checksum_type property of this SoftwarePackageFile.
+        :type checksum_type: str
+
+        :param size_in_bytes:
+            The value to assign to the size_in_bytes property of this SoftwarePackageFile.
+        :type size_in_bytes: int
+
+        """
+        self.swagger_types = {
+            'path': 'str',
+            'type': 'str',
+            'time_modified': 'datetime',
+            'checksum': 'str',
+            'checksum_type': 'str',
+            'size_in_bytes': 'int'
+        }
+
+        self.attribute_map = {
+            'path': 'path',
+            'type': 'type',
+            'time_modified': 'timeModified',
+            'checksum': 'checksum',
+            'checksum_type': 'checksumType',
+            'size_in_bytes': 'sizeInBytes'
+        }
+
+        self._path = None
+        self._type = None
+        self._time_modified = None
+        self._checksum = None
+        self._checksum_type = None
+        self._size_in_bytes = None
+
+    @property
+    def path(self):
+        """
+        Gets the path of this SoftwarePackageFile.
+        file path
+
+
+        :return: The path of this SoftwarePackageFile.
+        :rtype: str
+        """
+        return self._path
+
+    @path.setter
+    def path(self, path):
+        """
+        Sets the path of this SoftwarePackageFile.
+        file path
+
+
+        :param path: The path of this SoftwarePackageFile.
+        :type: str
+        """
+        self._path = path
+
+    @property
+    def type(self):
+        """
+        Gets the type of this SoftwarePackageFile.
+        type of the file
+
+
+        :return: The type of this SoftwarePackageFile.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this SoftwarePackageFile.
+        type of the file
+
+
+        :param type: The type of this SoftwarePackageFile.
+        :type: str
+        """
+        self._type = type
+
+    @property
+    def time_modified(self):
+        """
+        Gets the time_modified of this SoftwarePackageFile.
+        The date and time of the last modification to this file, as described
+        in `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_modified of this SoftwarePackageFile.
+        :rtype: datetime
+        """
+        return self._time_modified
+
+    @time_modified.setter
+    def time_modified(self, time_modified):
+        """
+        Sets the time_modified of this SoftwarePackageFile.
+        The date and time of the last modification to this file, as described
+        in `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_modified: The time_modified of this SoftwarePackageFile.
+        :type: datetime
+        """
+        self._time_modified = time_modified
+
+    @property
+    def checksum(self):
+        """
+        Gets the checksum of this SoftwarePackageFile.
+        checksum of the file
+
+
+        :return: The checksum of this SoftwarePackageFile.
+        :rtype: str
+        """
+        return self._checksum
+
+    @checksum.setter
+    def checksum(self, checksum):
+        """
+        Sets the checksum of this SoftwarePackageFile.
+        checksum of the file
+
+
+        :param checksum: The checksum of this SoftwarePackageFile.
+        :type: str
+        """
+        self._checksum = checksum
+
+    @property
+    def checksum_type(self):
+        """
+        Gets the checksum_type of this SoftwarePackageFile.
+        type of the checksum
+
+
+        :return: The checksum_type of this SoftwarePackageFile.
+        :rtype: str
+        """
+        return self._checksum_type
+
+    @checksum_type.setter
+    def checksum_type(self, checksum_type):
+        """
+        Sets the checksum_type of this SoftwarePackageFile.
+        type of the checksum
+
+
+        :param checksum_type: The checksum_type of this SoftwarePackageFile.
+        :type: str
+        """
+        self._checksum_type = checksum_type
+
+    @property
+    def size_in_bytes(self):
+        """
+        Gets the size_in_bytes of this SoftwarePackageFile.
+        size of the file in bytes
+
+
+        :return: The size_in_bytes of this SoftwarePackageFile.
+        :rtype: int
+        """
+        return self._size_in_bytes
+
+    @size_in_bytes.setter
+    def size_in_bytes(self, size_in_bytes):
+        """
+        Sets the size_in_bytes of this SoftwarePackageFile.
+        size of the file in bytes
+
+
+        :param size_in_bytes: The size_in_bytes of this SoftwarePackageFile.
+        :type: int
+        """
+        self._size_in_bytes = size_in_bytes
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/software_package_search_summary.py
+++ b/src/oci/os_management/models/software_package_search_summary.py
@@ -1,0 +1,337 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SoftwarePackageSearchSummary(object):
+    """
+    Summary information for a software package
+    """
+
+    #: A constant which can be used with the advisory_type property of a SoftwarePackageSearchSummary.
+    #: This constant has a value of "SECURITY"
+    ADVISORY_TYPE_SECURITY = "SECURITY"
+
+    #: A constant which can be used with the advisory_type property of a SoftwarePackageSearchSummary.
+    #: This constant has a value of "BUG"
+    ADVISORY_TYPE_BUG = "BUG"
+
+    #: A constant which can be used with the advisory_type property of a SoftwarePackageSearchSummary.
+    #: This constant has a value of "ENHANCEMENT"
+    ADVISORY_TYPE_ENHANCEMENT = "ENHANCEMENT"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SoftwarePackageSearchSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this SoftwarePackageSearchSummary.
+        :type display_name: str
+
+        :param name:
+            The value to assign to the name property of this SoftwarePackageSearchSummary.
+        :type name: str
+
+        :param type:
+            The value to assign to the type property of this SoftwarePackageSearchSummary.
+        :type type: str
+
+        :param version:
+            The value to assign to the version property of this SoftwarePackageSearchSummary.
+        :type version: str
+
+        :param architecture:
+            The value to assign to the architecture property of this SoftwarePackageSearchSummary.
+        :type architecture: str
+
+        :param summary:
+            The value to assign to the summary property of this SoftwarePackageSearchSummary.
+        :type summary: str
+
+        :param advisory_type:
+            The value to assign to the advisory_type property of this SoftwarePackageSearchSummary.
+            Allowed values for this property are: "SECURITY", "BUG", "ENHANCEMENT", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type advisory_type: str
+
+        :param errata:
+            The value to assign to the errata property of this SoftwarePackageSearchSummary.
+        :type errata: list[Id]
+
+        :param software_sources:
+            The value to assign to the software_sources property of this SoftwarePackageSearchSummary.
+        :type software_sources: list[SoftwareSourceId]
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'name': 'str',
+            'type': 'str',
+            'version': 'str',
+            'architecture': 'str',
+            'summary': 'str',
+            'advisory_type': 'str',
+            'errata': 'list[Id]',
+            'software_sources': 'list[SoftwareSourceId]'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'name': 'name',
+            'type': 'type',
+            'version': 'version',
+            'architecture': 'architecture',
+            'summary': 'summary',
+            'advisory_type': 'advisoryType',
+            'errata': 'errata',
+            'software_sources': 'softwareSources'
+        }
+
+        self._display_name = None
+        self._name = None
+        self._type = None
+        self._version = None
+        self._architecture = None
+        self._summary = None
+        self._advisory_type = None
+        self._errata = None
+        self._software_sources = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this SoftwarePackageSearchSummary.
+        Package name
+
+
+        :return: The display_name of this SoftwarePackageSearchSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this SoftwarePackageSearchSummary.
+        Package name
+
+
+        :param display_name: The display_name of this SoftwarePackageSearchSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this SoftwarePackageSearchSummary.
+        Unique identifier for the package. NOTE - This is not an OCID
+
+
+        :return: The name of this SoftwarePackageSearchSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this SoftwarePackageSearchSummary.
+        Unique identifier for the package. NOTE - This is not an OCID
+
+
+        :param name: The name of this SoftwarePackageSearchSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def type(self):
+        """
+        **[Required]** Gets the type of this SoftwarePackageSearchSummary.
+        Type of the package
+
+
+        :return: The type of this SoftwarePackageSearchSummary.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this SoftwarePackageSearchSummary.
+        Type of the package
+
+
+        :param type: The type of this SoftwarePackageSearchSummary.
+        :type: str
+        """
+        self._type = type
+
+    @property
+    def version(self):
+        """
+        **[Required]** Gets the version of this SoftwarePackageSearchSummary.
+        Version of the package
+
+
+        :return: The version of this SoftwarePackageSearchSummary.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this SoftwarePackageSearchSummary.
+        Version of the package
+
+
+        :param version: The version of this SoftwarePackageSearchSummary.
+        :type: str
+        """
+        self._version = version
+
+    @property
+    def architecture(self):
+        """
+        Gets the architecture of this SoftwarePackageSearchSummary.
+        the architecture for which this software was built
+
+
+        :return: The architecture of this SoftwarePackageSearchSummary.
+        :rtype: str
+        """
+        return self._architecture
+
+    @architecture.setter
+    def architecture(self, architecture):
+        """
+        Sets the architecture of this SoftwarePackageSearchSummary.
+        the architecture for which this software was built
+
+
+        :param architecture: The architecture of this SoftwarePackageSearchSummary.
+        :type: str
+        """
+        self._architecture = architecture
+
+    @property
+    def summary(self):
+        """
+        Gets the summary of this SoftwarePackageSearchSummary.
+        a summary description of the software package
+
+
+        :return: The summary of this SoftwarePackageSearchSummary.
+        :rtype: str
+        """
+        return self._summary
+
+    @summary.setter
+    def summary(self, summary):
+        """
+        Sets the summary of this SoftwarePackageSearchSummary.
+        a summary description of the software package
+
+
+        :param summary: The summary of this SoftwarePackageSearchSummary.
+        :type: str
+        """
+        self._summary = summary
+
+    @property
+    def advisory_type(self):
+        """
+        Gets the advisory_type of this SoftwarePackageSearchSummary.
+        Type of the erratum.
+
+        Allowed values for this property are: "SECURITY", "BUG", "ENHANCEMENT", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The advisory_type of this SoftwarePackageSearchSummary.
+        :rtype: str
+        """
+        return self._advisory_type
+
+    @advisory_type.setter
+    def advisory_type(self, advisory_type):
+        """
+        Sets the advisory_type of this SoftwarePackageSearchSummary.
+        Type of the erratum.
+
+
+        :param advisory_type: The advisory_type of this SoftwarePackageSearchSummary.
+        :type: str
+        """
+        allowed_values = ["SECURITY", "BUG", "ENHANCEMENT"]
+        if not value_allowed_none_or_none_sentinel(advisory_type, allowed_values):
+            advisory_type = 'UNKNOWN_ENUM_VALUE'
+        self._advisory_type = advisory_type
+
+    @property
+    def errata(self):
+        """
+        Gets the errata of this SoftwarePackageSearchSummary.
+        List of errata containing this software package
+
+
+        :return: The errata of this SoftwarePackageSearchSummary.
+        :rtype: list[Id]
+        """
+        return self._errata
+
+    @errata.setter
+    def errata(self, errata):
+        """
+        Sets the errata of this SoftwarePackageSearchSummary.
+        List of errata containing this software package
+
+
+        :param errata: The errata of this SoftwarePackageSearchSummary.
+        :type: list[Id]
+        """
+        self._errata = errata
+
+    @property
+    def software_sources(self):
+        """
+        Gets the software_sources of this SoftwarePackageSearchSummary.
+        list of software sources that provide the software package
+
+
+        :return: The software_sources of this SoftwarePackageSearchSummary.
+        :rtype: list[SoftwareSourceId]
+        """
+        return self._software_sources
+
+    @software_sources.setter
+    def software_sources(self, software_sources):
+        """
+        Sets the software_sources of this SoftwarePackageSearchSummary.
+        list of software sources that provide the software package
+
+
+        :param software_sources: The software_sources of this SoftwarePackageSearchSummary.
+        :type: list[SoftwareSourceId]
+        """
+        self._software_sources = software_sources
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/software_package_summary.py
+++ b/src/oci/os_management/models/software_package_summary.py
@@ -1,0 +1,255 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SoftwarePackageSummary(object):
+    """
+    Summary information for a software package
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SoftwarePackageSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this SoftwarePackageSummary.
+        :type display_name: str
+
+        :param name:
+            The value to assign to the name property of this SoftwarePackageSummary.
+        :type name: str
+
+        :param type:
+            The value to assign to the type property of this SoftwarePackageSummary.
+        :type type: str
+
+        :param version:
+            The value to assign to the version property of this SoftwarePackageSummary.
+        :type version: str
+
+        :param architecture:
+            The value to assign to the architecture property of this SoftwarePackageSummary.
+        :type architecture: str
+
+        :param checksum:
+            The value to assign to the checksum property of this SoftwarePackageSummary.
+        :type checksum: str
+
+        :param checksum_type:
+            The value to assign to the checksum_type property of this SoftwarePackageSummary.
+        :type checksum_type: str
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'name': 'str',
+            'type': 'str',
+            'version': 'str',
+            'architecture': 'str',
+            'checksum': 'str',
+            'checksum_type': 'str'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'name': 'name',
+            'type': 'type',
+            'version': 'version',
+            'architecture': 'architecture',
+            'checksum': 'checksum',
+            'checksum_type': 'checksumType'
+        }
+
+        self._display_name = None
+        self._name = None
+        self._type = None
+        self._version = None
+        self._architecture = None
+        self._checksum = None
+        self._checksum_type = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this SoftwarePackageSummary.
+        Package name
+
+
+        :return: The display_name of this SoftwarePackageSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this SoftwarePackageSummary.
+        Package name
+
+
+        :param display_name: The display_name of this SoftwarePackageSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this SoftwarePackageSummary.
+        Unique identifier for the package. NOTE - This is not an OCID
+
+
+        :return: The name of this SoftwarePackageSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this SoftwarePackageSummary.
+        Unique identifier for the package. NOTE - This is not an OCID
+
+
+        :param name: The name of this SoftwarePackageSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def type(self):
+        """
+        **[Required]** Gets the type of this SoftwarePackageSummary.
+        Type of the package
+
+
+        :return: The type of this SoftwarePackageSummary.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this SoftwarePackageSummary.
+        Type of the package
+
+
+        :param type: The type of this SoftwarePackageSummary.
+        :type: str
+        """
+        self._type = type
+
+    @property
+    def version(self):
+        """
+        **[Required]** Gets the version of this SoftwarePackageSummary.
+        Version of the package
+
+
+        :return: The version of this SoftwarePackageSummary.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this SoftwarePackageSummary.
+        Version of the package
+
+
+        :param version: The version of this SoftwarePackageSummary.
+        :type: str
+        """
+        self._version = version
+
+    @property
+    def architecture(self):
+        """
+        Gets the architecture of this SoftwarePackageSummary.
+        the architecture for which this software was built
+
+
+        :return: The architecture of this SoftwarePackageSummary.
+        :rtype: str
+        """
+        return self._architecture
+
+    @architecture.setter
+    def architecture(self, architecture):
+        """
+        Sets the architecture of this SoftwarePackageSummary.
+        the architecture for which this software was built
+
+
+        :param architecture: The architecture of this SoftwarePackageSummary.
+        :type: str
+        """
+        self._architecture = architecture
+
+    @property
+    def checksum(self):
+        """
+        Gets the checksum of this SoftwarePackageSummary.
+        checksum of the package
+
+
+        :return: The checksum of this SoftwarePackageSummary.
+        :rtype: str
+        """
+        return self._checksum
+
+    @checksum.setter
+    def checksum(self, checksum):
+        """
+        Sets the checksum of this SoftwarePackageSummary.
+        checksum of the package
+
+
+        :param checksum: The checksum of this SoftwarePackageSummary.
+        :type: str
+        """
+        self._checksum = checksum
+
+    @property
+    def checksum_type(self):
+        """
+        Gets the checksum_type of this SoftwarePackageSummary.
+        type of the checksum
+
+
+        :return: The checksum_type of this SoftwarePackageSummary.
+        :rtype: str
+        """
+        return self._checksum_type
+
+    @checksum_type.setter
+    def checksum_type(self, checksum_type):
+        """
+        Sets the checksum_type of this SoftwarePackageSummary.
+        type of the checksum
+
+
+        :param checksum_type: The checksum_type of this SoftwarePackageSummary.
+        :type: str
+        """
+        self._checksum_type = checksum_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/software_source.py
+++ b/src/oci/os_management/models/software_source.py
@@ -1,0 +1,832 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SoftwareSource(object):
+    """
+    A software source contains a collection of packages
+    """
+
+    #: A constant which can be used with the arch_type property of a SoftwareSource.
+    #: This constant has a value of "IA_32"
+    ARCH_TYPE_IA_32 = "IA_32"
+
+    #: A constant which can be used with the arch_type property of a SoftwareSource.
+    #: This constant has a value of "X86_64"
+    ARCH_TYPE_X86_64 = "X86_64"
+
+    #: A constant which can be used with the arch_type property of a SoftwareSource.
+    #: This constant has a value of "AARCH64"
+    ARCH_TYPE_AARCH64 = "AARCH64"
+
+    #: A constant which can be used with the arch_type property of a SoftwareSource.
+    #: This constant has a value of "SPARC"
+    ARCH_TYPE_SPARC = "SPARC"
+
+    #: A constant which can be used with the arch_type property of a SoftwareSource.
+    #: This constant has a value of "AMD64_DEBIAN"
+    ARCH_TYPE_AMD64_DEBIAN = "AMD64_DEBIAN"
+
+    #: A constant which can be used with the checksum_type property of a SoftwareSource.
+    #: This constant has a value of "SHA1"
+    CHECKSUM_TYPE_SHA1 = "SHA1"
+
+    #: A constant which can be used with the checksum_type property of a SoftwareSource.
+    #: This constant has a value of "SHA256"
+    CHECKSUM_TYPE_SHA256 = "SHA256"
+
+    #: A constant which can be used with the checksum_type property of a SoftwareSource.
+    #: This constant has a value of "SHA384"
+    CHECKSUM_TYPE_SHA384 = "SHA384"
+
+    #: A constant which can be used with the checksum_type property of a SoftwareSource.
+    #: This constant has a value of "SHA512"
+    CHECKSUM_TYPE_SHA512 = "SHA512"
+
+    #: A constant which can be used with the status property of a SoftwareSource.
+    #: This constant has a value of "NORMAL"
+    STATUS_NORMAL = "NORMAL"
+
+    #: A constant which can be used with the status property of a SoftwareSource.
+    #: This constant has a value of "UNREACHABLE"
+    STATUS_UNREACHABLE = "UNREACHABLE"
+
+    #: A constant which can be used with the status property of a SoftwareSource.
+    #: This constant has a value of "ERROR"
+    STATUS_ERROR = "ERROR"
+
+    #: A constant which can be used with the status property of a SoftwareSource.
+    #: This constant has a value of "WARNING"
+    STATUS_WARNING = "WARNING"
+
+    #: A constant which can be used with the lifecycle_state property of a SoftwareSource.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a SoftwareSource.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a SoftwareSource.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a SoftwareSource.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a SoftwareSource.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a SoftwareSource.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SoftwareSource object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this SoftwareSource.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this SoftwareSource.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this SoftwareSource.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this SoftwareSource.
+        :type description: str
+
+        :param repo_type:
+            The value to assign to the repo_type property of this SoftwareSource.
+        :type repo_type: str
+
+        :param arch_type:
+            The value to assign to the arch_type property of this SoftwareSource.
+            Allowed values for this property are: "IA_32", "X86_64", "AARCH64", "SPARC", "AMD64_DEBIAN", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type arch_type: str
+
+        :param url:
+            The value to assign to the url property of this SoftwareSource.
+        :type url: str
+
+        :param parent_id:
+            The value to assign to the parent_id property of this SoftwareSource.
+        :type parent_id: str
+
+        :param parent_name:
+            The value to assign to the parent_name property of this SoftwareSource.
+        :type parent_name: str
+
+        :param checksum_type:
+            The value to assign to the checksum_type property of this SoftwareSource.
+            Allowed values for this property are: "SHA1", "SHA256", "SHA384", "SHA512", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type checksum_type: str
+
+        :param maintainer_name:
+            The value to assign to the maintainer_name property of this SoftwareSource.
+        :type maintainer_name: str
+
+        :param maintainer_email:
+            The value to assign to the maintainer_email property of this SoftwareSource.
+        :type maintainer_email: str
+
+        :param maintainer_phone:
+            The value to assign to the maintainer_phone property of this SoftwareSource.
+        :type maintainer_phone: str
+
+        :param gpg_key_url:
+            The value to assign to the gpg_key_url property of this SoftwareSource.
+        :type gpg_key_url: str
+
+        :param gpg_key_id:
+            The value to assign to the gpg_key_id property of this SoftwareSource.
+        :type gpg_key_id: str
+
+        :param gpg_key_fingerprint:
+            The value to assign to the gpg_key_fingerprint property of this SoftwareSource.
+        :type gpg_key_fingerprint: str
+
+        :param status:
+            The value to assign to the status property of this SoftwareSource.
+            Allowed values for this property are: "NORMAL", "UNREACHABLE", "ERROR", "WARNING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this SoftwareSource.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param packages:
+            The value to assign to the packages property of this SoftwareSource.
+        :type packages: int
+
+        :param associated_managed_instances:
+            The value to assign to the associated_managed_instances property of this SoftwareSource.
+        :type associated_managed_instances: list[Id]
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this SoftwareSource.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this SoftwareSource.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'description': 'str',
+            'repo_type': 'str',
+            'arch_type': 'str',
+            'url': 'str',
+            'parent_id': 'str',
+            'parent_name': 'str',
+            'checksum_type': 'str',
+            'maintainer_name': 'str',
+            'maintainer_email': 'str',
+            'maintainer_phone': 'str',
+            'gpg_key_url': 'str',
+            'gpg_key_id': 'str',
+            'gpg_key_fingerprint': 'str',
+            'status': 'str',
+            'lifecycle_state': 'str',
+            'packages': 'int',
+            'associated_managed_instances': 'list[Id]',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'description': 'description',
+            'repo_type': 'repoType',
+            'arch_type': 'archType',
+            'url': 'url',
+            'parent_id': 'parentId',
+            'parent_name': 'parentName',
+            'checksum_type': 'checksumType',
+            'maintainer_name': 'maintainerName',
+            'maintainer_email': 'maintainerEmail',
+            'maintainer_phone': 'maintainerPhone',
+            'gpg_key_url': 'gpgKeyUrl',
+            'gpg_key_id': 'gpgKeyId',
+            'gpg_key_fingerprint': 'gpgKeyFingerprint',
+            'status': 'status',
+            'lifecycle_state': 'lifecycleState',
+            'packages': 'packages',
+            'associated_managed_instances': 'associatedManagedInstances',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._display_name = None
+        self._description = None
+        self._repo_type = None
+        self._arch_type = None
+        self._url = None
+        self._parent_id = None
+        self._parent_name = None
+        self._checksum_type = None
+        self._maintainer_name = None
+        self._maintainer_email = None
+        self._maintainer_phone = None
+        self._gpg_key_url = None
+        self._gpg_key_id = None
+        self._gpg_key_fingerprint = None
+        self._status = None
+        self._lifecycle_state = None
+        self._packages = None
+        self._associated_managed_instances = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this SoftwareSource.
+        OCID for the Software Source
+
+
+        :return: The id of this SoftwareSource.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this SoftwareSource.
+        OCID for the Software Source
+
+
+        :param id: The id of this SoftwareSource.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this SoftwareSource.
+        OCID for the Compartment
+
+
+        :return: The compartment_id of this SoftwareSource.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this SoftwareSource.
+        OCID for the Compartment
+
+
+        :param compartment_id: The compartment_id of this SoftwareSource.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this SoftwareSource.
+        User friendly name for the software source
+
+
+        :return: The display_name of this SoftwareSource.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this SoftwareSource.
+        User friendly name for the software source
+
+
+        :param display_name: The display_name of this SoftwareSource.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this SoftwareSource.
+        Information specified by the user about the software source
+
+
+        :return: The description of this SoftwareSource.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this SoftwareSource.
+        Information specified by the user about the software source
+
+
+        :param description: The description of this SoftwareSource.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def repo_type(self):
+        """
+        **[Required]** Gets the repo_type of this SoftwareSource.
+        Type of the Software Source
+
+
+        :return: The repo_type of this SoftwareSource.
+        :rtype: str
+        """
+        return self._repo_type
+
+    @repo_type.setter
+    def repo_type(self, repo_type):
+        """
+        Sets the repo_type of this SoftwareSource.
+        Type of the Software Source
+
+
+        :param repo_type: The repo_type of this SoftwareSource.
+        :type: str
+        """
+        self._repo_type = repo_type
+
+    @property
+    def arch_type(self):
+        """
+        Gets the arch_type of this SoftwareSource.
+        The architecture type supported by the Software Source
+
+        Allowed values for this property are: "IA_32", "X86_64", "AARCH64", "SPARC", "AMD64_DEBIAN", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The arch_type of this SoftwareSource.
+        :rtype: str
+        """
+        return self._arch_type
+
+    @arch_type.setter
+    def arch_type(self, arch_type):
+        """
+        Sets the arch_type of this SoftwareSource.
+        The architecture type supported by the Software Source
+
+
+        :param arch_type: The arch_type of this SoftwareSource.
+        :type: str
+        """
+        allowed_values = ["IA_32", "X86_64", "AARCH64", "SPARC", "AMD64_DEBIAN"]
+        if not value_allowed_none_or_none_sentinel(arch_type, allowed_values):
+            arch_type = 'UNKNOWN_ENUM_VALUE'
+        self._arch_type = arch_type
+
+    @property
+    def url(self):
+        """
+        **[Required]** Gets the url of this SoftwareSource.
+        URL for the repostiory
+
+
+        :return: The url of this SoftwareSource.
+        :rtype: str
+        """
+        return self._url
+
+    @url.setter
+    def url(self, url):
+        """
+        Sets the url of this SoftwareSource.
+        URL for the repostiory
+
+
+        :param url: The url of this SoftwareSource.
+        :type: str
+        """
+        self._url = url
+
+    @property
+    def parent_id(self):
+        """
+        Gets the parent_id of this SoftwareSource.
+        OCID for the parent software source, if there is one
+
+
+        :return: The parent_id of this SoftwareSource.
+        :rtype: str
+        """
+        return self._parent_id
+
+    @parent_id.setter
+    def parent_id(self, parent_id):
+        """
+        Sets the parent_id of this SoftwareSource.
+        OCID for the parent software source, if there is one
+
+
+        :param parent_id: The parent_id of this SoftwareSource.
+        :type: str
+        """
+        self._parent_id = parent_id
+
+    @property
+    def parent_name(self):
+        """
+        Gets the parent_name of this SoftwareSource.
+        Display name the parent software source, if there is one
+
+
+        :return: The parent_name of this SoftwareSource.
+        :rtype: str
+        """
+        return self._parent_name
+
+    @parent_name.setter
+    def parent_name(self, parent_name):
+        """
+        Sets the parent_name of this SoftwareSource.
+        Display name the parent software source, if there is one
+
+
+        :param parent_name: The parent_name of this SoftwareSource.
+        :type: str
+        """
+        self._parent_name = parent_name
+
+    @property
+    def checksum_type(self):
+        """
+        Gets the checksum_type of this SoftwareSource.
+        The yum repository checksum type used by this software source
+
+        Allowed values for this property are: "SHA1", "SHA256", "SHA384", "SHA512", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The checksum_type of this SoftwareSource.
+        :rtype: str
+        """
+        return self._checksum_type
+
+    @checksum_type.setter
+    def checksum_type(self, checksum_type):
+        """
+        Sets the checksum_type of this SoftwareSource.
+        The yum repository checksum type used by this software source
+
+
+        :param checksum_type: The checksum_type of this SoftwareSource.
+        :type: str
+        """
+        allowed_values = ["SHA1", "SHA256", "SHA384", "SHA512"]
+        if not value_allowed_none_or_none_sentinel(checksum_type, allowed_values):
+            checksum_type = 'UNKNOWN_ENUM_VALUE'
+        self._checksum_type = checksum_type
+
+    @property
+    def maintainer_name(self):
+        """
+        Gets the maintainer_name of this SoftwareSource.
+        Name of the person maintaining this software source
+
+
+        :return: The maintainer_name of this SoftwareSource.
+        :rtype: str
+        """
+        return self._maintainer_name
+
+    @maintainer_name.setter
+    def maintainer_name(self, maintainer_name):
+        """
+        Sets the maintainer_name of this SoftwareSource.
+        Name of the person maintaining this software source
+
+
+        :param maintainer_name: The maintainer_name of this SoftwareSource.
+        :type: str
+        """
+        self._maintainer_name = maintainer_name
+
+    @property
+    def maintainer_email(self):
+        """
+        Gets the maintainer_email of this SoftwareSource.
+        Email address of the person maintaining this software source
+
+
+        :return: The maintainer_email of this SoftwareSource.
+        :rtype: str
+        """
+        return self._maintainer_email
+
+    @maintainer_email.setter
+    def maintainer_email(self, maintainer_email):
+        """
+        Sets the maintainer_email of this SoftwareSource.
+        Email address of the person maintaining this software source
+
+
+        :param maintainer_email: The maintainer_email of this SoftwareSource.
+        :type: str
+        """
+        self._maintainer_email = maintainer_email
+
+    @property
+    def maintainer_phone(self):
+        """
+        Gets the maintainer_phone of this SoftwareSource.
+        Phone number of the person maintaining this software source
+
+
+        :return: The maintainer_phone of this SoftwareSource.
+        :rtype: str
+        """
+        return self._maintainer_phone
+
+    @maintainer_phone.setter
+    def maintainer_phone(self, maintainer_phone):
+        """
+        Sets the maintainer_phone of this SoftwareSource.
+        Phone number of the person maintaining this software source
+
+
+        :param maintainer_phone: The maintainer_phone of this SoftwareSource.
+        :type: str
+        """
+        self._maintainer_phone = maintainer_phone
+
+    @property
+    def gpg_key_url(self):
+        """
+        Gets the gpg_key_url of this SoftwareSource.
+        URL of the GPG key for this software source
+
+
+        :return: The gpg_key_url of this SoftwareSource.
+        :rtype: str
+        """
+        return self._gpg_key_url
+
+    @gpg_key_url.setter
+    def gpg_key_url(self, gpg_key_url):
+        """
+        Sets the gpg_key_url of this SoftwareSource.
+        URL of the GPG key for this software source
+
+
+        :param gpg_key_url: The gpg_key_url of this SoftwareSource.
+        :type: str
+        """
+        self._gpg_key_url = gpg_key_url
+
+    @property
+    def gpg_key_id(self):
+        """
+        Gets the gpg_key_id of this SoftwareSource.
+        ID of the GPG key for this software source
+
+
+        :return: The gpg_key_id of this SoftwareSource.
+        :rtype: str
+        """
+        return self._gpg_key_id
+
+    @gpg_key_id.setter
+    def gpg_key_id(self, gpg_key_id):
+        """
+        Sets the gpg_key_id of this SoftwareSource.
+        ID of the GPG key for this software source
+
+
+        :param gpg_key_id: The gpg_key_id of this SoftwareSource.
+        :type: str
+        """
+        self._gpg_key_id = gpg_key_id
+
+    @property
+    def gpg_key_fingerprint(self):
+        """
+        Gets the gpg_key_fingerprint of this SoftwareSource.
+        Fingerprint of the GPG key for this software source
+
+
+        :return: The gpg_key_fingerprint of this SoftwareSource.
+        :rtype: str
+        """
+        return self._gpg_key_fingerprint
+
+    @gpg_key_fingerprint.setter
+    def gpg_key_fingerprint(self, gpg_key_fingerprint):
+        """
+        Sets the gpg_key_fingerprint of this SoftwareSource.
+        Fingerprint of the GPG key for this software source
+
+
+        :param gpg_key_fingerprint: The gpg_key_fingerprint of this SoftwareSource.
+        :type: str
+        """
+        self._gpg_key_fingerprint = gpg_key_fingerprint
+
+    @property
+    def status(self):
+        """
+        Gets the status of this SoftwareSource.
+        status of the software source.
+
+        Allowed values for this property are: "NORMAL", "UNREACHABLE", "ERROR", "WARNING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this SoftwareSource.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this SoftwareSource.
+        status of the software source.
+
+
+        :param status: The status of this SoftwareSource.
+        :type: str
+        """
+        allowed_values = ["NORMAL", "UNREACHABLE", "ERROR", "WARNING"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this SoftwareSource.
+        The current state of the Software Source.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this SoftwareSource.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this SoftwareSource.
+        The current state of the Software Source.
+
+
+        :param lifecycle_state: The lifecycle_state of this SoftwareSource.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def packages(self):
+        """
+        Gets the packages of this SoftwareSource.
+        Number of packages
+
+
+        :return: The packages of this SoftwareSource.
+        :rtype: int
+        """
+        return self._packages
+
+    @packages.setter
+    def packages(self, packages):
+        """
+        Sets the packages of this SoftwareSource.
+        Number of packages
+
+
+        :param packages: The packages of this SoftwareSource.
+        :type: int
+        """
+        self._packages = packages
+
+    @property
+    def associated_managed_instances(self):
+        """
+        Gets the associated_managed_instances of this SoftwareSource.
+        list of the Managed Instances associated with this Software Sources
+
+
+        :return: The associated_managed_instances of this SoftwareSource.
+        :rtype: list[Id]
+        """
+        return self._associated_managed_instances
+
+    @associated_managed_instances.setter
+    def associated_managed_instances(self, associated_managed_instances):
+        """
+        Sets the associated_managed_instances of this SoftwareSource.
+        list of the Managed Instances associated with this Software Sources
+
+
+        :param associated_managed_instances: The associated_managed_instances of this SoftwareSource.
+        :type: list[Id]
+        """
+        self._associated_managed_instances = associated_managed_instances
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this SoftwareSource.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this SoftwareSource.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this SoftwareSource.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this SoftwareSource.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this SoftwareSource.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this SoftwareSource.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this SoftwareSource.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this SoftwareSource.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/software_source_id.py
+++ b/src/oci/os_management/models/software_source_id.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SoftwareSourceId(object):
+    """
+    Identifying information for the specified software source
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SoftwareSourceId object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this SoftwareSourceId.
+        :type name: str
+
+        :param id:
+            The value to assign to the id property of this SoftwareSourceId.
+        :type id: str
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'id': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'id': 'id'
+        }
+
+        self._name = None
+        self._id = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this SoftwareSourceId.
+        software source name
+
+
+        :return: The name of this SoftwareSourceId.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this SoftwareSourceId.
+        software source name
+
+
+        :param name: The name of this SoftwareSourceId.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this SoftwareSourceId.
+        software source identifier
+
+
+        :return: The id of this SoftwareSourceId.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this SoftwareSourceId.
+        software source identifier
+
+
+        :param id: The id of this SoftwareSourceId.
+        :type: str
+        """
+        self._id = id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/software_source_summary.py
+++ b/src/oci/os_management/models/software_source_summary.py
@@ -1,0 +1,470 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SoftwareSourceSummary(object):
+    """
+    A software source contains a collection of packages
+    """
+
+    #: A constant which can be used with the status property of a SoftwareSourceSummary.
+    #: This constant has a value of "NORMAL"
+    STATUS_NORMAL = "NORMAL"
+
+    #: A constant which can be used with the status property of a SoftwareSourceSummary.
+    #: This constant has a value of "UNREACHABLE"
+    STATUS_UNREACHABLE = "UNREACHABLE"
+
+    #: A constant which can be used with the status property of a SoftwareSourceSummary.
+    #: This constant has a value of "ERROR"
+    STATUS_ERROR = "ERROR"
+
+    #: A constant which can be used with the status property of a SoftwareSourceSummary.
+    #: This constant has a value of "WARNING"
+    STATUS_WARNING = "WARNING"
+
+    #: A constant which can be used with the lifecycle_state property of a SoftwareSourceSummary.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a SoftwareSourceSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a SoftwareSourceSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a SoftwareSourceSummary.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a SoftwareSourceSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a SoftwareSourceSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SoftwareSourceSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this SoftwareSourceSummary.
+        :type id: str
+
+        :param description:
+            The value to assign to the description property of this SoftwareSourceSummary.
+        :type description: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this SoftwareSourceSummary.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this SoftwareSourceSummary.
+        :type display_name: str
+
+        :param repo_type:
+            The value to assign to the repo_type property of this SoftwareSourceSummary.
+        :type repo_type: str
+
+        :param status:
+            The value to assign to the status property of this SoftwareSourceSummary.
+            Allowed values for this property are: "NORMAL", "UNREACHABLE", "ERROR", "WARNING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param packages:
+            The value to assign to the packages property of this SoftwareSourceSummary.
+        :type packages: int
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this SoftwareSourceSummary.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param parent_id:
+            The value to assign to the parent_id property of this SoftwareSourceSummary.
+        :type parent_id: str
+
+        :param parent_name:
+            The value to assign to the parent_name property of this SoftwareSourceSummary.
+        :type parent_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this SoftwareSourceSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this SoftwareSourceSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'description': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'repo_type': 'str',
+            'status': 'str',
+            'packages': 'int',
+            'lifecycle_state': 'str',
+            'parent_id': 'str',
+            'parent_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'description': 'description',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'repo_type': 'repoType',
+            'status': 'status',
+            'packages': 'packages',
+            'lifecycle_state': 'lifecycleState',
+            'parent_id': 'parentId',
+            'parent_name': 'parentName',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._description = None
+        self._compartment_id = None
+        self._display_name = None
+        self._repo_type = None
+        self._status = None
+        self._packages = None
+        self._lifecycle_state = None
+        self._parent_id = None
+        self._parent_name = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this SoftwareSourceSummary.
+        OCID for the Software Source
+
+
+        :return: The id of this SoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this SoftwareSourceSummary.
+        OCID for the Software Source
+
+
+        :param id: The id of this SoftwareSourceSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this SoftwareSourceSummary.
+        Information specified by the user about the software source
+
+
+        :return: The description of this SoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this SoftwareSourceSummary.
+        Information specified by the user about the software source
+
+
+        :param description: The description of this SoftwareSourceSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this SoftwareSourceSummary.
+        OCID for the Compartment
+
+
+        :return: The compartment_id of this SoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this SoftwareSourceSummary.
+        OCID for the Compartment
+
+
+        :param compartment_id: The compartment_id of this SoftwareSourceSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this SoftwareSourceSummary.
+        User friendly name for the software source
+
+
+        :return: The display_name of this SoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this SoftwareSourceSummary.
+        User friendly name for the software source
+
+
+        :param display_name: The display_name of this SoftwareSourceSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def repo_type(self):
+        """
+        **[Required]** Gets the repo_type of this SoftwareSourceSummary.
+        Type of the Software Source
+
+
+        :return: The repo_type of this SoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._repo_type
+
+    @repo_type.setter
+    def repo_type(self, repo_type):
+        """
+        Sets the repo_type of this SoftwareSourceSummary.
+        Type of the Software Source
+
+
+        :param repo_type: The repo_type of this SoftwareSourceSummary.
+        :type: str
+        """
+        self._repo_type = repo_type
+
+    @property
+    def status(self):
+        """
+        Gets the status of this SoftwareSourceSummary.
+        status of the software source.
+
+        Allowed values for this property are: "NORMAL", "UNREACHABLE", "ERROR", "WARNING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this SoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this SoftwareSourceSummary.
+        status of the software source.
+
+
+        :param status: The status of this SoftwareSourceSummary.
+        :type: str
+        """
+        allowed_values = ["NORMAL", "UNREACHABLE", "ERROR", "WARNING"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def packages(self):
+        """
+        Gets the packages of this SoftwareSourceSummary.
+        Number of packages
+
+
+        :return: The packages of this SoftwareSourceSummary.
+        :rtype: int
+        """
+        return self._packages
+
+    @packages.setter
+    def packages(self, packages):
+        """
+        Sets the packages of this SoftwareSourceSummary.
+        Number of packages
+
+
+        :param packages: The packages of this SoftwareSourceSummary.
+        :type: int
+        """
+        self._packages = packages
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this SoftwareSourceSummary.
+        The current state of the software source.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this SoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this SoftwareSourceSummary.
+        The current state of the software source.
+
+
+        :param lifecycle_state: The lifecycle_state of this SoftwareSourceSummary.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def parent_id(self):
+        """
+        Gets the parent_id of this SoftwareSourceSummary.
+        OCID for the parent software source, if there is one
+
+
+        :return: The parent_id of this SoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._parent_id
+
+    @parent_id.setter
+    def parent_id(self, parent_id):
+        """
+        Sets the parent_id of this SoftwareSourceSummary.
+        OCID for the parent software source, if there is one
+
+
+        :param parent_id: The parent_id of this SoftwareSourceSummary.
+        :type: str
+        """
+        self._parent_id = parent_id
+
+    @property
+    def parent_name(self):
+        """
+        Gets the parent_name of this SoftwareSourceSummary.
+        Display name the parent software source, if there is one
+
+
+        :return: The parent_name of this SoftwareSourceSummary.
+        :rtype: str
+        """
+        return self._parent_name
+
+    @parent_name.setter
+    def parent_name(self, parent_name):
+        """
+        Sets the parent_name of this SoftwareSourceSummary.
+        Display name the parent software source, if there is one
+
+
+        :param parent_name: The parent_name of this SoftwareSourceSummary.
+        :type: str
+        """
+        self._parent_name = parent_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this SoftwareSourceSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this SoftwareSourceSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this SoftwareSourceSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this SoftwareSourceSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this SoftwareSourceSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this SoftwareSourceSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this SoftwareSourceSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this SoftwareSourceSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/updatable_package_summary.py
+++ b/src/oci/os_management/models/updatable_package_summary.py
@@ -1,0 +1,286 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdatablePackageSummary(object):
+    """
+    A software package available for update on a managed instance
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdatablePackageSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdatablePackageSummary.
+        :type display_name: str
+
+        :param name:
+            The value to assign to the name property of this UpdatablePackageSummary.
+        :type name: str
+
+        :param available_package_name:
+            The value to assign to the available_package_name property of this UpdatablePackageSummary.
+        :type available_package_name: str
+
+        :param type:
+            The value to assign to the type property of this UpdatablePackageSummary.
+        :type type: str
+
+        :param installed_version:
+            The value to assign to the installed_version property of this UpdatablePackageSummary.
+        :type installed_version: str
+
+        :param available_version:
+            The value to assign to the available_version property of this UpdatablePackageSummary.
+        :type available_version: str
+
+        :param architecture:
+            The value to assign to the architecture property of this UpdatablePackageSummary.
+        :type architecture: str
+
+        :param software_sources:
+            The value to assign to the software_sources property of this UpdatablePackageSummary.
+        :type software_sources: list[SoftwareSourceId]
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'name': 'str',
+            'available_package_name': 'str',
+            'type': 'str',
+            'installed_version': 'str',
+            'available_version': 'str',
+            'architecture': 'str',
+            'software_sources': 'list[SoftwareSourceId]'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'name': 'name',
+            'available_package_name': 'availablePackageName',
+            'type': 'type',
+            'installed_version': 'installedVersion',
+            'available_version': 'availableVersion',
+            'architecture': 'architecture',
+            'software_sources': 'softwareSources'
+        }
+
+        self._display_name = None
+        self._name = None
+        self._available_package_name = None
+        self._type = None
+        self._installed_version = None
+        self._available_version = None
+        self._architecture = None
+        self._software_sources = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this UpdatablePackageSummary.
+        Package name
+
+
+        :return: The display_name of this UpdatablePackageSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdatablePackageSummary.
+        Package name
+
+
+        :param display_name: The display_name of this UpdatablePackageSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this UpdatablePackageSummary.
+        Unique name for the package.
+
+
+        :return: The name of this UpdatablePackageSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this UpdatablePackageSummary.
+        Unique name for the package.
+
+
+        :param name: The name of this UpdatablePackageSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def available_package_name(self):
+        """
+        Gets the available_package_name of this UpdatablePackageSummary.
+        Unique name for the package available for update.
+
+
+        :return: The available_package_name of this UpdatablePackageSummary.
+        :rtype: str
+        """
+        return self._available_package_name
+
+    @available_package_name.setter
+    def available_package_name(self, available_package_name):
+        """
+        Sets the available_package_name of this UpdatablePackageSummary.
+        Unique name for the package available for update.
+
+
+        :param available_package_name: The available_package_name of this UpdatablePackageSummary.
+        :type: str
+        """
+        self._available_package_name = available_package_name
+
+    @property
+    def type(self):
+        """
+        **[Required]** Gets the type of this UpdatablePackageSummary.
+        Type of the update.
+
+
+        :return: The type of this UpdatablePackageSummary.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this UpdatablePackageSummary.
+        Type of the update.
+
+
+        :param type: The type of this UpdatablePackageSummary.
+        :type: str
+        """
+        self._type = type
+
+    @property
+    def installed_version(self):
+        """
+        **[Required]** Gets the installed_version of this UpdatablePackageSummary.
+        Version of the installed package
+
+
+        :return: The installed_version of this UpdatablePackageSummary.
+        :rtype: str
+        """
+        return self._installed_version
+
+    @installed_version.setter
+    def installed_version(self, installed_version):
+        """
+        Sets the installed_version of this UpdatablePackageSummary.
+        Version of the installed package
+
+
+        :param installed_version: The installed_version of this UpdatablePackageSummary.
+        :type: str
+        """
+        self._installed_version = installed_version
+
+    @property
+    def available_version(self):
+        """
+        **[Required]** Gets the available_version of this UpdatablePackageSummary.
+        Version of the package available for update
+
+
+        :return: The available_version of this UpdatablePackageSummary.
+        :rtype: str
+        """
+        return self._available_version
+
+    @available_version.setter
+    def available_version(self, available_version):
+        """
+        Sets the available_version of this UpdatablePackageSummary.
+        Version of the package available for update
+
+
+        :param available_version: The available_version of this UpdatablePackageSummary.
+        :type: str
+        """
+        self._available_version = available_version
+
+    @property
+    def architecture(self):
+        """
+        Gets the architecture of this UpdatablePackageSummary.
+        The architecture for which this package was built
+
+
+        :return: The architecture of this UpdatablePackageSummary.
+        :rtype: str
+        """
+        return self._architecture
+
+    @architecture.setter
+    def architecture(self, architecture):
+        """
+        Sets the architecture of this UpdatablePackageSummary.
+        The architecture for which this package was built
+
+
+        :param architecture: The architecture of this UpdatablePackageSummary.
+        :type: str
+        """
+        self._architecture = architecture
+
+    @property
+    def software_sources(self):
+        """
+        Gets the software_sources of this UpdatablePackageSummary.
+        list of software sources that provide the software package
+
+
+        :return: The software_sources of this UpdatablePackageSummary.
+        :rtype: list[SoftwareSourceId]
+        """
+        return self._software_sources
+
+    @software_sources.setter
+    def software_sources(self, software_sources):
+        """
+        Sets the software_sources of this UpdatablePackageSummary.
+        list of software sources that provide the software package
+
+
+        :param software_sources: The software_sources of this UpdatablePackageSummary.
+        :type: list[SoftwareSourceId]
+        """
+        self._software_sources = software_sources
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/update_managed_instance_group_details.py
+++ b/src/oci/os_management/models/update_managed_instance_group_details.py
@@ -1,0 +1,166 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateManagedInstanceGroupDetails(object):
+    """
+    Information for updating a managed instance group
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateManagedInstanceGroupDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateManagedInstanceGroupDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this UpdateManagedInstanceGroupDetails.
+        :type description: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateManagedInstanceGroupDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateManagedInstanceGroupDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'description': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'description': 'description',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._description = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateManagedInstanceGroupDetails.
+        Managed Instance Group identifier
+
+
+        :return: The display_name of this UpdateManagedInstanceGroupDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateManagedInstanceGroupDetails.
+        Managed Instance Group identifier
+
+
+        :param display_name: The display_name of this UpdateManagedInstanceGroupDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this UpdateManagedInstanceGroupDetails.
+        Information specified by the user about the managed instance group
+
+
+        :return: The description of this UpdateManagedInstanceGroupDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this UpdateManagedInstanceGroupDetails.
+        Information specified by the user about the managed instance group
+
+
+        :param description: The description of this UpdateManagedInstanceGroupDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateManagedInstanceGroupDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this UpdateManagedInstanceGroupDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateManagedInstanceGroupDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this UpdateManagedInstanceGroupDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateManagedInstanceGroupDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this UpdateManagedInstanceGroupDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateManagedInstanceGroupDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this UpdateManagedInstanceGroupDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/update_scheduled_job_details.py
+++ b/src/oci/os_management/models/update_scheduled_job_details.py
@@ -1,0 +1,475 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateScheduledJobDetails(object):
+    """
+    Information for updating a Scheduled Job
+    """
+
+    #: A constant which can be used with the schedule_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "ONETIME"
+    SCHEDULE_TYPE_ONETIME = "ONETIME"
+
+    #: A constant which can be used with the schedule_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "RECURRING"
+    SCHEDULE_TYPE_RECURRING = "RECURRING"
+
+    #: A constant which can be used with the interval_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "HOUR"
+    INTERVAL_TYPE_HOUR = "HOUR"
+
+    #: A constant which can be used with the interval_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "DAY"
+    INTERVAL_TYPE_DAY = "DAY"
+
+    #: A constant which can be used with the interval_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "WEEK"
+    INTERVAL_TYPE_WEEK = "WEEK"
+
+    #: A constant which can be used with the interval_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "MONTH"
+    INTERVAL_TYPE_MONTH = "MONTH"
+
+    #: A constant which can be used with the operation_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "INSTALL"
+    OPERATION_TYPE_INSTALL = "INSTALL"
+
+    #: A constant which can be used with the operation_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "UPDATE"
+    OPERATION_TYPE_UPDATE = "UPDATE"
+
+    #: A constant which can be used with the operation_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "REMOVE"
+    OPERATION_TYPE_REMOVE = "REMOVE"
+
+    #: A constant which can be used with the operation_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "UPDATEALL"
+    OPERATION_TYPE_UPDATEALL = "UPDATEALL"
+
+    #: A constant which can be used with the update_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "SECURITY"
+    UPDATE_TYPE_SECURITY = "SECURITY"
+
+    #: A constant which can be used with the update_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "BUGFIX"
+    UPDATE_TYPE_BUGFIX = "BUGFIX"
+
+    #: A constant which can be used with the update_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "ENHANCEMENT"
+    UPDATE_TYPE_ENHANCEMENT = "ENHANCEMENT"
+
+    #: A constant which can be used with the update_type property of a UpdateScheduledJobDetails.
+    #: This constant has a value of "ALL"
+    UPDATE_TYPE_ALL = "ALL"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateScheduledJobDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateScheduledJobDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this UpdateScheduledJobDetails.
+        :type description: str
+
+        :param schedule_type:
+            The value to assign to the schedule_type property of this UpdateScheduledJobDetails.
+            Allowed values for this property are: "ONETIME", "RECURRING"
+        :type schedule_type: str
+
+        :param time_next_execution:
+            The value to assign to the time_next_execution property of this UpdateScheduledJobDetails.
+        :type time_next_execution: datetime
+
+        :param interval_type:
+            The value to assign to the interval_type property of this UpdateScheduledJobDetails.
+            Allowed values for this property are: "HOUR", "DAY", "WEEK", "MONTH"
+        :type interval_type: str
+
+        :param interval_value:
+            The value to assign to the interval_value property of this UpdateScheduledJobDetails.
+        :type interval_value: str
+
+        :param operation_type:
+            The value to assign to the operation_type property of this UpdateScheduledJobDetails.
+            Allowed values for this property are: "INSTALL", "UPDATE", "REMOVE", "UPDATEALL"
+        :type operation_type: str
+
+        :param update_type:
+            The value to assign to the update_type property of this UpdateScheduledJobDetails.
+            Allowed values for this property are: "SECURITY", "BUGFIX", "ENHANCEMENT", "ALL"
+        :type update_type: str
+
+        :param package_names:
+            The value to assign to the package_names property of this UpdateScheduledJobDetails.
+        :type package_names: list[PackageName]
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateScheduledJobDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateScheduledJobDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'description': 'str',
+            'schedule_type': 'str',
+            'time_next_execution': 'datetime',
+            'interval_type': 'str',
+            'interval_value': 'str',
+            'operation_type': 'str',
+            'update_type': 'str',
+            'package_names': 'list[PackageName]',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'description': 'description',
+            'schedule_type': 'scheduleType',
+            'time_next_execution': 'timeNextExecution',
+            'interval_type': 'intervalType',
+            'interval_value': 'intervalValue',
+            'operation_type': 'operationType',
+            'update_type': 'updateType',
+            'package_names': 'packageNames',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._description = None
+        self._schedule_type = None
+        self._time_next_execution = None
+        self._interval_type = None
+        self._interval_value = None
+        self._operation_type = None
+        self._update_type = None
+        self._package_names = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateScheduledJobDetails.
+        Scheduled Job name
+
+
+        :return: The display_name of this UpdateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateScheduledJobDetails.
+        Scheduled Job name
+
+
+        :param display_name: The display_name of this UpdateScheduledJobDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this UpdateScheduledJobDetails.
+        Details describing the Scheduled Job.
+
+
+        :return: The description of this UpdateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this UpdateScheduledJobDetails.
+        Details describing the Scheduled Job.
+
+
+        :param description: The description of this UpdateScheduledJobDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def schedule_type(self):
+        """
+        Gets the schedule_type of this UpdateScheduledJobDetails.
+        the type of scheduling this Scheduled Job follows
+
+        Allowed values for this property are: "ONETIME", "RECURRING"
+
+
+        :return: The schedule_type of this UpdateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._schedule_type
+
+    @schedule_type.setter
+    def schedule_type(self, schedule_type):
+        """
+        Sets the schedule_type of this UpdateScheduledJobDetails.
+        the type of scheduling this Scheduled Job follows
+
+
+        :param schedule_type: The schedule_type of this UpdateScheduledJobDetails.
+        :type: str
+        """
+        allowed_values = ["ONETIME", "RECURRING"]
+        if not value_allowed_none_or_none_sentinel(schedule_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `schedule_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._schedule_type = schedule_type
+
+    @property
+    def time_next_execution(self):
+        """
+        Gets the time_next_execution of this UpdateScheduledJobDetails.
+        the desired time for the next execution of this Scheduled Job
+
+
+        :return: The time_next_execution of this UpdateScheduledJobDetails.
+        :rtype: datetime
+        """
+        return self._time_next_execution
+
+    @time_next_execution.setter
+    def time_next_execution(self, time_next_execution):
+        """
+        Sets the time_next_execution of this UpdateScheduledJobDetails.
+        the desired time for the next execution of this Scheduled Job
+
+
+        :param time_next_execution: The time_next_execution of this UpdateScheduledJobDetails.
+        :type: datetime
+        """
+        self._time_next_execution = time_next_execution
+
+    @property
+    def interval_type(self):
+        """
+        Gets the interval_type of this UpdateScheduledJobDetails.
+        the interval period for a recurring Scheduled Job (only if schedule type is RECURRING)
+
+        Allowed values for this property are: "HOUR", "DAY", "WEEK", "MONTH"
+
+
+        :return: The interval_type of this UpdateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._interval_type
+
+    @interval_type.setter
+    def interval_type(self, interval_type):
+        """
+        Sets the interval_type of this UpdateScheduledJobDetails.
+        the interval period for a recurring Scheduled Job (only if schedule type is RECURRING)
+
+
+        :param interval_type: The interval_type of this UpdateScheduledJobDetails.
+        :type: str
+        """
+        allowed_values = ["HOUR", "DAY", "WEEK", "MONTH"]
+        if not value_allowed_none_or_none_sentinel(interval_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `interval_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._interval_type = interval_type
+
+    @property
+    def interval_value(self):
+        """
+        Gets the interval_value of this UpdateScheduledJobDetails.
+        the value for the interval period for a recurring Scheduled Job (only if schedule type is RECURRING)
+
+
+        :return: The interval_value of this UpdateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._interval_value
+
+    @interval_value.setter
+    def interval_value(self, interval_value):
+        """
+        Sets the interval_value of this UpdateScheduledJobDetails.
+        the value for the interval period for a recurring Scheduled Job (only if schedule type is RECURRING)
+
+
+        :param interval_value: The interval_value of this UpdateScheduledJobDetails.
+        :type: str
+        """
+        self._interval_value = interval_value
+
+    @property
+    def operation_type(self):
+        """
+        Gets the operation_type of this UpdateScheduledJobDetails.
+        the type of operation this Scheduled Job performs
+
+        Allowed values for this property are: "INSTALL", "UPDATE", "REMOVE", "UPDATEALL"
+
+
+        :return: The operation_type of this UpdateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._operation_type
+
+    @operation_type.setter
+    def operation_type(self, operation_type):
+        """
+        Sets the operation_type of this UpdateScheduledJobDetails.
+        the type of operation this Scheduled Job performs
+
+
+        :param operation_type: The operation_type of this UpdateScheduledJobDetails.
+        :type: str
+        """
+        allowed_values = ["INSTALL", "UPDATE", "REMOVE", "UPDATEALL"]
+        if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `operation_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._operation_type = operation_type
+
+    @property
+    def update_type(self):
+        """
+        Gets the update_type of this UpdateScheduledJobDetails.
+        Type of the update (only if operation type is UPDATE_ALL_PACKAGES)
+
+        Allowed values for this property are: "SECURITY", "BUGFIX", "ENHANCEMENT", "ALL"
+
+
+        :return: The update_type of this UpdateScheduledJobDetails.
+        :rtype: str
+        """
+        return self._update_type
+
+    @update_type.setter
+    def update_type(self, update_type):
+        """
+        Sets the update_type of this UpdateScheduledJobDetails.
+        Type of the update (only if operation type is UPDATE_ALL_PACKAGES)
+
+
+        :param update_type: The update_type of this UpdateScheduledJobDetails.
+        :type: str
+        """
+        allowed_values = ["SECURITY", "BUGFIX", "ENHANCEMENT", "ALL"]
+        if not value_allowed_none_or_none_sentinel(update_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `update_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._update_type = update_type
+
+    @property
+    def package_names(self):
+        """
+        Gets the package_names of this UpdateScheduledJobDetails.
+        the id of the package (only if operation type is INSTALL/UPDATE/REMOVE_PACKAGE)
+
+
+        :return: The package_names of this UpdateScheduledJobDetails.
+        :rtype: list[PackageName]
+        """
+        return self._package_names
+
+    @package_names.setter
+    def package_names(self, package_names):
+        """
+        Sets the package_names of this UpdateScheduledJobDetails.
+        the id of the package (only if operation type is INSTALL/UPDATE/REMOVE_PACKAGE)
+
+
+        :param package_names: The package_names of this UpdateScheduledJobDetails.
+        :type: list[PackageName]
+        """
+        self._package_names = package_names
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateScheduledJobDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this UpdateScheduledJobDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateScheduledJobDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this UpdateScheduledJobDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateScheduledJobDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this UpdateScheduledJobDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateScheduledJobDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this UpdateScheduledJobDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/update_software_source_details.py
+++ b/src/oci/os_management/models/update_software_source_details.py
@@ -1,0 +1,315 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateSoftwareSourceDetails(object):
+    """
+    Information for updating a software source on the management system
+    """
+
+    #: A constant which can be used with the checksum_type property of a UpdateSoftwareSourceDetails.
+    #: This constant has a value of "SHA1"
+    CHECKSUM_TYPE_SHA1 = "SHA1"
+
+    #: A constant which can be used with the checksum_type property of a UpdateSoftwareSourceDetails.
+    #: This constant has a value of "SHA256"
+    CHECKSUM_TYPE_SHA256 = "SHA256"
+
+    #: A constant which can be used with the checksum_type property of a UpdateSoftwareSourceDetails.
+    #: This constant has a value of "SHA384"
+    CHECKSUM_TYPE_SHA384 = "SHA384"
+
+    #: A constant which can be used with the checksum_type property of a UpdateSoftwareSourceDetails.
+    #: This constant has a value of "SHA512"
+    CHECKSUM_TYPE_SHA512 = "SHA512"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateSoftwareSourceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateSoftwareSourceDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this UpdateSoftwareSourceDetails.
+        :type description: str
+
+        :param maintainer_name:
+            The value to assign to the maintainer_name property of this UpdateSoftwareSourceDetails.
+        :type maintainer_name: str
+
+        :param maintainer_email:
+            The value to assign to the maintainer_email property of this UpdateSoftwareSourceDetails.
+        :type maintainer_email: str
+
+        :param maintainer_phone:
+            The value to assign to the maintainer_phone property of this UpdateSoftwareSourceDetails.
+        :type maintainer_phone: str
+
+        :param checksum_type:
+            The value to assign to the checksum_type property of this UpdateSoftwareSourceDetails.
+            Allowed values for this property are: "SHA1", "SHA256", "SHA384", "SHA512"
+        :type checksum_type: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateSoftwareSourceDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateSoftwareSourceDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'description': 'str',
+            'maintainer_name': 'str',
+            'maintainer_email': 'str',
+            'maintainer_phone': 'str',
+            'checksum_type': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'description': 'description',
+            'maintainer_name': 'maintainerName',
+            'maintainer_email': 'maintainerEmail',
+            'maintainer_phone': 'maintainerPhone',
+            'checksum_type': 'checksumType',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._description = None
+        self._maintainer_name = None
+        self._maintainer_email = None
+        self._maintainer_phone = None
+        self._checksum_type = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateSoftwareSourceDetails.
+        User friendly name for the software source
+
+
+        :return: The display_name of this UpdateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateSoftwareSourceDetails.
+        User friendly name for the software source
+
+
+        :param display_name: The display_name of this UpdateSoftwareSourceDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this UpdateSoftwareSourceDetails.
+        Information specified by the user about the software source
+
+
+        :return: The description of this UpdateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this UpdateSoftwareSourceDetails.
+        Information specified by the user about the software source
+
+
+        :param description: The description of this UpdateSoftwareSourceDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def maintainer_name(self):
+        """
+        Gets the maintainer_name of this UpdateSoftwareSourceDetails.
+        Name of the person maintaining this software source
+
+
+        :return: The maintainer_name of this UpdateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._maintainer_name
+
+    @maintainer_name.setter
+    def maintainer_name(self, maintainer_name):
+        """
+        Sets the maintainer_name of this UpdateSoftwareSourceDetails.
+        Name of the person maintaining this software source
+
+
+        :param maintainer_name: The maintainer_name of this UpdateSoftwareSourceDetails.
+        :type: str
+        """
+        self._maintainer_name = maintainer_name
+
+    @property
+    def maintainer_email(self):
+        """
+        Gets the maintainer_email of this UpdateSoftwareSourceDetails.
+        Email address of the person maintaining this software source
+
+
+        :return: The maintainer_email of this UpdateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._maintainer_email
+
+    @maintainer_email.setter
+    def maintainer_email(self, maintainer_email):
+        """
+        Sets the maintainer_email of this UpdateSoftwareSourceDetails.
+        Email address of the person maintaining this software source
+
+
+        :param maintainer_email: The maintainer_email of this UpdateSoftwareSourceDetails.
+        :type: str
+        """
+        self._maintainer_email = maintainer_email
+
+    @property
+    def maintainer_phone(self):
+        """
+        Gets the maintainer_phone of this UpdateSoftwareSourceDetails.
+        Phone number of the person maintaining this software source
+
+
+        :return: The maintainer_phone of this UpdateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._maintainer_phone
+
+    @maintainer_phone.setter
+    def maintainer_phone(self, maintainer_phone):
+        """
+        Sets the maintainer_phone of this UpdateSoftwareSourceDetails.
+        Phone number of the person maintaining this software source
+
+
+        :param maintainer_phone: The maintainer_phone of this UpdateSoftwareSourceDetails.
+        :type: str
+        """
+        self._maintainer_phone = maintainer_phone
+
+    @property
+    def checksum_type(self):
+        """
+        Gets the checksum_type of this UpdateSoftwareSourceDetails.
+        The yum repository checksum type used by this software source
+
+        Allowed values for this property are: "SHA1", "SHA256", "SHA384", "SHA512"
+
+
+        :return: The checksum_type of this UpdateSoftwareSourceDetails.
+        :rtype: str
+        """
+        return self._checksum_type
+
+    @checksum_type.setter
+    def checksum_type(self, checksum_type):
+        """
+        Sets the checksum_type of this UpdateSoftwareSourceDetails.
+        The yum repository checksum type used by this software source
+
+
+        :param checksum_type: The checksum_type of this UpdateSoftwareSourceDetails.
+        :type: str
+        """
+        allowed_values = ["SHA1", "SHA256", "SHA384", "SHA512"]
+        if not value_allowed_none_or_none_sentinel(checksum_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `checksum_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._checksum_type = checksum_type
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateSoftwareSourceDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this UpdateSoftwareSourceDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateSoftwareSourceDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this UpdateSoftwareSourceDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateSoftwareSourceDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this UpdateSoftwareSourceDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateSoftwareSourceDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this UpdateSoftwareSourceDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/work_request.py
+++ b/src/oci/os_management/models/work_request.py
@@ -1,0 +1,457 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequest(object):
+    """
+    A description of workrequest status
+    """
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "INSTALL"
+    OPERATION_TYPE_INSTALL = "INSTALL"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "UPDATE"
+    OPERATION_TYPE_UPDATE = "UPDATE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "REMOVE"
+    OPERATION_TYPE_REMOVE = "REMOVE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "UPDATEALL"
+    OPERATION_TYPE_UPDATEALL = "UPDATEALL"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "ACCEPTED"
+    STATUS_ACCEPTED = "ACCEPTED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "IN_PROGRESS"
+    STATUS_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "FAILED"
+    STATUS_FAILED = "FAILED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "SUCCEEDED"
+    STATUS_SUCCEEDED = "SUCCEEDED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "CANCELLING"
+    STATUS_CANCELLING = "CANCELLING"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "CANCELED"
+    STATUS_CANCELED = "CANCELED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequest object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation_type:
+            The value to assign to the operation_type property of this WorkRequest.
+            Allowed values for this property are: "INSTALL", "UPDATE", "REMOVE", "UPDATEALL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type operation_type: str
+
+        :param status:
+            The value to assign to the status property of this WorkRequest.
+            Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELLING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param id:
+            The value to assign to the id property of this WorkRequest.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this WorkRequest.
+        :type compartment_id: str
+
+        :param description:
+            The value to assign to the description property of this WorkRequest.
+        :type description: str
+
+        :param message:
+            The value to assign to the message property of this WorkRequest.
+        :type message: str
+
+        :param resources:
+            The value to assign to the resources property of this WorkRequest.
+        :type resources: list[WorkRequestResource]
+
+        :param percent_complete:
+            The value to assign to the percent_complete property of this WorkRequest.
+        :type percent_complete: float
+
+        :param time_accepted:
+            The value to assign to the time_accepted property of this WorkRequest.
+        :type time_accepted: datetime
+
+        :param time_started:
+            The value to assign to the time_started property of this WorkRequest.
+        :type time_started: datetime
+
+        :param time_finished:
+            The value to assign to the time_finished property of this WorkRequest.
+        :type time_finished: datetime
+
+        """
+        self.swagger_types = {
+            'operation_type': 'str',
+            'status': 'str',
+            'id': 'str',
+            'compartment_id': 'str',
+            'description': 'str',
+            'message': 'str',
+            'resources': 'list[WorkRequestResource]',
+            'percent_complete': 'float',
+            'time_accepted': 'datetime',
+            'time_started': 'datetime',
+            'time_finished': 'datetime'
+        }
+
+        self.attribute_map = {
+            'operation_type': 'operationType',
+            'status': 'status',
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'description': 'description',
+            'message': 'message',
+            'resources': 'resources',
+            'percent_complete': 'percentComplete',
+            'time_accepted': 'timeAccepted',
+            'time_started': 'timeStarted',
+            'time_finished': 'timeFinished'
+        }
+
+        self._operation_type = None
+        self._status = None
+        self._id = None
+        self._compartment_id = None
+        self._description = None
+        self._message = None
+        self._resources = None
+        self._percent_complete = None
+        self._time_accepted = None
+        self._time_started = None
+        self._time_finished = None
+
+    @property
+    def operation_type(self):
+        """
+        **[Required]** Gets the operation_type of this WorkRequest.
+        the type of operation this Work Request performs
+
+        Allowed values for this property are: "INSTALL", "UPDATE", "REMOVE", "UPDATEALL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The operation_type of this WorkRequest.
+        :rtype: str
+        """
+        return self._operation_type
+
+    @operation_type.setter
+    def operation_type(self, operation_type):
+        """
+        Sets the operation_type of this WorkRequest.
+        the type of operation this Work Request performs
+
+
+        :param operation_type: The operation_type of this WorkRequest.
+        :type: str
+        """
+        allowed_values = ["INSTALL", "UPDATE", "REMOVE", "UPDATEALL"]
+        if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
+            operation_type = 'UNKNOWN_ENUM_VALUE'
+        self._operation_type = operation_type
+
+    @property
+    def status(self):
+        """
+        **[Required]** Gets the status of this WorkRequest.
+        status of current work request.
+
+        Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELLING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this WorkRequest.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this WorkRequest.
+        status of current work request.
+
+
+        :param status: The status of this WorkRequest.
+        :type: str
+        """
+        allowed_values = ["ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELLING", "CANCELED"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this WorkRequest.
+        The id of the work request.
+
+
+        :return: The id of this WorkRequest.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this WorkRequest.
+        The id of the work request.
+
+
+        :param id: The id of this WorkRequest.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this WorkRequest.
+        The ocid of the compartment that contains the work request. Work requests should be scoped to
+        the same compartment as the resource the work request affects. If the work request affects multiple resources,
+        and those resources are not in the same compartment, it is up to the service team to pick the primary
+        resource whose compartment should be used
+
+
+        :return: The compartment_id of this WorkRequest.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this WorkRequest.
+        The ocid of the compartment that contains the work request. Work requests should be scoped to
+        the same compartment as the resource the work request affects. If the work request affects multiple resources,
+        and those resources are not in the same compartment, it is up to the service team to pick the primary
+        resource whose compartment should be used
+
+
+        :param compartment_id: The compartment_id of this WorkRequest.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this WorkRequest.
+        Description of the type of work.
+
+
+        :return: The description of this WorkRequest.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this WorkRequest.
+        Description of the type of work.
+
+
+        :param description: The description of this WorkRequest.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def message(self):
+        """
+        Gets the message of this WorkRequest.
+        A progress or error message, if there is any.
+
+
+        :return: The message of this WorkRequest.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this WorkRequest.
+        A progress or error message, if there is any.
+
+
+        :param message: The message of this WorkRequest.
+        :type: str
+        """
+        self._message = message
+
+    @property
+    def resources(self):
+        """
+        **[Required]** Gets the resources of this WorkRequest.
+        The resources affected by this work request.
+
+
+        :return: The resources of this WorkRequest.
+        :rtype: list[WorkRequestResource]
+        """
+        return self._resources
+
+    @resources.setter
+    def resources(self, resources):
+        """
+        Sets the resources of this WorkRequest.
+        The resources affected by this work request.
+
+
+        :param resources: The resources of this WorkRequest.
+        :type: list[WorkRequestResource]
+        """
+        self._resources = resources
+
+    @property
+    def percent_complete(self):
+        """
+        **[Required]** Gets the percent_complete of this WorkRequest.
+        Percentage of the request completed.
+
+
+        :return: The percent_complete of this WorkRequest.
+        :rtype: float
+        """
+        return self._percent_complete
+
+    @percent_complete.setter
+    def percent_complete(self, percent_complete):
+        """
+        Sets the percent_complete of this WorkRequest.
+        Percentage of the request completed.
+
+
+        :param percent_complete: The percent_complete of this WorkRequest.
+        :type: float
+        """
+        self._percent_complete = percent_complete
+
+    @property
+    def time_accepted(self):
+        """
+        **[Required]** Gets the time_accepted of this WorkRequest.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_accepted of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_accepted
+
+    @time_accepted.setter
+    def time_accepted(self, time_accepted):
+        """
+        Sets the time_accepted of this WorkRequest.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_accepted: The time_accepted of this WorkRequest.
+        :type: datetime
+        """
+        self._time_accepted = time_accepted
+
+    @property
+    def time_started(self):
+        """
+        Gets the time_started of this WorkRequest.
+        The date and time the request was started, as described in `RFC 3339`__,
+        section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_started of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_started
+
+    @time_started.setter
+    def time_started(self, time_started):
+        """
+        Sets the time_started of this WorkRequest.
+        The date and time the request was started, as described in `RFC 3339`__,
+        section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_started: The time_started of this WorkRequest.
+        :type: datetime
+        """
+        self._time_started = time_started
+
+    @property
+    def time_finished(self):
+        """
+        Gets the time_finished of this WorkRequest.
+        The date and time the object was finished, as described in `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_finished of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_finished
+
+    @time_finished.setter
+    def time_finished(self, time_finished):
+        """
+        Sets the time_finished of this WorkRequest.
+        The date and time the object was finished, as described in `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_finished: The time_finished of this WorkRequest.
+        :type: datetime
+        """
+        self._time_finished = time_finished
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/work_request_error.py
+++ b/src/oci/os_management/models/work_request_error.py
@@ -1,0 +1,137 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestError(object):
+    """
+    Human readable error message describing why the work request failed
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestError object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param code:
+            The value to assign to the code property of this WorkRequestError.
+        :type code: str
+
+        :param message:
+            The value to assign to the message property of this WorkRequestError.
+        :type message: str
+
+        :param timestamp:
+            The value to assign to the timestamp property of this WorkRequestError.
+        :type timestamp: datetime
+
+        """
+        self.swagger_types = {
+            'code': 'str',
+            'message': 'str',
+            'timestamp': 'datetime'
+        }
+
+        self.attribute_map = {
+            'code': 'code',
+            'message': 'message',
+            'timestamp': 'timestamp'
+        }
+
+        self._code = None
+        self._message = None
+        self._timestamp = None
+
+    @property
+    def code(self):
+        """
+        **[Required]** Gets the code of this WorkRequestError.
+        A machine-usable code for the error that occured.
+
+
+        :return: The code of this WorkRequestError.
+        :rtype: str
+        """
+        return self._code
+
+    @code.setter
+    def code(self, code):
+        """
+        Sets the code of this WorkRequestError.
+        A machine-usable code for the error that occured.
+
+
+        :param code: The code of this WorkRequestError.
+        :type: str
+        """
+        self._code = code
+
+    @property
+    def message(self):
+        """
+        **[Required]** Gets the message of this WorkRequestError.
+        A human readable description of the issue encountered.
+
+
+        :return: The message of this WorkRequestError.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this WorkRequestError.
+        A human readable description of the issue encountered.
+
+
+        :param message: The message of this WorkRequestError.
+        :type: str
+        """
+        self._message = message
+
+    @property
+    def timestamp(self):
+        """
+        Gets the timestamp of this WorkRequestError.
+        The date and time the error happened, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The timestamp of this WorkRequestError.
+        :rtype: datetime
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp):
+        """
+        Sets the timestamp of this WorkRequestError.
+        The date and time the error happened, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param timestamp: The timestamp of this WorkRequestError.
+        :type: datetime
+        """
+        self._timestamp = timestamp
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/work_request_log_entry.py
+++ b/src/oci/os_management/models/work_request_log_entry.py
@@ -1,0 +1,106 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestLogEntry(object):
+    """
+    Human readable log message describing what the work request is doing
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestLogEntry object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param message:
+            The value to assign to the message property of this WorkRequestLogEntry.
+        :type message: str
+
+        :param timestamp:
+            The value to assign to the timestamp property of this WorkRequestLogEntry.
+        :type timestamp: datetime
+
+        """
+        self.swagger_types = {
+            'message': 'str',
+            'timestamp': 'datetime'
+        }
+
+        self.attribute_map = {
+            'message': 'message',
+            'timestamp': 'timestamp'
+        }
+
+        self._message = None
+        self._timestamp = None
+
+    @property
+    def message(self):
+        """
+        **[Required]** Gets the message of this WorkRequestLogEntry.
+        A human readable log message.
+
+
+        :return: The message of this WorkRequestLogEntry.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this WorkRequestLogEntry.
+        A human readable log message.
+
+
+        :param message: The message of this WorkRequestLogEntry.
+        :type: str
+        """
+        self._message = message
+
+    @property
+    def timestamp(self):
+        """
+        **[Required]** Gets the timestamp of this WorkRequestLogEntry.
+        The date and time the error happened, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The timestamp of this WorkRequestLogEntry.
+        :rtype: datetime
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp):
+        """
+        Sets the timestamp of this WorkRequestLogEntry.
+        The date and time the error happened, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param timestamp: The timestamp of this WorkRequestLogEntry.
+        :type: datetime
+        """
+        self._timestamp = timestamp
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/work_request_resource.py
+++ b/src/oci/os_management/models/work_request_resource.py
@@ -1,0 +1,237 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestResource(object):
+    """
+    A resource created, operated on or used by a work request.
+    """
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "CREATED"
+    ACTION_TYPE_CREATED = "CREATED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "UPDATED"
+    ACTION_TYPE_UPDATED = "UPDATED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "DELETED"
+    ACTION_TYPE_DELETED = "DELETED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "FAILED"
+    ACTION_TYPE_FAILED = "FAILED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "IN_PROGRESS"
+    ACTION_TYPE_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "INSTALLED"
+    ACTION_TYPE_INSTALLED = "INSTALLED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "REMOVED"
+    ACTION_TYPE_REMOVED = "REMOVED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestResource object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param entity_type:
+            The value to assign to the entity_type property of this WorkRequestResource.
+        :type entity_type: str
+
+        :param action_type:
+            The value to assign to the action_type property of this WorkRequestResource.
+            Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "FAILED", "IN_PROGRESS", "INSTALLED", "REMOVED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type action_type: str
+
+        :param identifier:
+            The value to assign to the identifier property of this WorkRequestResource.
+        :type identifier: str
+
+        :param name:
+            The value to assign to the name property of this WorkRequestResource.
+        :type name: str
+
+        :param entity_uri:
+            The value to assign to the entity_uri property of this WorkRequestResource.
+        :type entity_uri: str
+
+        """
+        self.swagger_types = {
+            'entity_type': 'str',
+            'action_type': 'str',
+            'identifier': 'str',
+            'name': 'str',
+            'entity_uri': 'str'
+        }
+
+        self.attribute_map = {
+            'entity_type': 'entityType',
+            'action_type': 'actionType',
+            'identifier': 'identifier',
+            'name': 'name',
+            'entity_uri': 'entityUri'
+        }
+
+        self._entity_type = None
+        self._action_type = None
+        self._identifier = None
+        self._name = None
+        self._entity_uri = None
+
+    @property
+    def entity_type(self):
+        """
+        **[Required]** Gets the entity_type of this WorkRequestResource.
+        The resource type for the work request.
+
+
+        :return: The entity_type of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._entity_type
+
+    @entity_type.setter
+    def entity_type(self, entity_type):
+        """
+        Sets the entity_type of this WorkRequestResource.
+        The resource type for the work request.
+
+
+        :param entity_type: The entity_type of this WorkRequestResource.
+        :type: str
+        """
+        self._entity_type = entity_type
+
+    @property
+    def action_type(self):
+        """
+        **[Required]** Gets the action_type of this WorkRequestResource.
+        The way in which this resource is affected by the work tracked in the work request.
+        A resource being created, updated, or deleted will remain in the IN_PROGRESS state until
+        work is complete for that resource at which point it will transition to CREATED, UPDATED,
+        or DELETED, respectively. If the request failed for that resource,
+        the state will be FAILED.
+
+        Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "FAILED", "IN_PROGRESS", "INSTALLED", "REMOVED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The action_type of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._action_type
+
+    @action_type.setter
+    def action_type(self, action_type):
+        """
+        Sets the action_type of this WorkRequestResource.
+        The way in which this resource is affected by the work tracked in the work request.
+        A resource being created, updated, or deleted will remain in the IN_PROGRESS state until
+        work is complete for that resource at which point it will transition to CREATED, UPDATED,
+        or DELETED, respectively. If the request failed for that resource,
+        the state will be FAILED.
+
+
+        :param action_type: The action_type of this WorkRequestResource.
+        :type: str
+        """
+        allowed_values = ["CREATED", "UPDATED", "DELETED", "FAILED", "IN_PROGRESS", "INSTALLED", "REMOVED"]
+        if not value_allowed_none_or_none_sentinel(action_type, allowed_values):
+            action_type = 'UNKNOWN_ENUM_VALUE'
+        self._action_type = action_type
+
+    @property
+    def identifier(self):
+        """
+        **[Required]** Gets the identifier of this WorkRequestResource.
+        The identifier of the resource. Not all resources will have an id.
+
+
+        :return: The identifier of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this WorkRequestResource.
+        The identifier of the resource. Not all resources will have an id.
+
+
+        :param identifier: The identifier of this WorkRequestResource.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def name(self):
+        """
+        Gets the name of this WorkRequestResource.
+        The name of the resource. Not all resources will have a name specified.
+
+
+        :return: The name of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this WorkRequestResource.
+        The name of the resource. Not all resources will have a name specified.
+
+
+        :param name: The name of this WorkRequestResource.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def entity_uri(self):
+        """
+        **[Required]** Gets the entity_uri of this WorkRequestResource.
+        The URI path that the user can do a GET on to access the resource metadata.
+
+
+        :return: The entity_uri of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._entity_uri
+
+    @entity_uri.setter
+    def entity_uri(self, entity_uri):
+        """
+        Sets the entity_uri of this WorkRequestResource.
+        The URI path that the user can do a GET on to access the resource metadata.
+
+
+        :param entity_uri: The entity_uri of this WorkRequestResource.
+        :type: str
+        """
+        self._entity_uri = entity_uri
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/models/work_request_summary.py
+++ b/src/oci/os_management/models/work_request_summary.py
@@ -1,0 +1,354 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestSummary(object):
+    """
+    A work request summary
+    """
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "INSTALL"
+    OPERATION_TYPE_INSTALL = "INSTALL"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "UPDATE"
+    OPERATION_TYPE_UPDATE = "UPDATE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "REMOVE"
+    OPERATION_TYPE_REMOVE = "REMOVE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "UPDATEALL"
+    OPERATION_TYPE_UPDATEALL = "UPDATEALL"
+
+    #: A constant which can be used with the status property of a WorkRequestSummary.
+    #: This constant has a value of "ACCEPTED"
+    STATUS_ACCEPTED = "ACCEPTED"
+
+    #: A constant which can be used with the status property of a WorkRequestSummary.
+    #: This constant has a value of "IN_PROGRESS"
+    STATUS_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the status property of a WorkRequestSummary.
+    #: This constant has a value of "FAILED"
+    STATUS_FAILED = "FAILED"
+
+    #: A constant which can be used with the status property of a WorkRequestSummary.
+    #: This constant has a value of "SUCCEEDED"
+    STATUS_SUCCEEDED = "SUCCEEDED"
+
+    #: A constant which can be used with the status property of a WorkRequestSummary.
+    #: This constant has a value of "CANCELLING"
+    STATUS_CANCELLING = "CANCELLING"
+
+    #: A constant which can be used with the status property of a WorkRequestSummary.
+    #: This constant has a value of "CANCELED"
+    STATUS_CANCELED = "CANCELED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation_type:
+            The value to assign to the operation_type property of this WorkRequestSummary.
+            Allowed values for this property are: "INSTALL", "UPDATE", "REMOVE", "UPDATEALL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type operation_type: str
+
+        :param status:
+            The value to assign to the status property of this WorkRequestSummary.
+            Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELLING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param id:
+            The value to assign to the id property of this WorkRequestSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this WorkRequestSummary.
+        :type compartment_id: str
+
+        :param description:
+            The value to assign to the description property of this WorkRequestSummary.
+        :type description: str
+
+        :param message:
+            The value to assign to the message property of this WorkRequestSummary.
+        :type message: str
+
+        :param percent_complete:
+            The value to assign to the percent_complete property of this WorkRequestSummary.
+        :type percent_complete: float
+
+        :param time_accepted:
+            The value to assign to the time_accepted property of this WorkRequestSummary.
+        :type time_accepted: datetime
+
+        """
+        self.swagger_types = {
+            'operation_type': 'str',
+            'status': 'str',
+            'id': 'str',
+            'compartment_id': 'str',
+            'description': 'str',
+            'message': 'str',
+            'percent_complete': 'float',
+            'time_accepted': 'datetime'
+        }
+
+        self.attribute_map = {
+            'operation_type': 'operationType',
+            'status': 'status',
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'description': 'description',
+            'message': 'message',
+            'percent_complete': 'percentComplete',
+            'time_accepted': 'timeAccepted'
+        }
+
+        self._operation_type = None
+        self._status = None
+        self._id = None
+        self._compartment_id = None
+        self._description = None
+        self._message = None
+        self._percent_complete = None
+        self._time_accepted = None
+
+    @property
+    def operation_type(self):
+        """
+        **[Required]** Gets the operation_type of this WorkRequestSummary.
+        the type of operation this Work Request performs
+
+        Allowed values for this property are: "INSTALL", "UPDATE", "REMOVE", "UPDATEALL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The operation_type of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._operation_type
+
+    @operation_type.setter
+    def operation_type(self, operation_type):
+        """
+        Sets the operation_type of this WorkRequestSummary.
+        the type of operation this Work Request performs
+
+
+        :param operation_type: The operation_type of this WorkRequestSummary.
+        :type: str
+        """
+        allowed_values = ["INSTALL", "UPDATE", "REMOVE", "UPDATEALL"]
+        if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
+            operation_type = 'UNKNOWN_ENUM_VALUE'
+        self._operation_type = operation_type
+
+    @property
+    def status(self):
+        """
+        **[Required]** Gets the status of this WorkRequestSummary.
+        status of current work request.
+
+        Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELLING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this WorkRequestSummary.
+        status of current work request.
+
+
+        :param status: The status of this WorkRequestSummary.
+        :type: str
+        """
+        allowed_values = ["ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELLING", "CANCELED"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this WorkRequestSummary.
+        The id of the work request.
+
+
+        :return: The id of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this WorkRequestSummary.
+        The id of the work request.
+
+
+        :param id: The id of this WorkRequestSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this WorkRequestSummary.
+        The ocid of the compartment that contains the work request. Work requests should be scoped to
+        the same compartment as the resource the work request affects. If the work request affects multiple resources,
+        and those resources are not in the same compartment, it is up to the service team to pick the primary
+        resource whose compartment should be used
+
+
+        :return: The compartment_id of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this WorkRequestSummary.
+        The ocid of the compartment that contains the work request. Work requests should be scoped to
+        the same compartment as the resource the work request affects. If the work request affects multiple resources,
+        and those resources are not in the same compartment, it is up to the service team to pick the primary
+        resource whose compartment should be used
+
+
+        :param compartment_id: The compartment_id of this WorkRequestSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this WorkRequestSummary.
+        Description of the type of work.
+
+
+        :return: The description of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this WorkRequestSummary.
+        Description of the type of work.
+
+
+        :param description: The description of this WorkRequestSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def message(self):
+        """
+        Gets the message of this WorkRequestSummary.
+        A progress or error message, if there is any.
+
+
+        :return: The message of this WorkRequestSummary.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this WorkRequestSummary.
+        A progress or error message, if there is any.
+
+
+        :param message: The message of this WorkRequestSummary.
+        :type: str
+        """
+        self._message = message
+
+    @property
+    def percent_complete(self):
+        """
+        Gets the percent_complete of this WorkRequestSummary.
+        Percentage of the request completed.
+
+
+        :return: The percent_complete of this WorkRequestSummary.
+        :rtype: float
+        """
+        return self._percent_complete
+
+    @percent_complete.setter
+    def percent_complete(self, percent_complete):
+        """
+        Sets the percent_complete of this WorkRequestSummary.
+        Percentage of the request completed.
+
+
+        :param percent_complete: The percent_complete of this WorkRequestSummary.
+        :type: float
+        """
+        self._percent_complete = percent_complete
+
+    @property
+    def time_accepted(self):
+        """
+        **[Required]** Gets the time_accepted of this WorkRequestSummary.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_accepted of this WorkRequestSummary.
+        :rtype: datetime
+        """
+        return self._time_accepted
+
+    @time_accepted.setter
+    def time_accepted(self, time_accepted):
+        """
+        Sets the time_accepted of this WorkRequestSummary.
+        The date and time the request was created, as described in
+        `RFC 3339`__, section 14.29.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_accepted: The time_accepted of this WorkRequestSummary.
+        :type: datetime
+        """
+        self._time_accepted = time_accepted
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/os_management/os_management_client.py
+++ b/src/oci/os_management/os_management_client.py
@@ -1,0 +1,4632 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import os_management_type_mapping
+missing = Sentinel("Missing")
+
+
+class OsManagementClient(object):
+    """
+    OS Management as a Service API definition
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20190801',
+            'service_endpoint_template': 'https://osms.{region}.oci.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("os_management", config, signer, os_management_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def add_packages_to_software_source(self, software_source_id, add_packages_to_software_source_details, **kwargs):
+        """
+        Adds packages to a Software Source
+        Adds a given list of Software Packages to a specific Software Source.
+
+
+        :param str software_source_id: (required)
+            The OCID of the software source.
+
+        :param AddPackagesToSoftwareSourceDetails add_packages_to_software_source_details: (required)
+            A list of package identifiers
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/softwareSources/{softwareSourceId}/actions/addPackages"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "add_packages_to_software_source got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "softwareSourceId": software_source_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=add_packages_to_software_source_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=add_packages_to_software_source_details)
+
+    def attach_child_software_source_to_managed_instance(self, managed_instance_id, attach_child_software_source_to_managed_instance_details, **kwargs):
+        """
+        Add a software source to a managed instance
+        Adds a child software source to a managed instance. After the software
+        source has been added, then packages from that software source can be
+        installed on the managed instance.
+
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param AttachChildSoftwareSourceToManagedInstanceDetails attach_child_software_source_to_managed_instance_details: (required)
+            Details for attaching a Software Source to a Managed Instance
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances/{managedInstanceId}/actions/attachChildSoftwareSource"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "attach_child_software_source_to_managed_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceId": managed_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=attach_child_software_source_to_managed_instance_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=attach_child_software_source_to_managed_instance_details)
+
+    def attach_managed_instance_to_managed_instance_group(self, managed_instance_group_id, managed_instance_id, **kwargs):
+        """
+        Add a Managed Instance to a Managed Instance Group
+        Adds a Managed Instance to a Managed Instance Group. After the Managed
+        Instance has been added, then operations can be performed on the Managed
+        Instance Group which will then apply to all Managed Instances in the
+        group.
+
+
+        :param str managed_instance_group_id: (required)
+            OCID for the managed instance group
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstanceGroups/{managedInstanceGroupId}/actions/attachManagedInstance"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "attach_managed_instance_to_managed_instance_group got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceGroupId": managed_instance_group_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "managedInstanceId": managed_instance_id
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+
+    def attach_parent_software_source_to_managed_instance(self, managed_instance_id, attach_parent_software_source_to_managed_instance_details, **kwargs):
+        """
+        Add a software source to a managed instance
+        Adds a parent software source to a managed instance. After the software
+        source has been added, then packages from that software source can be
+        installed on the managed instance. Software sources that have this
+        software source as a parent will be able to be added to this managed instance.
+
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param AttachParentSoftwareSourceToManagedInstanceDetails attach_parent_software_source_to_managed_instance_details: (required)
+            Details for attaching a Software Source to a Managed Instance
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances/{managedInstanceId}/actions/attachParentSoftwareSource"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "attach_parent_software_source_to_managed_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceId": managed_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=attach_parent_software_source_to_managed_instance_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=attach_parent_software_source_to_managed_instance_details)
+
+    def change_managed_instance_group_compartment(self, managed_instance_group_id, change_managed_instance_group_compartment_details, **kwargs):
+        """
+        Moves a resource into a different compartment
+        Moves a resource into a different compartment. When provided, If-Match
+        is checked against ETag values of the resource.
+
+
+        :param str managed_instance_group_id: (required)
+            OCID for the managed instance group
+
+        :param ChangeManagedInstanceGroupCompartmentDetails change_managed_instance_group_compartment_details: (required)
+            OCID for the compartment to which the resource will be moved.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstanceGroups/{managedInstanceGroupId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_managed_instance_group_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceGroupId": managed_instance_group_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_managed_instance_group_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_managed_instance_group_compartment_details)
+
+    def change_scheduled_job_compartment(self, scheduled_job_id, change_scheduled_job_compartment_details, **kwargs):
+        """
+        Moves a resource into a different compartment
+        Moves a resource into a different compartment. When provided, If-Match
+        is checked against ETag values of the resource.
+
+
+        :param str scheduled_job_id: (required)
+            The ID of the scheduled job.
+
+        :param ChangeScheduledJobCompartmentDetails change_scheduled_job_compartment_details: (required)
+            OCID for the compartment to which the resource will be moved.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/scheduledJobs/{scheduledJobId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_scheduled_job_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "scheduledJobId": scheduled_job_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_scheduled_job_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_scheduled_job_compartment_details)
+
+    def change_software_source_compartment(self, software_source_id, change_software_source_compartment_details, **kwargs):
+        """
+        Moves a resource into a different compartment
+        Moves a resource into a different compartment. When provided, If-Match
+        is checked against ETag values of the resource.
+
+
+        :param str software_source_id: (required)
+            The OCID of the software source.
+
+        :param ChangeSoftwareSourceCompartmentDetails change_software_source_compartment_details: (required)
+            OCID for the compartment to which the resource will be moved.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/softwareSources/{softwareSourceId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_software_source_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "softwareSourceId": software_source_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_software_source_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_software_source_compartment_details)
+
+    def create_managed_instance_group(self, create_managed_instance_group_details, **kwargs):
+        """
+        Create a Managed Instance Group
+        Creates a new Managed Instance Group on the management system.
+        This will not contain any managed instances after it is first created,
+        and they must be added later.
+
+
+        :param CreateManagedInstanceGroupDetails create_managed_instance_group_details: (required)
+            Details about a Managed Instance Group to create
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.os_management.models.ManagedInstanceGroup`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstanceGroups"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_managed_instance_group got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_managed_instance_group_details,
+                response_type="ManagedInstanceGroup")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_managed_instance_group_details,
+                response_type="ManagedInstanceGroup")
+
+    def create_scheduled_job(self, create_scheduled_job_details, **kwargs):
+        """
+        Create a Scheduled Job
+        Creates a new Scheduled Job to perform a specific package operation on
+        a set of managed instances or managed instance groups.  Can be created
+        as a one-time execution in the future, or as a recurring execution
+        that repeats on a defined interval.
+
+
+        :param CreateScheduledJobDetails create_scheduled_job_details: (required)
+            Details about a Scheduled Job to create
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.os_management.models.ScheduledJob`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/scheduledJobs"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_scheduled_job got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_scheduled_job_details,
+                response_type="ScheduledJob")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_scheduled_job_details,
+                response_type="ScheduledJob")
+
+    def create_software_source(self, create_software_source_details, **kwargs):
+        """
+        Create a custom Software Source
+        Creates a new custom Software Source on the management system.
+        This will not contain any packages after it is first created,
+        and they must be added later.
+
+
+        :param CreateSoftwareSourceDetails create_software_source_details: (required)
+            Details about a Sofware Source to create
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.os_management.models.SoftwareSource`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/softwareSources"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_software_source got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_software_source_details,
+                response_type="SoftwareSource")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_software_source_details,
+                response_type="SoftwareSource")
+
+    def delete_managed_instance_group(self, managed_instance_group_id, **kwargs):
+        """
+        Delete a Managed Instance Group
+        Deletes a Managed Instance Group from the management system
+
+
+        :param str managed_instance_group_id: (required)
+            OCID for the managed instance group
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstanceGroups/{managedInstanceGroupId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_managed_instance_group got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceGroupId": managed_instance_group_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_scheduled_job(self, scheduled_job_id, **kwargs):
+        """
+        Cancel (delete) a Scheduled Job
+        Cancels an existing Scheduled Job on the management system
+
+
+        :param str scheduled_job_id: (required)
+            The ID of the scheduled job.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/scheduledJobs/{scheduledJobId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_scheduled_job got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "scheduledJobId": scheduled_job_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_software_source(self, software_source_id, **kwargs):
+        """
+        Delete a custom Software Source
+        Deletes a custom Software Source on the management system
+
+
+        :param str software_source_id: (required)
+            The OCID of the software source.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/softwareSources/{softwareSourceId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_software_source got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "softwareSourceId": software_source_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def detach_child_software_source_from_managed_instance(self, managed_instance_id, detach_child_software_source_from_managed_instance_details, **kwargs):
+        """
+        Removes a child software source from a managed instance
+        Removes a child software source from a managed instance. Packages will no longer be able to be
+        installed from these software sources.
+
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param DetachChildSoftwareSourceFromManagedInstanceDetails detach_child_software_source_from_managed_instance_details: (required)
+            Details for detaching a Software Source from a Managed Instance
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances/{managedInstanceId}/actions/detachChildSoftwareSource"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "detach_child_software_source_from_managed_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceId": managed_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=detach_child_software_source_from_managed_instance_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=detach_child_software_source_from_managed_instance_details)
+
+    def detach_managed_instance_from_managed_instance_group(self, managed_instance_group_id, managed_instance_id, **kwargs):
+        """
+        Removes a Managed Instance from a Managed Instance Group
+        Removes a Managed Instance from a Managed Instance Group.
+
+
+        :param str managed_instance_group_id: (required)
+            OCID for the managed instance group
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstanceGroups/{managedInstanceGroupId}/actions/detachManagedInstance"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "detach_managed_instance_from_managed_instance_group got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceGroupId": managed_instance_group_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "managedInstanceId": managed_instance_id
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+
+    def detach_parent_software_source_from_managed_instance(self, managed_instance_id, detach_parent_software_source_from_managed_instance_details, **kwargs):
+        """
+        Removes a parent software source from a managed instance
+        Removes a software source from a managed instance. All child software sources will also be removed
+        from the managed instance. Packages will no longer be able to be installed from these software sources.
+
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param DetachParentSoftwareSourceFromManagedInstanceDetails detach_parent_software_source_from_managed_instance_details: (required)
+            Details for detaching a Software Source from a Managed Instance
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances/{managedInstanceId}/actions/detachParentSoftwareSource"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "detach_parent_software_source_from_managed_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceId": managed_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=detach_parent_software_source_from_managed_instance_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=detach_parent_software_source_from_managed_instance_details)
+
+    def get_erratum(self, erratum_id, **kwargs):
+        """
+        Gets an erratum by identifier
+        Returns a specific erratum.
+
+
+        :param str erratum_id: (required)
+            The OCID of the erratum.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.os_management.models.Erratum`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/errata/{erratumId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_erratum got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "erratumId": erratum_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Erratum")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Erratum")
+
+    def get_managed_instance(self, managed_instance_id, **kwargs):
+        """
+        Gets a Managed Instance by identifier
+        Returns a specific Managed Instance.
+
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.os_management.models.ManagedInstance`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances/{managedInstanceId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_managed_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceId": managed_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ManagedInstance")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ManagedInstance")
+
+    def get_managed_instance_group(self, managed_instance_group_id, **kwargs):
+        """
+        Gets the details for a Managed Instance Group
+        Returns a specific Managed Instance Group.
+
+
+        :param str managed_instance_group_id: (required)
+            OCID for the managed instance group
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.os_management.models.ManagedInstanceGroup`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstanceGroups/{managedInstanceGroupId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_managed_instance_group got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceGroupId": managed_instance_group_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ManagedInstanceGroup")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ManagedInstanceGroup")
+
+    def get_scheduled_job(self, scheduled_job_id, **kwargs):
+        """
+        Gets a Scheduled Job
+        Gets the detailed information for the Scheduled Job with the given ID.
+
+
+        :param str scheduled_job_id: (required)
+            The ID of the scheduled job.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.os_management.models.ScheduledJob`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/scheduledJobs/{scheduledJobId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_scheduled_job got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "scheduledJobId": scheduled_job_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ScheduledJob")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ScheduledJob")
+
+    def get_software_package(self, software_source_id, software_package_name, **kwargs):
+        """
+        Gets a Software Package by identifier
+        Returns a specific Software Package.
+
+
+        :param str software_source_id: (required)
+            The OCID of the software source.
+
+        :param str software_package_name: (required)
+            The id of the software package.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.os_management.models.SoftwarePackage`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/softwareSources/{softwareSourceId}/softwarePackages/{softwarePackageName}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_software_package got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "softwareSourceId": software_source_id,
+            "softwarePackageName": software_package_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="SoftwarePackage")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="SoftwarePackage")
+
+    def get_software_source(self, software_source_id, **kwargs):
+        """
+        Gets a Software Source by identifier
+        Returns a specific Software Source.
+
+
+        :param str software_source_id: (required)
+            The OCID of the software source.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.os_management.models.SoftwareSource`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/softwareSources/{softwareSourceId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_software_source got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "softwareSourceId": software_source_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="SoftwareSource")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="SoftwareSource")
+
+    def get_work_request(self, work_request_id, **kwargs):
+        """
+        Get Work Request
+        Gets the detailed information for the work request with the given ID.
+
+
+        :param str work_request_id: (required)
+            The ID of the asynchronous request.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.os_management.models.WorkRequest`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_work_request got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="WorkRequest")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="WorkRequest")
+
+    def install_all_package_updates_on_managed_instance(self, managed_instance_id, **kwargs):
+        """
+        Update all packages on a managed instance
+        Install all of the available package updates for the managed instance.
+
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances/{managedInstanceId}/actions/packages/updateAll"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "install_all_package_updates_on_managed_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceId": managed_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def install_package_on_managed_instance(self, managed_instance_id, software_package_name, **kwargs):
+        """
+        Install a package on a managed instance
+        Installs a package on a managed instance.
+
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str software_package_name: (required)
+            Package name
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances/{managedInstanceId}/actions/packages/install"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "install_package_on_managed_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceId": managed_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "softwarePackageName": software_package_name
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+
+    def install_package_update_on_managed_instance(self, managed_instance_id, software_package_name, **kwargs):
+        """
+        Update a package on a managed instance
+        Updates a package on a managed instance.
+
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str software_package_name: (required)
+            Package name
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances/{managedInstanceId}/actions/packages/update"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "install_package_update_on_managed_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceId": managed_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "softwarePackageName": software_package_name
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+
+    def list_available_packages_for_managed_instance(self, managed_instance_id, **kwargs):
+        """
+        Gets a list of all packages available for install on the Managed Instance
+        Returns a list of packages available for install on the Managed Instance.
+
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param str compartment_id: (optional)
+            The ID of the compartment in which to list resources.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.InstallablePackageSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances/{managedInstanceId}/packages/available"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "compartment_id",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_available_packages_for_managed_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceId": managed_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "displayName": kwargs.get("display_name", missing),
+            "compartmentId": kwargs.get("compartment_id", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[InstallablePackageSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[InstallablePackageSummary]")
+
+    def list_available_software_sources_for_managed_instance(self, managed_instance_id, **kwargs):
+        """
+        Gets a list of all software sources available for the Managed Instance. These only include software sources that are not already added to the managed instance, but can be added.
+        Returns a list of available software sources for a Managed Instance.
+
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param str compartment_id: (optional)
+            The ID of the compartment in which to list resources.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.AvailableSoftwareSourceSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances/{managedInstanceId}/availableSoftwareSources"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "compartment_id",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_available_software_sources_for_managed_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceId": managed_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "displayName": kwargs.get("display_name", missing),
+            "compartmentId": kwargs.get("compartment_id", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AvailableSoftwareSourceSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AvailableSoftwareSourceSummary]")
+
+    def list_available_updates_for_managed_instance(self, managed_instance_id, **kwargs):
+        """
+        Gets a list of all updates available for the Managed Instance
+        Returns a list of available updates for a Managed Instance.
+
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param str compartment_id: (optional)
+            The ID of the compartment in which to list resources.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.AvailableUpdateSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances/{managedInstanceId}/packages/updates"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "compartment_id",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_available_updates_for_managed_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceId": managed_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "displayName": kwargs.get("display_name", missing),
+            "compartmentId": kwargs.get("compartment_id", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AvailableUpdateSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AvailableUpdateSummary]")
+
+    def list_managed_instance_groups(self, compartment_id, **kwargs):
+        """
+        Gets a list of all Managed Instance Groups
+        Returns a list of all Managed Instance Groups.
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str lifecycle_state: (optional)
+            The current lifecycle state for the object.
+
+            Allowed values are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.ManagedInstanceGroupSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstanceGroups"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id",
+            "lifecycle_state"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_managed_instance_groups got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "displayName": kwargs.get("display_name", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ManagedInstanceGroupSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ManagedInstanceGroupSummary]")
+
+    def list_managed_instances(self, compartment_id, **kwargs):
+        """
+        Gets a list of all Managed Instances
+        Returns a list of all Managed Instances.
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.ManagedInstanceSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_managed_instances got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "displayName": kwargs.get("display_name", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ManagedInstanceSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ManagedInstanceSummary]")
+
+    def list_packages_installed_on_managed_instance(self, managed_instance_id, **kwargs):
+        """
+        Gets a list of all packages installed on the Managed Instance
+        Returns a list of installed packages on the Managed Instance.
+
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param str compartment_id: (optional)
+            The ID of the compartment in which to list resources.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.InstalledPackageSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances/{managedInstanceId}/packages"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "compartment_id",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_packages_installed_on_managed_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceId": managed_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "displayName": kwargs.get("display_name", missing),
+            "compartmentId": kwargs.get("compartment_id", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[InstalledPackageSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[InstalledPackageSummary]")
+
+    def list_scheduled_jobs(self, compartment_id, **kwargs):
+        """
+        Gets a list of the current Scheduled Jobs
+        Returns a list of all of the currently active Scheduled Jobs in the system
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param str managed_instance_id: (optional)
+            The ID of the managed instance for which to list resources.
+
+        :param str managed_instance_group_id: (optional)
+            The ID of the managed instace group for which to list resources.
+
+        :param str operation_type: (optional)
+            The operation type for which to list resources
+
+            Allowed values are: "INSTALL", "UPDATE", "REMOVE", "UPDATEALL"
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str lifecycle_state: (optional)
+            The current lifecycle state for the object.
+
+            Allowed values are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.ScheduledJobSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/scheduledJobs"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "managed_instance_id",
+            "managed_instance_group_id",
+            "operation_type",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "lifecycle_state",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_scheduled_jobs got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'operation_type' in kwargs:
+            operation_type_allowed_values = ["INSTALL", "UPDATE", "REMOVE", "UPDATEALL"]
+            if kwargs['operation_type'] not in operation_type_allowed_values:
+                raise ValueError(
+                    "Invalid value for `operation_type`, must be one of {0}".format(operation_type_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "displayName": kwargs.get("display_name", missing),
+            "managedInstanceId": kwargs.get("managed_instance_id", missing),
+            "managedInstanceGroupId": kwargs.get("managed_instance_group_id", missing),
+            "operationType": kwargs.get("operation_type", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ScheduledJobSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ScheduledJobSummary]")
+
+    def list_software_source_packages(self, software_source_id, **kwargs):
+        """
+        Lists Software Packages
+        Lists Software Packages in a Software Source
+
+
+        :param str software_source_id: (required)
+            The OCID of the software source.
+
+        :param str compartment_id: (optional)
+            The ID of the compartment in which to list resources.
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.SoftwarePackageSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/softwareSources/{softwareSourceId}/softwarePackages"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "compartment_id",
+            "display_name",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_software_source_packages got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "softwareSourceId": software_source_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": kwargs.get("compartment_id", missing),
+            "displayName": kwargs.get("display_name", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[SoftwarePackageSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[SoftwarePackageSummary]")
+
+    def list_software_sources(self, compartment_id, **kwargs):
+        """
+        Gets a list of all Software Sources
+        Returns a list of all Software Sources.
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str lifecycle_state: (optional)
+            The current lifecycle state for the object.
+
+            Allowed values are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.SoftwareSourceSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/softwareSources"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "lifecycle_state",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_software_sources got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "displayName": kwargs.get("display_name", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[SoftwareSourceSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[SoftwareSourceSummary]")
+
+    def list_upcoming_scheduled_jobs(self, compartment_id, time_end, **kwargs):
+        """
+        Gets a list of the upcoming Scheduled Jobs
+        Returns a list of all of the Scheduled Jobs whose next execution time is at or before the specified time.
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param datetime time_end: (required)
+            The cut-off time before which to list all upcoming schedules, in ISO 8601 format
+
+            Example: 2017-07-14T02:40:00.000Z
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str tag_name: (optional)
+            The name of the tag.
+
+        :param str tag_value: (optional)
+            The value for the tag.
+
+        :param str lifecycle_state: (optional)
+            The current lifecycle state for the object.
+
+            Allowed values are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.ScheduledJobSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/scheduledJobs/upcomingSchedules"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "tag_name",
+            "tag_value",
+            "lifecycle_state",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_upcoming_scheduled_jobs got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "displayName": kwargs.get("display_name", missing),
+            "timeEnd": time_end,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "tagName": kwargs.get("tag_name", missing),
+            "tagValue": kwargs.get("tag_value", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ScheduledJobSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ScheduledJobSummary]")
+
+    def list_work_request_errors(self, work_request_id, **kwargs):
+        """
+        List Work Request Errors
+        Gets the errors for the work request with the given ID.
+
+
+        :param str work_request_id: (required)
+            The ID of the asynchronous request.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.WorkRequestError`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}/errors"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_request_errors got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestError]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestError]")
+
+    def list_work_request_logs(self, work_request_id, **kwargs):
+        """
+        List Work Request Logs
+        Lists the log entries for the work request with the given ID.
+
+
+        :param str work_request_id: (required)
+            The ID of the asynchronous request.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.WorkRequestLogEntry`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}/logs"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_request_logs got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestLogEntry]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestLogEntry]")
+
+    def list_work_requests(self, compartment_id, **kwargs):
+        """
+        List Work Requests
+        Lists the work requests in a compartment.
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param str managed_instance_id: (optional)
+            The ID of the managed instance for which to list resources.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.WorkRequestSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "managed_instance_id",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_requests got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "displayName": kwargs.get("display_name", missing),
+            "managedInstanceId": kwargs.get("managed_instance_id", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[WorkRequestSummary]")
+
+    def remove_package_from_managed_instance(self, managed_instance_id, software_package_name, **kwargs):
+        """
+        Removes a package from a managed instance
+        Removes an installed package from a managed instance.
+
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str software_package_name: (required)
+            Package name
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstances/{managedInstanceId}/actions/packages/remove"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "remove_package_from_managed_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceId": managed_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "softwarePackageName": software_package_name
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+
+    def remove_packages_from_software_source(self, software_source_id, remove_packages_from_software_source_details, **kwargs):
+        """
+        Removes packages from a Software Source
+        Removes a given list of Software Packages from a specific Software Source.
+
+
+        :param str software_source_id: (required)
+            The OCID of the software source.
+
+        :param RemovePackagesFromSoftwareSourceDetails remove_packages_from_software_source_details: (required)
+            A list of package identifiers
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/softwareSources/{softwareSourceId}/actions/removePackages"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "remove_packages_from_software_source got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "softwareSourceId": software_source_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=remove_packages_from_software_source_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=remove_packages_from_software_source_details)
+
+    def run_scheduled_job_now(self, scheduled_job_id, **kwargs):
+        """
+        Triggers a Scheduled Job to execute immediately
+        This will trigger an already created Scheduled Job to being executing
+        immediately instead of waiting for its next regularly scheduled time.
+
+
+        :param str scheduled_job_id: (required)
+            The ID of the scheduled job.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/scheduledJobs/{scheduledJobId}/actions/runNow"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "run_scheduled_job_now got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "scheduledJobId": scheduled_job_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def search_software_packages(self, **kwargs):
+        """
+        Search Software Packages
+        Searches all of the available Software Sources and returns any/all Software Packages matching
+        the search criteria.
+
+
+        :param str software_package_name: (optional)
+            the identifier for the software package (not an OCID)
+
+        :param str display_name: (optional)
+            A user-friendly name. Does not have to be unique, and it's changeable.
+
+            Example: `My new resource`
+
+        :param str cve_name: (optional)
+            The name of the CVE as published.
+            Example: `CVE-2006-4535`
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.os_management.models.SoftwarePackageSearchSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/softwareSources/softwarePackages"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "software_package_name",
+            "display_name",
+            "cve_name",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "search_software_packages got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "softwarePackageName": kwargs.get("software_package_name", missing),
+            "displayName": kwargs.get("display_name", missing),
+            "cveName": kwargs.get("cve_name", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[SoftwarePackageSearchSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[SoftwarePackageSearchSummary]")
+
+    def skip_next_scheduled_job_execution(self, scheduled_job_id, **kwargs):
+        """
+        Forces a Scheduled Job to skip its next execution
+        This will force an already created Scheduled Job to skip its
+        next regularly scheduled execution
+
+
+        :param str scheduled_job_id: (required)
+            The ID of the scheduled job.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/scheduledJobs/{scheduledJobId}/actions/skipNextExecution"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "skip_next_scheduled_job_execution got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "scheduledJobId": scheduled_job_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def update_managed_instance_group(self, managed_instance_group_id, update_managed_instance_group_details, **kwargs):
+        """
+        Updates the Managed Instance Group identified by the id
+        Updates a specific Managed Instance Group.
+
+
+        :param str managed_instance_group_id: (required)
+            OCID for the managed instance group
+
+        :param UpdateManagedInstanceGroupDetails update_managed_instance_group_details: (required)
+            Details about a Managed Instance Group to update
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.os_management.models.ManagedInstanceGroup`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managedInstanceGroups/{managedInstanceGroupId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_managed_instance_group got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managedInstanceGroupId": managed_instance_group_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_managed_instance_group_details,
+                response_type="ManagedInstanceGroup")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_managed_instance_group_details,
+                response_type="ManagedInstanceGroup")
+
+    def update_scheduled_job(self, scheduled_job_id, update_scheduled_job_details, **kwargs):
+        """
+        Update the Scheduled Job identified by the id
+        Updates an existing Scheduled Job on the management system.
+
+
+        :param str scheduled_job_id: (required)
+            The ID of the scheduled job.
+
+        :param UpdateScheduledJobDetails update_scheduled_job_details: (required)
+            Details about a Scheduled Job to update
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.os_management.models.ScheduledJob`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/scheduledJobs/{scheduledJobId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_scheduled_job got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "scheduledJobId": scheduled_job_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_scheduled_job_details,
+                response_type="ScheduledJob")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_scheduled_job_details,
+                response_type="ScheduledJob")
+
+    def update_software_source(self, software_source_id, update_software_source_details, **kwargs):
+        """
+        Update the custom Software Source identified by the id
+        Updates an existing custom Software Source on the management system.
+
+
+        :param str software_source_id: (required)
+            The OCID of the software source.
+
+        :param UpdateSoftwareSourceDetails update_software_source_details: (required)
+            Details about a Sofware Source to update
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.os_management.models.SoftwareSource`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/softwareSources/{softwareSourceId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_software_source got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "softwareSourceId": software_source_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_software_source_details,
+                response_type="SoftwareSource")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_software_source_details,
+                response_type="SoftwareSource")

--- a/src/oci/os_management/os_management_client_composite_operations.py
+++ b/src/oci/os_management/os_management_client_composite_operations.py
@@ -1,0 +1,562 @@
+# coding: utf-8
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class OsManagementClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.os_management.OsManagementClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new OsManagementClientCompositeOperations object
+
+        :param OsManagementClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client
+
+    def create_managed_instance_group_and_wait_for_state(self, create_managed_instance_group_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.os_management.OsManagementClient.create_managed_instance_group` and waits for the :py:class:`~oci.os_management.models.ManagedInstanceGroup` acted upon
+        to enter the given state(s).
+
+        :param CreateManagedInstanceGroupDetails create_managed_instance_group_details: (required)
+            Details about a Managed Instance Group to create
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.os_management.models.ManagedInstanceGroup.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.os_management.OsManagementClient.create_managed_instance_group`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_managed_instance_group(create_managed_instance_group_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_managed_instance_group(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_scheduled_job_and_wait_for_state(self, create_scheduled_job_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.os_management.OsManagementClient.create_scheduled_job` and waits for the :py:class:`~oci.os_management.models.ScheduledJob` acted upon
+        to enter the given state(s).
+
+        :param CreateScheduledJobDetails create_scheduled_job_details: (required)
+            Details about a Scheduled Job to create
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.os_management.models.ScheduledJob.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.os_management.OsManagementClient.create_scheduled_job`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_scheduled_job(create_scheduled_job_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_scheduled_job(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_software_source_and_wait_for_state(self, create_software_source_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.os_management.OsManagementClient.create_software_source` and waits for the :py:class:`~oci.os_management.models.SoftwareSource` acted upon
+        to enter the given state(s).
+
+        :param CreateSoftwareSourceDetails create_software_source_details: (required)
+            Details about a Sofware Source to create
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.os_management.models.SoftwareSource.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.os_management.OsManagementClient.create_software_source`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_software_source(create_software_source_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_software_source(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_managed_instance_group_and_wait_for_state(self, managed_instance_group_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.os_management.OsManagementClient.delete_managed_instance_group` and waits for the :py:class:`~oci.os_management.models.ManagedInstanceGroup` acted upon
+        to enter the given state(s).
+
+        :param str managed_instance_group_id: (required)
+            OCID for the managed instance group
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.os_management.models.ManagedInstanceGroup.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.os_management.OsManagementClient.delete_managed_instance_group`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        initial_get_result = self.client.get_managed_instance_group(managed_instance_group_id)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_managed_instance_group(managed_instance_group_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                initial_get_result,
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                succeed_on_not_found=True,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_scheduled_job_and_wait_for_state(self, scheduled_job_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.os_management.OsManagementClient.delete_scheduled_job` and waits for the :py:class:`~oci.os_management.models.ScheduledJob` acted upon
+        to enter the given state(s).
+
+        :param str scheduled_job_id: (required)
+            The ID of the scheduled job.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.os_management.models.ScheduledJob.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.os_management.OsManagementClient.delete_scheduled_job`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        initial_get_result = self.client.get_scheduled_job(scheduled_job_id)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_scheduled_job(scheduled_job_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                initial_get_result,
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                succeed_on_not_found=True,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_software_source_and_wait_for_state(self, software_source_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.os_management.OsManagementClient.delete_software_source` and waits for the :py:class:`~oci.os_management.models.SoftwareSource` acted upon
+        to enter the given state(s).
+
+        :param str software_source_id: (required)
+            The OCID of the software source.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.os_management.models.SoftwareSource.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.os_management.OsManagementClient.delete_software_source`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        initial_get_result = self.client.get_software_source(software_source_id)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_software_source(software_source_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                initial_get_result,
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                succeed_on_not_found=True,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def install_all_package_updates_on_managed_instance_and_wait_for_state(self, managed_instance_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.os_management.OsManagementClient.install_all_package_updates_on_managed_instance` and waits for the :py:class:`~oci.os_management.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.os_management.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.os_management.OsManagementClient.install_all_package_updates_on_managed_instance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.install_all_package_updates_on_managed_instance(managed_instance_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def install_package_on_managed_instance_and_wait_for_state(self, managed_instance_id, software_package_name, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.os_management.OsManagementClient.install_package_on_managed_instance` and waits for the :py:class:`~oci.os_management.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str software_package_name: (required)
+            Package name
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.os_management.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.os_management.OsManagementClient.install_package_on_managed_instance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.install_package_on_managed_instance(managed_instance_id, software_package_name, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def install_package_update_on_managed_instance_and_wait_for_state(self, managed_instance_id, software_package_name, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.os_management.OsManagementClient.install_package_update_on_managed_instance` and waits for the :py:class:`~oci.os_management.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str software_package_name: (required)
+            Package name
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.os_management.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.os_management.OsManagementClient.install_package_update_on_managed_instance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.install_package_update_on_managed_instance(managed_instance_id, software_package_name, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def remove_package_from_managed_instance_and_wait_for_state(self, managed_instance_id, software_package_name, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.os_management.OsManagementClient.remove_package_from_managed_instance` and waits for the :py:class:`~oci.os_management.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str managed_instance_id: (required)
+            OCID for the managed instance
+
+        :param str software_package_name: (required)
+            Package name
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.os_management.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.os_management.OsManagementClient.remove_package_from_managed_instance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.remove_package_from_managed_instance(managed_instance_id, software_package_name, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_managed_instance_group_and_wait_for_state(self, managed_instance_group_id, update_managed_instance_group_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.os_management.OsManagementClient.update_managed_instance_group` and waits for the :py:class:`~oci.os_management.models.ManagedInstanceGroup` acted upon
+        to enter the given state(s).
+
+        :param str managed_instance_group_id: (required)
+            OCID for the managed instance group
+
+        :param UpdateManagedInstanceGroupDetails update_managed_instance_group_details: (required)
+            Details about a Managed Instance Group to update
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.os_management.models.ManagedInstanceGroup.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.os_management.OsManagementClient.update_managed_instance_group`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_managed_instance_group(managed_instance_group_id, update_managed_instance_group_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_managed_instance_group(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_scheduled_job_and_wait_for_state(self, scheduled_job_id, update_scheduled_job_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.os_management.OsManagementClient.update_scheduled_job` and waits for the :py:class:`~oci.os_management.models.ScheduledJob` acted upon
+        to enter the given state(s).
+
+        :param str scheduled_job_id: (required)
+            The ID of the scheduled job.
+
+        :param UpdateScheduledJobDetails update_scheduled_job_details: (required)
+            Details about a Scheduled Job to update
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.os_management.models.ScheduledJob.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.os_management.OsManagementClient.update_scheduled_job`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_scheduled_job(scheduled_job_id, update_scheduled_job_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_scheduled_job(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_software_source_and_wait_for_state(self, software_source_id, update_software_source_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.os_management.OsManagementClient.update_software_source` and waits for the :py:class:`~oci.os_management.models.SoftwareSource` acted upon
+        to enter the given state(s).
+
+        :param str software_source_id: (required)
+            The OCID of the software source.
+
+        :param UpdateSoftwareSourceDetails update_software_source_details: (required)
+            Details about a Sofware Source to update
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.os_management.models.SoftwareSource.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.os_management.OsManagementClient.update_software_source`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_software_source(software_source_id, update_software_source_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_software_source(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)


### PR DESCRIPTION
Added
-----
* Support for the API Gateway service
* Support for the OS Management service
* Support for the Marketplace service
* Support for "default"-type vaults in the Key Management service
* Support for bringing your own keys in the Key Management service 
* Support for cross-region backups of boot volumes in the Block Storage service
* Support for top-level TSIG keys in the DNS service
* Support for resizing virtual machine instances to different shapes in the Compute service
* Support for management configuration of cloud agents in the Compute service
* Support for launching node pools using image IDs in the Container Engine for Kubernetes service

Breaking changes
----
* Removed support for v1 auth tokens in kubeconfig files in the `CreateClusterKubeconfigContentDetails` class of the Container Engine for Kubernetes service
* Removed the IDCS access token requirement on the delete deleteOceInstance operation in the Content and Experience service, which is why the `DeleteOceInstanceDetails` class was removed
* Set `compartment_id` as a required parameter in `list_stream_pools` for streaming service