### PR TITLE
Releasing version 2.10.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.10.4 - 2020-02-11
+====================
+
+Added
+-----
+* Support for listing supported database versions for Autonomous Database Serverless, and selecting a version at provisioning time in the Database service
+* Support for TCP proxy protocol versions on listener connection configurations in the Load Balancer service
+* Support for calling the Notifications service in alternate realms
+* Support for calling Oracle Cloud Infrastructure services in the eu-amsterdam-1 and me-jeddah-1 regions
+
+====================
 2.10.3 - 2020-02-04
 ====================
 

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -38,6 +38,7 @@ Database
     oci.database.models.AutonomousDatabaseSummary
     oci.database.models.AutonomousDatabaseWallet
     oci.database.models.AutonomousDbPreviewVersionSummary
+    oci.database.models.AutonomousDbVersionSummary
     oci.database.models.AutonomousExadataInfrastructure
     oci.database.models.AutonomousExadataInfrastructureMaintenanceWindow
     oci.database.models.AutonomousExadataInfrastructureShapeSummary

--- a/docs/api/database/models/oci.database.models.AutonomousDbVersionSummary.rst
+++ b/docs/api/database/models/oci.database.models.AutonomousDbVersionSummary.rst
@@ -1,0 +1,11 @@
+AutonomousDbVersionSummary
+==========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: AutonomousDbVersionSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/showoci/CHANGELOG.rst
+++ b/examples/showoci/CHANGELOG.rst
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 =====================
+20.02.11 - 2020-02-11
+=====================
+* Add support for Function Applications (-fun)
+* Add support for API gateways (-api)
+* Fix limits to use pagination to produce all rows
+
+=====================
+20.01.30 - 2020-01-30
+=====================
+* Add DRG Redundant status
+
+=====================
 20.01.29 - 2020-01-29
 =====================
 * Fix call to list_databases due to OCI change the parameters requirement

--- a/examples/showoci/README.md
+++ b/examples/showoci/README.md
@@ -36,6 +36,8 @@ Output can be printer friendly, CSV files or JSON file.
 - oci.analytics.AnalyticsClient
 - oci.oda.OdaClient
 - oci.oce.OceInstanceClient
+- oci.apigateway.GatewaysClient
+- oci.functions.FunctionsManagementClient
 
 ** DISCLAIMER – This is not an official Oracle application
 
@@ -176,57 +178,57 @@ Execute
 ```
 $ ./showoci.py  
 
-usage: showoci.py [-h] [-a] [-ani] [-an] [-b] [-n] [-i] [-ic] [-c] [-cn] [-o]
-                  [-l] [-d] [-f] [-e] [-m] [-s] [-rm] [-so] [-paas] [-edge]
-                  [-lq] [-mc] [-nr] [-ip] [-t PROFILE] [-p PROXY] [-rg REGION]
-                  [-cp COMPART] [-cpr COMPART_RECURSIVE] [-cpath COMPARTPATH]
-                  [-tenantid TENANTID] [-cf CONFIG] [-csv CSV] [-jf JOUTFILE]
-                  [-js] [-sjf SJOUTFILE] [-cachef SERVICEFILE] [-caches]
-                  [--version]
+usage: showoci.py [-h] [-a] [-ani] [-an] [-api] [-b] [-c] [-cn] [-d] [-e]
+                  [-edge] [-f] [-fun] [-i] [-ic] [-l] [-lq] [-m] [-n] [-o]
+                  [-paas] [-rm] [-s] [-so] [-mc] [-nr] [-ip] [-t PROFILE]
+                  [-p PROXY] [-rg REGION] [-cp COMPART] [-cpr COMPART_RECUR]
+                  [-cpath COMPARTPATH] [-tenantid TENANTID] [-cf CONFIG]
+                  [-csv CSV] [-jf JOUTFILE] [-js] [-sjf SJOUTFILE]
+                  [-cachef SERVICEFILE] [-caches] [--version]
 
 optional arguments:
-  -h, --help            show this help message and exit
-  -a                    Print All Resources
-  -ani                  Print All Resources but identity
-  -an                   Print Announcements
-  -b                    Print Budgets
-  -n                    Print Network
-  -i                    Print Identity
-  -ic                   Print Identity Compartments only
-  -c                    Print Compute
-  -cn                   Print Containers
-  -o                    Print Object Storage
-  -l                    Print Load Balancer
-  -d                    Print Database
-  -f                    Print File Storage
-  -e                    Print EMail
-  -m                    Print Monitoring and Notifications
-  -s                    Print Streams
-  -rm                   Print Resource management
-  -so                   Print Summary Only
-  -paas                 Print Oracle Paas Native - OIC OAC ODA
-  -edge                 Print Edge Services (Healthcheck)
-  -lq                   Print Limits and Quotas
-  -mc                   exclude ManagedCompartmentForPaaS
-  -nr                   Not include root compartment
-  -ip                   Use Instance Principals for Authentication
-  -t PROFILE            Config file section to use (tenancy profile)
-  -p PROXY              Set Proxy (i.e. www-proxy-server.com:80)
-  -rg REGION            Filter by Region
-  -cp COMPART           Filter by Compartment Name or OCID
-  -cpr COMPART_RECURSIVE
-                        Filter by Compartment Name or OCID include sub
-                        compartments
-  -cpath COMPARTPATH    Filter by Compartment path ,(i.e. -cpath "Adi / Sub"
-  -tenantid TENANTID    Override confile file tenancy_id
-  -cf CONFIG            Config File
-  -csv CSV              Output to CSV files, Input as file header
-  -jf JOUTFILE          Output to file (JSON format)
-  -js                   Output to screen (JSON format)
-  -sjf SJOUTFILE        Output to screen (nice format) and JSON File
-  -cachef SERVICEFILE   Output Cache to file (JSON format)
-  -caches               Output Cache to screen (JSON format)
-  --version             show program's version number and exit
+  -h, --help           show this help message and exit
+  -a                   Print All Resources
+  -ani                 Print All Resources but identity
+  -an                  Print Announcements
+  -api                 Print API Gateways
+  -b                   Print Budgets
+  -c                   Print Compute
+  -cn                  Print Containers
+  -d                   Print Database
+  -e                   Print EMail
+  -edge                Print Edge Services (Healthcheck)
+  -f                   Print File Storage
+  -fun                 Print Functions
+  -i                   Print Identity
+  -ic                  Print Identity Compartments only
+  -l                   Print Load Balancer
+  -lq                  Print Limits and Quotas
+  -m                   Print Monitoring and Notifications
+  -n                   Print Network
+  -o                   Print Object Storage
+  -paas                Print Oracle Paas Native - OIC OAC ODA
+  -rm                  Print Resource management
+  -s                   Print Streams
+  -so                  Print Summary Only
+  -mc                  exclude ManagedCompartmentForPaaS
+  -nr                  Not include root compartment
+  -ip                  Use Instance Principals for Authentication
+  -t PROFILE           Config file section to use (tenancy profile)
+  -p PROXY             Set Proxy (i.e. www-proxy-server.com:80)
+  -rg REGION           Filter by Region
+  -cp COMPART          Filter by Compartment Name or OCID
+  -cpr COMPART_RECUR   Filter by Comp Name or OCID Recursive
+  -cpath COMPARTPATH   Filter by Compartment path ,(i.e. -cpath "Adi / Sub"
+  -tenantid TENANTID   Override confile file tenancy_id
+  -cf CONFIG           Config File
+  -csv CSV             Output to CSV files, Input as file header
+  -jf JOUTFILE         Output to file (JSON format)
+  -js                  Output to screen (JSON format)
+  -sjf SJOUTFILE       Output to screen (nice format) and JSON File
+  -cachef SERVICEFILE  Output Cache to file (JSON format)
+  -caches              Output Cache to screen (JSON format)
+  --version            show program's version number and exit
 
 ```
 

--- a/examples/showoci/showoci.py
+++ b/examples/showoci/showoci.py
@@ -47,10 +47,20 @@
 # - oci.healthchecks.HealthChecksClient
 # - oci.announcements_service.AnnouncementClient
 # - oci.limits.LimitsClient
+# - oci.integration.IntegrationInstanceClient
+# - oci.analytics.AnalyticsClient
+# - oci.oda.OdaClient
+# - oci.oce.OceInstanceClient
+# - oci.apigateway.GatewaysClient
+# - oci.functions.FunctionsManagementClient
 #
 # Modules Not Yet Covered:
 # - oci.waas.WaasClient
 # - oci.dns.DnsClient
+# - oci.data_catalog.DataCatalogClient
+# - oci.data_flow.DataFlowClient
+# - oci.data_science.DataScienceClient
+# - oci.events.EventsClient
 #
 ##########################################################################
 from __future__ import print_function
@@ -62,7 +72,7 @@ import sys
 import argparse
 import datetime
 
-version = "20.1.29"
+version = "20.2.11"
 
 ##########################################################################
 # execute_extract
@@ -219,24 +229,27 @@ def set_parser_arguments():
     parser.add_argument('-a', action='store_true', default=False, dest='all', help='Print All Resources')
     parser.add_argument('-ani', action='store_true', default=False, dest='allnoiam', help='Print All Resources but identity')
     parser.add_argument('-an', action='store_true', default=False, dest='announcement', help='Print Announcements')
+    parser.add_argument('-api', action='store_true', default=False, dest='api', help='Print API Gateways')
     parser.add_argument('-b', action='store_true', default=False, dest='budgets', help='Print Budgets')
-    parser.add_argument('-n', action='store_true', default=False, dest='network', help='Print Network')
-    parser.add_argument('-i', action='store_true', default=False, dest='identity', help='Print Identity')
-    parser.add_argument('-ic', action='store_true', default=False, dest='identity_compartments', help='Print Identity Compartments only')
     parser.add_argument('-c', action='store_true', default=False, dest='compute', help='Print Compute')
     parser.add_argument('-cn', action='store_true', default=False, dest='container', help='Print Containers')
-    parser.add_argument('-o', action='store_true', default=False, dest='object', help='Print Object Storage')
-    parser.add_argument('-l', action='store_true', default=False, dest='load', help='Print Load Balancer')
     parser.add_argument('-d', action='store_true', default=False, dest='database', help='Print Database')
-    parser.add_argument('-f', action='store_true', default=False, dest='file', help='Print File Storage')
     parser.add_argument('-e', action='store_true', default=False, dest='email', help='Print EMail')
-    parser.add_argument('-m', action='store_true', default=False, dest='monitoring', help='Print Monitoring and Notifications')
-    parser.add_argument('-s', action='store_true', default=False, dest='streams', help='Print Streams')
-    parser.add_argument('-rm', action='store_true', default=False, dest='orm', help='Print Resource management')
-    parser.add_argument('-so', action='store_true', default=False, dest='sumonly', help='Print Summary Only')
-    parser.add_argument('-paas', action='store_true', default=False, dest='paas_native', help='Print Oracle Paas Native - OIC OAC ODA')
     parser.add_argument('-edge', action='store_true', default=False, dest='edge', help='Print Edge Services (Healthcheck)')
+    parser.add_argument('-f', action='store_true', default=False, dest='file', help='Print File Storage')
+    parser.add_argument('-fun', action='store_true', default=False, dest='function', help='Print Functions')
+    parser.add_argument('-i', action='store_true', default=False, dest='identity', help='Print Identity')
+    parser.add_argument('-ic', action='store_true', default=False, dest='identity_compartments', help='Print Identity Compartments only')
+    parser.add_argument('-l', action='store_true', default=False, dest='load', help='Print Load Balancer')
     parser.add_argument('-lq', action='store_true', default=False, dest='limits', help='Print Limits and Quotas')
+    parser.add_argument('-m', action='store_true', default=False, dest='monitoring', help='Print Monitoring and Notifications')
+    parser.add_argument('-n', action='store_true', default=False, dest='network', help='Print Network')
+    parser.add_argument('-o', action='store_true', default=False, dest='object', help='Print Object Storage')
+    parser.add_argument('-paas', action='store_true', default=False, dest='paas_native', help='Print Oracle Paas Native - OIC OAC ODA')
+    parser.add_argument('-rm', action='store_true', default=False, dest='orm', help='Print Resource management')
+    parser.add_argument('-s', action='store_true', default=False, dest='streams', help='Print Streams')
+
+    parser.add_argument('-so', action='store_true', default=False, dest='sumonly', help='Print Summary Only')
     parser.add_argument('-mc', action='store_true', default=False, dest='mgdcompart', help='exclude ManagedCompartmentForPaaS')
     parser.add_argument('-nr', action='store_true', default=False, dest='noroot', help='Not include root compartment')
     parser.add_argument('-ip', action='store_true', default=False, dest='instance_principals', help='Use Instance Principals for Authentication')
@@ -244,7 +257,7 @@ def set_parser_arguments():
     parser.add_argument('-p', default="", dest='proxy', help='Set Proxy (i.e. www-proxy-server.com:80) ')
     parser.add_argument('-rg', default="", dest='region', help='Filter by Region')
     parser.add_argument('-cp', default="", dest='compart', help='Filter by Compartment Name or OCID')
-    parser.add_argument('-cpr', default="", dest='compart_recursive', help='Filter by Compartment Name or OCID include sub compartments')
+    parser.add_argument('-cpr', default="", dest='compart_recur', help='Filter by Comp Name or OCID Recursive')
     parser.add_argument('-cpath', default="", dest='compartpath', help='Filter by Compartment path ,(i.e. -cpath "Adi / Sub"')
     parser.add_argument('-tenantid', default="", dest='tenantid', help='Override confile file tenancy_id')
     parser.add_argument('-cf', type=argparse.FileType('r'), dest='config', help="Config File")
@@ -265,7 +278,8 @@ def set_parser_arguments():
     if not (result.all or result.allnoiam or result.network or result.identity or result.identity_compartments or
             result.compute or result.object or
             result.load or result.database or result.file or result.email or result.orm or result.container or
-            result.streams or result.budgets or result.monitoring or result.edge or result.announcement or result.limits or result.paas_native):
+            result.streams or result.budgets or result.monitoring or result.edge or result.announcement or result.limits or result.paas_native or
+            result.api or result.function):
 
         parser.print_help()
 
@@ -328,6 +342,12 @@ def set_service_extract_flags(cmd):
     if cmd.all or cmd.allnoiam or cmd.budgets:
         prm.read_budgets = True
 
+    if cmd.all or cmd.allnoiam or cmd.function:
+        prm.read_function = True
+
+    if cmd.all or cmd.allnoiam or cmd.api:
+        prm.read_api = True
+
     if cmd.all or cmd.allnoiam or cmd.limits:
         prm.read_limits = True
 
@@ -359,8 +379,8 @@ def set_service_extract_flags(cmd):
     if cmd.compart:
         prm.filter_by_compartment = str(cmd.compart)
 
-    if cmd.compart_recursive:
-        prm.filter_by_compartment_recursive = str(cmd.compart_recursive)
+    if cmd.compart_recur:
+        prm.filter_by_compartment_recursive = str(cmd.compart_recur)
 
     if cmd.compartpath:
         prm.filter_by_compartment_path = str(cmd.compartpath)

--- a/examples/showoci/showoci_output.py
+++ b/examples/showoci/showoci_output.py
@@ -469,7 +469,7 @@ class ShowOCIOutput(object):
 
             self.print_header("DRGs", 2)
             for drg in drgs:
-                print(self.taba + "DRG    " + drg['name'])
+                print(self.taba + "DRG    " + drg['name'] + ", Redundant: " + drg['redundancy'])
 
         except Exception as e:
             self.__print_error("__print_core_network_vcn", e)
@@ -982,6 +982,48 @@ class ShowOCIOutput(object):
                 print(self.taba + ct['name'] + ", partitions (" + ct['partitions'] + "), Created: " + ct['time_created'][0:16])
                 print(self.tabs + "URL   : " + str(ct['messages_endpoint']))
 
+                print("")
+
+        except Exception as e:
+            self.__print_error("__print_streams_main", e)
+
+    ##########################################################################
+    # Functions
+    ##########################################################################
+    def __print_functions_main(self, functions):
+
+        try:
+            if not functions:
+                return
+
+            self.print_header("Function Applications", 2)
+
+            for ct in functions:
+                print(self.taba + ct['display_name'] + ", Created: " + ct['time_created'][0:16])
+                if ct['subnets']:
+                    for sub in ct['subnets']:
+                        print(self.tabs + self.tabs + "Subnet: " + sub)
+
+                print("")
+
+        except Exception as e:
+            self.__print_error("__print_streams_main", e)
+
+    ##########################################################################
+    # API Gateways
+    ##########################################################################
+    def __print_api_gateways_main(self, apigatways):
+
+        try:
+            if not apigatways:
+                return
+
+            self.print_header("API Gateways", 2)
+
+            for ct in apigatways:
+                print(self.taba + ct['display_name'] + ", " + ct['endpoint_type'] + ", Created: " + ct['time_created'][0:16])
+                print(self.tabs2 + "Host  : " + ct['hostname'])
+                print(self.tabs2 + "Subnet: " + ct['subnet_name'])
                 print("")
 
         except Exception as e:
@@ -1551,6 +1593,10 @@ class ShowOCIOutput(object):
                     self.__print_quotas_main(cdata['quotas'])
                 if 'paas_services' in cdata:
                     self.__print_paas_services_main(cdata['paas_services'])
+                if 'apigateways' in cdata:
+                    self.__print_api_gateways_main(cdata['apigateways'])
+                if 'functions' in cdata:
+                    self.__print_functions_main(cdata['functions'])
 
         except Exception as e:
             self.__print_error("__print_region_data", e)

--- a/src/oci/database/database_client.py
+++ b/src/oci/database/database_client.py
@@ -6029,6 +6029,9 @@ class DatabaseClient(object):
 
             Allowed values are: "OLTP", "DW"
 
+        :param str db_version: (optional)
+            A filter to return only autonomous database resources that match the specified dbVersion.
+
         :param bool is_free_tier: (optional)
             Filter on the value of the resource's 'isFreeTier' property. A value of `true` returns only Always Free resources.
             A value of `false` excludes Always Free resources from the returned results. Omitting this parameter returns both Always Free and paid resources.
@@ -6063,6 +6066,7 @@ class DatabaseClient(object):
             "sort_order",
             "lifecycle_state",
             "db_workload",
+            "db_version",
             "is_free_tier",
             "display_name",
             "opc_request_id"
@@ -6109,6 +6113,7 @@ class DatabaseClient(object):
             "sortOrder": kwargs.get("sort_order", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "dbWorkload": kwargs.get("db_workload", missing),
+            "dbVersion": kwargs.get("db_version", missing),
             "isFreeTier": kwargs.get("is_free_tier", missing),
             "displayName": kwargs.get("display_name", missing)
         }
@@ -6144,7 +6149,8 @@ class DatabaseClient(object):
     def list_autonomous_db_preview_versions(self, compartment_id, **kwargs):
         """
         Gets a list of supported Autonomous Database versions.
-        Gets a list of supported Autonomous Database versions. Note that preview version software is only available for `serverless deployments`__.
+        Gets a list of supported Autonomous Database versions. Note that preview version software is only available for
+        databases with `shared Exadata infrastructure`__.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -6252,6 +6258,114 @@ class DatabaseClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="list[AutonomousDbPreviewVersionSummary]")
+
+    def list_autonomous_db_versions(self, compartment_id, **kwargs):
+        """
+        Gets a list of supported Autonomous Database versions.
+        Gets a list of supported Autonomous Database versions.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str db_workload: (optional)
+            A filter to return only autonomous database resources that match the specified workload type.
+
+            Allowed values are: "OLTP", "DW"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.AutonomousDbVersionSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousDbVersions"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "opc_request_id",
+            "db_workload",
+            "sort_order"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_autonomous_db_versions got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'db_workload' in kwargs:
+            db_workload_allowed_values = ["OLTP", "DW"]
+            if kwargs['db_workload'] not in db_workload_allowed_values:
+                raise ValueError(
+                    "Invalid value for `db_workload`, must be one of {0}".format(db_workload_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "dbWorkload": kwargs.get("db_workload", missing),
+            "sortOrder": kwargs.get("sort_order", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AutonomousDbVersionSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AutonomousDbVersionSummary]")
 
     def list_autonomous_exadata_infrastructure_shapes(self, availability_domain, compartment_id, **kwargs):
         """

--- a/src/oci/database/models/__init__.py
+++ b/src/oci/database/models/__init__.py
@@ -23,6 +23,7 @@ from .autonomous_database_console_token_details import AutonomousDatabaseConsole
 from .autonomous_database_summary import AutonomousDatabaseSummary
 from .autonomous_database_wallet import AutonomousDatabaseWallet
 from .autonomous_db_preview_version_summary import AutonomousDbPreviewVersionSummary
+from .autonomous_db_version_summary import AutonomousDbVersionSummary
 from .autonomous_exadata_infrastructure import AutonomousExadataInfrastructure
 from .autonomous_exadata_infrastructure_maintenance_window import AutonomousExadataInfrastructureMaintenanceWindow
 from .autonomous_exadata_infrastructure_shape_summary import AutonomousExadataInfrastructureShapeSummary
@@ -158,6 +159,7 @@ database_type_mapping = {
     "AutonomousDatabaseSummary": AutonomousDatabaseSummary,
     "AutonomousDatabaseWallet": AutonomousDatabaseWallet,
     "AutonomousDbPreviewVersionSummary": AutonomousDbPreviewVersionSummary,
+    "AutonomousDbVersionSummary": AutonomousDbVersionSummary,
     "AutonomousExadataInfrastructure": AutonomousExadataInfrastructure,
     "AutonomousExadataInfrastructureMaintenanceWindow": AutonomousExadataInfrastructureMaintenanceWindow,
     "AutonomousExadataInfrastructureShapeSummary": AutonomousExadataInfrastructureShapeSummary,

--- a/src/oci/database/models/autonomous_database.py
+++ b/src/oci/database/models/autonomous_database.py
@@ -627,7 +627,7 @@ class AutonomousDatabase(object):
     def is_dedicated(self):
         """
         Gets the is_dedicated of this AutonomousDatabase.
-        True if the database uses the `dedicated deployment`__ option.
+        True if the database uses `dedicated Exadata infrastructure`__.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 
@@ -641,7 +641,7 @@ class AutonomousDatabase(object):
     def is_dedicated(self, is_dedicated):
         """
         Sets the is_dedicated of this AutonomousDatabase.
-        True if the database uses the `dedicated deployment`__ option.
+        True if the database uses `dedicated Exadata infrastructure`__.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 
@@ -799,11 +799,11 @@ class AutonomousDatabase(object):
     def license_model(self):
         """
         Gets the license_model of this AutonomousDatabase.
-        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database using the `dedicated deployment`__ option, this attribute must be null because the attribute is already set at the
-        Autonomous Exadata Infrastructure level. When using the `serverless deployment`__ option, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
+        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database on `dedicated Exadata infrastructure`__, this attribute must be null because the attribute is already set at the
+        Autonomous Exadata Infrastructure level. When using `shared Exadata infrastructure`__, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
-        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#DeploymentTypes
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
         Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -818,11 +818,11 @@ class AutonomousDatabase(object):
     def license_model(self, license_model):
         """
         Sets the license_model of this AutonomousDatabase.
-        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database using the `dedicated deployment`__ option, this attribute must be null because the attribute is already set at the
-        Autonomous Exadata Infrastructure level. When using the `serverless deployment`__ option, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
+        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database on `dedicated Exadata infrastructure`__, this attribute must be null because the attribute is already set at the
+        Autonomous Exadata Infrastructure level. When using `shared Exadata infrastructure`__, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
-        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#DeploymentTypes
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
 
         :param license_model: The license_model of this AutonomousDatabase.
@@ -1003,8 +1003,9 @@ class AutonomousDatabase(object):
     def whitelisted_ips(self):
         """
         Gets the whitelisted_ips of this AutonomousDatabase.
-        The client IP access control list (ACL). This feature is available for `serverless deployments`__ only.
+        The client IP access control list (ACL). This feature is available for databases on `shared Exadata infrastructure`__ only.
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
+
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
         Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
 
@@ -1020,8 +1021,9 @@ class AutonomousDatabase(object):
     def whitelisted_ips(self, whitelisted_ips):
         """
         Sets the whitelisted_ips of this AutonomousDatabase.
-        The client IP access control list (ACL). This feature is available for `serverless deployments`__ only.
+        The client IP access control list (ACL). This feature is available for databases on `shared Exadata infrastructure`__ only.
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
+
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
         Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
 
@@ -1037,7 +1039,7 @@ class AutonomousDatabase(object):
     def is_auto_scaling_enabled(self):
         """
         Gets the is_auto_scaling_enabled of this AutonomousDatabase.
-        Indicates if auto scaling is enabled for the Autonomous Database CPU core count. Note that auto scaling is available for `serverless deployments`__ only.
+        Indicates if auto scaling is enabled for the Autonomous Database CPU core count. Note that auto scaling is available for databases on `shared Exadata infrastructure`__ only.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -1051,7 +1053,7 @@ class AutonomousDatabase(object):
     def is_auto_scaling_enabled(self, is_auto_scaling_enabled):
         """
         Sets the is_auto_scaling_enabled of this AutonomousDatabase.
-        Indicates if auto scaling is enabled for the Autonomous Database CPU core count. Note that auto scaling is available for `serverless deployments`__ only.
+        Indicates if auto scaling is enabled for the Autonomous Database CPU core count. Note that auto scaling is available for databases on `shared Exadata infrastructure`__ only.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 

--- a/src/oci/database/models/autonomous_database_connection_urls.py
+++ b/src/oci/database/models/autonomous_database_connection_urls.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class AutonomousDatabaseConnectionUrls(object):
     """
-    The URLs for accessing Oracle Application Express (APEX) and SQL Developer Web with a browser from a Compute instance within your VCN or that has a direct connection to your VCN. Note that these URLs are provided by the console only for `dedicated deployments`__.
+    The URLs for accessing Oracle Application Express (APEX) and SQL Developer Web with a browser from a Compute instance within your VCN or that has a direct connection to your VCN. Note that these URLs are provided by the console only for databases on `dedicated Exadata infrastructure`__.
 
     Example: `{\"sqlDevWebUrl\": \"https://<hostname>/ords...\", \"apexUrl\", \"https://<hostname>/ords...\"}`
 

--- a/src/oci/database/models/autonomous_database_summary.py
+++ b/src/oci/database/models/autonomous_database_summary.py
@@ -629,7 +629,7 @@ class AutonomousDatabaseSummary(object):
     def is_dedicated(self):
         """
         Gets the is_dedicated of this AutonomousDatabaseSummary.
-        True if the database uses the `dedicated deployment`__ option.
+        True if the database uses `dedicated Exadata infrastructure`__.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 
@@ -643,7 +643,7 @@ class AutonomousDatabaseSummary(object):
     def is_dedicated(self, is_dedicated):
         """
         Sets the is_dedicated of this AutonomousDatabaseSummary.
-        True if the database uses the `dedicated deployment`__ option.
+        True if the database uses `dedicated Exadata infrastructure`__.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 
@@ -801,11 +801,11 @@ class AutonomousDatabaseSummary(object):
     def license_model(self):
         """
         Gets the license_model of this AutonomousDatabaseSummary.
-        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database using the `dedicated deployment`__ option, this attribute must be null because the attribute is already set at the
-        Autonomous Exadata Infrastructure level. When using the `serverless deployment`__ option, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
+        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database on `dedicated Exadata infrastructure`__, this attribute must be null because the attribute is already set at the
+        Autonomous Exadata Infrastructure level. When using `shared Exadata infrastructure`__, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
-        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#DeploymentTypes
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
         Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -820,11 +820,11 @@ class AutonomousDatabaseSummary(object):
     def license_model(self, license_model):
         """
         Sets the license_model of this AutonomousDatabaseSummary.
-        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database using the `dedicated deployment`__ option, this attribute must be null because the attribute is already set at the
-        Autonomous Exadata Infrastructure level. When using the `serverless deployment`__ option, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
+        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database on `dedicated Exadata infrastructure`__, this attribute must be null because the attribute is already set at the
+        Autonomous Exadata Infrastructure level. When using `shared Exadata infrastructure`__, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
-        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#DeploymentTypes
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
 
         :param license_model: The license_model of this AutonomousDatabaseSummary.
@@ -1005,8 +1005,9 @@ class AutonomousDatabaseSummary(object):
     def whitelisted_ips(self):
         """
         Gets the whitelisted_ips of this AutonomousDatabaseSummary.
-        The client IP access control list (ACL). This feature is available for `serverless deployments`__ only.
+        The client IP access control list (ACL). This feature is available for databases on `shared Exadata infrastructure`__ only.
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
+
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
         Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
 
@@ -1022,8 +1023,9 @@ class AutonomousDatabaseSummary(object):
     def whitelisted_ips(self, whitelisted_ips):
         """
         Sets the whitelisted_ips of this AutonomousDatabaseSummary.
-        The client IP access control list (ACL). This feature is available for `serverless deployments`__ only.
+        The client IP access control list (ACL). This feature is available for databases on `shared Exadata infrastructure`__ only.
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
+
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
         Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
 
@@ -1039,7 +1041,7 @@ class AutonomousDatabaseSummary(object):
     def is_auto_scaling_enabled(self):
         """
         Gets the is_auto_scaling_enabled of this AutonomousDatabaseSummary.
-        Indicates if auto scaling is enabled for the Autonomous Database CPU core count. Note that auto scaling is available for `serverless deployments`__ only.
+        Indicates if auto scaling is enabled for the Autonomous Database CPU core count. Note that auto scaling is available for databases on `shared Exadata infrastructure`__ only.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -1053,7 +1055,7 @@ class AutonomousDatabaseSummary(object):
     def is_auto_scaling_enabled(self, is_auto_scaling_enabled):
         """
         Sets the is_auto_scaling_enabled of this AutonomousDatabaseSummary.
-        Indicates if auto scaling is enabled for the Autonomous Database CPU core count. Note that auto scaling is available for `serverless deployments`__ only.
+        Indicates if auto scaling is enabled for the Autonomous Database CPU core count. Note that auto scaling is available for databases on `shared Exadata infrastructure`__ only.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 

--- a/src/oci/database/models/autonomous_db_preview_version_summary.py
+++ b/src/oci/database/models/autonomous_db_preview_version_summary.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class AutonomousDbPreviewVersionSummary(object):
     """
-    The Autonomous Database preview version. Note that preview version software is only available for `serverless deployments`__.
+    The Autonomous Database preview version. Note that preview version software is only available for databases on `shared Exadata infrastructure`__.
 
     __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
     """

--- a/src/oci/database/models/autonomous_db_version_summary.py
+++ b/src/oci/database/models/autonomous_db_version_summary.py
@@ -1,0 +1,182 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AutonomousDbVersionSummary(object):
+    """
+    The supported Autonomous Database version.
+    """
+
+    #: A constant which can be used with the db_workload property of a AutonomousDbVersionSummary.
+    #: This constant has a value of "OLTP"
+    DB_WORKLOAD_OLTP = "OLTP"
+
+    #: A constant which can be used with the db_workload property of a AutonomousDbVersionSummary.
+    #: This constant has a value of "DW"
+    DB_WORKLOAD_DW = "DW"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AutonomousDbVersionSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param version:
+            The value to assign to the version property of this AutonomousDbVersionSummary.
+        :type version: str
+
+        :param db_workload:
+            The value to assign to the db_workload property of this AutonomousDbVersionSummary.
+            Allowed values for this property are: "OLTP", "DW", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type db_workload: str
+
+        :param is_dedicated:
+            The value to assign to the is_dedicated property of this AutonomousDbVersionSummary.
+        :type is_dedicated: bool
+
+        :param details:
+            The value to assign to the details property of this AutonomousDbVersionSummary.
+        :type details: str
+
+        """
+        self.swagger_types = {
+            'version': 'str',
+            'db_workload': 'str',
+            'is_dedicated': 'bool',
+            'details': 'str'
+        }
+
+        self.attribute_map = {
+            'version': 'version',
+            'db_workload': 'dbWorkload',
+            'is_dedicated': 'isDedicated',
+            'details': 'details'
+        }
+
+        self._version = None
+        self._db_workload = None
+        self._is_dedicated = None
+        self._details = None
+
+    @property
+    def version(self):
+        """
+        **[Required]** Gets the version of this AutonomousDbVersionSummary.
+        A valid Oracle Database version for Autonomous Database.
+
+
+        :return: The version of this AutonomousDbVersionSummary.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this AutonomousDbVersionSummary.
+        A valid Oracle Database version for Autonomous Database.
+
+
+        :param version: The version of this AutonomousDbVersionSummary.
+        :type: str
+        """
+        self._version = version
+
+    @property
+    def db_workload(self):
+        """
+        Gets the db_workload of this AutonomousDbVersionSummary.
+        The Autonomous Database workload type. OLTP indicates an Autonomous Transaction Processing database and DW indicates an Autonomous Data Warehouse database.
+
+        Allowed values for this property are: "OLTP", "DW", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The db_workload of this AutonomousDbVersionSummary.
+        :rtype: str
+        """
+        return self._db_workload
+
+    @db_workload.setter
+    def db_workload(self, db_workload):
+        """
+        Sets the db_workload of this AutonomousDbVersionSummary.
+        The Autonomous Database workload type. OLTP indicates an Autonomous Transaction Processing database and DW indicates an Autonomous Data Warehouse database.
+
+
+        :param db_workload: The db_workload of this AutonomousDbVersionSummary.
+        :type: str
+        """
+        allowed_values = ["OLTP", "DW"]
+        if not value_allowed_none_or_none_sentinel(db_workload, allowed_values):
+            db_workload = 'UNKNOWN_ENUM_VALUE'
+        self._db_workload = db_workload
+
+    @property
+    def is_dedicated(self):
+        """
+        Gets the is_dedicated of this AutonomousDbVersionSummary.
+        True if the database uses `dedicated Exadata infrastructure`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
+
+
+        :return: The is_dedicated of this AutonomousDbVersionSummary.
+        :rtype: bool
+        """
+        return self._is_dedicated
+
+    @is_dedicated.setter
+    def is_dedicated(self, is_dedicated):
+        """
+        Sets the is_dedicated of this AutonomousDbVersionSummary.
+        True if the database uses `dedicated Exadata infrastructure`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
+
+
+        :param is_dedicated: The is_dedicated of this AutonomousDbVersionSummary.
+        :type: bool
+        """
+        self._is_dedicated = is_dedicated
+
+    @property
+    def details(self):
+        """
+        Gets the details of this AutonomousDbVersionSummary.
+        A URL that points to a detailed description of the Autonomous Database version.
+
+
+        :return: The details of this AutonomousDbVersionSummary.
+        :rtype: str
+        """
+        return self._details
+
+    @details.setter
+    def details(self, details):
+        """
+        Sets the details of this AutonomousDbVersionSummary.
+        A URL that points to a detailed description of the Autonomous Database version.
+
+
+        :param details: The details of this AutonomousDbVersionSummary.
+        :type: str
+        """
+        self._details = details
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_autonomous_database_base.py
+++ b/src/oci/database/models/create_autonomous_database_base.py
@@ -124,6 +124,10 @@ class CreateAutonomousDatabaseBase(object):
             The value to assign to the defined_tags property of this CreateAutonomousDatabaseBase.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param db_version:
+            The value to assign to the db_version property of this CreateAutonomousDatabaseBase.
+        :type db_version: str
+
         :param source:
             The value to assign to the source property of this CreateAutonomousDatabaseBase.
             Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP"
@@ -147,6 +151,7 @@ class CreateAutonomousDatabaseBase(object):
             'whitelisted_ips': 'list[str]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
+            'db_version': 'str',
             'source': 'str'
         }
 
@@ -167,6 +172,7 @@ class CreateAutonomousDatabaseBase(object):
             'whitelisted_ips': 'whitelistedIps',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
+            'db_version': 'dbVersion',
             'source': 'source'
         }
 
@@ -186,6 +192,7 @@ class CreateAutonomousDatabaseBase(object):
         self._whitelisted_ips = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._db_version = None
         self._source = None
 
     @staticmethod
@@ -418,11 +425,11 @@ class CreateAutonomousDatabaseBase(object):
     def license_model(self):
         """
         Gets the license_model of this CreateAutonomousDatabaseBase.
-        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database using the `dedicated deployment`__ option, this attribute must be null because the attribute is already set at the
-        Autonomous Exadata Infrastructure level. When using the `serverless deployment`__ option, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
+        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database on `dedicated Exadata infrastructure`__, this attribute must be null because the attribute is already set at the
+        Autonomous Exadata Infrastructure level. When using `shared Exadata infrastructure`__, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
-        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#DeploymentTypes
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
         Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
 
@@ -436,11 +443,11 @@ class CreateAutonomousDatabaseBase(object):
     def license_model(self, license_model):
         """
         Sets the license_model of this CreateAutonomousDatabaseBase.
-        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database using the `dedicated deployment`__ option, this attribute must be null because the attribute is already set at the
-        Autonomous Exadata Infrastructure level. When using the `serverless deployment`__ option, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
+        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database on `dedicated Exadata infrastructure`__, this attribute must be null because the attribute is already set at the
+        Autonomous Exadata Infrastructure level. When using `shared Exadata infrastructure`__, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
-        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#DeploymentTypes
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
 
         :param license_model: The license_model of this CreateAutonomousDatabaseBase.
@@ -458,7 +465,7 @@ class CreateAutonomousDatabaseBase(object):
     def is_preview_version_with_service_terms_accepted(self):
         """
         Gets the is_preview_version_with_service_terms_accepted of this CreateAutonomousDatabaseBase.
-        If set to `TRUE`, indicates that an Autonomous Database preview version is being provisioned, and that the preview version's terms of service have been accepted. Note that preview version software is only available for `serverless deployments`__.
+        If set to `TRUE`, indicates that an Autonomous Database preview version is being provisioned, and that the preview version's terms of service have been accepted. Note that preview version software is only available for databases on `shared Exadata infrastructure`__.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -472,7 +479,7 @@ class CreateAutonomousDatabaseBase(object):
     def is_preview_version_with_service_terms_accepted(self, is_preview_version_with_service_terms_accepted):
         """
         Sets the is_preview_version_with_service_terms_accepted of this CreateAutonomousDatabaseBase.
-        If set to `TRUE`, indicates that an Autonomous Database preview version is being provisioned, and that the preview version's terms of service have been accepted. Note that preview version software is only available for `serverless deployments`__.
+        If set to `TRUE`, indicates that an Autonomous Database preview version is being provisioned, and that the preview version's terms of service have been accepted. Note that preview version software is only available for databases on `shared Exadata infrastructure`__.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -486,7 +493,7 @@ class CreateAutonomousDatabaseBase(object):
     def is_auto_scaling_enabled(self):
         """
         Gets the is_auto_scaling_enabled of this CreateAutonomousDatabaseBase.
-        Indicates if auto scaling is enabled for the Autonomous Database OCPU core count. The default value is `FALSE`. Note that auto scaling is available for `serverless deployments`__ only.
+        Indicates if auto scaling is enabled for the Autonomous Database OCPU core count. The default value is `FALSE`. Note that auto scaling is available for databases on `shared Exadata infrastructure`__ only.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -500,7 +507,7 @@ class CreateAutonomousDatabaseBase(object):
     def is_auto_scaling_enabled(self, is_auto_scaling_enabled):
         """
         Sets the is_auto_scaling_enabled of this CreateAutonomousDatabaseBase.
-        Indicates if auto scaling is enabled for the Autonomous Database OCPU core count. The default value is `FALSE`. Note that auto scaling is available for `serverless deployments`__ only.
+        Indicates if auto scaling is enabled for the Autonomous Database OCPU core count. The default value is `FALSE`. Note that auto scaling is available for databases on `shared Exadata infrastructure`__ only.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -514,7 +521,7 @@ class CreateAutonomousDatabaseBase(object):
     def is_dedicated(self):
         """
         Gets the is_dedicated of this CreateAutonomousDatabaseBase.
-        True if the database uses the `dedicated deployment`__ option.
+        True if the database is on `dedicated Exadata infrastructure`__.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 
@@ -528,7 +535,7 @@ class CreateAutonomousDatabaseBase(object):
     def is_dedicated(self, is_dedicated):
         """
         Sets the is_dedicated of this CreateAutonomousDatabaseBase.
-        True if the database uses the `dedicated deployment`__ option.
+        True if the database is on `dedicated Exadata infrastructure`__.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
 
@@ -570,7 +577,7 @@ class CreateAutonomousDatabaseBase(object):
     def whitelisted_ips(self):
         """
         Gets the whitelisted_ips of this CreateAutonomousDatabaseBase.
-        The client IP access control list (ACL). This feature is available for `serverless deployments`__ only.
+        The client IP access control list (ACL). This feature is available for databases on `shared Exadata infrastructure`__ only.
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
         Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
@@ -587,7 +594,7 @@ class CreateAutonomousDatabaseBase(object):
     def whitelisted_ips(self, whitelisted_ips):
         """
         Sets the whitelisted_ips of this CreateAutonomousDatabaseBase.
-        The client IP access control list (ACL). This feature is available for `serverless deployments`__ only.
+        The client IP access control list (ACL). This feature is available for databases on `shared Exadata infrastructure`__ only.
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
         Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
@@ -665,12 +672,36 @@ class CreateAutonomousDatabaseBase(object):
         self._defined_tags = defined_tags
 
     @property
+    def db_version(self):
+        """
+        Gets the db_version of this CreateAutonomousDatabaseBase.
+        A valid Oracle Database version for Autonomous Database.
+
+
+        :return: The db_version of this CreateAutonomousDatabaseBase.
+        :rtype: str
+        """
+        return self._db_version
+
+    @db_version.setter
+    def db_version(self, db_version):
+        """
+        Sets the db_version of this CreateAutonomousDatabaseBase.
+        A valid Oracle Database version for Autonomous Database.
+
+
+        :param db_version: The db_version of this CreateAutonomousDatabaseBase.
+        :type: str
+        """
+        self._db_version = db_version
+
+    @property
     def source(self):
         """
         Gets the source of this CreateAutonomousDatabaseBase.
         The source of the database: Use `NONE` for creating a new Autonomous Database. Use `DATABASE` for creating a new Autonomous Database by cloning an existing Autonomous Database.
 
-        For Autonomous Databases using the `serverless deployment`__, the following cloning options are available: Use `BACKUP_FROM_ID` for creating a new Autonomous Database from a specified backup. Use `BACKUP_FROM_TIMESTAMP` for creating a point-in-time Autonomous Database clone using backups. For more information, see `Cloning an Autonomous Database`__.
+        For Autonomous Databases on `shared Exadata infrastructure`__, the following cloning options are available: Use `BACKUP_FROM_ID` for creating a new Autonomous Database from a specified backup. Use `BACKUP_FROM_TIMESTAMP` for creating a point-in-time Autonomous Database clone using backups. For more information, see `Cloning an Autonomous Database`__.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
         __ https://docs.cloud.oracle.com/Content/Database/Tasks/adbcloning.htm
@@ -689,7 +720,7 @@ class CreateAutonomousDatabaseBase(object):
         Sets the source of this CreateAutonomousDatabaseBase.
         The source of the database: Use `NONE` for creating a new Autonomous Database. Use `DATABASE` for creating a new Autonomous Database by cloning an existing Autonomous Database.
 
-        For Autonomous Databases using the `serverless deployment`__, the following cloning options are available: Use `BACKUP_FROM_ID` for creating a new Autonomous Database from a specified backup. Use `BACKUP_FROM_TIMESTAMP` for creating a point-in-time Autonomous Database clone using backups. For more information, see `Cloning an Autonomous Database`__.
+        For Autonomous Databases on `shared Exadata infrastructure`__, the following cloning options are available: Use `BACKUP_FROM_ID` for creating a new Autonomous Database from a specified backup. Use `BACKUP_FROM_TIMESTAMP` for creating a point-in-time Autonomous Database clone using backups. For more information, see `Cloning an Autonomous Database`__.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
         __ https://docs.cloud.oracle.com/Content/Database/Tasks/adbcloning.htm

--- a/src/oci/database/models/create_autonomous_database_clone_details.py
+++ b/src/oci/database/models/create_autonomous_database_clone_details.py
@@ -92,6 +92,10 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             The value to assign to the defined_tags property of this CreateAutonomousDatabaseCloneDetails.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param db_version:
+            The value to assign to the db_version property of this CreateAutonomousDatabaseCloneDetails.
+        :type db_version: str
+
         :param source:
             The value to assign to the source property of this CreateAutonomousDatabaseCloneDetails.
             Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP"
@@ -124,6 +128,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'whitelisted_ips': 'list[str]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
+            'db_version': 'str',
             'source': 'str',
             'source_id': 'str',
             'clone_type': 'str'
@@ -146,6 +151,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'whitelisted_ips': 'whitelistedIps',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
+            'db_version': 'dbVersion',
             'source': 'source',
             'source_id': 'sourceId',
             'clone_type': 'cloneType'
@@ -167,6 +173,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
         self._whitelisted_ips = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._db_version = None
         self._source = None
         self._source_id = None
         self._clone_type = None

--- a/src/oci/database/models/create_autonomous_database_details.py
+++ b/src/oci/database/models/create_autonomous_database_details.py
@@ -84,6 +84,10 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             The value to assign to the defined_tags property of this CreateAutonomousDatabaseDetails.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param db_version:
+            The value to assign to the db_version property of this CreateAutonomousDatabaseDetails.
+        :type db_version: str
+
         :param source:
             The value to assign to the source property of this CreateAutonomousDatabaseDetails.
             Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP"
@@ -107,6 +111,7 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'whitelisted_ips': 'list[str]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
+            'db_version': 'str',
             'source': 'str'
         }
 
@@ -127,6 +132,7 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'whitelisted_ips': 'whitelistedIps',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
+            'db_version': 'dbVersion',
             'source': 'source'
         }
 
@@ -146,6 +152,7 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
         self._whitelisted_ips = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._db_version = None
         self._source = None
         self._source = 'NONE'
 

--- a/src/oci/database/models/create_autonomous_database_from_backup_details.py
+++ b/src/oci/database/models/create_autonomous_database_from_backup_details.py
@@ -92,6 +92,10 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
             The value to assign to the defined_tags property of this CreateAutonomousDatabaseFromBackupDetails.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param db_version:
+            The value to assign to the db_version property of this CreateAutonomousDatabaseFromBackupDetails.
+        :type db_version: str
+
         :param source:
             The value to assign to the source property of this CreateAutonomousDatabaseFromBackupDetails.
             Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP"
@@ -124,6 +128,7 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
             'whitelisted_ips': 'list[str]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
+            'db_version': 'str',
             'source': 'str',
             'autonomous_database_backup_id': 'str',
             'clone_type': 'str'
@@ -146,6 +151,7 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
             'whitelisted_ips': 'whitelistedIps',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
+            'db_version': 'dbVersion',
             'source': 'source',
             'autonomous_database_backup_id': 'autonomousDatabaseBackupId',
             'clone_type': 'cloneType'
@@ -167,6 +173,7 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
         self._whitelisted_ips = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._db_version = None
         self._source = None
         self._autonomous_database_backup_id = None
         self._clone_type = None

--- a/src/oci/database/models/create_autonomous_database_from_backup_timestamp_details.py
+++ b/src/oci/database/models/create_autonomous_database_from_backup_timestamp_details.py
@@ -92,6 +92,10 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
             The value to assign to the defined_tags property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param db_version:
+            The value to assign to the db_version property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
+        :type db_version: str
+
         :param source:
             The value to assign to the source property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
             Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP"
@@ -128,6 +132,7 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
             'whitelisted_ips': 'list[str]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
+            'db_version': 'str',
             'source': 'str',
             'autonomous_database_id': 'str',
             'timestamp': 'datetime',
@@ -151,6 +156,7 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
             'whitelisted_ips': 'whitelistedIps',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
+            'db_version': 'dbVersion',
             'source': 'source',
             'autonomous_database_id': 'autonomousDatabaseId',
             'timestamp': 'timestamp',
@@ -173,6 +179,7 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
         self._whitelisted_ips = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._db_version = None
         self._source = None
         self._autonomous_database_id = None
         self._timestamp = None

--- a/src/oci/database/models/update_autonomous_database_details.py
+++ b/src/oci/database/models/update_autonomous_database_details.py
@@ -329,11 +329,11 @@ class UpdateAutonomousDatabaseDetails(object):
     def license_model(self):
         """
         Gets the license_model of this UpdateAutonomousDatabaseDetails.
-        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database using the `dedicated deployment`__ option, this attribute must be null because the attribute is already set at the
-        Autonomous Exadata Infrastructure level. When using the `serverless deployment`__ option, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
+        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database on `dedicated Exadata infrastructure`__, this attribute must be null because the attribute is already set at the
+        Autonomous Exadata Infrastructure level. When using `shared Exadata infrastructure`__, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
-        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#DeploymentTypes
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
         Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
 
@@ -347,11 +347,11 @@ class UpdateAutonomousDatabaseDetails(object):
     def license_model(self, license_model):
         """
         Sets the license_model of this UpdateAutonomousDatabaseDetails.
-        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database using the `dedicated deployment`__ option, this attribute must be null because the attribute is already set at the
-        Autonomous Exadata Infrastructure level. When using the `serverless deployment`__ option, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
+        The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database on `dedicated Exadata infrastructure`__, this attribute must be null because the attribute is already set at the
+        Autonomous Exadata Infrastructure level. When using `shared Exadata infrastructure`__, if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm
-        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#DeploymentTypes
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
 
         :param license_model: The license_model of this UpdateAutonomousDatabaseDetails.
@@ -369,7 +369,7 @@ class UpdateAutonomousDatabaseDetails(object):
     def whitelisted_ips(self):
         """
         Gets the whitelisted_ips of this UpdateAutonomousDatabaseDetails.
-        The client IP access control list (ACL). This feature is available for `serverless deployments`__ only.
+        The client IP access control list (ACL). This feature is available for databases on `shared Exadata infrastructure`__ only.
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID. To delete all the existing white listed IP\u2019s, use an array with a single empty string entry.
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
         Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\"]`
@@ -386,7 +386,7 @@ class UpdateAutonomousDatabaseDetails(object):
     def whitelisted_ips(self, whitelisted_ips):
         """
         Sets the whitelisted_ips of this UpdateAutonomousDatabaseDetails.
-        The client IP access control list (ACL). This feature is available for `serverless deployments`__ only.
+        The client IP access control list (ACL). This feature is available for databases on `shared Exadata infrastructure`__ only.
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID. To delete all the existing white listed IP\u2019s, use an array with a single empty string entry.
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
         Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\"]`
@@ -403,7 +403,7 @@ class UpdateAutonomousDatabaseDetails(object):
     def is_auto_scaling_enabled(self):
         """
         Gets the is_auto_scaling_enabled of this UpdateAutonomousDatabaseDetails.
-        Indicates whether to enable or disable auto scaling for the Autonomous Database OCPU core count. Setting to `true` enables auto scaling. Setting to `false` disables auto scaling. The default value is true. Auto scaling is available for `serverless deployments`__ only.
+        Indicates whether to enable or disable auto scaling for the Autonomous Database OCPU core count. Setting to `true` enables auto scaling. Setting to `false` disables auto scaling. The default value is true. Auto scaling is available for databases on `shared Exadata infrastructure`__ only.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -417,7 +417,7 @@ class UpdateAutonomousDatabaseDetails(object):
     def is_auto_scaling_enabled(self, is_auto_scaling_enabled):
         """
         Sets the is_auto_scaling_enabled of this UpdateAutonomousDatabaseDetails.
-        Indicates whether to enable or disable auto scaling for the Autonomous Database OCPU core count. Setting to `true` enables auto scaling. Setting to `false` disables auto scaling. The default value is true. Auto scaling is available for `serverless deployments`__ only.
+        Indicates whether to enable or disable auto scaling for the Autonomous Database OCPU core count. Setting to `true` enables auto scaling. Setting to `false` disables auto scaling. The default value is true. Auto scaling is available for databases on `shared Exadata infrastructure`__ only.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 

--- a/src/oci/load_balancer/models/connection_configuration.py
+++ b/src/oci/load_balancer/models/connection_configuration.py
@@ -21,16 +21,23 @@ class ConnectionConfiguration(object):
             The value to assign to the idle_timeout property of this ConnectionConfiguration.
         :type idle_timeout: int
 
+        :param backend_tcp_proxy_protocol_version:
+            The value to assign to the backend_tcp_proxy_protocol_version property of this ConnectionConfiguration.
+        :type backend_tcp_proxy_protocol_version: int
+
         """
         self.swagger_types = {
-            'idle_timeout': 'int'
+            'idle_timeout': 'int',
+            'backend_tcp_proxy_protocol_version': 'int'
         }
 
         self.attribute_map = {
-            'idle_timeout': 'idleTimeout'
+            'idle_timeout': 'idleTimeout',
+            'backend_tcp_proxy_protocol_version': 'backendTcpProxyProtocolVersion'
         }
 
         self._idle_timeout = None
+        self._backend_tcp_proxy_protocol_version = None
 
     @property
     def idle_timeout(self):
@@ -71,6 +78,34 @@ class ConnectionConfiguration(object):
         :type: int
         """
         self._idle_timeout = idle_timeout
+
+    @property
+    def backend_tcp_proxy_protocol_version(self):
+        """
+        Gets the backend_tcp_proxy_protocol_version of this ConnectionConfiguration.
+        The backend TCP Proxy Protocol version.
+
+        Example: `1`
+
+
+        :return: The backend_tcp_proxy_protocol_version of this ConnectionConfiguration.
+        :rtype: int
+        """
+        return self._backend_tcp_proxy_protocol_version
+
+    @backend_tcp_proxy_protocol_version.setter
+    def backend_tcp_proxy_protocol_version(self, backend_tcp_proxy_protocol_version):
+        """
+        Sets the backend_tcp_proxy_protocol_version of this ConnectionConfiguration.
+        The backend TCP Proxy Protocol version.
+
+        Example: `1`
+
+
+        :param backend_tcp_proxy_protocol_version: The backend_tcp_proxy_protocol_version of this ConnectionConfiguration.
+        :type: int
+        """
+        self._backend_tcp_proxy_protocol_version = backend_tcp_proxy_protocol_version
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/load_balancer/models/redirect_rule.py
+++ b/src/oci/load_balancer/models/redirect_rule.py
@@ -12,7 +12,7 @@ class RedirectRule(Rule):
     An object that represents the action of returning a specified response code and a redirect URI. Each RedirectRule
     object is configured for a particular listener and a designated path.
 
-    The default response code is `302 Moved Temporarily`.
+    The default response code is `302 Found`.
 
     **NOTES:**
     *  This rule applies only to HTTP listeners.
@@ -82,7 +82,7 @@ class RedirectRule(Rule):
         *  307
         *  308
 
-        The default value is `302` (Moved Temporarily).
+        The default value is `302` (Found).
 
         Example: `301`
 
@@ -107,7 +107,7 @@ class RedirectRule(Rule):
         *  307
         *  308
 
-        The default value is `302` (Moved Temporarily).
+        The default value is `302` (Found).
 
         Example: `301`
 

--- a/src/oci/load_balancer/models/redirect_uri.py
+++ b/src/oci/load_balancer/models/redirect_uri.py
@@ -255,10 +255,10 @@ class RedirectUri(object):
         *  __{path}/123__ appears as `/example/video/123` in the redirect URI if `/example/video` is the path in the
            incoming HTTP request URI.
 
-        *  __{path}123__ appears as `/example/video123` in the redirect URI if `/example/video is the path in the
+        *  __{path}123__ appears as `/example/video123` in the redirect URI if `/example/video` is the path in the
            incoming HTTP request URI.
 
-        *  __/{host}/123__ appears as `/example.com/video/123` in the redirect URI if `example.com` is the hostname
+        *  __/{host}/123__ appears as `/example.com/123` in the redirect URI if `example.com` is the hostname
            in the incoming HTTP request URI.
 
         *  __/{host}/{port}__ appears as `/example.com/123` in the redirect URI if `example.com` is the hostname and
@@ -296,10 +296,10 @@ class RedirectUri(object):
         *  __{path}/123__ appears as `/example/video/123` in the redirect URI if `/example/video` is the path in the
            incoming HTTP request URI.
 
-        *  __{path}123__ appears as `/example/video123` in the redirect URI if `/example/video is the path in the
+        *  __{path}123__ appears as `/example/video123` in the redirect URI if `/example/video` is the path in the
            incoming HTTP request URI.
 
-        *  __/{host}/123__ appears as `/example.com/video/123` in the redirect URI if `example.com` is the hostname
+        *  __/{host}/123__ appears as `/example.com/123` in the redirect URI if `example.com` is the hostname
            in the incoming HTTP request URI.
 
         *  __/{host}/{port}__ appears as `/example.com/123` in the redirect URI if `example.com` is the hostname and

--- a/src/oci/ons/models/notification_topic.py
+++ b/src/oci/ons/models/notification_topic.py
@@ -362,7 +362,7 @@ class NotificationTopic(object):
     def api_endpoint(self):
         """
         **[Required]** Gets the api_endpoint of this NotificationTopic.
-        The endpoint for managing topic subscriptions or publishing messages to the topic.
+        The endpoint for managing subscriptions or publishing messages to the topic.
 
 
         :return: The api_endpoint of this NotificationTopic.
@@ -374,7 +374,7 @@ class NotificationTopic(object):
     def api_endpoint(self, api_endpoint):
         """
         Sets the api_endpoint of this NotificationTopic.
-        The endpoint for managing topic subscriptions or publishing messages to the topic.
+        The endpoint for managing subscriptions or publishing messages to the topic.
 
 
         :param api_endpoint: The api_endpoint of this NotificationTopic.

--- a/src/oci/ons/models/notification_topic_summary.py
+++ b/src/oci/ons/models/notification_topic_summary.py
@@ -359,7 +359,7 @@ class NotificationTopicSummary(object):
     def api_endpoint(self):
         """
         **[Required]** Gets the api_endpoint of this NotificationTopicSummary.
-        The endpoint for managing topic subscriptions or publishing messages to the topic.
+        The endpoint for managing subscriptions or publishing messages to the topic.
 
 
         :return: The api_endpoint of this NotificationTopicSummary.
@@ -371,7 +371,7 @@ class NotificationTopicSummary(object):
     def api_endpoint(self, api_endpoint):
         """
         Sets the api_endpoint of this NotificationTopicSummary.
-        The endpoint for managing topic subscriptions or publishing messages to the topic.
+        The endpoint for managing subscriptions or publishing messages to the topic.
 
 
         :param api_endpoint: The api_endpoint of this NotificationTopicSummary.

--- a/src/oci/ons/notification_control_plane_client.py
+++ b/src/oci/ons/notification_control_plane_client.py
@@ -75,7 +75,7 @@ class NotificationControlPlaneClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20181201',
-            'service_endpoint_template': 'https://notification.{region}.oraclecloud.com',
+            'service_endpoint_template': 'https://notification.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("notification_control_plane", config, signer, ons_type_mapping, **base_client_init_kwargs)

--- a/src/oci/ons/notification_data_plane_client.py
+++ b/src/oci/ons/notification_data_plane_client.py
@@ -75,7 +75,7 @@ class NotificationDataPlaneClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20181201',
-            'service_endpoint_template': 'https://notification.{region}.oraclecloud.com',
+            'service_endpoint_template': 'https://notification.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("notification_data_plane", config, signer, ons_type_mapping, **base_client_init_kwargs)
@@ -723,7 +723,13 @@ class NotificationDataPlaneClient(object):
 
     def publish_message(self, topic_id, message_details, **kwargs):
         """
-        Publishes a message to the specified topic. Limits information follows.
+        Publishes a message to the specified topic.
+
+        The topic endpoint is required for this operation.
+        To get the topic endpoint, use :func:`get_topic`
+        and review the `apiEndpoint` value in the response (:class:`NotificationTopic`).
+
+        Limits information follows.
 
         Message size limit per request: 64KB.
 

--- a/src/oci/regions.py
+++ b/src/oci/regions.py
@@ -17,7 +17,9 @@ REGIONS_SHORT_NAMES = {
     'syd': 'ap-sydney-1',
     'ltn': 'uk-gov-london-1',
     'kix': 'ap-osaka-1',
-    'mel': 'ap-melbourne-1'
+    'mel': 'ap-melbourne-1',
+    'ams': 'eu-amsterdam-1',
+    'jed': 'me-jeddah-1'
 }
 REGION_REALMS = {
     'ap-melbourne-1': 'oc1',
@@ -28,8 +30,10 @@ REGION_REALMS = {
     'ap-tokyo-1': 'oc1',
     'us-phoenix-1': 'oc1',
     'us-ashburn-1': 'oc1',
+    'eu-amsterdam-1': 'oc1',
     'eu-frankfurt-1': 'oc1',
     'eu-zurich-1': 'oc1',
+    'me-jeddah-1': 'oc1',
     'uk-london-1': 'oc1',
     'ca-toronto-1': 'oc1',
     'sa-saopaulo-1': 'oc1',
@@ -58,8 +62,10 @@ REGIONS = [
     "ap-tokyo-1",
     "us-phoenix-1",
     "us-ashburn-1",
+    "eu-amsterdam-1",
     "eu-frankfurt-1",
     "eu-zurich-1",
+    "me-jeddah-1",
     "uk-london-1",
     "ca-toronto-1",
     "us-langley-1",

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "2.10.3"
+__version__ = "2.10.4"


### PR DESCRIPTION
## Added

* Support for listing supported database versions for Autonomous Database Serverless, and selecting a version at provisioning time in the Database service

* Support for TCP proxy protocol versions on listener connection configurations in the Load Balancer service

* Support for calling the Notifications service in alternate realms

* Support for calling Oracle Cloud Infrastructure services in the eu-amsterdam-1 and me-jeddah-1 regions


