### PR TITLE
Releasing version 2.10.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.10.0 - 2020-01-14
+====================
+
+Added
+-----
+* Support for a description field on route rules and security rules in the Networking service
+* Support for starting and stopping Digital Assistant instances in the Digital Assistant service
+* Support for shared database homes on Exadata, bare metal, and virtual machine instances in the Database service
+* Support for tracking a number of Database service operations through the Work Requests service
+
+Breaking
+--------
+* Field `db_home_id` in `list_databases` from database service is changed from required to optional
+
+====================
 2.9.0 - 2020-01-07
 ====================
 

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -63,6 +63,7 @@ Database
     oci.database.models.CreateDataGuardAssociationDetails
     oci.database.models.CreateDataGuardAssociationToExistingDbSystemDetails
     oci.database.models.CreateDataGuardAssociationWithNewDbSystemDetails
+    oci.database.models.CreateDatabaseBase
     oci.database.models.CreateDatabaseDetails
     oci.database.models.CreateDatabaseFromBackupDetails
     oci.database.models.CreateDbHomeBase
@@ -74,6 +75,7 @@ Database
     oci.database.models.CreateExadataInfrastructureDetails
     oci.database.models.CreateExternalBackupJobDetails
     oci.database.models.CreateNFSBackupDestinationDetails
+    oci.database.models.CreateNewDatabaseDetails
     oci.database.models.CreateRecoveryApplianceBackupDestinationDetails
     oci.database.models.CreateVmClusterDetails
     oci.database.models.DataGuardAssociation

--- a/docs/api/database/models/oci.database.models.CreateDatabaseBase.rst
+++ b/docs/api/database/models/oci.database.models.CreateDatabaseBase.rst
@@ -1,0 +1,11 @@
+CreateDatabaseBase
+==================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateDatabaseBase
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateNewDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateNewDatabaseDetails.rst
@@ -1,0 +1,11 @@
+CreateNewDatabaseDetails
+========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateNewDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ autodocsumm==0.1.11
 certifi
 configparser==3.5.0
 coverage==4.5.2
-cryptography==2.5
+cryptography==2.8
 flake8==3.6.0
 mock==2.0.0
 pyOpenSSL==18.0.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open_relative("README.rst") as f:
 requires = [
     "certifi",
     "configparser>=3.5.0b1",
-    "cryptography>=2.1.4",
+    "cryptography==2.8",
     "pyOpenSSL>=17.5.0",
     "python-dateutil>=2.5.3,<3.0.0",
     "pytz>=2016.10",

--- a/src/oci/analytics/analytics_client.py
+++ b/src/oci/analytics/analytics_client.py
@@ -35,7 +35,7 @@ class AnalyticsClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/announcements_service/announcement_client.py
+++ b/src/oci/announcements_service/announcement_client.py
@@ -35,7 +35,7 @@ class AnnouncementClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/apigateway/deployment_client.py
+++ b/src/oci/apigateway/deployment_client.py
@@ -37,7 +37,7 @@ class DeploymentClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/apigateway/gateway_client.py
+++ b/src/oci/apigateway/gateway_client.py
@@ -37,7 +37,7 @@ class GatewayClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/apigateway/work_requests_client.py
+++ b/src/oci/apigateway/work_requests_client.py
@@ -37,7 +37,7 @@ class WorkRequestsClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/audit/audit_client.py
+++ b/src/oci/audit/audit_client.py
@@ -38,7 +38,7 @@ class AuditClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/autoscaling/auto_scaling_client.py
+++ b/src/oci/autoscaling/auto_scaling_client.py
@@ -36,7 +36,7 @@ class AutoScalingClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/base_client.py
+++ b/src/oci/base_client.py
@@ -61,6 +61,10 @@ def utc_now():
 STREAM_RESPONSE_TYPE = 'stream'
 BYTES_RESPONSE_TYPE = 'bytes'
 
+# Default timeout value(second)
+DEFAULT_CONNECTION_TIMEOUT = 10.0
+DEFAULT_READ_TIMEOUT = 60.0
+
 # The keys here correspond to the Swagger collection format values described here: https://swagger.io/docs/specification/2-0/describing-parameters/
 # and the values represent delimiters we'll use between values of the collection when placing those values in the query string.
 #
@@ -124,7 +128,7 @@ class BaseClient(object):
         self.complex_type_mappings = type_mapping
         self.type_mappings = merge_type_mappings(self.primitive_type_map, type_mapping)
         self.session = requests.Session()
-        self.timeout = kwargs.get('timeout')
+        self.timeout = kwargs.get('timeout', (DEFAULT_CONNECTION_TIMEOUT, DEFAULT_READ_TIMEOUT))
         self.user_agent = build_user_agent(get_config_value_or_default(config, "additional_user_agent"))
 
         self.logger = logging.getLogger("{}.{}".format(__name__, id(self)))

--- a/src/oci/budget/budget_client.py
+++ b/src/oci/budget/budget_client.py
@@ -35,7 +35,7 @@ class BudgetClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/container_engine/container_engine_client.py
+++ b/src/oci/container_engine/container_engine_client.py
@@ -37,7 +37,7 @@ class ContainerEngineClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/core/blockstorage_client.py
+++ b/src/oci/core/blockstorage_client.py
@@ -39,7 +39,7 @@ class BlockstorageClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/core/compute_client.py
+++ b/src/oci/core/compute_client.py
@@ -39,7 +39,7 @@ class ComputeClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)
@@ -183,7 +183,7 @@ class ComputeClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.BootVolumeAttachment`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/bootVolumeAttachments/"
+        resource_path = "/bootVolumeAttachments"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -256,7 +256,7 @@ class ComputeClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.VnicAttachment`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/vnicAttachments/"
+        resource_path = "/vnicAttachments"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -325,7 +325,7 @@ class ComputeClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.VolumeAttachment`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/volumeAttachments/"
+        resource_path = "/volumeAttachments"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -410,7 +410,7 @@ class ComputeClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.ConsoleHistory`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/instanceConsoleHistories/"
+        resource_path = "/instanceConsoleHistories"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -2826,7 +2826,7 @@ class ComputeClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.Instance`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/instances/"
+        resource_path = "/instances"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -3259,7 +3259,7 @@ class ComputeClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.core.models.BootVolumeAttachment`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/bootVolumeAttachments/"
+        resource_path = "/bootVolumeAttachments"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -3379,7 +3379,7 @@ class ComputeClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.core.models.ConsoleHistory`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/instanceConsoleHistories/"
+        resource_path = "/instanceConsoleHistories"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -4450,7 +4450,7 @@ class ComputeClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.core.models.Instance`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/instances/"
+        resource_path = "/instances"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -4677,7 +4677,7 @@ class ComputeClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.core.models.VnicAttachment`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/vnicAttachments/"
+        resource_path = "/vnicAttachments"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -4782,7 +4782,7 @@ class ComputeClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.core.models.VolumeAttachment`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/volumeAttachments/"
+        resource_path = "/volumeAttachments"
         method = "GET"
 
         # Don't accept unknown kwargs

--- a/src/oci/core/compute_management_client.py
+++ b/src/oci/core/compute_management_client.py
@@ -39,7 +39,7 @@ class ComputeManagementClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/core/models/egress_security_rule.py
+++ b/src/oci/core/models/egress_security_rule.py
@@ -55,6 +55,10 @@ class EgressSecurityRule(object):
             The value to assign to the udp_options property of this EgressSecurityRule.
         :type udp_options: UdpOptions
 
+        :param description:
+            The value to assign to the description property of this EgressSecurityRule.
+        :type description: str
+
         """
         self.swagger_types = {
             'destination': 'str',
@@ -63,7 +67,8 @@ class EgressSecurityRule(object):
             'is_stateless': 'bool',
             'protocol': 'str',
             'tcp_options': 'TcpOptions',
-            'udp_options': 'UdpOptions'
+            'udp_options': 'UdpOptions',
+            'description': 'str'
         }
 
         self.attribute_map = {
@@ -73,7 +78,8 @@ class EgressSecurityRule(object):
             'is_stateless': 'isStateless',
             'protocol': 'protocol',
             'tcp_options': 'tcpOptions',
-            'udp_options': 'udpOptions'
+            'udp_options': 'udpOptions',
+            'description': 'description'
         }
 
         self._destination = None
@@ -83,6 +89,7 @@ class EgressSecurityRule(object):
         self._protocol = None
         self._tcp_options = None
         self._udp_options = None
+        self._description = None
 
     @property
     def destination(self):
@@ -341,6 +348,30 @@ class EgressSecurityRule(object):
         :type: UdpOptions
         """
         self._udp_options = udp_options
+
+    @property
+    def description(self):
+        """
+        Gets the description of this EgressSecurityRule.
+        An optional description of your choice for the rule.
+
+
+        :return: The description of this EgressSecurityRule.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this EgressSecurityRule.
+        An optional description of your choice for the rule.
+
+
+        :param description: The description of this EgressSecurityRule.
+        :type: str
+        """
+        self._description = description
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/ingress_security_rule.py
+++ b/src/oci/core/models/ingress_security_rule.py
@@ -55,6 +55,10 @@ class IngressSecurityRule(object):
             The value to assign to the udp_options property of this IngressSecurityRule.
         :type udp_options: UdpOptions
 
+        :param description:
+            The value to assign to the description property of this IngressSecurityRule.
+        :type description: str
+
         """
         self.swagger_types = {
             'icmp_options': 'IcmpOptions',
@@ -63,7 +67,8 @@ class IngressSecurityRule(object):
             'source': 'str',
             'source_type': 'str',
             'tcp_options': 'TcpOptions',
-            'udp_options': 'UdpOptions'
+            'udp_options': 'UdpOptions',
+            'description': 'str'
         }
 
         self.attribute_map = {
@@ -73,7 +78,8 @@ class IngressSecurityRule(object):
             'source': 'source',
             'source_type': 'sourceType',
             'tcp_options': 'tcpOptions',
-            'udp_options': 'udpOptions'
+            'udp_options': 'udpOptions',
+            'description': 'description'
         }
 
         self._icmp_options = None
@@ -83,6 +89,7 @@ class IngressSecurityRule(object):
         self._source_type = None
         self._tcp_options = None
         self._udp_options = None
+        self._description = None
 
     @property
     def icmp_options(self):
@@ -337,6 +344,30 @@ class IngressSecurityRule(object):
         :type: UdpOptions
         """
         self._udp_options = udp_options
+
+    @property
+    def description(self):
+        """
+        Gets the description of this IngressSecurityRule.
+        An optional description of your choice for the rule.
+
+
+        :return: The description of this IngressSecurityRule.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this IngressSecurityRule.
+        An optional description of your choice for the rule.
+
+
+        :param description: The description of this IngressSecurityRule.
+        :type: str
+        """
+        self._description = description
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/route_rule.py
+++ b/src/oci/core/models/route_rule.py
@@ -44,25 +44,32 @@ class RouteRule(object):
             The value to assign to the network_entity_id property of this RouteRule.
         :type network_entity_id: str
 
+        :param description:
+            The value to assign to the description property of this RouteRule.
+        :type description: str
+
         """
         self.swagger_types = {
             'cidr_block': 'str',
             'destination': 'str',
             'destination_type': 'str',
-            'network_entity_id': 'str'
+            'network_entity_id': 'str',
+            'description': 'str'
         }
 
         self.attribute_map = {
             'cidr_block': 'cidrBlock',
             'destination': 'destination',
             'destination_type': 'destinationType',
-            'network_entity_id': 'networkEntityId'
+            'network_entity_id': 'networkEntityId',
+            'description': 'description'
         }
 
         self._cidr_block = None
         self._destination = None
         self._destination_type = None
         self._network_entity_id = None
+        self._description = None
 
     @property
     def cidr_block(self):
@@ -225,6 +232,30 @@ class RouteRule(object):
         :type: str
         """
         self._network_entity_id = network_entity_id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this RouteRule.
+        An optional description of your choice for the rule.
+
+
+        :return: The description of this RouteRule.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this RouteRule.
+        An optional description of your choice for the rule.
+
+
+        :param description: The description of this RouteRule.
+        :type: str
+        """
+        self._description = description
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/virtual_network_client.py
+++ b/src/oci/core/virtual_network_client.py
@@ -39,7 +39,7 @@ class VirtualNetworkClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/database/database_client.py
+++ b/src/oci/database/database_client.py
@@ -35,7 +35,7 @@ class DatabaseClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)
@@ -1558,6 +1558,80 @@ class DatabaseClient(object):
                 body=create_data_guard_association_details,
                 response_type="DataGuardAssociation")
 
+    def create_database(self, create_new_database_details, **kwargs):
+        """
+        CreateDatabase
+        Creates a new database in the specified Database Home. If the database version is provided, it must match the version of the Database Home. Applies only to Exadata DB systems.
+
+
+        :param CreateDatabaseBase create_new_database_details: (required)
+            Request to create a new database.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.Database`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/databases"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_new_database_details,
+                response_type="Database")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_new_database_details,
+                response_type="Database")
+
     def create_db_home(self, create_db_home_with_db_system_id_details, **kwargs):
         """
         CreateDbHome
@@ -2361,10 +2435,111 @@ class DatabaseClient(object):
                 path_params=path_params,
                 header_params=header_params)
 
+    def delete_database(self, database_id, **kwargs):
+        """
+        DeleteDatabase
+        Deletes the database. Applies only to Exadata DB systems.
+
+        The data in this database is local to the DB system and will be lost when the database is deleted. Oracle recommends that you back up any data in the DB system prior to deleting it. You can use the `performFinalBackup` parameter to have the Exadata DB system database backed up before it is deleted.
+
+
+        :param str database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param bool perform_final_backup: (optional)
+            Whether to perform a final backup of the database or not. Default is false.
+
+            If you previously used RMAN or dbcli to configure backups and then you switch to using the Console or the API for backups, a new backup configuration is created and associated with your database. This means that you can no longer rely on your previously configured unmanaged backups to work.
+
+            This parameter is used in multiple APIs. Refer to the API description for details on how the operation uses it.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/databases/{databaseId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "perform_final_backup",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "databaseId": database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "performFinalBackup": kwargs.get("perform_final_backup", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+
     def delete_db_home(self, db_home_id, **kwargs):
         """
         DeleteDbHome
-        Deletes a Database Home. The Database Home and its database data are local to the DB system and are lost when you delete the Database Home. Oracle recommends that you back up any data on the DB system before you delete it.
+        Deletes a Database Home. Applies only to bare metal and Exadata DB systems.
+
+        The Database Home and its database data are local to the DB system, and on a bare metal DB system, both are lost when you delete the Database Home. Oracle recommends that you back up any data on the DB system before you delete it. You can use the `performFinalBackup` parameter with this operation on bare metal DB systems.
+
+        On an Exadata DB system, the delete request is rejected if the Database Home is not empty. You must terminate all databases in the Database Home before you delete the home. The `performFinalBackup` parameter is not used with this operation on Exadata DB systems.
 
 
         :param str db_home_id: (required)
@@ -2381,6 +2556,8 @@ class DatabaseClient(object):
             Whether to perform a final backup of the database or not. Default is false.
 
             If you previously used RMAN or dbcli to configure backups and then you switch to using the Console or the API for backups, a new backup configuration is created and associated with your database. This means that you can no longer rely on your previously configured unmanaged backups to work.
+
+            This parameter is used in multiple APIs. Refer to the API description for details on how the operation uses it.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -6540,7 +6717,7 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="list[DataGuardAssociationSummary]")
 
-    def list_databases(self, compartment_id, db_home_id, **kwargs):
+    def list_databases(self, compartment_id, **kwargs):
         """
         ListDatabases
         Gets a list of the databases in the specified Database Home.
@@ -6551,8 +6728,13 @@ class DatabaseClient(object):
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
-        :param str db_home_id: (required)
+        :param str db_home_id: (optional)
             A Database Home `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str system_id: (optional)
+            The `OCID`__ of the Exadata DB system that you want to filter the database results by. Applies only to Exadata DB systems.
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -6597,6 +6779,8 @@ class DatabaseClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
+            "db_home_id",
+            "system_id",
             "limit",
             "page",
             "sort_by",
@@ -6632,7 +6816,8 @@ class DatabaseClient(object):
 
         query_params = {
             "compartmentId": compartment_id,
-            "dbHomeId": db_home_id,
+            "dbHomeId": kwargs.get("db_home_id", missing),
+            "systemId": kwargs.get("system_id", missing),
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing),
             "sortBy": kwargs.get("sort_by", missing),
@@ -6858,6 +7043,11 @@ class DatabaseClient(object):
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
+        :param str backup_id: (optional)
+            The `OCID`__ of the backup. Specify a backupId to list only the DB systems or DB homes that support creating a database using this backup in this compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
         :param int limit: (optional)
             The maximum number of items to return per page.
 
@@ -6901,6 +7091,7 @@ class DatabaseClient(object):
             "retry_strategy",
             "db_system_id",
             "vm_cluster_id",
+            "backup_id",
             "limit",
             "page",
             "sort_by",
@@ -6938,6 +7129,7 @@ class DatabaseClient(object):
             "compartmentId": compartment_id,
             "dbSystemId": kwargs.get("db_system_id", missing),
             "vmClusterId": kwargs.get("vm_cluster_id", missing),
+            "backupId": kwargs.get("backup_id", missing),
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing),
             "sortBy": kwargs.get("sort_by", missing),

--- a/src/oci/database/database_client_composite_operations.py
+++ b/src/oci/database/database_client_composite_operations.py
@@ -26,6 +26,46 @@ class DatabaseClientCompositeOperations(object):
         self.client = client
         self._work_request_client = work_request_client if work_request_client else oci.work_requests.WorkRequestClient(self.client._config, **self.client._kwargs)
 
+    def activate_exadata_infrastructure_and_wait_for_work_request(self, exadata_infrastructure_id, activate_exadata_infrastructure_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.activate_exadata_infrastructure` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param ActivateExadataInfrastructureDetails activate_exadata_infrastructure_details: (required)
+            The activation details for the Exadata infrastructure.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.activate_exadata_infrastructure`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.activate_exadata_infrastructure(exadata_infrastructure_id, activate_exadata_infrastructure_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def activate_exadata_infrastructure_and_wait_for_state(self, exadata_infrastructure_id, activate_exadata_infrastructure_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.activate_exadata_infrastructure` and waits for the :py:class:`~oci.database.models.ExadataInfrastructure` acted upon
@@ -349,6 +389,46 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def complete_external_backup_job_and_wait_for_work_request(self, backup_id, complete_external_backup_job_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.complete_external_backup_job` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str backup_id: (required)
+            The backup `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param CompleteExternalBackupJobDetails complete_external_backup_job_details: (required)
+            Updates the status of the backup resource.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.complete_external_backup_job`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.complete_external_backup_job(backup_id, complete_external_backup_job_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_autonomous_container_database_and_wait_for_work_request(self, create_autonomous_container_database_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.create_autonomous_container_database` and waits for the oci.work_requests.models.WorkRequest
@@ -644,6 +724,41 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def create_backup_and_wait_for_work_request(self, create_backup_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_backup` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param CreateBackupDetails create_backup_details: (required)
+            Request to create a new database backup.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_backup`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_backup(create_backup_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_backup_and_wait_for_state(self, create_backup_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.create_backup` and waits for the :py:class:`~oci.database.models.Backup` acted upon
@@ -720,6 +835,46 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def create_data_guard_association_and_wait_for_work_request(self, database_id, create_data_guard_association_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_data_guard_association` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param CreateDataGuardAssociationDetails create_data_guard_association_details: (required)
+            A request to create a Data Guard association.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_data_guard_association`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_data_guard_association(database_id, create_data_guard_association_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_data_guard_association_and_wait_for_state(self, database_id, create_data_guard_association_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.create_data_guard_association` and waits for the :py:class:`~oci.database.models.DataGuardAssociation` acted upon
@@ -763,6 +918,114 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def create_database_and_wait_for_work_request(self, create_new_database_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_database` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param CreateDatabaseBase create_new_database_details: (required)
+            Request to create a new database.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_database(create_new_database_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_database_and_wait_for_state(self, create_new_database_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_database` and waits for the :py:class:`~oci.database.models.Database` acted upon
+        to enter the given state(s).
+
+        :param CreateDatabaseBase create_new_database_details: (required)
+            Request to create a new database.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.Database.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_database(create_new_database_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_database(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_db_home_and_wait_for_work_request(self, create_db_home_with_db_system_id_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_db_home` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param CreateDbHomeBase create_db_home_with_db_system_id_details: (required)
+            Request to create a new Database Home.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_db_home`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_db_home(create_db_home_with_db_system_id_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_db_home_and_wait_for_state(self, create_db_home_with_db_system_id_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.create_db_home` and waits for the :py:class:`~oci.database.models.DbHome` acted upon
@@ -798,6 +1061,41 @@ class DatabaseClientCompositeOperations(object):
             result_to_return = waiter_result
 
             return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_exadata_infrastructure_and_wait_for_work_request(self, create_exadata_infrastructure_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_exadata_infrastructure` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param CreateExadataInfrastructureDetails create_exadata_infrastructure_details: (required)
+            Request to create Exadata infrastructure.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_exadata_infrastructure`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_exadata_infrastructure(create_exadata_infrastructure_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -839,6 +1137,76 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def create_external_backup_job_and_wait_for_work_request(self, create_external_backup_job_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_external_backup_job` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param CreateExternalBackupJobDetails create_external_backup_job_details: (required)
+            Request to create a cloud backup resource for a database running outside the cloud.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_external_backup_job`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_external_backup_job(create_external_backup_job_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_vm_cluster_and_wait_for_work_request(self, create_vm_cluster_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_vm_cluster` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param CreateVmClusterDetails create_vm_cluster_details: (required)
+            Request to create a VM cluster.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_vm_cluster`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_vm_cluster(create_vm_cluster_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_vm_cluster_and_wait_for_state(self, create_vm_cluster_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.create_vm_cluster` and waits for the :py:class:`~oci.database.models.VmCluster` acted upon
@@ -874,6 +1242,46 @@ class DatabaseClientCompositeOperations(object):
             result_to_return = waiter_result
 
             return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_vm_cluster_network_and_wait_for_work_request(self, exadata_infrastructure_id, vm_cluster_network_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_vm_cluster_network` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param VmClusterNetworkDetails vm_cluster_network_details: (required)
+            Request to create the VM cluster network.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_vm_cluster_network`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_vm_cluster_network(exadata_infrastructure_id, vm_cluster_network_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -917,6 +1325,48 @@ class DatabaseClientCompositeOperations(object):
             result_to_return = waiter_result
 
             return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def db_node_action_and_wait_for_work_request(self, db_node_id, action, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.db_node_action` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str db_node_id: (required)
+            The database node `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str action: (required)
+            The action to perform on the DB Node.
+
+            Allowed values are: "STOP", "START", "SOFTRESET", "RESET"
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.db_node_action`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.db_node_action(db_node_id, action, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -1051,9 +1501,9 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
-    def delete_backup_and_wait_for_state(self, backup_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+    def delete_backup_and_wait_for_work_request(self, backup_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
-        Calls :py:func:`~oci.database.DatabaseClient.delete_backup` and waits for the :py:class:`~oci.database.models.Backup` acted upon
+        Calls :py:func:`~oci.database.DatabaseClient.delete_backup` and waits for the oci.work_requests.models.WorkRequest
         to enter the given state(s).
 
         :param str backup_id: (required)
@@ -1061,8 +1511,9 @@ class DatabaseClientCompositeOperations(object):
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
-        :param list[str] wait_for_states:
-            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.Backup.lifecycle_state`
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
 
         :param dict operation_kwargs:
             A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.delete_backup`
@@ -1071,32 +1522,19 @@ class DatabaseClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        initial_get_result = self.client.get_backup(backup_id)
-        operation_result = None
-        try:
-            operation_result = self.client.delete_backup(backup_id, **operation_kwargs)
-        except oci.exceptions.ServiceError as e:
-            if e.status == 404:
-                return WAIT_RESOURCE_NOT_FOUND
-            else:
-                raise e
-
-        if not wait_for_states:
-            return operation_result
-
-        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        operation_result = self.client.delete_backup(backup_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
 
         try:
             waiter_result = oci.wait_until(
-                self.client,
-                initial_get_result,
-                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
-                succeed_on_not_found=True,
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
                 **waiter_kwargs
             )
-            result_to_return = waiter_result
-
-            return result_to_return
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -1149,9 +1587,46 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
-    def delete_db_home_and_wait_for_state(self, db_home_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+    def delete_database_and_wait_for_work_request(self, database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
-        Calls :py:func:`~oci.database.DatabaseClient.delete_db_home` and waits for the :py:class:`~oci.database.models.DbHome` acted upon
+        Calls :py:func:`~oci.database.DatabaseClient.delete_database` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.delete_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.delete_database(database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_db_home_and_wait_for_work_request(self, db_home_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.delete_db_home` and waits for the oci.work_requests.models.WorkRequest
         to enter the given state(s).
 
         :param str db_home_id: (required)
@@ -1159,8 +1634,9 @@ class DatabaseClientCompositeOperations(object):
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
-        :param list[str] wait_for_states:
-            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.DbHome.lifecycle_state`
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
 
         :param dict operation_kwargs:
             A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.delete_db_home`
@@ -1169,38 +1645,25 @@ class DatabaseClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        initial_get_result = self.client.get_db_home(db_home_id)
-        operation_result = None
-        try:
-            operation_result = self.client.delete_db_home(db_home_id, **operation_kwargs)
-        except oci.exceptions.ServiceError as e:
-            if e.status == 404:
-                return WAIT_RESOURCE_NOT_FOUND
-            else:
-                raise e
-
-        if not wait_for_states:
-            return operation_result
-
-        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        operation_result = self.client.delete_db_home(db_home_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
 
         try:
             waiter_result = oci.wait_until(
-                self.client,
-                initial_get_result,
-                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
-                succeed_on_not_found=True,
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
                 **waiter_kwargs
             )
-            result_to_return = waiter_result
-
-            return result_to_return
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
-    def delete_exadata_infrastructure_and_wait_for_state(self, exadata_infrastructure_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+    def delete_exadata_infrastructure_and_wait_for_work_request(self, exadata_infrastructure_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
-        Calls :py:func:`~oci.database.DatabaseClient.delete_exadata_infrastructure` and waits for the :py:class:`~oci.database.models.ExadataInfrastructure` acted upon
+        Calls :py:func:`~oci.database.DatabaseClient.delete_exadata_infrastructure` and waits for the oci.work_requests.models.WorkRequest
         to enter the given state(s).
 
         :param str exadata_infrastructure_id: (required)
@@ -1208,8 +1671,9 @@ class DatabaseClientCompositeOperations(object):
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
-        :param list[str] wait_for_states:
-            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.ExadataInfrastructure.lifecycle_state`
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
 
         :param dict operation_kwargs:
             A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.delete_exadata_infrastructure`
@@ -1218,38 +1682,25 @@ class DatabaseClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        initial_get_result = self.client.get_exadata_infrastructure(exadata_infrastructure_id)
-        operation_result = None
-        try:
-            operation_result = self.client.delete_exadata_infrastructure(exadata_infrastructure_id, **operation_kwargs)
-        except oci.exceptions.ServiceError as e:
-            if e.status == 404:
-                return WAIT_RESOURCE_NOT_FOUND
-            else:
-                raise e
-
-        if not wait_for_states:
-            return operation_result
-
-        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        operation_result = self.client.delete_exadata_infrastructure(exadata_infrastructure_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
 
         try:
             waiter_result = oci.wait_until(
-                self.client,
-                initial_get_result,
-                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
-                succeed_on_not_found=True,
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
                 **waiter_kwargs
             )
-            result_to_return = waiter_result
-
-            return result_to_return
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
-    def delete_vm_cluster_and_wait_for_state(self, vm_cluster_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+    def delete_vm_cluster_and_wait_for_work_request(self, vm_cluster_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
-        Calls :py:func:`~oci.database.DatabaseClient.delete_vm_cluster` and waits for the :py:class:`~oci.database.models.VmCluster` acted upon
+        Calls :py:func:`~oci.database.DatabaseClient.delete_vm_cluster` and waits for the oci.work_requests.models.WorkRequest
         to enter the given state(s).
 
         :param str vm_cluster_id: (required)
@@ -1257,8 +1708,9 @@ class DatabaseClientCompositeOperations(object):
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
-        :param list[str] wait_for_states:
-            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.VmCluster.lifecycle_state`
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
 
         :param dict operation_kwargs:
             A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.delete_vm_cluster`
@@ -1267,32 +1719,61 @@ class DatabaseClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        initial_get_result = self.client.get_vm_cluster(vm_cluster_id)
-        operation_result = None
-        try:
-            operation_result = self.client.delete_vm_cluster(vm_cluster_id, **operation_kwargs)
-        except oci.exceptions.ServiceError as e:
-            if e.status == 404:
-                return WAIT_RESOURCE_NOT_FOUND
-            else:
-                raise e
-
-        if not wait_for_states:
-            return operation_result
-
-        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        operation_result = self.client.delete_vm_cluster(vm_cluster_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
 
         try:
             waiter_result = oci.wait_until(
-                self.client,
-                initial_get_result,
-                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
-                succeed_on_not_found=True,
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
                 **waiter_kwargs
             )
-            result_to_return = waiter_result
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
-            return result_to_return
+    def delete_vm_cluster_network_and_wait_for_work_request(self, exadata_infrastructure_id, vm_cluster_network_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.delete_vm_cluster_network` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str vm_cluster_network_id: (required)
+            The VM cluster network `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.delete_vm_cluster_network`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.delete_vm_cluster_network(exadata_infrastructure_id, vm_cluster_network_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -1318,6 +1799,51 @@ class DatabaseClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         operation_result = self.client.deregister_autonomous_database_data_safe(autonomous_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def failover_data_guard_association_and_wait_for_work_request(self, database_id, data_guard_association_id, failover_data_guard_association_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.failover_data_guard_association` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str data_guard_association_id: (required)
+            The Data Guard association's `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param FailoverDataGuardAssociationDetails failover_data_guard_association_details: (required)
+            A request to perform a failover, transitioning a standby database into a primary database.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.failover_data_guard_association`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.failover_data_guard_association(database_id, data_guard_association_id, failover_data_guard_association_details, **operation_kwargs)
         work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
         lowered_work_request_states = [w.lower() for w in work_request_states]
         work_request_id = operation_result.headers['opc-work-request-id']
@@ -1454,6 +1980,41 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def launch_db_system_and_wait_for_work_request(self, launch_db_system_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.launch_db_system` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param LaunchDbSystemBase launch_db_system_details: (required)
+            Request to launch a DB system.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.launch_db_system`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.launch_db_system(launch_db_system_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def launch_db_system_and_wait_for_state(self, launch_db_system_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.launch_db_system` and waits for the :py:class:`~oci.database.models.DbSystem` acted upon
@@ -1514,6 +2075,51 @@ class DatabaseClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         operation_result = self.client.register_autonomous_database_data_safe(autonomous_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def reinstate_data_guard_association_and_wait_for_work_request(self, database_id, data_guard_association_id, reinstate_data_guard_association_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.reinstate_data_guard_association` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str data_guard_association_id: (required)
+            The Data Guard association's `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param ReinstateDataGuardAssociationDetails reinstate_data_guard_association_details: (required)
+            A request to reinstate a database in a standby role.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.reinstate_data_guard_association`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.reinstate_data_guard_association(database_id, data_guard_association_id, reinstate_data_guard_association_details, **operation_kwargs)
         work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
         lowered_work_request_states = [w.lower() for w in work_request_states]
         work_request_id = operation_result.headers['opc-work-request-id']
@@ -1777,6 +2383,46 @@ class DatabaseClientCompositeOperations(object):
             result_to_return = waiter_result
 
             return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def restore_database_and_wait_for_work_request(self, database_id, restore_database_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.restore_database` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param RestoreDatabaseDetails restore_database_details: (required)
+            Request to perform database restore.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.restore_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.restore_database(database_id, restore_database_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -2057,6 +2703,51 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def switchover_data_guard_association_and_wait_for_work_request(self, database_id, data_guard_association_id, switchover_data_guard_association_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.switchover_data_guard_association` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str data_guard_association_id: (required)
+            The Data Guard association's `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param SwitchoverDataGuardAssociationDetails switchover_data_guard_association_details: (required)
+            Request to swtichover a primary to a standby.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.switchover_data_guard_association`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.switchover_data_guard_association(database_id, data_guard_association_id, switchover_data_guard_association_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def switchover_data_guard_association_and_wait_for_state(self, database_id, data_guard_association_id, switchover_data_guard_association_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.switchover_data_guard_association` and waits for the :py:class:`~oci.database.models.DataGuardAssociation` acted upon
@@ -2179,9 +2870,9 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
-    def terminate_db_system_and_wait_for_state(self, db_system_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+    def terminate_db_system_and_wait_for_work_request(self, db_system_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
-        Calls :py:func:`~oci.database.DatabaseClient.terminate_db_system` and waits for the :py:class:`~oci.database.models.DbSystem` acted upon
+        Calls :py:func:`~oci.database.DatabaseClient.terminate_db_system` and waits for the oci.work_requests.models.WorkRequest
         to enter the given state(s).
 
         :param str db_system_id: (required)
@@ -2189,8 +2880,9 @@ class DatabaseClientCompositeOperations(object):
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
-        :param list[str] wait_for_states:
-            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.DbSystem.lifecycle_state`
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
 
         :param dict operation_kwargs:
             A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.terminate_db_system`
@@ -2199,32 +2891,19 @@ class DatabaseClientCompositeOperations(object):
             A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
-        initial_get_result = self.client.get_db_system(db_system_id)
-        operation_result = None
-        try:
-            operation_result = self.client.terminate_db_system(db_system_id, **operation_kwargs)
-        except oci.exceptions.ServiceError as e:
-            if e.status == 404:
-                return WAIT_RESOURCE_NOT_FOUND
-            else:
-                raise e
-
-        if not wait_for_states:
-            return operation_result
-
-        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        operation_result = self.client.terminate_db_system(db_system_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
 
         try:
             waiter_result = oci.wait_until(
-                self.client,
-                initial_get_result,
-                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
-                succeed_on_not_found=True,
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
                 **waiter_kwargs
             )
-            result_to_return = waiter_result
-
-            return result_to_return
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -2639,6 +3318,46 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def update_database_and_wait_for_work_request(self, database_id, update_database_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_database` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateDatabaseDetails update_database_details: (required)
+            Request to perform database update.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_database(database_id, update_database_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def update_database_and_wait_for_state(self, database_id, update_database_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.update_database` and waits for the :py:class:`~oci.database.models.Database` acted upon
@@ -2679,6 +3398,46 @@ class DatabaseClientCompositeOperations(object):
             result_to_return = waiter_result
 
             return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_db_home_and_wait_for_work_request(self, db_home_id, update_db_home_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_db_home` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str db_home_id: (required)
+            The Database Home `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateDbHomeDetails update_db_home_details: (required)
+            Request to update the properties of a DB Home.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_db_home`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_db_home(db_home_id, update_db_home_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -2725,6 +3484,46 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def update_db_system_and_wait_for_work_request(self, db_system_id, update_db_system_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_db_system` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str db_system_id: (required)
+            The DB system `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateDbSystemDetails update_db_system_details: (required)
+            Request to update the properties of a DB system.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_db_system`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_db_system(db_system_id, update_db_system_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def update_db_system_and_wait_for_state(self, db_system_id, update_db_system_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.update_db_system` and waits for the :py:class:`~oci.database.models.DbSystem` acted upon
@@ -2768,6 +3567,46 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def update_exadata_infrastructure_and_wait_for_work_request(self, exadata_infrastructure_id, update_exadata_infrastructure_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_exadata_infrastructure` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateExadataInfrastructureDetails update_exadata_infrastructure_details: (required)
+            Request to update the properties of an Exadata infrastructure
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_exadata_infrastructure`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_exadata_infrastructure(exadata_infrastructure_id, update_exadata_infrastructure_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def update_exadata_infrastructure_and_wait_for_state(self, exadata_infrastructure_id, update_exadata_infrastructure_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.update_exadata_infrastructure` and waits for the :py:class:`~oci.database.models.ExadataInfrastructure` acted upon
@@ -2808,6 +3647,46 @@ class DatabaseClientCompositeOperations(object):
             result_to_return = waiter_result
 
             return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_exadata_iorm_config_and_wait_for_work_request(self, db_system_id, exadata_iorm_config_update_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_exadata_iorm_config` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str db_system_id: (required)
+            The DB system `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param ExadataIormConfigUpdateDetails exadata_iorm_config_update_details: (required)
+            Request to perform database update.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_exadata_iorm_config`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_exadata_iorm_config(db_system_id, exadata_iorm_config_update_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -2895,6 +3774,46 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def update_vm_cluster_and_wait_for_work_request(self, vm_cluster_id, update_vm_cluster_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_vm_cluster` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str vm_cluster_id: (required)
+            The VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateVmClusterDetails update_vm_cluster_details: (required)
+            Request to update the attributes of a VM cluster.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_vm_cluster`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_vm_cluster(vm_cluster_id, update_vm_cluster_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def update_vm_cluster_and_wait_for_state(self, vm_cluster_id, update_vm_cluster_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.update_vm_cluster` and waits for the :py:class:`~oci.database.models.VmCluster` acted upon
@@ -2935,6 +3854,51 @@ class DatabaseClientCompositeOperations(object):
             result_to_return = waiter_result
 
             return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_vm_cluster_network_and_wait_for_work_request(self, exadata_infrastructure_id, vm_cluster_network_id, update_vm_cluster_network_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_vm_cluster_network` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str vm_cluster_network_id: (required)
+            The VM cluster network `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateVmClusterNetworkDetails update_vm_cluster_network_details: (required)
+            Request to update the properties of a VM cluster network.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_vm_cluster_network`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_vm_cluster_network(exadata_infrastructure_id, vm_cluster_network_id, update_vm_cluster_network_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -2983,6 +3947,48 @@ class DatabaseClientCompositeOperations(object):
             result_to_return = waiter_result
 
             return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def validate_vm_cluster_network_and_wait_for_work_request(self, exadata_infrastructure_id, vm_cluster_network_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.validate_vm_cluster_network` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str exadata_infrastructure_id: (required)
+            The Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str vm_cluster_network_id: (required)
+            The VM cluster network `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.validate_vm_cluster_network`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.validate_vm_cluster_network(exadata_infrastructure_id, vm_cluster_network_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 

--- a/src/oci/database/models/__init__.py
+++ b/src/oci/database/models/__init__.py
@@ -48,6 +48,7 @@ from .create_backup_details import CreateBackupDetails
 from .create_data_guard_association_details import CreateDataGuardAssociationDetails
 from .create_data_guard_association_to_existing_db_system_details import CreateDataGuardAssociationToExistingDbSystemDetails
 from .create_data_guard_association_with_new_db_system_details import CreateDataGuardAssociationWithNewDbSystemDetails
+from .create_database_base import CreateDatabaseBase
 from .create_database_details import CreateDatabaseDetails
 from .create_database_from_backup_details import CreateDatabaseFromBackupDetails
 from .create_db_home_base import CreateDbHomeBase
@@ -59,6 +60,7 @@ from .create_db_home_with_vm_cluster_id_details import CreateDbHomeWithVmCluster
 from .create_exadata_infrastructure_details import CreateExadataInfrastructureDetails
 from .create_external_backup_job_details import CreateExternalBackupJobDetails
 from .create_nfs_backup_destination_details import CreateNFSBackupDestinationDetails
+from .create_new_database_details import CreateNewDatabaseDetails
 from .create_recovery_appliance_backup_destination_details import CreateRecoveryApplianceBackupDestinationDetails
 from .create_vm_cluster_details import CreateVmClusterDetails
 from .data_guard_association import DataGuardAssociation
@@ -179,6 +181,7 @@ database_type_mapping = {
     "CreateDataGuardAssociationDetails": CreateDataGuardAssociationDetails,
     "CreateDataGuardAssociationToExistingDbSystemDetails": CreateDataGuardAssociationToExistingDbSystemDetails,
     "CreateDataGuardAssociationWithNewDbSystemDetails": CreateDataGuardAssociationWithNewDbSystemDetails,
+    "CreateDatabaseBase": CreateDatabaseBase,
     "CreateDatabaseDetails": CreateDatabaseDetails,
     "CreateDatabaseFromBackupDetails": CreateDatabaseFromBackupDetails,
     "CreateDbHomeBase": CreateDbHomeBase,
@@ -190,6 +193,7 @@ database_type_mapping = {
     "CreateExadataInfrastructureDetails": CreateExadataInfrastructureDetails,
     "CreateExternalBackupJobDetails": CreateExternalBackupJobDetails,
     "CreateNFSBackupDestinationDetails": CreateNFSBackupDestinationDetails,
+    "CreateNewDatabaseDetails": CreateNewDatabaseDetails,
     "CreateRecoveryApplianceBackupDestinationDetails": CreateRecoveryApplianceBackupDestinationDetails,
     "CreateVmClusterDetails": CreateVmClusterDetails,
     "DataGuardAssociation": DataGuardAssociation,

--- a/src/oci/database/models/create_database_base.py
+++ b/src/oci/database/models/create_database_base.py
@@ -1,0 +1,171 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDatabaseBase(object):
+    """
+    Details for creating a database.
+
+    **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+    """
+
+    #: A constant which can be used with the source property of a CreateDatabaseBase.
+    #: This constant has a value of "NONE"
+    SOURCE_NONE = "NONE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDatabaseBase object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.database.models.CreateNewDatabaseDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param db_home_id:
+            The value to assign to the db_home_id property of this CreateDatabaseBase.
+        :type db_home_id: str
+
+        :param db_version:
+            The value to assign to the db_version property of this CreateDatabaseBase.
+        :type db_version: str
+
+        :param source:
+            The value to assign to the source property of this CreateDatabaseBase.
+            Allowed values for this property are: "NONE"
+        :type source: str
+
+        """
+        self.swagger_types = {
+            'db_home_id': 'str',
+            'db_version': 'str',
+            'source': 'str'
+        }
+
+        self.attribute_map = {
+            'db_home_id': 'dbHomeId',
+            'db_version': 'dbVersion',
+            'source': 'source'
+        }
+
+        self._db_home_id = None
+        self._db_version = None
+        self._source = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['source']
+
+        if type == 'NONE':
+            return 'CreateNewDatabaseDetails'
+        else:
+            return 'CreateDatabaseBase'
+
+    @property
+    def db_home_id(self):
+        """
+        **[Required]** Gets the db_home_id of this CreateDatabaseBase.
+        The `OCID`__ of the Database Home.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The db_home_id of this CreateDatabaseBase.
+        :rtype: str
+        """
+        return self._db_home_id
+
+    @db_home_id.setter
+    def db_home_id(self, db_home_id):
+        """
+        Sets the db_home_id of this CreateDatabaseBase.
+        The `OCID`__ of the Database Home.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param db_home_id: The db_home_id of this CreateDatabaseBase.
+        :type: str
+        """
+        self._db_home_id = db_home_id
+
+    @property
+    def db_version(self):
+        """
+        Gets the db_version of this CreateDatabaseBase.
+        A valid Oracle Database version. To get a list of supported versions, use the :func:`list_db_versions` operation.
+
+
+        :return: The db_version of this CreateDatabaseBase.
+        :rtype: str
+        """
+        return self._db_version
+
+    @db_version.setter
+    def db_version(self, db_version):
+        """
+        Sets the db_version of this CreateDatabaseBase.
+        A valid Oracle Database version. To get a list of supported versions, use the :func:`list_db_versions` operation.
+
+
+        :param db_version: The db_version of this CreateDatabaseBase.
+        :type: str
+        """
+        self._db_version = db_version
+
+    @property
+    def source(self):
+        """
+        **[Required]** Gets the source of this CreateDatabaseBase.
+        The source of the database:
+        Use `NONE` for creating a new database.
+        The default is `NONE`.
+
+        Allowed values for this property are: "NONE"
+
+
+        :return: The source of this CreateDatabaseBase.
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """
+        Sets the source of this CreateDatabaseBase.
+        The source of the database:
+        Use `NONE` for creating a new database.
+        The default is `NONE`.
+
+
+        :param source: The source of this CreateDatabaseBase.
+        :type: str
+        """
+        allowed_values = ["NONE"]
+        if not value_allowed_none_or_none_sentinel(source, allowed_values):
+            raise ValueError(
+                "Invalid value for `source`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._source = source
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_db_home_with_db_system_id_details.py
+++ b/src/oci/database/models/create_db_home_with_db_system_id_details.py
@@ -118,7 +118,7 @@ class CreateDbHomeWithDbSystemIdDetails(CreateDbHomeBase):
     @property
     def database(self):
         """
-        **[Required]** Gets the database of this CreateDbHomeWithDbSystemIdDetails.
+        Gets the database of this CreateDbHomeWithDbSystemIdDetails.
 
         :return: The database of this CreateDbHomeWithDbSystemIdDetails.
         :rtype: CreateDatabaseDetails

--- a/src/oci/database/models/create_new_database_details.py
+++ b/src/oci/database/models/create_new_database_details.py
@@ -1,0 +1,91 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+
+from .create_database_base import CreateDatabaseBase
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateNewDatabaseDetails(CreateDatabaseBase):
+    """
+    Details for creating a new database.
+
+    **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateNewDatabaseDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.CreateNewDatabaseDetails.source` attribute
+        of this class is ``NONE`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param db_home_id:
+            The value to assign to the db_home_id property of this CreateNewDatabaseDetails.
+        :type db_home_id: str
+
+        :param db_version:
+            The value to assign to the db_version property of this CreateNewDatabaseDetails.
+        :type db_version: str
+
+        :param source:
+            The value to assign to the source property of this CreateNewDatabaseDetails.
+            Allowed values for this property are: "NONE"
+        :type source: str
+
+        :param database:
+            The value to assign to the database property of this CreateNewDatabaseDetails.
+        :type database: CreateDatabaseDetails
+
+        """
+        self.swagger_types = {
+            'db_home_id': 'str',
+            'db_version': 'str',
+            'source': 'str',
+            'database': 'CreateDatabaseDetails'
+        }
+
+        self.attribute_map = {
+            'db_home_id': 'dbHomeId',
+            'db_version': 'dbVersion',
+            'source': 'source',
+            'database': 'database'
+        }
+
+        self._db_home_id = None
+        self._db_version = None
+        self._source = None
+        self._database = None
+        self._source = 'NONE'
+
+    @property
+    def database(self):
+        """
+        **[Required]** Gets the database of this CreateNewDatabaseDetails.
+
+        :return: The database of this CreateNewDatabaseDetails.
+        :rtype: CreateDatabaseDetails
+        """
+        return self._database
+
+    @database.setter
+    def database(self, database):
+        """
+        Sets the database of this CreateNewDatabaseDetails.
+
+        :param database: The database of this CreateNewDatabaseDetails.
+        :type: CreateDatabaseDetails
+        """
+        self._database = database
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/database.py
+++ b/src/oci/database/models/database.py
@@ -69,6 +69,14 @@ class Database(object):
             The value to assign to the db_home_id property of this Database.
         :type db_home_id: str
 
+        :param db_system_id:
+            The value to assign to the db_system_id property of this Database.
+        :type db_system_id: str
+
+        :param vm_cluster_id:
+            The value to assign to the vm_cluster_id property of this Database.
+        :type vm_cluster_id: str
+
         :param db_name:
             The value to assign to the db_name property of this Database.
         :type db_name: str
@@ -122,6 +130,8 @@ class Database(object):
             'character_set': 'str',
             'ncharacter_set': 'str',
             'db_home_id': 'str',
+            'db_system_id': 'str',
+            'vm_cluster_id': 'str',
             'db_name': 'str',
             'pdb_name': 'str',
             'db_workload': 'str',
@@ -141,6 +151,8 @@ class Database(object):
             'character_set': 'characterSet',
             'ncharacter_set': 'ncharacterSet',
             'db_home_id': 'dbHomeId',
+            'db_system_id': 'dbSystemId',
+            'vm_cluster_id': 'vmClusterId',
             'db_name': 'dbName',
             'pdb_name': 'pdbName',
             'db_workload': 'dbWorkload',
@@ -159,6 +171,8 @@ class Database(object):
         self._character_set = None
         self._ncharacter_set = None
         self._db_home_id = None
+        self._db_system_id = None
+        self._vm_cluster_id = None
         self._db_name = None
         self._pdb_name = None
         self._db_workload = None
@@ -302,6 +316,62 @@ class Database(object):
         :type: str
         """
         self._db_home_id = db_home_id
+
+    @property
+    def db_system_id(self):
+        """
+        Gets the db_system_id of this Database.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The db_system_id of this Database.
+        :rtype: str
+        """
+        return self._db_system_id
+
+    @db_system_id.setter
+    def db_system_id(self, db_system_id):
+        """
+        Sets the db_system_id of this Database.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param db_system_id: The db_system_id of this Database.
+        :type: str
+        """
+        self._db_system_id = db_system_id
+
+    @property
+    def vm_cluster_id(self):
+        """
+        Gets the vm_cluster_id of this Database.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vm_cluster_id of this Database.
+        :rtype: str
+        """
+        return self._vm_cluster_id
+
+    @vm_cluster_id.setter
+    def vm_cluster_id(self, vm_cluster_id):
+        """
+        Sets the vm_cluster_id of this Database.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vm_cluster_id: The vm_cluster_id of this Database.
+        :type: str
+        """
+        self._vm_cluster_id = vm_cluster_id
 
     @property
     def db_name(self):

--- a/src/oci/database/models/database_summary.py
+++ b/src/oci/database/models/database_summary.py
@@ -76,6 +76,14 @@ class DatabaseSummary(object):
             The value to assign to the db_home_id property of this DatabaseSummary.
         :type db_home_id: str
 
+        :param db_system_id:
+            The value to assign to the db_system_id property of this DatabaseSummary.
+        :type db_system_id: str
+
+        :param vm_cluster_id:
+            The value to assign to the vm_cluster_id property of this DatabaseSummary.
+        :type vm_cluster_id: str
+
         :param db_name:
             The value to assign to the db_name property of this DatabaseSummary.
         :type db_name: str
@@ -129,6 +137,8 @@ class DatabaseSummary(object):
             'character_set': 'str',
             'ncharacter_set': 'str',
             'db_home_id': 'str',
+            'db_system_id': 'str',
+            'vm_cluster_id': 'str',
             'db_name': 'str',
             'pdb_name': 'str',
             'db_workload': 'str',
@@ -148,6 +158,8 @@ class DatabaseSummary(object):
             'character_set': 'characterSet',
             'ncharacter_set': 'ncharacterSet',
             'db_home_id': 'dbHomeId',
+            'db_system_id': 'dbSystemId',
+            'vm_cluster_id': 'vmClusterId',
             'db_name': 'dbName',
             'pdb_name': 'pdbName',
             'db_workload': 'dbWorkload',
@@ -166,6 +178,8 @@ class DatabaseSummary(object):
         self._character_set = None
         self._ncharacter_set = None
         self._db_home_id = None
+        self._db_system_id = None
+        self._vm_cluster_id = None
         self._db_name = None
         self._pdb_name = None
         self._db_workload = None
@@ -309,6 +323,62 @@ class DatabaseSummary(object):
         :type: str
         """
         self._db_home_id = db_home_id
+
+    @property
+    def db_system_id(self):
+        """
+        Gets the db_system_id of this DatabaseSummary.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The db_system_id of this DatabaseSummary.
+        :rtype: str
+        """
+        return self._db_system_id
+
+    @db_system_id.setter
+    def db_system_id(self, db_system_id):
+        """
+        Sets the db_system_id of this DatabaseSummary.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param db_system_id: The db_system_id of this DatabaseSummary.
+        :type: str
+        """
+        self._db_system_id = db_system_id
+
+    @property
+    def vm_cluster_id(self):
+        """
+        Gets the vm_cluster_id of this DatabaseSummary.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vm_cluster_id of this DatabaseSummary.
+        :rtype: str
+        """
+        return self._vm_cluster_id
+
+    @vm_cluster_id.setter
+    def vm_cluster_id(self, vm_cluster_id):
+        """
+        Sets the vm_cluster_id of this DatabaseSummary.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vm_cluster_id: The vm_cluster_id of this DatabaseSummary.
+        :type: str
+        """
+        self._vm_cluster_id = vm_cluster_id
 
     @property
     def db_name(self):

--- a/src/oci/database/models/db_home.py
+++ b/src/oci/database/models/db_home.py
@@ -75,6 +75,14 @@ class DbHome(object):
             The value to assign to the db_version property of this DbHome.
         :type db_version: str
 
+        :param db_home_location:
+            The value to assign to the db_home_location property of this DbHome.
+        :type db_home_location: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this DbHome.
+        :type lifecycle_details: str
+
         :param time_created:
             The value to assign to the time_created property of this DbHome.
         :type time_created: datetime
@@ -89,6 +97,8 @@ class DbHome(object):
             'db_system_id': 'str',
             'vm_cluster_id': 'str',
             'db_version': 'str',
+            'db_home_location': 'str',
+            'lifecycle_details': 'str',
             'time_created': 'datetime'
         }
 
@@ -101,6 +111,8 @@ class DbHome(object):
             'db_system_id': 'dbSystemId',
             'vm_cluster_id': 'vmClusterId',
             'db_version': 'dbVersion',
+            'db_home_location': 'dbHomeLocation',
+            'lifecycle_details': 'lifecycleDetails',
             'time_created': 'timeCreated'
         }
 
@@ -112,6 +124,8 @@ class DbHome(object):
         self._db_system_id = None
         self._vm_cluster_id = None
         self._db_version = None
+        self._db_home_location = None
+        self._lifecycle_details = None
         self._time_created = None
 
     @property
@@ -331,6 +345,54 @@ class DbHome(object):
         :type: str
         """
         self._db_version = db_version
+
+    @property
+    def db_home_location(self):
+        """
+        **[Required]** Gets the db_home_location of this DbHome.
+        The location of the Oracle Database Home.
+
+
+        :return: The db_home_location of this DbHome.
+        :rtype: str
+        """
+        return self._db_home_location
+
+    @db_home_location.setter
+    def db_home_location(self, db_home_location):
+        """
+        Sets the db_home_location of this DbHome.
+        The location of the Oracle Database Home.
+
+
+        :param db_home_location: The db_home_location of this DbHome.
+        :type: str
+        """
+        self._db_home_location = db_home_location
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this DbHome.
+        Additional information about the current lifecycleState.
+
+
+        :return: The lifecycle_details of this DbHome.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this DbHome.
+        Additional information about the current lifecycleState.
+
+
+        :param lifecycle_details: The lifecycle_details of this DbHome.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
 
     @property
     def time_created(self):

--- a/src/oci/database/models/db_home_summary.py
+++ b/src/oci/database/models/db_home_summary.py
@@ -87,6 +87,14 @@ class DbHomeSummary(object):
             The value to assign to the db_version property of this DbHomeSummary.
         :type db_version: str
 
+        :param db_home_location:
+            The value to assign to the db_home_location property of this DbHomeSummary.
+        :type db_home_location: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this DbHomeSummary.
+        :type lifecycle_details: str
+
         :param time_created:
             The value to assign to the time_created property of this DbHomeSummary.
         :type time_created: datetime
@@ -101,6 +109,8 @@ class DbHomeSummary(object):
             'db_system_id': 'str',
             'vm_cluster_id': 'str',
             'db_version': 'str',
+            'db_home_location': 'str',
+            'lifecycle_details': 'str',
             'time_created': 'datetime'
         }
 
@@ -113,6 +123,8 @@ class DbHomeSummary(object):
             'db_system_id': 'dbSystemId',
             'vm_cluster_id': 'vmClusterId',
             'db_version': 'dbVersion',
+            'db_home_location': 'dbHomeLocation',
+            'lifecycle_details': 'lifecycleDetails',
             'time_created': 'timeCreated'
         }
 
@@ -124,6 +136,8 @@ class DbHomeSummary(object):
         self._db_system_id = None
         self._vm_cluster_id = None
         self._db_version = None
+        self._db_home_location = None
+        self._lifecycle_details = None
         self._time_created = None
 
     @property
@@ -343,6 +357,54 @@ class DbHomeSummary(object):
         :type: str
         """
         self._db_version = db_version
+
+    @property
+    def db_home_location(self):
+        """
+        **[Required]** Gets the db_home_location of this DbHomeSummary.
+        The location of the Oracle Database Home.
+
+
+        :return: The db_home_location of this DbHomeSummary.
+        :rtype: str
+        """
+        return self._db_home_location
+
+    @db_home_location.setter
+    def db_home_location(self, db_home_location):
+        """
+        Sets the db_home_location of this DbHomeSummary.
+        The location of the Oracle Database Home.
+
+
+        :param db_home_location: The db_home_location of this DbHomeSummary.
+        :type: str
+        """
+        self._db_home_location = db_home_location
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this DbHomeSummary.
+        Additional information about the current lifecycleState.
+
+
+        :return: The lifecycle_details of this DbHomeSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this DbHomeSummary.
+        Additional information about the current lifecycleState.
+
+
+        :param lifecycle_details: The lifecycle_details of this DbHomeSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
 
     @property
     def time_created(self):

--- a/src/oci/dns/dns_client.py
+++ b/src/oci/dns/dns_client.py
@@ -36,7 +36,7 @@ class DnsClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/dts/shipping_vendors_client.py
+++ b/src/oci/dts/shipping_vendors_client.py
@@ -35,7 +35,7 @@ class ShippingVendorsClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/dts/transfer_appliance_client.py
+++ b/src/oci/dts/transfer_appliance_client.py
@@ -35,7 +35,7 @@ class TransferApplianceClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/dts/transfer_appliance_entitlement_client.py
+++ b/src/oci/dts/transfer_appliance_entitlement_client.py
@@ -35,7 +35,7 @@ class TransferApplianceEntitlementClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/dts/transfer_device_client.py
+++ b/src/oci/dts/transfer_device_client.py
@@ -35,7 +35,7 @@ class TransferDeviceClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/dts/transfer_job_client.py
+++ b/src/oci/dts/transfer_job_client.py
@@ -35,7 +35,7 @@ class TransferJobClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/dts/transfer_package_client.py
+++ b/src/oci/dts/transfer_package_client.py
@@ -35,7 +35,7 @@ class TransferPackageClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/email/email_client.py
+++ b/src/oci/email/email_client.py
@@ -39,7 +39,7 @@ class EmailClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/events/events_client.py
+++ b/src/oci/events/events_client.py
@@ -36,7 +36,7 @@ class EventsClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/file_storage/file_storage_client.py
+++ b/src/oci/file_storage/file_storage_client.py
@@ -35,7 +35,7 @@ class FileStorageClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/functions/functions_invoke_client.py
+++ b/src/oci/functions/functions_invoke_client.py
@@ -35,7 +35,7 @@ class FunctionsInvokeClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)
@@ -174,6 +174,9 @@ class FunctionsInvokeClient(object):
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')
 
+        # Disable the retry_strategy to work around data corruption issue temporarily
+        if retry_strategy:
+            retry_strategy = None
         if retry_strategy:
             return retry_strategy.make_retrying_call(
                 self.base_client.call_api,

--- a/src/oci/functions/functions_management_client.py
+++ b/src/oci/functions/functions_management_client.py
@@ -35,7 +35,7 @@ class FunctionsManagementClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/healthchecks/health_checks_client.py
+++ b/src/oci/healthchecks/health_checks_client.py
@@ -37,7 +37,7 @@ class HealthChecksClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/identity/identity_client.py
+++ b/src/oci/identity/identity_client.py
@@ -35,7 +35,7 @@ class IdentityClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)
@@ -204,7 +204,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.UserGroupMembership`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/userGroupMemberships/"
+        resource_path = "/userGroupMemberships"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -455,7 +455,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.AuthToken`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/{userId}/authTokens/"
+        resource_path = "/users/{userId}/authTokens"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -557,7 +557,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.Compartment`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/compartments/"
+        resource_path = "/compartments"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -641,7 +641,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.CustomerSecretKey`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/{userId}/customerSecretKeys/"
+        resource_path = "/users/{userId}/customerSecretKeys"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -742,7 +742,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.DynamicGroup`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/dynamicGroups/"
+        resource_path = "/dynamicGroups"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -834,7 +834,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.Group`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/groups/"
+        resource_path = "/groups"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -923,7 +923,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.IdentityProvider`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/identityProviders/"
+        resource_path = "/identityProviders"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -996,7 +996,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.IdpGroupMapping`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/identityProviders/{identityProviderId}/groupMappings/"
+        resource_path = "/identityProviders/{identityProviderId}/groupMappings"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -1267,7 +1267,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.Policy`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/policies/"
+        resource_path = "/policies"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -1426,7 +1426,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.SmtpCredential`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/{userId}/smtpCredentials/"
+        resource_path = "/users/{userId}/smtpCredentials"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -1523,7 +1523,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.SwiftPassword`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/{userId}/swiftPasswords/"
+        resource_path = "/users/{userId}/swiftPasswords"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -1911,7 +1911,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.User`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/"
+        resource_path = "/users"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -4410,7 +4410,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.ApiKey`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/{userId}/apiKeys/"
+        resource_path = "/users/{userId}/apiKeys"
         method = "GET"
 
         expected_kwargs = ["retry_strategy"]
@@ -4475,7 +4475,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.AuthToken`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/{userId}/authTokens/"
+        resource_path = "/users/{userId}/authTokens"
         method = "GET"
 
         expected_kwargs = ["retry_strategy"]
@@ -4545,7 +4545,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.AvailabilityDomain`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/availabilityDomains/"
+        resource_path = "/availabilityDomains"
         method = "GET"
 
         expected_kwargs = ["retry_strategy"]
@@ -4647,7 +4647,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.Compartment`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/compartments/"
+        resource_path = "/compartments"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -4800,7 +4800,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.CustomerSecretKeySummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/{userId}/customerSecretKeys/"
+        resource_path = "/users/{userId}/customerSecretKeys"
         method = "GET"
 
         expected_kwargs = ["retry_strategy"]
@@ -4874,7 +4874,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.DynamicGroup`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/dynamicGroups/"
+        resource_path = "/dynamicGroups"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -4947,7 +4947,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.FaultDomain`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/faultDomains/"
+        resource_path = "/faultDomains"
         method = "GET"
 
         expected_kwargs = ["retry_strategy"]
@@ -5017,7 +5017,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.Group`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/groups/"
+        resource_path = "/groups"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -5089,7 +5089,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.IdentityProviderGroupSummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/identityProviders/{identityProviderId}/groups/"
+        resource_path = "/identityProviders/{identityProviderId}/groups"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -5182,7 +5182,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.IdentityProvider`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/identityProviders/"
+        resource_path = "/identityProviders"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -5255,7 +5255,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.IdpGroupMapping`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/identityProviders/{identityProviderId}/groupMappings/"
+        resource_path = "/identityProviders/{identityProviderId}/groupMappings"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -5464,7 +5464,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.Policy`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/policies/"
+        resource_path = "/policies"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -5644,7 +5644,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.SmtpCredentialSummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/{userId}/smtpCredentials/"
+        resource_path = "/users/{userId}/smtpCredentials"
         method = "GET"
 
         expected_kwargs = ["retry_strategy"]
@@ -5711,7 +5711,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.SwiftPassword`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/{userId}/swiftPasswords/"
+        resource_path = "/users/{userId}/swiftPasswords"
         method = "GET"
 
         expected_kwargs = ["retry_strategy"]
@@ -6139,7 +6139,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.TaggingWorkRequestSummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/taggingWorkRequests/"
+        resource_path = "/taggingWorkRequests"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -6327,7 +6327,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.UserGroupMembership`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/userGroupMemberships/"
+        resource_path = "/userGroupMemberships"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -6413,7 +6413,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.User`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/"
+        resource_path = "/users"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -6492,7 +6492,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.identity.models.WorkRequestSummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/workRequests/"
+        resource_path = "/workRequests"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -6818,7 +6818,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.ScimClientCredentials`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/identityProviders/{identityProviderId}/actions/resetScimClient/"
+        resource_path = "/identityProviders/{identityProviderId}/actions/resetScimClient"
         method = "POST"
 
         expected_kwargs = ["retry_strategy"]
@@ -8137,7 +8137,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.User`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/{userId}/capabilities/"
+        resource_path = "/users/{userId}/capabilities"
         method = "PUT"
 
         # Don't accept unknown kwargs
@@ -8217,7 +8217,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.User`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/{userId}/state/"
+        resource_path = "/users/{userId}/state"
         method = "PUT"
 
         # Don't accept unknown kwargs
@@ -8313,7 +8313,7 @@ class IdentityClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.ApiKey`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/users/{userId}/apiKeys/"
+        resource_path = "/users/{userId}/apiKeys"
         method = "POST"
 
         # Don't accept unknown kwargs

--- a/src/oci/integration/integration_instance_client.py
+++ b/src/oci/integration/integration_instance_client.py
@@ -35,7 +35,7 @@ class IntegrationInstanceClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/key_management/kms_crypto_client.py
+++ b/src/oci/key_management/kms_crypto_client.py
@@ -33,7 +33,7 @@ class KmsCryptoClient(object):
             The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/key_management/kms_management_client.py
+++ b/src/oci/key_management/kms_management_client.py
@@ -33,7 +33,7 @@ class KmsManagementClient(object):
             The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/key_management/kms_vault_client.py
+++ b/src/oci/key_management/kms_vault_client.py
@@ -35,7 +35,7 @@ class KmsVaultClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/limits/limits_client.py
+++ b/src/oci/limits/limits_client.py
@@ -35,7 +35,7 @@ class LimitsClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/limits/quotas_client.py
+++ b/src/oci/limits/quotas_client.py
@@ -35,7 +35,7 @@ class QuotasClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)
@@ -111,7 +111,7 @@ class QuotasClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.limits.models.Quota`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20181025/quotas/"
+        resource_path = "/20181025/quotas"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -356,7 +356,7 @@ class QuotasClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.limits.models.QuotaSummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/20181025/quotas/"
+        resource_path = "/20181025/quotas"
         method = "GET"
 
         # Don't accept unknown kwargs

--- a/src/oci/load_balancer/load_balancer_client.py
+++ b/src/oci/load_balancer/load_balancer_client.py
@@ -36,7 +36,7 @@ class LoadBalancerClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/marketplace/marketplace_client.py
+++ b/src/oci/marketplace/marketplace_client.py
@@ -35,7 +35,7 @@ class MarketplaceClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/monitoring/monitoring_client.py
+++ b/src/oci/monitoring/monitoring_client.py
@@ -37,7 +37,7 @@ class MonitoringClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/object_storage/object_storage_client.py
+++ b/src/oci/object_storage/object_storage_client.py
@@ -35,7 +35,7 @@ class ObjectStorageClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)
@@ -459,7 +459,7 @@ class ObjectStorageClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.object_storage.models.Bucket`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/n/{namespaceName}/b/"
+        resource_path = "/n/{namespaceName}/b"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -637,7 +637,7 @@ class ObjectStorageClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.object_storage.models.PreauthenticatedRequest`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/n/{namespaceName}/b/{bucketName}/p/"
+        resource_path = "/n/{namespaceName}/b/{bucketName}/p"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -724,7 +724,7 @@ class ObjectStorageClient(object):
         :return: A :class:`~oci.response.Response` object with data of type None
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/n/{namespaceName}/b/{bucketName}/"
+        resource_path = "/n/{namespaceName}/b/{bucketName}"
         method = "DELETE"
 
         # Don't accept unknown kwargs
@@ -1068,7 +1068,7 @@ class ObjectStorageClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.object_storage.models.Bucket`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/n/{namespaceName}/b/{bucketName}/"
+        resource_path = "/n/{namespaceName}/b/{bucketName}"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -1169,7 +1169,7 @@ class ObjectStorageClient(object):
         :return: A :class:`~oci.response.Response` object with data of type str
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/n/"
+        resource_path = "/n"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -1670,7 +1670,7 @@ class ObjectStorageClient(object):
         :return: A :class:`~oci.response.Response` object with data of type None
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/n/{namespaceName}/b/{bucketName}/"
+        resource_path = "/n/{namespaceName}/b/{bucketName}"
         method = "HEAD"
 
         # Don't accept unknown kwargs
@@ -1863,7 +1863,7 @@ class ObjectStorageClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.object_storage.models.BucketSummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/n/{namespaceName}/b/"
+        resource_path = "/n/{namespaceName}/b"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -2296,7 +2296,7 @@ class ObjectStorageClient(object):
         :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.object_storage.models.PreauthenticatedRequestSummary`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/n/{namespaceName}/b/{bucketName}/p/"
+        resource_path = "/n/{namespaceName}/b/{bucketName}/p"
         method = "GET"
 
         # Don't accept unknown kwargs
@@ -2771,7 +2771,6 @@ class ObjectStorageClient(object):
         # Disable the retry_strategy to work around data corruption issue temporarily
         if retry_strategy:
             retry_strategy = None
-
         if retry_strategy:
             return retry_strategy.make_retrying_call(
                 self.base_client.call_api,
@@ -3178,7 +3177,7 @@ class ObjectStorageClient(object):
         :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.object_storage.models.Bucket`
         :rtype: :class:`~oci.response.Response`
         """
-        resource_path = "/n/{namespaceName}/b/{bucketName}/"
+        resource_path = "/n/{namespaceName}/b/{bucketName}"
         method = "POST"
 
         # Don't accept unknown kwargs
@@ -3445,6 +3444,9 @@ class ObjectStorageClient(object):
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')
 
+        # Disable the retry_strategy to work around data corruption issue temporarily
+        if retry_strategy:
+            retry_strategy = None
         if retry_strategy:
             return retry_strategy.make_retrying_call(
                 self.base_client.call_api,

--- a/src/oci/oce/oce_instance_client.py
+++ b/src/oci/oce/oce_instance_client.py
@@ -35,7 +35,7 @@ class OceInstanceClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/oda/models/work_request.py
+++ b/src/oci/oda/models/work_request.py
@@ -33,6 +33,14 @@ class WorkRequest(object):
     REQUEST_ACTION_RECOVER_ODA_INSTANCE = "RECOVER_ODA_INSTANCE"
 
     #: A constant which can be used with the request_action property of a WorkRequest.
+    #: This constant has a value of "STOP_ODA_INSTANCE"
+    REQUEST_ACTION_STOP_ODA_INSTANCE = "STOP_ODA_INSTANCE"
+
+    #: A constant which can be used with the request_action property of a WorkRequest.
+    #: This constant has a value of "START_ODA_INSTANCE"
+    REQUEST_ACTION_START_ODA_INSTANCE = "START_ODA_INSTANCE"
+
+    #: A constant which can be used with the request_action property of a WorkRequest.
     #: This constant has a value of "CHANGE_ODA_INSTANCE_COMPARTMENT"
     REQUEST_ACTION_CHANGE_ODA_INSTANCE_COMPARTMENT = "CHANGE_ODA_INSTANCE_COMPARTMENT"
 
@@ -95,7 +103,7 @@ class WorkRequest(object):
 
         :param request_action:
             The value to assign to the request_action property of this WorkRequest.
-            Allowed values for this property are: "CREATE_ODA_INSTANCE", "UPGRADE_ODA_INSTANCE", "DELETE_ODA_INSTANCE", "PURGE_ODA_INSTANCE", "RECOVER_ODA_INSTANCE", "CHANGE_ODA_INSTANCE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", "LOOKUP_ODA_INSTANCES_FOR_CACCT", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATE_ODA_INSTANCE", "UPGRADE_ODA_INSTANCE", "DELETE_ODA_INSTANCE", "PURGE_ODA_INSTANCE", "RECOVER_ODA_INSTANCE", "STOP_ODA_INSTANCE", "START_ODA_INSTANCE", "CHANGE_ODA_INSTANCE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", "LOOKUP_ODA_INSTANCES_FOR_CACCT", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type request_action: str
 
@@ -248,7 +256,7 @@ class WorkRequest(object):
         **[Required]** Gets the request_action of this WorkRequest.
         The type of the operation that's associated with the work request.
 
-        Allowed values for this property are: "CREATE_ODA_INSTANCE", "UPGRADE_ODA_INSTANCE", "DELETE_ODA_INSTANCE", "PURGE_ODA_INSTANCE", "RECOVER_ODA_INSTANCE", "CHANGE_ODA_INSTANCE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", "LOOKUP_ODA_INSTANCES_FOR_CACCT", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATE_ODA_INSTANCE", "UPGRADE_ODA_INSTANCE", "DELETE_ODA_INSTANCE", "PURGE_ODA_INSTANCE", "RECOVER_ODA_INSTANCE", "STOP_ODA_INSTANCE", "START_ODA_INSTANCE", "CHANGE_ODA_INSTANCE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", "LOOKUP_ODA_INSTANCES_FOR_CACCT", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -267,7 +275,7 @@ class WorkRequest(object):
         :param request_action: The request_action of this WorkRequest.
         :type: str
         """
-        allowed_values = ["CREATE_ODA_INSTANCE", "UPGRADE_ODA_INSTANCE", "DELETE_ODA_INSTANCE", "PURGE_ODA_INSTANCE", "RECOVER_ODA_INSTANCE", "CHANGE_ODA_INSTANCE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", "LOOKUP_ODA_INSTANCES_FOR_CACCT"]
+        allowed_values = ["CREATE_ODA_INSTANCE", "UPGRADE_ODA_INSTANCE", "DELETE_ODA_INSTANCE", "PURGE_ODA_INSTANCE", "RECOVER_ODA_INSTANCE", "STOP_ODA_INSTANCE", "START_ODA_INSTANCE", "CHANGE_ODA_INSTANCE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", "LOOKUP_ODA_INSTANCES_FOR_CACCT"]
         if not value_allowed_none_or_none_sentinel(request_action, allowed_values):
             request_action = 'UNKNOWN_ENUM_VALUE'
         self._request_action = request_action

--- a/src/oci/oda/models/work_request_resource.py
+++ b/src/oci/oda/models/work_request_resource.py
@@ -29,6 +29,14 @@ class WorkRequestResource(object):
     RESOURCE_ACTION_RECOVER = "RECOVER"
 
     #: A constant which can be used with the resource_action property of a WorkRequestResource.
+    #: This constant has a value of "STOP"
+    RESOURCE_ACTION_STOP = "STOP"
+
+    #: A constant which can be used with the resource_action property of a WorkRequestResource.
+    #: This constant has a value of "START"
+    RESOURCE_ACTION_START = "START"
+
+    #: A constant which can be used with the resource_action property of a WorkRequestResource.
     #: This constant has a value of "CHANGE_COMPARTMENT"
     RESOURCE_ACTION_CHANGE_COMPARTMENT = "CHANGE_COMPARTMENT"
 
@@ -75,7 +83,7 @@ class WorkRequestResource(object):
 
         :param resource_action:
             The value to assign to the resource_action property of this WorkRequestResource.
-            Allowed values for this property are: "CREATE", "DELETE", "PURGE", "RECOVER", "CHANGE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATE", "DELETE", "PURGE", "RECOVER", "STOP", "START", "CHANGE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type resource_action: str
 
@@ -133,7 +141,7 @@ class WorkRequestResource(object):
         **[Required]** Gets the resource_action of this WorkRequestResource.
         The action to take against the Digital Assistant instance.
 
-        Allowed values for this property are: "CREATE", "DELETE", "PURGE", "RECOVER", "CHANGE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATE", "DELETE", "PURGE", "RECOVER", "STOP", "START", "CHANGE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -152,7 +160,7 @@ class WorkRequestResource(object):
         :param resource_action: The resource_action of this WorkRequestResource.
         :type: str
         """
-        allowed_values = ["CREATE", "DELETE", "PURGE", "RECOVER", "CHANGE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT"]
+        allowed_values = ["CREATE", "DELETE", "PURGE", "RECOVER", "STOP", "START", "CHANGE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT"]
         if not value_allowed_none_or_none_sentinel(resource_action, allowed_values):
             resource_action = 'UNKNOWN_ENUM_VALUE'
         self._resource_action = resource_action

--- a/src/oci/oda/models/work_request_summary.py
+++ b/src/oci/oda/models/work_request_summary.py
@@ -33,6 +33,14 @@ class WorkRequestSummary(object):
     REQUEST_ACTION_RECOVER_ODA_INSTANCE = "RECOVER_ODA_INSTANCE"
 
     #: A constant which can be used with the request_action property of a WorkRequestSummary.
+    #: This constant has a value of "STOP_ODA_INSTANCE"
+    REQUEST_ACTION_STOP_ODA_INSTANCE = "STOP_ODA_INSTANCE"
+
+    #: A constant which can be used with the request_action property of a WorkRequestSummary.
+    #: This constant has a value of "START_ODA_INSTANCE"
+    REQUEST_ACTION_START_ODA_INSTANCE = "START_ODA_INSTANCE"
+
+    #: A constant which can be used with the request_action property of a WorkRequestSummary.
     #: This constant has a value of "CHANGE_ODA_INSTANCE_COMPARTMENT"
     REQUEST_ACTION_CHANGE_ODA_INSTANCE_COMPARTMENT = "CHANGE_ODA_INSTANCE_COMPARTMENT"
 
@@ -95,7 +103,7 @@ class WorkRequestSummary(object):
 
         :param request_action:
             The value to assign to the request_action property of this WorkRequestSummary.
-            Allowed values for this property are: "CREATE_ODA_INSTANCE", "UPGRADE_ODA_INSTANCE", "DELETE_ODA_INSTANCE", "PURGE_ODA_INSTANCE", "RECOVER_ODA_INSTANCE", "CHANGE_ODA_INSTANCE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", "LOOKUP_ODA_INSTANCES_FOR_CACCT", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATE_ODA_INSTANCE", "UPGRADE_ODA_INSTANCE", "DELETE_ODA_INSTANCE", "PURGE_ODA_INSTANCE", "RECOVER_ODA_INSTANCE", "STOP_ODA_INSTANCE", "START_ODA_INSTANCE", "CHANGE_ODA_INSTANCE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", "LOOKUP_ODA_INSTANCES_FOR_CACCT", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type request_action: str
 
@@ -213,7 +221,7 @@ class WorkRequestSummary(object):
         **[Required]** Gets the request_action of this WorkRequestSummary.
         The type of the operation that's associated with the work request.
 
-        Allowed values for this property are: "CREATE_ODA_INSTANCE", "UPGRADE_ODA_INSTANCE", "DELETE_ODA_INSTANCE", "PURGE_ODA_INSTANCE", "RECOVER_ODA_INSTANCE", "CHANGE_ODA_INSTANCE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", "LOOKUP_ODA_INSTANCES_FOR_CACCT", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATE_ODA_INSTANCE", "UPGRADE_ODA_INSTANCE", "DELETE_ODA_INSTANCE", "PURGE_ODA_INSTANCE", "RECOVER_ODA_INSTANCE", "STOP_ODA_INSTANCE", "START_ODA_INSTANCE", "CHANGE_ODA_INSTANCE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", "LOOKUP_ODA_INSTANCES_FOR_CACCT", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -232,7 +240,7 @@ class WorkRequestSummary(object):
         :param request_action: The request_action of this WorkRequestSummary.
         :type: str
         """
-        allowed_values = ["CREATE_ODA_INSTANCE", "UPGRADE_ODA_INSTANCE", "DELETE_ODA_INSTANCE", "PURGE_ODA_INSTANCE", "RECOVER_ODA_INSTANCE", "CHANGE_ODA_INSTANCE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", "LOOKUP_ODA_INSTANCES_FOR_CACCT"]
+        allowed_values = ["CREATE_ODA_INSTANCE", "UPGRADE_ODA_INSTANCE", "DELETE_ODA_INSTANCE", "PURGE_ODA_INSTANCE", "RECOVER_ODA_INSTANCE", "STOP_ODA_INSTANCE", "START_ODA_INSTANCE", "CHANGE_ODA_INSTANCE_COMPARTMENT", "CREATE_ASSOCIATION", "DELETE_ASSOCIATION", "UPDATE_ENTITLEMENTS_FOR_CACCT", "LOOKUP_ODA_INSTANCES_FOR_CACCT"]
         if not value_allowed_none_or_none_sentinel(request_action, allowed_values):
             request_action = 'UNKNOWN_ENUM_VALUE'
         self._request_action = request_action

--- a/src/oci/oda/oda_client.py
+++ b/src/oci/oda/oda_client.py
@@ -35,7 +35,7 @@ class OdaClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)
@@ -1004,6 +1004,195 @@ class OdaClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="list[WorkRequestSummary]")
+
+    def start_oda_instance(self, oda_instance_id, **kwargs):
+        """
+        Starts an inactive Digital Assistant instance.
+        Starts an inactive Digital Assistant instance. Once active, the instance will be accessible and metering
+        of requests will be started again.
+
+
+        :param str oda_instance_id: (required)
+            Unique Digital Assistant instance identifier.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing. This value is included in the opc-request-id response header.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control in a PUT or DELETE call for
+            a Digital Assistant instance, set the `if-match` query parameter
+            to the value of the `ETAG` header from a previous GET or POST
+            response for that instance. The service updates or deletes the
+            instance only if the etag that you provide matches the instance's
+            current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so that you can retry the request if there's
+            a timeout or server error without the risk of executing that same action again.
+
+            Retry tokens expire after 24 hours, but they can become invalid before then if there are
+            conflicting operations. For example, if an instance was deleted and purged from the system,
+            then the service might reject a retry of the original creation request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/odaInstances/{odaInstanceId}/actions/start"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "start_oda_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "odaInstanceId": oda_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def stop_oda_instance(self, oda_instance_id, **kwargs):
+        """
+        Stops an active Digital Assistant instance.
+        Stops an active Digital Assistant instance. Once inactive, the instance will not be accessible and metering
+        of requests will be stopped until the instance is started again. Data associated with the instance
+        is not affected.
+
+
+        :param str oda_instance_id: (required)
+            Unique Digital Assistant instance identifier.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing. This value is included in the opc-request-id response header.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control in a PUT or DELETE call for
+            a Digital Assistant instance, set the `if-match` query parameter
+            to the value of the `ETAG` header from a previous GET or POST
+            response for that instance. The service updates or deletes the
+            instance only if the etag that you provide matches the instance's
+            current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so that you can retry the request if there's
+            a timeout or server error without the risk of executing that same action again.
+
+            Retry tokens expire after 24 hours, but they can become invalid before then if there are
+            conflicting operations. For example, if an instance was deleted and purged from the system,
+            then the service might reject a retry of the original creation request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/odaInstances/{odaInstanceId}/actions/stop"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "stop_oda_instance got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "odaInstanceId": oda_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
 
     def update_oda_instance(self, oda_instance_id, update_oda_instance_details, **kwargs):
         """

--- a/src/oci/oda/oda_client_composite_operations.py
+++ b/src/oci/oda/oda_client_composite_operations.py
@@ -147,6 +147,82 @@ class OdaClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def start_oda_instance_and_wait_for_state(self, oda_instance_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.oda.OdaClient.start_oda_instance` and waits for the :py:class:`~oci.oda.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str oda_instance_id: (required)
+            Unique Digital Assistant instance identifier.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.oda.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.oda.OdaClient.start_oda_instance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.start_oda_instance(oda_instance_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def stop_oda_instance_and_wait_for_state(self, oda_instance_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.oda.OdaClient.stop_oda_instance` and waits for the :py:class:`~oci.oda.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str oda_instance_id: (required)
+            Unique Digital Assistant instance identifier.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.oda.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.oda.OdaClient.stop_oda_instance`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.stop_oda_instance(oda_instance_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def update_oda_instance_and_wait_for_state(self, oda_instance_id, update_oda_instance_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.oda.OdaClient.update_oda_instance` and waits for the :py:class:`~oci.oda.models.OdaInstance` acted upon

--- a/src/oci/ons/notification_control_plane_client.py
+++ b/src/oci/ons/notification_control_plane_client.py
@@ -36,7 +36,7 @@ class NotificationControlPlaneClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/ons/notification_data_plane_client.py
+++ b/src/oci/ons/notification_data_plane_client.py
@@ -36,7 +36,7 @@ class NotificationDataPlaneClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/os_management/os_management_client.py
+++ b/src/oci/os_management/os_management_client.py
@@ -35,7 +35,7 @@ class OsManagementClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/resource_manager/resource_manager_client.py
+++ b/src/oci/resource_manager/resource_manager_client.py
@@ -35,7 +35,7 @@ class ResourceManagerClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/resource_search/resource_search_client.py
+++ b/src/oci/resource_search/resource_search_client.py
@@ -35,7 +35,7 @@ class ResourceSearchClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/streaming/stream_admin_client.py
+++ b/src/oci/streaming/stream_admin_client.py
@@ -35,7 +35,7 @@ class StreamAdminClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/streaming/stream_client.py
+++ b/src/oci/streaming/stream_client.py
@@ -33,7 +33,7 @@ class StreamClient(object):
             The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
-# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "2.9.0"
+__version__ = "2.10.0"

--- a/src/oci/waas/redirect_client.py
+++ b/src/oci/waas/redirect_client.py
@@ -35,7 +35,7 @@ class RedirectClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/waas/waas_client.py
+++ b/src/oci/waas/waas_client.py
@@ -35,7 +35,7 @@ class WaasClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/src/oci/work_requests/work_request_client.py
+++ b/src/oci/work_requests/work_request_client.py
@@ -40,7 +40,7 @@ class WorkRequestClient(object):
             need to specify a service endpoint.
 
         :param timeout: (optional)
-            The connection and read timeouts for the client. The default is that the client never times out. This keyword argument can be provided
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
             as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
             a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
         :type timeout: float or tuple(float, float)

--- a/tests/unit/test_basic_api_calls.py
+++ b/tests/unit/test_basic_api_calls.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
 
 import oci
-import pytest
 
 
 def test_identity_list_users(identity, config):
@@ -39,24 +38,3 @@ def test_limit(identity, config):
     assert type(response.data[0]) is oci.identity.models.User
     assert response.status == 200
     assert response.request_id is not None
-
-
-@pytest.mark.skip(reason="re-enable after fix the issue on py35.")
-def test_api_call_with_explicit_timeout(config):
-    client = oci.identity.IdentityClient(config)
-
-    # Test connection timeout
-    client.base_client.timeout = (0.0001, 1)  # 0.1ms timeout on connection and 1s on read. Should be too short to connect without timing out
-    with pytest.raises(oci.exceptions.ConnectTimeout):
-        client.list_users(config['tenancy'])
-        assert False
-
-    # Test read timeout
-    client.base_client.timeout = (1, 0.0005)  # 1s timeout on connection, 0.5ms on read. Should be too short to read
-    with pytest.raises(oci.exceptions.RequestException):
-        client.list_users(config['tenancy'])
-        assert False
-
-    client.base_client.timeout = 5
-    response = client.list_users(config['tenancy'])
-    assert len(response.data) > 0


### PR DESCRIPTION
Added
-----
* Support for a description field on route rules and security rules in the Networking service
* Support for starting and stopping Digital Assistant instances in the Digital Assistant service
* Support for shared database homes on Exadata, bare metal, and virtual machine instances in the Database service
* Support for tracking a number of Database service operations through the Work Requests service

Breaking
--------
* Field `db_home_id` in `list_databases` from database service is changed from required to optional