### PR TITLE
Releasing version 2.10.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.10.7 - 2020-03-03
+====================
+
+Added
+-----
+* Support for updating the shape of a Database System in the Database service
+* Support for generating CPE configurations for download in the Networking service
+* Support for private IPs and fault domains of cluster nodes in the Container Engine for Kubernetes service
+* Support for calling Oracle Cloud Infrastructure services in the ca-montreal-1 region
+* Fixed missed parameter when invoking request signing for delegation token
+
+====================
 2.10.6 - 2020-02-25
 ====================
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include CHANGELOG.rst
 include LICENSE.txt
+include THIRD_PARTY_LICENSES.txt
 include README.rst

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -93,6 +93,11 @@ Core Services
     oci.core.models.CopyBootVolumeBackupDetails
     oci.core.models.CopyVolumeBackupDetails
     oci.core.models.Cpe
+    oci.core.models.CpeDeviceConfigAnswer
+    oci.core.models.CpeDeviceConfigQuestion
+    oci.core.models.CpeDeviceInfo
+    oci.core.models.CpeDeviceShapeDetail
+    oci.core.models.CpeDeviceShapeSummary
     oci.core.models.CreateAppCatalogSubscriptionDetails
     oci.core.models.CreateBootVolumeBackupDetails
     oci.core.models.CreateBootVolumeDetails
@@ -241,6 +246,7 @@ Core Services
     oci.core.models.Subnet
     oci.core.models.TcpOptions
     oci.core.models.TunnelConfig
+    oci.core.models.TunnelCpeDeviceConfig
     oci.core.models.TunnelStatus
     oci.core.models.UdpOptions
     oci.core.models.UpdateBootVolumeBackupDetails
@@ -279,6 +285,7 @@ Core Services
     oci.core.models.UpdateSecurityRuleDetails
     oci.core.models.UpdateServiceGatewayDetails
     oci.core.models.UpdateSubnetDetails
+    oci.core.models.UpdateTunnelCpeDeviceConfigDetails
     oci.core.models.UpdateVcnDetails
     oci.core.models.UpdateVirtualCircuitDetails
     oci.core.models.UpdateVnicDetails

--- a/docs/api/core/models/oci.core.models.CpeDeviceConfigAnswer.rst
+++ b/docs/api/core/models/oci.core.models.CpeDeviceConfigAnswer.rst
@@ -1,0 +1,11 @@
+CpeDeviceConfigAnswer
+=====================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: CpeDeviceConfigAnswer
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.CpeDeviceConfigQuestion.rst
+++ b/docs/api/core/models/oci.core.models.CpeDeviceConfigQuestion.rst
@@ -1,0 +1,11 @@
+CpeDeviceConfigQuestion
+=======================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: CpeDeviceConfigQuestion
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.CpeDeviceInfo.rst
+++ b/docs/api/core/models/oci.core.models.CpeDeviceInfo.rst
@@ -1,0 +1,11 @@
+CpeDeviceInfo
+=============
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: CpeDeviceInfo
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.CpeDeviceShapeDetail.rst
+++ b/docs/api/core/models/oci.core.models.CpeDeviceShapeDetail.rst
@@ -1,0 +1,11 @@
+CpeDeviceShapeDetail
+====================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: CpeDeviceShapeDetail
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.CpeDeviceShapeSummary.rst
+++ b/docs/api/core/models/oci.core.models.CpeDeviceShapeSummary.rst
@@ -1,0 +1,11 @@
+CpeDeviceShapeSummary
+=====================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: CpeDeviceShapeSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.TunnelCpeDeviceConfig.rst
+++ b/docs/api/core/models/oci.core.models.TunnelCpeDeviceConfig.rst
@@ -1,0 +1,11 @@
+TunnelCpeDeviceConfig
+=====================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: TunnelCpeDeviceConfig
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.UpdateTunnelCpeDeviceConfigDetails.rst
+++ b/docs/api/core/models/oci.core.models.UpdateTunnelCpeDeviceConfigDetails.rst
@@ -1,0 +1,11 @@
+UpdateTunnelCpeDeviceConfigDetails
+==================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: UpdateTunnelCpeDeviceConfigDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,4 +14,4 @@ exclude =
 max-line-length = 99
 
 [metadata]
-license-file = LICENSE.txt
+license-files = LICENSE.txt THIRD_PARTY_LICENSES.txt

--- a/src/oci/container_engine/models/node.py
+++ b/src/oci/container_engine/models/node.py
@@ -65,6 +65,14 @@ class Node(object):
             The value to assign to the node_pool_id property of this Node.
         :type node_pool_id: str
 
+        :param fault_domain:
+            The value to assign to the fault_domain property of this Node.
+        :type fault_domain: str
+
+        :param private_ip:
+            The value to assign to the private_ip property of this Node.
+        :type private_ip: str
+
         :param public_ip:
             The value to assign to the public_ip property of this Node.
         :type public_ip: str
@@ -90,6 +98,8 @@ class Node(object):
             'availability_domain': 'str',
             'subnet_id': 'str',
             'node_pool_id': 'str',
+            'fault_domain': 'str',
+            'private_ip': 'str',
             'public_ip': 'str',
             'node_error': 'NodeError',
             'lifecycle_state': 'str',
@@ -102,6 +112,8 @@ class Node(object):
             'availability_domain': 'availabilityDomain',
             'subnet_id': 'subnetId',
             'node_pool_id': 'nodePoolId',
+            'fault_domain': 'faultDomain',
+            'private_ip': 'privateIp',
             'public_ip': 'publicIp',
             'node_error': 'nodeError',
             'lifecycle_state': 'lifecycleState',
@@ -113,6 +125,8 @@ class Node(object):
         self._availability_domain = None
         self._subnet_id = None
         self._node_pool_id = None
+        self._fault_domain = None
+        self._private_ip = None
         self._public_ip = None
         self._node_error = None
         self._lifecycle_state = None
@@ -237,6 +251,54 @@ class Node(object):
         :type: str
         """
         self._node_pool_id = node_pool_id
+
+    @property
+    def fault_domain(self):
+        """
+        Gets the fault_domain of this Node.
+        The fault domain of this node.
+
+
+        :return: The fault_domain of this Node.
+        :rtype: str
+        """
+        return self._fault_domain
+
+    @fault_domain.setter
+    def fault_domain(self, fault_domain):
+        """
+        Sets the fault_domain of this Node.
+        The fault domain of this node.
+
+
+        :param fault_domain: The fault_domain of this Node.
+        :type: str
+        """
+        self._fault_domain = fault_domain
+
+    @property
+    def private_ip(self):
+        """
+        Gets the private_ip of this Node.
+        The private IP address of this node.
+
+
+        :return: The private_ip of this Node.
+        :rtype: str
+        """
+        return self._private_ip
+
+    @private_ip.setter
+    def private_ip(self, private_ip):
+        """
+        Sets the private_ip of this Node.
+        The private IP address of this node.
+
+
+        :param private_ip: The private_ip of this Node.
+        :type: str
+        """
+        self._private_ip = private_ip
 
     @property
     def public_ip(self):

--- a/src/oci/core/compute_client.py
+++ b/src/oci/core/compute_client.py
@@ -2590,8 +2590,8 @@ class ComputeClient(object):
     def get_windows_instance_initial_credentials(self, instance_id, **kwargs):
         """
         GetWindowsInstanceInitialCredentials
-        Gets the generated credentials for the instance. Only works for instances that require password to log in (E.g. Windows).
-        For certain OS'es, users will be forced to change the initial credentials.
+        Gets the generated credentials for the instance. Only works for instances that require a password to log in, such as Windows.
+        For certain operating systems, users will be forced to change the initial credentials.
 
 
         :param str instance_id: (required)
@@ -2661,13 +2661,17 @@ class ComputeClient(object):
 
         - **STOP** - Powers off the instance.
 
-        - **SOFTRESET** - Gracefully reboots instance by sending a shutdown command to the operating system and then powers the instance back on.
-
-        - **SOFTSTOP** - Gracefully shuts down instance by sending a shutdown command to the operating system.
-
         - **RESET** - Powers off the instance and then powers it back on.
 
-        For more information see `Stopping and Starting an Instance`__.
+        - **SOFTSTOP** - Gracefully shuts down the instance by sending a shutdown command to the operating system.
+        If the applications that run on the instance take a long time to shut down, they could be improperly stopped, resulting
+        in data corruption. To avoid this, shut down the instance using the commands available in the OS before you softstop the
+        instance.
+
+        - **SOFTRESET** - Gracefully reboots the instance by sending a shutdown command to the operating system, and
+        then powers the instance back on.
+
+        For more information, see `Stopping and Starting an Instance`__.
 
         __ https://docs.cloud.oracle.com/Content/Compute/Tasks/restartinginstance.htm
 

--- a/src/oci/core/models/__init__.py
+++ b/src/oci/core/models/__init__.py
@@ -72,6 +72,11 @@ from .console_history import ConsoleHistory
 from .copy_boot_volume_backup_details import CopyBootVolumeBackupDetails
 from .copy_volume_backup_details import CopyVolumeBackupDetails
 from .cpe import Cpe
+from .cpe_device_config_answer import CpeDeviceConfigAnswer
+from .cpe_device_config_question import CpeDeviceConfigQuestion
+from .cpe_device_info import CpeDeviceInfo
+from .cpe_device_shape_detail import CpeDeviceShapeDetail
+from .cpe_device_shape_summary import CpeDeviceShapeSummary
 from .create_app_catalog_subscription_details import CreateAppCatalogSubscriptionDetails
 from .create_boot_volume_backup_details import CreateBootVolumeBackupDetails
 from .create_boot_volume_details import CreateBootVolumeDetails
@@ -220,6 +225,7 @@ from .shape import Shape
 from .subnet import Subnet
 from .tcp_options import TcpOptions
 from .tunnel_config import TunnelConfig
+from .tunnel_cpe_device_config import TunnelCpeDeviceConfig
 from .tunnel_status import TunnelStatus
 from .udp_options import UdpOptions
 from .update_boot_volume_backup_details import UpdateBootVolumeBackupDetails
@@ -258,6 +264,7 @@ from .update_security_list_details import UpdateSecurityListDetails
 from .update_security_rule_details import UpdateSecurityRuleDetails
 from .update_service_gateway_details import UpdateServiceGatewayDetails
 from .update_subnet_details import UpdateSubnetDetails
+from .update_tunnel_cpe_device_config_details import UpdateTunnelCpeDeviceConfigDetails
 from .update_vcn_details import UpdateVcnDetails
 from .update_virtual_circuit_details import UpdateVirtualCircuitDetails
 from .update_vnic_details import UpdateVnicDetails
@@ -362,6 +369,11 @@ core_type_mapping = {
     "CopyBootVolumeBackupDetails": CopyBootVolumeBackupDetails,
     "CopyVolumeBackupDetails": CopyVolumeBackupDetails,
     "Cpe": Cpe,
+    "CpeDeviceConfigAnswer": CpeDeviceConfigAnswer,
+    "CpeDeviceConfigQuestion": CpeDeviceConfigQuestion,
+    "CpeDeviceInfo": CpeDeviceInfo,
+    "CpeDeviceShapeDetail": CpeDeviceShapeDetail,
+    "CpeDeviceShapeSummary": CpeDeviceShapeSummary,
     "CreateAppCatalogSubscriptionDetails": CreateAppCatalogSubscriptionDetails,
     "CreateBootVolumeBackupDetails": CreateBootVolumeBackupDetails,
     "CreateBootVolumeDetails": CreateBootVolumeDetails,
@@ -510,6 +522,7 @@ core_type_mapping = {
     "Subnet": Subnet,
     "TcpOptions": TcpOptions,
     "TunnelConfig": TunnelConfig,
+    "TunnelCpeDeviceConfig": TunnelCpeDeviceConfig,
     "TunnelStatus": TunnelStatus,
     "UdpOptions": UdpOptions,
     "UpdateBootVolumeBackupDetails": UpdateBootVolumeBackupDetails,
@@ -548,6 +561,7 @@ core_type_mapping = {
     "UpdateSecurityRuleDetails": UpdateSecurityRuleDetails,
     "UpdateServiceGatewayDetails": UpdateServiceGatewayDetails,
     "UpdateSubnetDetails": UpdateSubnetDetails,
+    "UpdateTunnelCpeDeviceConfigDetails": UpdateTunnelCpeDeviceConfigDetails,
     "UpdateVcnDetails": UpdateVcnDetails,
     "UpdateVirtualCircuitDetails": UpdateVirtualCircuitDetails,
     "UpdateVnicDetails": UpdateVnicDetails,

--- a/src/oci/core/models/add_security_rule_details.py
+++ b/src/oci/core/models/add_security_rule_details.py
@@ -171,7 +171,8 @@ class AddSecurityRuleDetails(object):
         Allowed values:
 
           * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security rule for traffic destined for a particular `Service` through
@@ -180,6 +181,8 @@ class AddSecurityRuleDetails(object):
           * The OCID of a :class:`NetworkSecurityGroup` in the same
             VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
             traffic between VNICs in the same NSG.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The destination of this AddSecurityRuleDetails.
@@ -197,7 +200,8 @@ class AddSecurityRuleDetails(object):
         Allowed values:
 
           * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security rule for traffic destined for a particular `Service` through
@@ -206,6 +210,8 @@ class AddSecurityRuleDetails(object):
           * The OCID of a :class:`NetworkSecurityGroup` in the same
             VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
             traffic between VNICs in the same NSG.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param destination: The destination of this AddSecurityRuleDetails.
@@ -423,7 +429,8 @@ class AddSecurityRuleDetails(object):
         Allowed values:
 
           * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security rule for traffic coming from a particular `Service` through
@@ -432,6 +439,8 @@ class AddSecurityRuleDetails(object):
           * The OCID of a :class:`NetworkSecurityGroup` in the same
             VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
             traffic between VNICs in the same NSG.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The source of this AddSecurityRuleDetails.
@@ -449,7 +458,8 @@ class AddSecurityRuleDetails(object):
         Allowed values:
 
           * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security rule for traffic coming from a particular `Service` through
@@ -458,6 +468,8 @@ class AddSecurityRuleDetails(object):
           * The OCID of a :class:`NetworkSecurityGroup` in the same
             VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
             traffic between VNICs in the same NSG.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param source: The source of this AddSecurityRuleDetails.

--- a/src/oci/core/models/cpe.py
+++ b/src/oci/core/models/cpe.py
@@ -55,6 +55,10 @@ class Cpe(object):
             The value to assign to the ip_address property of this Cpe.
         :type ip_address: str
 
+        :param cpe_device_shape_id:
+            The value to assign to the cpe_device_shape_id property of this Cpe.
+        :type cpe_device_shape_id: str
+
         :param time_created:
             The value to assign to the time_created property of this Cpe.
         :type time_created: datetime
@@ -67,6 +71,7 @@ class Cpe(object):
             'freeform_tags': 'dict(str, str)',
             'id': 'str',
             'ip_address': 'str',
+            'cpe_device_shape_id': 'str',
             'time_created': 'datetime'
         }
 
@@ -77,6 +82,7 @@ class Cpe(object):
             'freeform_tags': 'freeformTags',
             'id': 'id',
             'ip_address': 'ipAddress',
+            'cpe_device_shape_id': 'cpeDeviceShapeId',
             'time_created': 'timeCreated'
         }
 
@@ -86,6 +92,7 @@ class Cpe(object):
         self._freeform_tags = None
         self._id = None
         self._ip_address = None
+        self._cpe_device_shape_id = None
         self._time_created = None
 
     @property
@@ -253,6 +260,60 @@ class Cpe(object):
         :type: str
         """
         self._ip_address = ip_address
+
+    @property
+    def cpe_device_shape_id(self):
+        """
+        Gets the cpe_device_shape_id of this Cpe.
+        The `OCID`__ of the CPE's device type.
+        The Networking service maintains a general list of CPE device types (for example,
+        Cisco ASA). For each type, Oracle provides CPE configuration content that can help
+        a network engineer configure the CPE. The OCID uniquely identifies the type of
+        device. To get the OCIDs for the device types on the list, see
+        :func:`list_cpe_device_shapes`.
+
+        For information about how to generate CPE configuration content for a
+        CPE device type, see:
+
+          * :func:`get_cpe_device_config_content`
+          * :func:`get_ipsec_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The cpe_device_shape_id of this Cpe.
+        :rtype: str
+        """
+        return self._cpe_device_shape_id
+
+    @cpe_device_shape_id.setter
+    def cpe_device_shape_id(self, cpe_device_shape_id):
+        """
+        Sets the cpe_device_shape_id of this Cpe.
+        The `OCID`__ of the CPE's device type.
+        The Networking service maintains a general list of CPE device types (for example,
+        Cisco ASA). For each type, Oracle provides CPE configuration content that can help
+        a network engineer configure the CPE. The OCID uniquely identifies the type of
+        device. To get the OCIDs for the device types on the list, see
+        :func:`list_cpe_device_shapes`.
+
+        For information about how to generate CPE configuration content for a
+        CPE device type, see:
+
+          * :func:`get_cpe_device_config_content`
+          * :func:`get_ipsec_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param cpe_device_shape_id: The cpe_device_shape_id of this Cpe.
+        :type: str
+        """
+        self._cpe_device_shape_id = cpe_device_shape_id
 
     @property
     def time_created(self):

--- a/src/oci/core/models/cpe_device_config_answer.py
+++ b/src/oci/core/models/cpe_device_config_answer.py
@@ -1,0 +1,105 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CpeDeviceConfigAnswer(object):
+    """
+    An individual answer to a CPE device question.
+
+    The answers correlate to the questions that are specific to the CPE device type (see the
+    `parameters` attribute of :class:`CpeDeviceShapeDetail`).
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CpeDeviceConfigAnswer object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this CpeDeviceConfigAnswer.
+        :type key: str
+
+        :param value:
+            The value to assign to the value property of this CpeDeviceConfigAnswer.
+        :type value: str
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'value': 'str'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'value': 'value'
+        }
+
+        self._key = None
+        self._value = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this CpeDeviceConfigAnswer.
+        A string that identifies the question to be answered. See the `key` attribute in
+        :func:`cpe_device_config_question`.
+
+
+        :return: The key of this CpeDeviceConfigAnswer.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this CpeDeviceConfigAnswer.
+        A string that identifies the question to be answered. See the `key` attribute in
+        :func:`cpe_device_config_question`.
+
+
+        :param key: The key of this CpeDeviceConfigAnswer.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def value(self):
+        """
+        Gets the value of this CpeDeviceConfigAnswer.
+        The answer to the question.
+
+
+        :return: The value of this CpeDeviceConfigAnswer.
+        :rtype: str
+        """
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        """
+        Sets the value of this CpeDeviceConfigAnswer.
+        The answer to the question.
+
+
+        :param value: The value of this CpeDeviceConfigAnswer.
+        :type: str
+        """
+        self._value = value
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/cpe_device_config_question.py
+++ b/src/oci/core/models/cpe_device_config_question.py
@@ -1,0 +1,134 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CpeDeviceConfigQuestion(object):
+    """
+    An individual question that the customer can answer about the CPE device.
+
+    The customer provides answers to these questions in
+    :func:`update_tunnel_cpe_device_config`.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CpeDeviceConfigQuestion object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this CpeDeviceConfigQuestion.
+        :type key: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CpeDeviceConfigQuestion.
+        :type display_name: str
+
+        :param explanation:
+            The value to assign to the explanation property of this CpeDeviceConfigQuestion.
+        :type explanation: str
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'display_name': 'str',
+            'explanation': 'str'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'display_name': 'displayName',
+            'explanation': 'explanation'
+        }
+
+        self._key = None
+        self._display_name = None
+        self._explanation = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this CpeDeviceConfigQuestion.
+        A string that identifies the question.
+
+
+        :return: The key of this CpeDeviceConfigQuestion.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this CpeDeviceConfigQuestion.
+        A string that identifies the question.
+
+
+        :param key: The key of this CpeDeviceConfigQuestion.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CpeDeviceConfigQuestion.
+        A descriptive label for the question (for example, to display in a form in a graphical interface).
+
+
+        :return: The display_name of this CpeDeviceConfigQuestion.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CpeDeviceConfigQuestion.
+        A descriptive label for the question (for example, to display in a form in a graphical interface).
+
+
+        :param display_name: The display_name of this CpeDeviceConfigQuestion.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def explanation(self):
+        """
+        Gets the explanation of this CpeDeviceConfigQuestion.
+        A description or explanation of the question, to help the customer answer accurately.
+
+
+        :return: The explanation of this CpeDeviceConfigQuestion.
+        :rtype: str
+        """
+        return self._explanation
+
+    @explanation.setter
+    def explanation(self, explanation):
+        """
+        Sets the explanation of this CpeDeviceConfigQuestion.
+        A description or explanation of the question, to help the customer answer accurately.
+
+
+        :param explanation: The explanation of this CpeDeviceConfigQuestion.
+        :type: str
+        """
+        self._explanation = explanation
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/cpe_device_info.py
+++ b/src/oci/core/models/cpe_device_info.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CpeDeviceInfo(object):
+    """
+    Basic information about a particular CPE device type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CpeDeviceInfo object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param vendor:
+            The value to assign to the vendor property of this CpeDeviceInfo.
+        :type vendor: str
+
+        :param platform_software_version:
+            The value to assign to the platform_software_version property of this CpeDeviceInfo.
+        :type platform_software_version: str
+
+        """
+        self.swagger_types = {
+            'vendor': 'str',
+            'platform_software_version': 'str'
+        }
+
+        self.attribute_map = {
+            'vendor': 'vendor',
+            'platform_software_version': 'platformSoftwareVersion'
+        }
+
+        self._vendor = None
+        self._platform_software_version = None
+
+    @property
+    def vendor(self):
+        """
+        Gets the vendor of this CpeDeviceInfo.
+        The vendor that makes the CPE device.
+
+
+        :return: The vendor of this CpeDeviceInfo.
+        :rtype: str
+        """
+        return self._vendor
+
+    @vendor.setter
+    def vendor(self, vendor):
+        """
+        Sets the vendor of this CpeDeviceInfo.
+        The vendor that makes the CPE device.
+
+
+        :param vendor: The vendor of this CpeDeviceInfo.
+        :type: str
+        """
+        self._vendor = vendor
+
+    @property
+    def platform_software_version(self):
+        """
+        Gets the platform_software_version of this CpeDeviceInfo.
+        The platform or software version of the CPE device.
+
+
+        :return: The platform_software_version of this CpeDeviceInfo.
+        :rtype: str
+        """
+        return self._platform_software_version
+
+    @platform_software_version.setter
+    def platform_software_version(self, platform_software_version):
+        """
+        Sets the platform_software_version of this CpeDeviceInfo.
+        The platform or software version of the CPE device.
+
+
+        :param platform_software_version: The platform_software_version of this CpeDeviceInfo.
+        :type: str
+        """
+        self._platform_software_version = platform_software_version
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/cpe_device_shape_detail.py
+++ b/src/oci/core/models/cpe_device_shape_detail.py
@@ -1,0 +1,189 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CpeDeviceShapeDetail(object):
+    """
+    The detailed information about a particular CPE device type. Compare with
+    :class:`CpeDeviceShapeSummary`.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CpeDeviceShapeDetail object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param cpe_device_shape_id:
+            The value to assign to the cpe_device_shape_id property of this CpeDeviceShapeDetail.
+        :type cpe_device_shape_id: str
+
+        :param cpe_device_info:
+            The value to assign to the cpe_device_info property of this CpeDeviceShapeDetail.
+        :type cpe_device_info: CpeDeviceInfo
+
+        :param parameters:
+            The value to assign to the parameters property of this CpeDeviceShapeDetail.
+        :type parameters: list[CpeDeviceConfigQuestion]
+
+        :param template:
+            The value to assign to the template property of this CpeDeviceShapeDetail.
+        :type template: str
+
+        """
+        self.swagger_types = {
+            'cpe_device_shape_id': 'str',
+            'cpe_device_info': 'CpeDeviceInfo',
+            'parameters': 'list[CpeDeviceConfigQuestion]',
+            'template': 'str'
+        }
+
+        self.attribute_map = {
+            'cpe_device_shape_id': 'cpeDeviceShapeId',
+            'cpe_device_info': 'cpeDeviceInfo',
+            'parameters': 'parameters',
+            'template': 'template'
+        }
+
+        self._cpe_device_shape_id = None
+        self._cpe_device_info = None
+        self._parameters = None
+        self._template = None
+
+    @property
+    def cpe_device_shape_id(self):
+        """
+        Gets the cpe_device_shape_id of this CpeDeviceShapeDetail.
+        The `OCID`__ of the CPE device shape.
+        This value uniquely identifies the type of CPE device.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The cpe_device_shape_id of this CpeDeviceShapeDetail.
+        :rtype: str
+        """
+        return self._cpe_device_shape_id
+
+    @cpe_device_shape_id.setter
+    def cpe_device_shape_id(self, cpe_device_shape_id):
+        """
+        Sets the cpe_device_shape_id of this CpeDeviceShapeDetail.
+        The `OCID`__ of the CPE device shape.
+        This value uniquely identifies the type of CPE device.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param cpe_device_shape_id: The cpe_device_shape_id of this CpeDeviceShapeDetail.
+        :type: str
+        """
+        self._cpe_device_shape_id = cpe_device_shape_id
+
+    @property
+    def cpe_device_info(self):
+        """
+        Gets the cpe_device_info of this CpeDeviceShapeDetail.
+        Basic information about this particular CPE device type.
+
+
+        :return: The cpe_device_info of this CpeDeviceShapeDetail.
+        :rtype: CpeDeviceInfo
+        """
+        return self._cpe_device_info
+
+    @cpe_device_info.setter
+    def cpe_device_info(self, cpe_device_info):
+        """
+        Sets the cpe_device_info of this CpeDeviceShapeDetail.
+        Basic information about this particular CPE device type.
+
+
+        :param cpe_device_info: The cpe_device_info of this CpeDeviceShapeDetail.
+        :type: CpeDeviceInfo
+        """
+        self._cpe_device_info = cpe_device_info
+
+    @property
+    def parameters(self):
+        """
+        Gets the parameters of this CpeDeviceShapeDetail.
+        For certain CPE devices types, the customer can provide answers to
+        questions that are specific to the device type. This attribute contains
+        a list of those questions. The Networking service merges the answers with
+        other information and renders a set of CPE configuration content. To
+        provide the answers, use
+        :func:`update_tunnel_cpe_device_config`.
+
+
+        :return: The parameters of this CpeDeviceShapeDetail.
+        :rtype: list[CpeDeviceConfigQuestion]
+        """
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        """
+        Sets the parameters of this CpeDeviceShapeDetail.
+        For certain CPE devices types, the customer can provide answers to
+        questions that are specific to the device type. This attribute contains
+        a list of those questions. The Networking service merges the answers with
+        other information and renders a set of CPE configuration content. To
+        provide the answers, use
+        :func:`update_tunnel_cpe_device_config`.
+
+
+        :param parameters: The parameters of this CpeDeviceShapeDetail.
+        :type: list[CpeDeviceConfigQuestion]
+        """
+        self._parameters = parameters
+
+    @property
+    def template(self):
+        """
+        Gets the template of this CpeDeviceShapeDetail.
+        A template of CPE device configuration information that will be merged with the customer's
+        answers to the questions to render the final CPE device configuration content. Also see:
+
+          * :func:`get_cpe_device_config_content`
+          * :func:`get_ipsec_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config_content`
+
+
+        :return: The template of this CpeDeviceShapeDetail.
+        :rtype: str
+        """
+        return self._template
+
+    @template.setter
+    def template(self, template):
+        """
+        Sets the template of this CpeDeviceShapeDetail.
+        A template of CPE device configuration information that will be merged with the customer's
+        answers to the questions to render the final CPE device configuration content. Also see:
+
+          * :func:`get_cpe_device_config_content`
+          * :func:`get_ipsec_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config_content`
+
+
+        :param template: The template of this CpeDeviceShapeDetail.
+        :type: str
+        """
+        self._template = template
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/cpe_device_shape_summary.py
+++ b/src/oci/core/models/cpe_device_shape_summary.py
@@ -1,0 +1,107 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CpeDeviceShapeSummary(object):
+    """
+    A summary of information about a particular CPE device type. Compare with
+    :class:`CpeDeviceShapeDetail`.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CpeDeviceShapeSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this CpeDeviceShapeSummary.
+        :type id: str
+
+        :param cpe_device_info:
+            The value to assign to the cpe_device_info property of this CpeDeviceShapeSummary.
+        :type cpe_device_info: CpeDeviceInfo
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'cpe_device_info': 'CpeDeviceInfo'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'cpe_device_info': 'cpeDeviceInfo'
+        }
+
+        self._id = None
+        self._cpe_device_info = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this CpeDeviceShapeSummary.
+        The `OCID`__ of the CPE device shape.
+        This value uniquely identifies the type of CPE device.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this CpeDeviceShapeSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this CpeDeviceShapeSummary.
+        The `OCID`__ of the CPE device shape.
+        This value uniquely identifies the type of CPE device.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this CpeDeviceShapeSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def cpe_device_info(self):
+        """
+        Gets the cpe_device_info of this CpeDeviceShapeSummary.
+        Basic information about this particular CPE device type.
+
+
+        :return: The cpe_device_info of this CpeDeviceShapeSummary.
+        :rtype: CpeDeviceInfo
+        """
+        return self._cpe_device_info
+
+    @cpe_device_info.setter
+    def cpe_device_info(self, cpe_device_info):
+        """
+        Sets the cpe_device_info of this CpeDeviceShapeSummary.
+        Basic information about this particular CPE device type.
+
+
+        :param cpe_device_info: The cpe_device_info of this CpeDeviceShapeSummary.
+        :type: CpeDeviceInfo
+        """
+        self._cpe_device_info = cpe_device_info
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/create_cpe_details.py
+++ b/src/oci/core/models/create_cpe_details.py
@@ -37,13 +37,18 @@ class CreateCpeDetails(object):
             The value to assign to the ip_address property of this CreateCpeDetails.
         :type ip_address: str
 
+        :param cpe_device_shape_id:
+            The value to assign to the cpe_device_shape_id property of this CreateCpeDetails.
+        :type cpe_device_shape_id: str
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
             'defined_tags': 'dict(str, dict(str, object))',
             'display_name': 'str',
             'freeform_tags': 'dict(str, str)',
-            'ip_address': 'str'
+            'ip_address': 'str',
+            'cpe_device_shape_id': 'str'
         }
 
         self.attribute_map = {
@@ -51,7 +56,8 @@ class CreateCpeDetails(object):
             'defined_tags': 'definedTags',
             'display_name': 'displayName',
             'freeform_tags': 'freeformTags',
-            'ip_address': 'ipAddress'
+            'ip_address': 'ipAddress',
+            'cpe_device_shape_id': 'cpeDeviceShapeId'
         }
 
         self._compartment_id = None
@@ -59,6 +65,7 @@ class CreateCpeDetails(object):
         self._display_name = None
         self._freeform_tags = None
         self._ip_address = None
+        self._cpe_device_shape_id = None
 
     @property
     def compartment_id(self):
@@ -203,6 +210,56 @@ class CreateCpeDetails(object):
         :type: str
         """
         self._ip_address = ip_address
+
+    @property
+    def cpe_device_shape_id(self):
+        """
+        Gets the cpe_device_shape_id of this CreateCpeDetails.
+        The `OCID`__ of the CPE device type. You can provide
+        a value if you want to later generate CPE device configuration content for IPSec connections
+        that use this CPE. You can also call :func:`update_cpe` later to
+        provide a value. For a list of possible values, see
+        :func:`list_cpe_device_shapes`.
+
+        For more information about generating CPE device configuration content, see:
+
+          * :func:`get_cpe_device_config_content`
+          * :func:`get_ipsec_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The cpe_device_shape_id of this CreateCpeDetails.
+        :rtype: str
+        """
+        return self._cpe_device_shape_id
+
+    @cpe_device_shape_id.setter
+    def cpe_device_shape_id(self, cpe_device_shape_id):
+        """
+        Sets the cpe_device_shape_id of this CreateCpeDetails.
+        The `OCID`__ of the CPE device type. You can provide
+        a value if you want to later generate CPE device configuration content for IPSec connections
+        that use this CPE. You can also call :func:`update_cpe` later to
+        provide a value. For a list of possible values, see
+        :func:`list_cpe_device_shapes`.
+
+        For more information about generating CPE device configuration content, see:
+
+          * :func:`get_cpe_device_config_content`
+          * :func:`get_ipsec_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param cpe_device_shape_id: The cpe_device_shape_id of this CreateCpeDetails.
+        :type: str
+        """
+        self._cpe_device_shape_id = cpe_device_shape_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/create_ip_sec_connection_details.py
+++ b/src/oci/core/models/create_ip_sec_connection_details.py
@@ -368,11 +368,13 @@ class CreateIPSecConnectionDetails(object):
         For more information, see the important note in :class:`IPSecConnection`.
 
         The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
-        in the Government Cloud.
+        in certain regions. See `IPv6 Addresses`__.
 
         Example: `10.0.1.0/24`
 
         Example: `2001:db8::/32`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The static_routes of this CreateIPSecConnectionDetails.
@@ -394,11 +396,13 @@ class CreateIPSecConnectionDetails(object):
         For more information, see the important note in :class:`IPSecConnection`.
 
         The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
-        in the Government Cloud.
+        in certain regions. See `IPv6 Addresses`__.
 
         Example: `10.0.1.0/24`
 
         Example: `2001:db8::/32`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param static_routes: The static_routes of this CreateIPSecConnectionDetails.

--- a/src/oci/core/models/create_virtual_circuit_public_prefix_details.py
+++ b/src/oci/core/models/create_virtual_circuit_public_prefix_details.py
@@ -37,7 +37,7 @@ class CreateVirtualCircuitPublicPrefixDetails(object):
         """
         **[Required]** Gets the cidr_block of this CreateVirtualCircuitPublicPrefixDetails.
         An individual public IP prefix (CIDR) to add to the public virtual circuit.
-        Must be /31 or less specific.
+        All prefix sizes are allowed.
 
 
         :return: The cidr_block of this CreateVirtualCircuitPublicPrefixDetails.
@@ -50,7 +50,7 @@ class CreateVirtualCircuitPublicPrefixDetails(object):
         """
         Sets the cidr_block of this CreateVirtualCircuitPublicPrefixDetails.
         An individual public IP prefix (CIDR) to add to the public virtual circuit.
-        Must be /31 or less specific.
+        All prefix sizes are allowed.
 
 
         :param cidr_block: The cidr_block of this CreateVirtualCircuitPublicPrefixDetails.

--- a/src/oci/core/models/create_vnic_details.py
+++ b/src/oci/core/models/create_vnic_details.py
@@ -357,12 +357,12 @@ class CreateVnicDetails(object):
     def private_ip(self):
         """
         Gets the private_ip of this CreateVnicDetails.
-        A private IP address of your choice to assign to the VNIC. Must be an
-        available IP address within the subnet's CIDR. If you don't specify a
-        value, Oracle automatically assigns a private IP address from the subnet.
-        This is the VNIC's *primary* private IP address. The value appears in
-        the :class:`Vnic` object and also the
-        :class:`PrivateIp` object returned by
+        A private IP address of your choice to assign to the VNIC. Value is ignored
+        if a `vlanId` value is specified. Must be an available IP address within
+        the subnet's CIDR. If you don't specify a value, Oracle automatically assigns
+        a private IP address from the subnet. This is the VNIC's *primary* private IP
+        address. The value appears in the :class:`Vnic` object and
+        also the :class:`PrivateIp` object returned by
         :func:`list_private_ips` and
         :func:`get_private_ip`.
 
@@ -378,12 +378,12 @@ class CreateVnicDetails(object):
     def private_ip(self, private_ip):
         """
         Sets the private_ip of this CreateVnicDetails.
-        A private IP address of your choice to assign to the VNIC. Must be an
-        available IP address within the subnet's CIDR. If you don't specify a
-        value, Oracle automatically assigns a private IP address from the subnet.
-        This is the VNIC's *primary* private IP address. The value appears in
-        the :class:`Vnic` object and also the
-        :class:`PrivateIp` object returned by
+        A private IP address of your choice to assign to the VNIC. Value is ignored
+        if a `vlanId` value is specified. Must be an available IP address within
+        the subnet's CIDR. If you don't specify a value, Oracle automatically assigns
+        a private IP address from the subnet. This is the VNIC's *primary* private IP
+        address. The value appears in the :class:`Vnic` object and
+        also the :class:`PrivateIp` object returned by
         :func:`list_private_ips` and
         :func:`get_private_ip`.
 
@@ -440,7 +440,10 @@ class CreateVnicDetails(object):
         The OCID of the subnet to create the VNIC in. When launching an instance,
         use this `subnetId` instead of the deprecated `subnetId` in
         :func:`launch_instance_details`.
-        At least one of them is required; if you provide both, the values must match.
+        Alternatively, the `vlanId` can be used instead of a `subnetId`.
+        At least one `subnetId` value is required if this field is populated; if
+        you provide both, the values must match. If both the `vlanId` and `subnetId`
+        fields are provided, the launch will fail.
 
 
         :return: The subnet_id of this CreateVnicDetails.
@@ -455,7 +458,10 @@ class CreateVnicDetails(object):
         The OCID of the subnet to create the VNIC in. When launching an instance,
         use this `subnetId` instead of the deprecated `subnetId` in
         :func:`launch_instance_details`.
-        At least one of them is required; if you provide both, the values must match.
+        Alternatively, the `vlanId` can be used instead of a `subnetId`.
+        At least one `subnetId` value is required if this field is populated; if
+        you provide both, the values must match. If both the `vlanId` and `subnetId`
+        fields are provided, the launch will fail.
 
 
         :param subnet_id: The subnet_id of this CreateVnicDetails.

--- a/src/oci/core/models/cross_connect_mapping.py
+++ b/src/oci/core/models/cross_connect_mapping.py
@@ -250,9 +250,12 @@ class CrossConnectMapping(object):
 
         There's one exception: for a public virtual circuit, Oracle specifies the BGP IPv6 addresses.
 
-        Note that IPv6 addressing is currently supported only in the Government Cloud.
+        Note that IPv6 addressing is currently supported only in certain regions. See
+        `IPv6 Addresses`__.
 
         Example: `2001:db8::1/64`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The customer_bgp_peering_ipv6 of this CrossConnectMapping.
@@ -272,9 +275,12 @@ class CrossConnectMapping(object):
 
         There's one exception: for a public virtual circuit, Oracle specifies the BGP IPv6 addresses.
 
-        Note that IPv6 addressing is currently supported only in the Government Cloud.
+        Note that IPv6 addressing is currently supported only in certain regions. See
+        `IPv6 Addresses`__.
 
         Example: `2001:db8::1/64`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param customer_bgp_peering_ipv6: The customer_bgp_peering_ipv6 of this CrossConnectMapping.
@@ -293,9 +299,12 @@ class CrossConnectMapping(object):
 
         There's one exception: for a public virtual circuit, Oracle specifies the BGP IPv6 addresses.
 
-        Note that IPv6 addressing is currently supported only in the Government Cloud.
+        Note that IPv6 addressing is currently supported only in certain regions. See
+        `IPv6 Addresses`__.
 
         Example: `2001:db8::2/64`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The oracle_bgp_peering_ipv6 of this CrossConnectMapping.
@@ -314,9 +323,12 @@ class CrossConnectMapping(object):
 
         There's one exception: for a public virtual circuit, Oracle specifies the BGP IPv6 addresses.
 
-        Note that IPv6 addressing is currently supported only in the Government Cloud.
+        Note that IPv6 addressing is currently supported only in certain regions. See
+        `IPv6 Addresses`__.
 
         Example: `2001:db8::2/64`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param oracle_bgp_peering_ipv6: The oracle_bgp_peering_ipv6 of this CrossConnectMapping.

--- a/src/oci/core/models/drg_redundancy_status.py
+++ b/src/oci/core/models/drg_redundancy_status.py
@@ -9,7 +9,10 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DrgRedundancyStatus(object):
     """
-    Redundancy status of the DRG object identified by ID
+    The redundancy status of the DRG. For more information, see
+    `Redundancy Remedies`__.
+
+    __ https://docs.cloud.oracle.com/Content/Network/Troubleshoot/drgredundancy.htm
     """
 
     #: A constant which can be used with the status property of a DrgRedundancyStatus.
@@ -77,7 +80,7 @@ class DrgRedundancyStatus(object):
     def id(self):
         """
         Gets the id of this DrgRedundancyStatus.
-        The DRG's unique identifier.
+        The OCID of the DRG.
 
 
         :return: The id of this DrgRedundancyStatus.
@@ -89,7 +92,7 @@ class DrgRedundancyStatus(object):
     def id(self, id):
         """
         Sets the id of this DrgRedundancyStatus.
-        The DRG's unique identifier.
+        The OCID of the DRG.
 
 
         :param id: The id of this DrgRedundancyStatus.
@@ -101,7 +104,7 @@ class DrgRedundancyStatus(object):
     def status(self):
         """
         Gets the status of this DrgRedundancyStatus.
-        The redudancy status of the DRG specified.
+        The redundancy status of the DRG.
 
         Allowed values for this property are: "NOT_AVAILABLE", "REDUNDANT", "NOT_REDUNDANT_SINGLE_IPSEC", "NOT_REDUNDANT_SINGLE_VIRTUALCIRCUIT", "NOT_REDUNDANT_MULTIPLE_IPSECS", "NOT_REDUNDANT_MULTIPLE_VIRTUALCIRCUITS", "NOT_REDUNDANT_MIX_CONNECTIONS", "NOT_REDUNDANT_NO_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -116,7 +119,7 @@ class DrgRedundancyStatus(object):
     def status(self, status):
         """
         Sets the status of this DrgRedundancyStatus.
-        The redudancy status of the DRG specified.
+        The redundancy status of the DRG.
 
 
         :param status: The status of this DrgRedundancyStatus.

--- a/src/oci/core/models/egress_security_rule.py
+++ b/src/oci/core/models/egress_security_rule.py
@@ -101,11 +101,14 @@ class EgressSecurityRule(object):
         Allowed values:
 
           * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security list rule for traffic destined for a particular `Service` through
             a service gateway. For example: `oci-phx-objectstorage`.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The destination of this EgressSecurityRule.
@@ -123,11 +126,14 @@ class EgressSecurityRule(object):
         Allowed values:
 
           * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security list rule for traffic destined for a particular `Service` through
             a service gateway. For example: `oci-phx-objectstorage`.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param destination: The destination of this EgressSecurityRule.

--- a/src/oci/core/models/ingress_security_rule.py
+++ b/src/oci/core/models/ingress_security_rule.py
@@ -217,11 +217,14 @@ class IngressSecurityRule(object):
         Allowed values:
 
           * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security list rule for traffic coming from a particular `Service` through
             a service gateway. For example: `oci-phx-objectstorage`.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The source of this IngressSecurityRule.
@@ -239,11 +242,14 @@ class IngressSecurityRule(object):
         Allowed values:
 
           * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security list rule for traffic coming from a particular `Service` through
             a service gateway. For example: `oci-phx-objectstorage`.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param source: The source of this IngressSecurityRule.

--- a/src/oci/core/models/ip_sec_connection.py
+++ b/src/oci/core/models/ip_sec_connection.py
@@ -480,11 +480,13 @@ class IPSecConnection(object):
         tunnels to use BGP dynamic routing, you can provide an empty list for the static routes.
 
         The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
-        in the Government Cloud.
+        in certain regions. See `IPv6 Addresses`__.
 
         Example: `10.0.1.0/24`
 
         Example: `2001:db8::/32`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The static_routes of this IPSecConnection.
@@ -505,11 +507,13 @@ class IPSecConnection(object):
         tunnels to use BGP dynamic routing, you can provide an empty list for the static routes.
 
         The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
-        in the Government Cloud.
+        in certain regions. See `IPv6 Addresses`__.
 
         Example: `10.0.1.0/24`
 
         Example: `2001:db8::/32`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param static_routes: The static_routes of this IPSecConnection.

--- a/src/oci/core/models/ipv6.py
+++ b/src/oci/core/models/ipv6.py
@@ -15,9 +15,8 @@ class Ipv6(object):
     You can create and assign an IPv6 to any VNIC that is in an IPv6-enabled subnet in an
     IPv6-enabled VCN.
 
-    **Note:** IPv6 addressing is currently supported only in the Government Cloud.
-
-    For important details about IPv6 addressing in a VCN, see `IPv6 Addresses`__.
+    **Note:** IPv6 addressing is currently supported only in certain regions. For important
+    details about IPv6 addressing in a VCN, see `IPv6 Addresses`__.
 
     __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
     """

--- a/src/oci/core/models/route_rule.py
+++ b/src/oci/core/models/route_rule.py
@@ -122,12 +122,14 @@ class RouteRule(object):
 
           * IP address range in CIDR notation. Can be an IPv4 or IPv6 CIDR. For example: `192.168.1.0/24`
           or `2001:0db8:0123:45::/56`. If you set this to an IPv6 CIDR, the route rule's target
-          can only be a DRG or internet gateway. Note that IPv6 addressing is currently supported only
-          in the Government Cloud.
+          can only be a DRG or internet gateway. Note that IPv6 addressing is currently supported
+          only in certain regions. See `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a route rule for traffic destined for a particular `Service` through
             a service gateway. For example: `oci-phx-objectstorage`.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The destination of this RouteRule.
@@ -146,12 +148,14 @@ class RouteRule(object):
 
           * IP address range in CIDR notation. Can be an IPv4 or IPv6 CIDR. For example: `192.168.1.0/24`
           or `2001:0db8:0123:45::/56`. If you set this to an IPv6 CIDR, the route rule's target
-          can only be a DRG or internet gateway. Note that IPv6 addressing is currently supported only
-          in the Government Cloud.
+          can only be a DRG or internet gateway. Note that IPv6 addressing is currently supported
+          only in certain regions. See `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a route rule for traffic destined for a particular `Service` through
             a service gateway. For example: `oci-phx-objectstorage`.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param destination: The destination of this RouteRule.

--- a/src/oci/core/models/security_rule.py
+++ b/src/oci/core/models/security_rule.py
@@ -197,7 +197,8 @@ class SecurityRule(object):
         Allowed values:
 
           * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security rule for traffic destined for a particular `Service` through
@@ -206,6 +207,8 @@ class SecurityRule(object):
           * The OCID of a :class:`NetworkSecurityGroup` in the same
             VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
             traffic between VNICs in the same NSG.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The destination of this SecurityRule.
@@ -223,7 +226,8 @@ class SecurityRule(object):
         Allowed values:
 
           * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security rule for traffic destined for a particular `Service` through
@@ -232,6 +236,8 @@ class SecurityRule(object):
           * The OCID of a :class:`NetworkSecurityGroup` in the same
             VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
             traffic between VNICs in the same NSG.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param destination: The destination of this SecurityRule.
@@ -503,7 +509,8 @@ class SecurityRule(object):
         Allowed values:
 
           * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security rule for traffic coming from a particular `Service` through
@@ -512,6 +519,8 @@ class SecurityRule(object):
           * The OCID of a :class:`NetworkSecurityGroup` in the same
             VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
             traffic between VNICs in the same NSG.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The source of this SecurityRule.
@@ -529,7 +538,8 @@ class SecurityRule(object):
         Allowed values:
 
           * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security rule for traffic coming from a particular `Service` through
@@ -538,6 +548,8 @@ class SecurityRule(object):
           * The OCID of a :class:`NetworkSecurityGroup` in the same
             VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
             traffic between VNICs in the same NSG.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param source: The source of this SecurityRule.

--- a/src/oci/core/models/subnet.py
+++ b/src/oci/core/models/subnet.py
@@ -9,7 +9,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Subnet(object):
     """
-    A logical subdivision of a VCN. Each subnet exists in a single availability domain and
+    A logical subdivision of a VCN. Each subnet
     consists of a contiguous range of IP addresses that do not overlap with
     other subnets in the VCN. Example: 172.16.1.0/24. For more information, see
     `Overview of the Networking Service`__ and
@@ -487,9 +487,11 @@ class Subnet(object):
         Gets the ipv6_cidr_block of this Subnet.
         For an IPv6-enabled subnet, this is the IPv6 CIDR block for the subnet's private IP address
         space. The subnet size is always /64. Note that IPv6 addressing is currently supported only
-        in the Government Cloud.
+        in certain regions. See `IPv6 Addresses`__.
 
         Example: `2001:0db8:0123:1111::/64`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The ipv6_cidr_block of this Subnet.
@@ -503,9 +505,11 @@ class Subnet(object):
         Sets the ipv6_cidr_block of this Subnet.
         For an IPv6-enabled subnet, this is the IPv6 CIDR block for the subnet's private IP address
         space. The subnet size is always /64. Note that IPv6 addressing is currently supported only
-        in the Government Cloud.
+        in certain regions. See `IPv6 Addresses`__.
 
         Example: `2001:0db8:0123:1111::/64`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param ipv6_cidr_block: The ipv6_cidr_block of this Subnet.

--- a/src/oci/core/models/tunnel_cpe_device_config.py
+++ b/src/oci/core/models/tunnel_cpe_device_config.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TunnelCpeDeviceConfig(object):
+    """
+    The set of CPE configuration answers for the tunnel, which the customer provides in
+    :func:`update_tunnel_cpe_device_config`.
+    The answers correlate to the questions that are specific to the CPE device type (see the
+    `parameters` attribute of :class:`CpeDeviceShapeDetail`).
+
+    See these related operations:
+
+    * :func:`get_tunnel_cpe_device_config`
+    * :func:`get_tunnel_cpe_device_config_content`
+    * :func:`get_ipsec_cpe_device_config_content`
+    * :func:`get_cpe_device_config_content`
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TunnelCpeDeviceConfig object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param tunnel_cpe_device_config_parameter:
+            The value to assign to the tunnel_cpe_device_config_parameter property of this TunnelCpeDeviceConfig.
+        :type tunnel_cpe_device_config_parameter: list[CpeDeviceConfigAnswer]
+
+        """
+        self.swagger_types = {
+            'tunnel_cpe_device_config_parameter': 'list[CpeDeviceConfigAnswer]'
+        }
+
+        self.attribute_map = {
+            'tunnel_cpe_device_config_parameter': 'tunnelCpeDeviceConfigParameter'
+        }
+
+        self._tunnel_cpe_device_config_parameter = None
+
+    @property
+    def tunnel_cpe_device_config_parameter(self):
+        """
+        Gets the tunnel_cpe_device_config_parameter of this TunnelCpeDeviceConfig.
+
+        :return: The tunnel_cpe_device_config_parameter of this TunnelCpeDeviceConfig.
+        :rtype: list[CpeDeviceConfigAnswer]
+        """
+        return self._tunnel_cpe_device_config_parameter
+
+    @tunnel_cpe_device_config_parameter.setter
+    def tunnel_cpe_device_config_parameter(self, tunnel_cpe_device_config_parameter):
+        """
+        Sets the tunnel_cpe_device_config_parameter of this TunnelCpeDeviceConfig.
+
+        :param tunnel_cpe_device_config_parameter: The tunnel_cpe_device_config_parameter of this TunnelCpeDeviceConfig.
+        :type: list[CpeDeviceConfigAnswer]
+        """
+        self._tunnel_cpe_device_config_parameter = tunnel_cpe_device_config_parameter
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/update_cpe_details.py
+++ b/src/oci/core/models/update_cpe_details.py
@@ -29,22 +29,29 @@ class UpdateCpeDetails(object):
             The value to assign to the freeform_tags property of this UpdateCpeDetails.
         :type freeform_tags: dict(str, str)
 
+        :param cpe_device_shape_id:
+            The value to assign to the cpe_device_shape_id property of this UpdateCpeDetails.
+        :type cpe_device_shape_id: str
+
         """
         self.swagger_types = {
             'defined_tags': 'dict(str, dict(str, object))',
             'display_name': 'str',
-            'freeform_tags': 'dict(str, str)'
+            'freeform_tags': 'dict(str, str)',
+            'cpe_device_shape_id': 'str'
         }
 
         self.attribute_map = {
             'defined_tags': 'definedTags',
             'display_name': 'displayName',
-            'freeform_tags': 'freeformTags'
+            'freeform_tags': 'freeformTags',
+            'cpe_device_shape_id': 'cpeDeviceShapeId'
         }
 
         self._defined_tags = None
         self._display_name = None
         self._freeform_tags = None
+        self._cpe_device_shape_id = None
 
     @property
     def defined_tags(self):
@@ -139,6 +146,54 @@ class UpdateCpeDetails(object):
         :type: dict(str, str)
         """
         self._freeform_tags = freeform_tags
+
+    @property
+    def cpe_device_shape_id(self):
+        """
+        Gets the cpe_device_shape_id of this UpdateCpeDetails.
+        The `OCID`__ of the CPE device type. You can provide
+        a value if you want to generate CPE device configuration content for IPSec connections
+        that use this CPE. For a list of possible values, see
+        :func:`list_cpe_device_shapes`.
+
+        For more information about generating CPE device configuration content, see:
+
+          * :func:`get_cpe_device_config_content`
+          * :func:`get_ipsec_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The cpe_device_shape_id of this UpdateCpeDetails.
+        :rtype: str
+        """
+        return self._cpe_device_shape_id
+
+    @cpe_device_shape_id.setter
+    def cpe_device_shape_id(self, cpe_device_shape_id):
+        """
+        Sets the cpe_device_shape_id of this UpdateCpeDetails.
+        The `OCID`__ of the CPE device type. You can provide
+        a value if you want to generate CPE device configuration content for IPSec connections
+        that use this CPE. For a list of possible values, see
+        :func:`list_cpe_device_shapes`.
+
+        For more information about generating CPE device configuration content, see:
+
+          * :func:`get_cpe_device_config_content`
+          * :func:`get_ipsec_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param cpe_device_shape_id: The cpe_device_shape_id of this UpdateCpeDetails.
+        :type: str
+        """
+        self._cpe_device_shape_id = cpe_device_shape_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/update_instance_details.py
+++ b/src/oci/core/models/update_instance_details.py
@@ -281,10 +281,23 @@ class UpdateInstanceDetails(object):
         """
         Gets the shape of this UpdateInstanceDetails.
         The shape of the instance. The shape determines the number of CPUs and the amount of memory
-        allocated to the instance. You can enumerate all available shapes by calling
+        allocated to the instance. For more information about how to change shapes, and a list of
+        shapes that are supported, see
+        `Changing the Shape of an Instance`__.
+
+        For details about the CPUs, memory, and other properties of each shape, see
+        `Compute Shapes`__.
+
+        The new shape must be compatible with the image that was used to launch the instance. You
+        can enumerate all available shapes and determine image compatibility by calling
         :func:`list_shapes`.
 
-        Example: `VM.Standard1.1`
+        If the instance is running when you change the shape, the instance is rebooted.
+
+        Example: `VM.Standard2.1`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/Compute/References/computeshapes.htm
 
 
         :return: The shape of this UpdateInstanceDetails.
@@ -297,10 +310,23 @@ class UpdateInstanceDetails(object):
         """
         Sets the shape of this UpdateInstanceDetails.
         The shape of the instance. The shape determines the number of CPUs and the amount of memory
-        allocated to the instance. You can enumerate all available shapes by calling
+        allocated to the instance. For more information about how to change shapes, and a list of
+        shapes that are supported, see
+        `Changing the Shape of an Instance`__.
+
+        For details about the CPUs, memory, and other properties of each shape, see
+        `Compute Shapes`__.
+
+        The new shape must be compatible with the image that was used to launch the instance. You
+        can enumerate all available shapes and determine image compatibility by calling
         :func:`list_shapes`.
 
-        Example: `VM.Standard1.1`
+        If the instance is running when you change the shape, the instance is rebooted.
+
+        Example: `VM.Standard2.1`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/Compute/References/computeshapes.htm
 
 
         :param shape: The shape of this UpdateInstanceDetails.

--- a/src/oci/core/models/update_ip_sec_connection_details.py
+++ b/src/oci/core/models/update_ip_sec_connection_details.py
@@ -257,11 +257,13 @@ class UpdateIPSecConnectionDetails(object):
         Static routes to the CPE. If you provide this attribute, it replaces the entire current set of
         static routes. A static route's CIDR must not be a multicast address or class E address.
         The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
-        in the Government Cloud.
+        in certain regions. See `IPv6 Addresses`__.
 
         Example: `10.0.1.0/24`
 
         Example: `2001:db8::/32`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The static_routes of this UpdateIPSecConnectionDetails.
@@ -276,11 +278,13 @@ class UpdateIPSecConnectionDetails(object):
         Static routes to the CPE. If you provide this attribute, it replaces the entire current set of
         static routes. A static route's CIDR must not be a multicast address or class E address.
         The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
-        in the Government Cloud.
+        in certain regions. See `IPv6 Addresses`__.
 
         Example: `10.0.1.0/24`
 
         Example: `2001:db8::/32`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param static_routes: The static_routes of this UpdateIPSecConnectionDetails.

--- a/src/oci/core/models/update_security_rule_details.py
+++ b/src/oci/core/models/update_security_rule_details.py
@@ -178,7 +178,8 @@ class UpdateSecurityRuleDetails(object):
         Allowed values:
 
           * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security rule for traffic destined for a particular `Service` through
@@ -187,6 +188,8 @@ class UpdateSecurityRuleDetails(object):
           * The OCID of a :class:`NetworkSecurityGroup` in the same
             VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
             traffic between VNICs in the same NSG.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The destination of this UpdateSecurityRuleDetails.
@@ -204,7 +207,8 @@ class UpdateSecurityRuleDetails(object):
         Allowed values:
 
           * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security rule for traffic destined for a particular `Service` through
@@ -213,6 +217,8 @@ class UpdateSecurityRuleDetails(object):
           * The OCID of a :class:`NetworkSecurityGroup` in the same
             VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
             traffic between VNICs in the same NSG.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param destination: The destination of this UpdateSecurityRuleDetails.
@@ -460,7 +466,8 @@ class UpdateSecurityRuleDetails(object):
         Allowed values:
 
           * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security rule for traffic coming from a particular `Service` through
@@ -469,6 +476,8 @@ class UpdateSecurityRuleDetails(object):
           * The OCID of a :class:`NetworkSecurityGroup` in the same
             VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
             traffic between VNICs in the same NSG.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The source of this UpdateSecurityRuleDetails.
@@ -486,7 +495,8 @@ class UpdateSecurityRuleDetails(object):
         Allowed values:
 
           * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-            Note that IPv6 addressing is currently supported only in the Government Cloud.
+            Note that IPv6 addressing is currently supported only in certain regions. See
+            `IPv6 Addresses`__.
 
           * The `cidrBlock` value for a :class:`Service`, if you're
             setting up a security rule for traffic coming from a particular `Service` through
@@ -495,6 +505,8 @@ class UpdateSecurityRuleDetails(object):
           * The OCID of a :class:`NetworkSecurityGroup` in the same
             VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
             traffic between VNICs in the same NSG.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param source: The source of this UpdateSecurityRuleDetails.

--- a/src/oci/core/models/update_tunnel_cpe_device_config_details.py
+++ b/src/oci/core/models/update_tunnel_cpe_device_config_details.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateTunnelCpeDeviceConfigDetails(object):
+    """
+    UpdateTunnelCpeDeviceConfigDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateTunnelCpeDeviceConfigDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param tunnel_cpe_device_config:
+            The value to assign to the tunnel_cpe_device_config property of this UpdateTunnelCpeDeviceConfigDetails.
+        :type tunnel_cpe_device_config: list[CpeDeviceConfigAnswer]
+
+        """
+        self.swagger_types = {
+            'tunnel_cpe_device_config': 'list[CpeDeviceConfigAnswer]'
+        }
+
+        self.attribute_map = {
+            'tunnel_cpe_device_config': 'tunnelCpeDeviceConfig'
+        }
+
+        self._tunnel_cpe_device_config = None
+
+    @property
+    def tunnel_cpe_device_config(self):
+        """
+        Gets the tunnel_cpe_device_config of this UpdateTunnelCpeDeviceConfigDetails.
+        The set of configuration answers for a CPE device.
+
+
+        :return: The tunnel_cpe_device_config of this UpdateTunnelCpeDeviceConfigDetails.
+        :rtype: list[CpeDeviceConfigAnswer]
+        """
+        return self._tunnel_cpe_device_config
+
+    @tunnel_cpe_device_config.setter
+    def tunnel_cpe_device_config(self, tunnel_cpe_device_config):
+        """
+        Sets the tunnel_cpe_device_config of this UpdateTunnelCpeDeviceConfigDetails.
+        The set of configuration answers for a CPE device.
+
+
+        :param tunnel_cpe_device_config: The tunnel_cpe_device_config of this UpdateTunnelCpeDeviceConfigDetails.
+        :type: list[CpeDeviceConfigAnswer]
+        """
+        self._tunnel_cpe_device_config = tunnel_cpe_device_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/update_vnic_details.py
+++ b/src/oci/core/models/update_vnic_details.py
@@ -222,7 +222,8 @@ class UpdateVnicDetails(object):
         """
         Gets the nsg_ids of this UpdateVnicDetails.
         A list of the OCIDs of the network security groups (NSGs) to add the VNIC to. Setting this as
-        an empty array removes the VNIC from all network security groups.
+        an empty array removes the VNIC from all network security groups. If the VNIC contains an
+        vlanId, the value of this field will be ignored.
 
         For more information about NSGs, see
         :class:`NetworkSecurityGroup`.
@@ -238,7 +239,8 @@ class UpdateVnicDetails(object):
         """
         Sets the nsg_ids of this UpdateVnicDetails.
         A list of the OCIDs of the network security groups (NSGs) to add the VNIC to. Setting this as
-        an empty array removes the VNIC from all network security groups.
+        an empty array removes the VNIC from all network security groups. If the VNIC contains an
+        vlanId, the value of this field will be ignored.
 
         For more information about NSGs, see
         :class:`NetworkSecurityGroup`.
@@ -254,8 +256,10 @@ class UpdateVnicDetails(object):
         """
         Gets the skip_source_dest_check of this UpdateVnicDetails.
         Whether the source/destination check is disabled on the VNIC.
-        Defaults to `false`, which means the check is performed. For information
-        about why you would skip the source/destination check, see
+        Defaults to `false`, which means the check is performed. If the VNIC
+        contains an vlanId, the value of this field will be ignored.
+
+        For information about why you would skip the source/destination check, see
         `Using a Private IP as a Route Target`__.
 
         Example: `true`
@@ -273,8 +277,10 @@ class UpdateVnicDetails(object):
         """
         Sets the skip_source_dest_check of this UpdateVnicDetails.
         Whether the source/destination check is disabled on the VNIC.
-        Defaults to `false`, which means the check is performed. For information
-        about why you would skip the source/destination check, see
+        Defaults to `false`, which means the check is performed. If the VNIC
+        contains an vlanId, the value of this field will be ignored.
+
+        For information about why you would skip the source/destination check, see
         `Using a Private IP as a Route Target`__.
 
         Example: `true`

--- a/src/oci/core/models/vcn.py
+++ b/src/oci/core/models/vcn.py
@@ -461,9 +461,12 @@ class Vcn(object):
         The VCN size is always /48. If you don't provide a value when creating the VCN, Oracle
         provides one and uses that *same* CIDR for the `ipv6PublicCidrBlock`. If you do provide a
         value, Oracle provides a *different* CIDR for the `ipv6PublicCidrBlock`. Note that IPv6
-        addressing is currently supported only in the Government Cloud.
+        addressing is currently supported only in certain regions. See
+        `IPv6 Addresses`__.
 
         Example: `2001:0db8:0123::/48`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :return: The ipv6_cidr_block of this Vcn.
@@ -479,9 +482,12 @@ class Vcn(object):
         The VCN size is always /48. If you don't provide a value when creating the VCN, Oracle
         provides one and uses that *same* CIDR for the `ipv6PublicCidrBlock`. If you do provide a
         value, Oracle provides a *different* CIDR for the `ipv6PublicCidrBlock`. Note that IPv6
-        addressing is currently supported only in the Government Cloud.
+        addressing is currently supported only in certain regions. See
+        `IPv6 Addresses`__.
 
         Example: `2001:0db8:0123::/48`
+
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
 
 
         :param ipv6_cidr_block: The ipv6_cidr_block of this Vcn.

--- a/src/oci/core/models/virtual_circuit.py
+++ b/src/oci/core/models/virtual_circuit.py
@@ -867,7 +867,7 @@ class VirtualCircuit(object):
         """
         Gets the public_prefixes of this VirtualCircuit.
         For a public virtual circuit. The public IP prefixes (CIDRs) the customer wants to
-        advertise across the connection. Each prefix must be /31 or less specific.
+        advertise across the connection. All prefix sizes are allowed.
 
 
         :return: The public_prefixes of this VirtualCircuit.
@@ -880,7 +880,7 @@ class VirtualCircuit(object):
         """
         Sets the public_prefixes of this VirtualCircuit.
         For a public virtual circuit. The public IP prefixes (CIDRs) the customer wants to
-        advertise across the connection. Each prefix must be /31 or less specific.
+        advertise across the connection. All prefix sizes are allowed.
 
 
         :param public_prefixes: The public_prefixes of this VirtualCircuit.

--- a/src/oci/core/models/vnic_attachment.py
+++ b/src/oci/core/models/vnic_attachment.py
@@ -324,7 +324,7 @@ class VnicAttachment(object):
     def subnet_id(self):
         """
         **[Required]** Gets the subnet_id of this VnicAttachment.
-        The OCID of the VNIC's subnet.
+        The OCID of the subnet to create the VNIC in.
 
 
         :return: The subnet_id of this VnicAttachment.
@@ -336,7 +336,7 @@ class VnicAttachment(object):
     def subnet_id(self, subnet_id):
         """
         Sets the subnet_id of this VnicAttachment.
-        The OCID of the VNIC's subnet.
+        The OCID of the subnet to create the VNIC in.
 
 
         :param subnet_id: The subnet_id of this VnicAttachment.

--- a/src/oci/core/virtual_network_client.py
+++ b/src/oci/core/virtual_network_client.py
@@ -5784,6 +5784,181 @@ class VirtualNetworkClient(object):
                 header_params=header_params,
                 response_type="Cpe")
 
+    def get_cpe_device_config_content(self, cpe_id, **kwargs):
+        """
+        GetCpeDeviceConfigContent
+        Renders a set of CPE configuration content that can help a network engineer configure the actual
+        CPE device (for example, a hardware router) represented by the specified :class:`Cpe`
+        object.
+
+        The rendered content is specific to the type of CPE device (for example, Cisco ASA). Therefore the
+        :class:`Cpe` must have the CPE's device type specified by the `cpeDeviceShapeId`
+        attribute. The content optionally includes answers that the customer provides (see
+        :func:`update_tunnel_cpe_device_config`),
+        merged with a template of other information specific to the CPE device type.
+
+        The operation returns configuration information for *all* of the
+        :class:`IPSecConnection` objects that use the specified CPE.
+        Here are similar operations:
+
+          * :func:`get_ipsec_cpe_device_config_content`
+          returns CPE configuration content for all tunnels in a single IPSec connection.
+          * :func:`get_tunnel_cpe_device_config_content`
+          returns CPE configuration content for a specific tunnel within an IPSec connection.
+
+
+        :param str cpe_id: (required)
+            The OCID of the CPE.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type stream
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cpes/{cpeId}/cpeConfigContent"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_cpe_device_config_content got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cpeId": cpe_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "text/plain; charset&#x3D;utf-8",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
+
+    def get_cpe_device_shape(self, cpe_device_shape_id, **kwargs):
+        """
+        GetCpeDeviceShape
+        Gets the detailed information about the specified CPE device type. This might include a set of questions
+        that are specific to the particular CPE device type. The customer must supply answers to those questions
+        (see :func:`update_tunnel_cpe_device_config`).
+        The service merges the answers with a template of other information for the CPE device type. The following
+        operations return the merged content:
+
+          * :func:`get_cpe_device_config_content`
+          * :func:`get_ipsec_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config_content`
+
+
+        :param str cpe_device_shape_id: (required)
+            The `OCID`__ of the CPE device shape.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.CpeDeviceShapeDetail`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cpeDeviceShapes/{cpeDeviceShapeId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_cpe_device_shape got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cpeDeviceShapeId": cpe_device_shape_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="CpeDeviceShapeDetail")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="CpeDeviceShapeDetail")
+
     def get_cross_connect(self, cross_connect_id, **kwargs):
         """
         GetCrossConnect
@@ -6235,7 +6410,10 @@ class VirtualNetworkClient(object):
     def get_drg_redundancy_status(self, drg_id, **kwargs):
         """
         GetDrgRedundancyStatus
-        Get redundancy status of single DRG object on Oracle side.
+        Gets the redundancy status for the specified DRG. For more information, see
+        `Redundancy Remedies`__.
+
+        __ https://docs.cloud.oracle.com/Content/Network/Troubleshoot/drgredundancy.htm
 
 
         :param str drg_id: (required)
@@ -6849,6 +7027,98 @@ class VirtualNetworkClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 response_type="IPSecConnectionTunnelSharedSecret")
+
+    def get_ipsec_cpe_device_config_content(self, ipsc_id, **kwargs):
+        """
+        GetIpsecCpeDeviceConfigContent
+        Renders a set of CPE configuration content for the specified IPSec connection (for all the
+        tunnels in the connection). The content helps a network engineer configure the actual CPE
+        device (for example, a hardware router) that the specified IPSec connection terminates on.
+
+        The rendered content is specific to the type of CPE device (for example, Cisco ASA). Therefore the
+        :class:`Cpe` used by the specified :class:`IPSecConnection`
+        must have the CPE's device type specified by the `cpeDeviceShapeId` attribute. The content
+        optionally includes answers that the customer provides (see
+        :func:`update_tunnel_cpe_device_config`),
+        merged with a template of other information specific to the CPE device type.
+
+        The operation returns configuration information for all tunnels in the single specified
+        :class:`IPSecConnection` object. Here are other similar
+        operations:
+
+          * :func:`get_tunnel_cpe_device_config_content`
+          returns CPE configuration content for a specific tunnel within an IPSec connection.
+          * :func:`get_cpe_device_config_content`
+          returns CPE configuration content for *all* IPSec connections that use a specific CPE.
+
+
+        :param str ipsc_id: (required)
+            The OCID of the IPSec connection.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type stream
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/ipsecConnections/{ipscId}/cpeConfigContent"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_ipsec_cpe_device_config_content got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "ipscId": ipsc_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "text/plain; charset&#x3D;utf-8",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
 
     def get_ipv6(self, ipv6_id, **kwargs):
         """
@@ -7782,6 +8052,187 @@ class VirtualNetworkClient(object):
                 header_params=header_params,
                 response_type="Subnet")
 
+    def get_tunnel_cpe_device_config(self, ipsc_id, tunnel_id, **kwargs):
+        """
+        GetTunnelCpeDeviceConfig
+        Gets the set of CPE configuration answers for the tunnel, which the customer provided in
+        :func:`update_tunnel_cpe_device_config`.
+        To get the full set of content for the tunnel (any answers merged with the template of other
+        information specific to the CPE device type), use
+        :func:`get_tunnel_cpe_device_config_content`.
+
+
+        :param str ipsc_id: (required)
+            The OCID of the IPSec connection.
+
+        :param str tunnel_id: (required)
+            The `OCID`__ of the tunnel.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.TunnelCpeDeviceConfig`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/ipsecConnections/{ipscId}/tunnels/{tunnelId}/tunnelDeviceConfig"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_tunnel_cpe_device_config got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "ipscId": ipsc_id,
+            "tunnelId": tunnel_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TunnelCpeDeviceConfig")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="TunnelCpeDeviceConfig")
+
+    def get_tunnel_cpe_device_config_content(self, ipsc_id, tunnel_id, **kwargs):
+        """
+        GetTunnelCpeDeviceConfigContent
+        Renders a set of CPE configuration content for the specified IPSec tunnel. The content helps a
+        network engineer configure the actual CPE device (for example, a hardware router) that the specified
+        IPSec tunnel terminates on.
+
+        The rendered content is specific to the type of CPE device (for example, Cisco ASA). Therefore the
+        :class:`Cpe` used by the specified :class:`IPSecConnection`
+        must have the CPE's device type specified by the `cpeDeviceShapeId` attribute. The content
+        optionally includes answers that the customer provides (see
+        :func:`update_tunnel_cpe_device_config`),
+        merged with a template of other information specific to the CPE device type.
+
+        The operation returns configuration information for only the specified IPSec tunnel.
+        Here are other similar operations:
+
+          * :func:`get_ipsec_cpe_device_config_content`
+          returns CPE configuration content for all tunnels in a single IPSec connection.
+          * :func:`get_cpe_device_config_content`
+          returns CPE configuration content for *all* IPSec connections that use a specific CPE.
+
+
+        :param str ipsc_id: (required)
+            The OCID of the IPSec connection.
+
+        :param str tunnel_id: (required)
+            The `OCID`__ of the tunnel.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type stream
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/ipsecConnections/{ipscId}/tunnels/{tunnelId}/tunnelDeviceConfig/content"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_tunnel_cpe_device_config_content got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "ipscId": ipsc_id,
+            "tunnelId": tunnel_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "text/plain; charset&#x3D;utf-8",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
+
     def get_vcn(self, vcn_id, **kwargs):
         """
         GetVcn
@@ -8030,6 +8481,103 @@ class VirtualNetworkClient(object):
                 method=method,
                 header_params=header_params,
                 response_type="list[PeerRegionForRemotePeering]")
+
+    def list_cpe_device_shapes(self, **kwargs):
+        """
+        ListCpeDeviceShapes
+        Lists the CPE device types that the Networking service provides CPE configuration
+        content for (example: Cisco ASA). The content helps a network engineer configure
+        the actual CPE device represented by a :class:`Cpe` object.
+
+        If you want to generate CPE configuration content for one of the returned CPE device types,
+        ensure that the :class:`Cpe` object's `cpeDeviceShapeId` attribute is set
+        to the CPE device type's OCID (returned by this operation).
+
+        For information about generating CPE configuration content, see these operations:
+
+          * :func:`get_cpe_device_config_content`
+          * :func:`get_ipsec_cpe_device_config_content`
+          * :func:`get_tunnel_cpe_device_config_content`
+
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            Example: `50`
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+            call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.core.models.CpeDeviceShapeSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cpeDeviceShapes"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_cpe_device_shapes got unknown kwargs: {!r}".format(extra_kwargs))
+
+        query_params = {
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[CpeDeviceShapeSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[CpeDeviceShapeSummary]")
 
     def list_cpes(self, compartment_id, **kwargs):
         """
@@ -13582,6 +14130,111 @@ class VirtualNetworkClient(object):
                 header_params=header_params,
                 body=update_subnet_details,
                 response_type="Subnet")
+
+    def update_tunnel_cpe_device_config(self, ipsc_id, tunnel_id, update_tunnel_cpe_device_config_details, **kwargs):
+        """
+        UpdateTunnelCpeDeviceConfig
+        Creates or updates the set of CPE configuration answers for the specified tunnel.
+        The answers correlate to the questions that are specific to the CPE device type (see the
+        `parameters` attribute of :class:`CpeDeviceShapeDetail`).
+
+
+        :param str ipsc_id: (required)
+            The OCID of the IPSec connection.
+
+        :param str tunnel_id: (required)
+            The `OCID`__ of the tunnel.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateTunnelCpeDeviceConfigDetails update_tunnel_cpe_device_config_details: (required)
+            Request to input the tunnel's cpe configuration parameters
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.TunnelCpeDeviceConfig`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/ipsecConnections/{ipscId}/tunnels/{tunnelId}/tunnelDeviceConfig"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_tunnel_cpe_device_config got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "ipscId": ipsc_id,
+            "tunnelId": tunnel_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_tunnel_cpe_device_config_details,
+                response_type="TunnelCpeDeviceConfig")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_tunnel_cpe_device_config_details,
+                response_type="TunnelCpeDeviceConfig")
 
     def update_vcn(self, vcn_id, update_vcn_details, **kwargs):
         """

--- a/src/oci/database/models/update_db_system_details.py
+++ b/src/oci/database/models/update_db_system_details.py
@@ -43,6 +43,10 @@ class UpdateDbSystemDetails(object):
             The value to assign to the defined_tags property of this UpdateDbSystemDetails.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param shape:
+            The value to assign to the shape property of this UpdateDbSystemDetails.
+        :type shape: str
+
         :param nsg_ids:
             The value to assign to the nsg_ids property of this UpdateDbSystemDetails.
         :type nsg_ids: list[str]
@@ -59,6 +63,7 @@ class UpdateDbSystemDetails(object):
             'data_storage_size_in_gbs': 'int',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
+            'shape': 'str',
             'nsg_ids': 'list[str]',
             'backup_network_nsg_ids': 'list[str]'
         }
@@ -70,6 +75,7 @@ class UpdateDbSystemDetails(object):
             'data_storage_size_in_gbs': 'dataStorageSizeInGBs',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
+            'shape': 'shape',
             'nsg_ids': 'nsgIds',
             'backup_network_nsg_ids': 'backupNetworkNsgIds'
         }
@@ -80,6 +86,7 @@ class UpdateDbSystemDetails(object):
         self._data_storage_size_in_gbs = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._shape = None
         self._nsg_ids = None
         self._backup_network_nsg_ids = None
 
@@ -238,6 +245,36 @@ class UpdateDbSystemDetails(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def shape(self):
+        """
+        Gets the shape of this UpdateDbSystemDetails.
+        The shape of the DB system. The shape determines resources allocated to the DB system.
+        - For virtual machine shapes, the number of CPU cores and memory
+
+        To get a list of shapes, use the :func:`list_db_system_shapes` operation.
+
+
+        :return: The shape of this UpdateDbSystemDetails.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this UpdateDbSystemDetails.
+        The shape of the DB system. The shape determines resources allocated to the DB system.
+        - For virtual machine shapes, the number of CPU cores and memory
+
+        To get a list of shapes, use the :func:`list_db_system_shapes` operation.
+
+
+        :param shape: The shape of this UpdateDbSystemDetails.
+        :type: str
+        """
+        self._shape = shape
 
     @property
     def nsg_ids(self):

--- a/src/oci/regions.py
+++ b/src/oci/regions.py
@@ -19,7 +19,8 @@ REGIONS_SHORT_NAMES = {
     'kix': 'ap-osaka-1',
     'mel': 'ap-melbourne-1',
     'ams': 'eu-amsterdam-1',
-    'jed': 'me-jeddah-1'
+    'jed': 'me-jeddah-1',
+    'yul': 'ca-montreal-1'
 }
 REGION_REALMS = {
     'ap-melbourne-1': 'oc1',
@@ -37,6 +38,7 @@ REGION_REALMS = {
     'uk-london-1': 'oc1',
     'ca-toronto-1': 'oc1',
     'sa-saopaulo-1': 'oc1',
+    'ca-montreal-1': 'oc1',
 
     'us-langley-1': 'oc2',
     'us-luke-1': 'oc2',
@@ -68,6 +70,7 @@ REGIONS = [
     "me-jeddah-1",
     "uk-london-1",
     "ca-toronto-1",
+    "ca-montreal-1",
     "us-langley-1",
     "us-luke-1",
     "us-gov-ashburn-1",

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "2.10.6"
+__version__ = "2.10.7"


### PR DESCRIPTION
Added
-----
* Support for updating the shape of a Database System in the Database service
* Support for generating CPE configurations for download in the Networking service
* Support for private IPs and fault domains of cluster nodes in the Container Engine for Kubernetes service
* Support for calling Oracle Cloud Infrastructure services in the ca-montreal-1 region
* Fixed missed parameter when invoking request signing for delegation token