### PR TITLE
Releasing version 2.16.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.16.0 - 2020-06-09
+====================
+
+Added
+-----
+* Support for returning the database version of backups in the Database service
+* Support for patching on Exadata Cloud at Customer resources in the Database service
+* Support for new lifecycle substates on instances in the Digital Assistant service
+* Support for file servers in the Integration service
+* Support for deleting non-empty tag namespaces and bulk deleting tags in the Identity service
+* Support for bulk move and bulk delete of resources by compartment in the Identity service
+
+Breaking
+--------
+* Data type for paramater `data_storage_size_in_tbs` changed from int to float in the Database service
+* Parameter `lifecycle_state` removed state `OFFLINE` and added `DISCONNECTED` in the Database service
+
+====================
 2.15.0 - 2020-06-02
 ====================
 

--- a/docs/api/identity.rst
+++ b/docs/api/identity.rst
@@ -24,6 +24,12 @@ Identity
     oci.identity.models.AuthenticationPolicy
     oci.identity.models.AvailabilityDomain
     oci.identity.models.BaseTagDefinitionValidator
+    oci.identity.models.BulkActionResource
+    oci.identity.models.BulkActionResourceType
+    oci.identity.models.BulkActionResourceTypeCollection
+    oci.identity.models.BulkDeleteResourcesDetails
+    oci.identity.models.BulkDeleteTagsDetails
+    oci.identity.models.BulkMoveResourcesDetails
     oci.identity.models.ChangeTagNamespaceCompartmentDetail
     oci.identity.models.Compartment
     oci.identity.models.CreateApiKeyDetails

--- a/docs/api/identity/models/oci.identity.models.BulkActionResource.rst
+++ b/docs/api/identity/models/oci.identity.models.BulkActionResource.rst
@@ -1,0 +1,11 @@
+BulkActionResource
+==================
+
+.. currentmodule:: oci.identity.models
+
+.. autoclass:: BulkActionResource
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/identity/models/oci.identity.models.BulkActionResourceType.rst
+++ b/docs/api/identity/models/oci.identity.models.BulkActionResourceType.rst
@@ -1,0 +1,11 @@
+BulkActionResourceType
+======================
+
+.. currentmodule:: oci.identity.models
+
+.. autoclass:: BulkActionResourceType
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/identity/models/oci.identity.models.BulkActionResourceTypeCollection.rst
+++ b/docs/api/identity/models/oci.identity.models.BulkActionResourceTypeCollection.rst
@@ -1,0 +1,11 @@
+BulkActionResourceTypeCollection
+================================
+
+.. currentmodule:: oci.identity.models
+
+.. autoclass:: BulkActionResourceTypeCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/identity/models/oci.identity.models.BulkDeleteResourcesDetails.rst
+++ b/docs/api/identity/models/oci.identity.models.BulkDeleteResourcesDetails.rst
@@ -1,0 +1,11 @@
+BulkDeleteResourcesDetails
+==========================
+
+.. currentmodule:: oci.identity.models
+
+.. autoclass:: BulkDeleteResourcesDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/identity/models/oci.identity.models.BulkDeleteTagsDetails.rst
+++ b/docs/api/identity/models/oci.identity.models.BulkDeleteTagsDetails.rst
@@ -1,0 +1,11 @@
+BulkDeleteTagsDetails
+=====================
+
+.. currentmodule:: oci.identity.models
+
+.. autoclass:: BulkDeleteTagsDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/identity/models/oci.identity.models.BulkMoveResourcesDetails.rst
+++ b/docs/api/identity/models/oci.identity.models.BulkMoveResourcesDetails.rst
@@ -1,0 +1,11 @@
+BulkMoveResourcesDetails
+========================
+
+.. currentmodule:: oci.identity.models
+
+.. autoclass:: BulkMoveResourcesDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/list_resources_in_tenancy/how_to_run_in_cloud_shell.rst
+++ b/examples/list_resources_in_tenancy/how_to_run_in_cloud_shell.rst
@@ -15,8 +15,10 @@ Executing using Cloud Shell:
        git clone https://github.com/oracle/oci-python-sdk
 
     4. Execute
-       cd $HOME/oci-python-sdk/examples/list_ipsec_and_virtual_circuits_in_tenancy
+       cd $HOME/oci-python-sdk/examples/list_resources_in_tenancy
        python list_all_ipsec_tunnels_in_tenancy.py -dt
        python list_all_virtual_circuits_in_tenancy.py -dt
+       python list_compute_tags_in_tenancy.py -dt
+       python list_dbsystem_with_maintenance_in_tenancy.py -dt
 
 

--- a/examples/list_resources_in_tenancy/list_all_ipsec_tunnels_in_tenancy.py
+++ b/examples/list_resources_in_tenancy/list_all_ipsec_tunnels_in_tenancy.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+##########################################################################
+# Copyright(c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+# list_all_ipsec_tunnels_in_tenancy.py
+#
+# @author: Adi Zohar
+#
+# Supports Python 2 and 3
+#
+# coding: utf-8
+##########################################################################
+# Info:
+#    List all IPSEC tunnels in Tenancy including DRG redundancy
+#
+# Connectivity:
+#    Option 1 - User Authentication
+#       $HOME/.oci/config, please follow - https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm
+#       OCI user part of ListIPsecGroup group with below Policy rules:
+#          Allow group ListIPsecGroup to inspect compartments in tenancy
+#          Allow group ListIPsecGroup to inspect tenancies in tenancy
+#          Allow group ListIPsecGroup to inspect ipsec-connections in tenancy
+#          Allow group ListIPsecGroup to inspect drgs in tenancy
+#
+#    Option 2 - Instance Principle
+#       Compute instance part of DynListIPsecGroup dynamic group with policy rules:
+#          Allow dynamic group DynListIPsecGroup to inspect compartments in tenancy
+#          Allow dynamic group DynListIPsecGroup to inspect tenancies in tenancy
+#          Allow dynamic group DynListIPsecGroup to inspect ipsec-connections in tenancy
+#          Allow dynamic group DynListIPsecGroup to inspect drgs in tenancy
+#
+##########################################################################
+# Modules Included:
+# - oci.identity.IdentityClient
+#
+# APIs Used:
+# - IdentityClient.list_compartments         - Policy COMPARTMENT_INSPECT
+# - IdentityClient.get_tenancy               - Policy TENANCY_INSPECT
+# - IdentityClient.list_region_subscriptions - Policy TENANCY_INSPECT
+# - VirtualNetworkClient.list_ip_sec_connections        - Policy IPSEC_CONNECTION_READ
+# - VirtualNetworkClient.list_ip_sec_connection_tunnels - Policy IPSEC_CONNECTION_READ
+# - VirtualNetworkClient.get_drg_redundancy_status      - Policy DRG_READ
+#
+##########################################################################
+# Application Command line parameters
+#
+#   -t config - Config file section to use (tenancy profile)
+#   -p proxy  - Set Proxy (i.e. www-proxy-server.com:80)
+#   -ip       - Use Instance Principals for Authentication
+#   -dt       - Use Instance Principals with delegation token for cloud shell
+##########################################################################
+from __future__ import print_function
+import sys
+import argparse
+import datetime
+import oci
+import json
+import os
+
+
+##########################################################################
+# Print header centered
+##########################################################################
+def print_header(name):
+    chars = int(90)
+    print("")
+    print('#' * chars)
+    print("#" + name.center(chars - 2, " ") + "#")
+    print('#' * chars)
+
+
+##########################################################################
+# check service error to warn instead of error
+##########################################################################
+def check_service_error(code):
+    return ('max retries exceeded' in str(code).lower() or
+            'auth' in str(code).lower() or
+            'notfound' in str(code).lower() or
+            code == 'Forbidden' or
+            code == 'TooManyRequests' or
+            code == 'IncorrectState' or
+            code == 'LimitExceeded'
+            )
+
+
+##########################################################################
+# Create signer for Authentication
+# Input - config_profile and is_instance_principals and is_delegation_token
+# Output - config and signer objects
+##########################################################################
+def create_signer(config_profile, is_instance_principals, is_delegation_token):
+
+    # if instance principals authentications
+    if is_instance_principals:
+        try:
+            signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+            config = {'region': signer.region, 'tenancy': signer.tenancy_id}
+            return config, signer
+
+        except Exception:
+            print_header("Error obtaining instance principals certificate, aborting")
+            raise SystemExit
+
+    # -----------------------------
+    # Delegation Token
+    # -----------------------------
+    elif is_delegation_token:
+
+        try:
+            # check if env variables OCI_CONFIG_FILE, OCI_CONFIG_PROFILE exist and use them
+            env_config_file = os.environ.get('OCI_CONFIG_FILE')
+            env_config_section = os.environ.get('OCI_CONFIG_PROFILE')
+
+            # check if file exist
+            if env_config_file is None or env_config_section is None:
+                print("*** OCI_CONFIG_FILE and OCI_CONFIG_PROFILE env variables not found, abort. ***")
+                print("")
+                raise SystemExit
+
+            config = oci.config.from_file(env_config_file, env_config_section)
+            delegation_token_location = config["delegation_token_file"]
+
+            with open(delegation_token_location, 'r') as delegation_token_file:
+                delegation_token = delegation_token_file.read().strip()
+                # get signer from delegation token
+                signer = oci.auth.signers.InstancePrincipalsDelegationTokenSigner(delegation_token=delegation_token)
+
+                return config, signer
+
+        except KeyError:
+            print("* Key Error obtaining delegation_token_file")
+            raise SystemExit
+
+        except Exception:
+            raise
+
+    # -----------------------------
+    # config file authentication
+    # -----------------------------
+    else:
+        config = oci.config.from_file(
+            oci.config.DEFAULT_LOCATION,
+            (config_profile if config_profile else oci.config.DEFAULT_PROFILE)
+        )
+        signer = oci.signer.Signer(
+            tenancy=config["tenancy"],
+            user=config["user"],
+            fingerprint=config["fingerprint"],
+            private_key_file_location=config.get("key_file"),
+            pass_phrase=oci.config.get_config_value_or_default(config, "pass_phrase"),
+            private_key_content=config.get("key_content")
+        )
+        return config, signer
+
+
+##########################################################################
+# Load compartments
+##########################################################################
+def identity_read_compartments(identity, tenancy):
+
+    print("Loading Compartments...")
+    try:
+        compartments = oci.pagination.list_call_get_all_results(
+            identity.list_compartments,
+            tenancy.id,
+            compartment_id_in_subtree=True
+        ).data
+
+        # Add root compartment which is not part of the list_compartments
+        compartments.append(tenancy)
+
+        print("    Total " + str(len(compartments)) + " compartments loaded.")
+        return compartments
+
+    except Exception as e:
+        raise RuntimeError("Error in identity_read_compartments: " + str(e.args))
+
+
+##########################################################################
+# Main
+##########################################################################
+
+# Get Command Line Parser
+parser = argparse.ArgumentParser()
+parser.add_argument('-t', default="", dest='config_profile', help='Config file section to use (tenancy profile)')
+parser.add_argument('-p', default="", dest='proxy', help='Set Proxy (i.e. www-proxy-server.com:80) ')
+parser.add_argument('-ip', action='store_true', default=False, dest='is_instance_principals', help='Use Instance Principals for Authentication')
+parser.add_argument('-dt', action='store_true', default=False, dest='is_delegation_token', help='Use Delegation Token for Authentication')
+cmd = parser.parse_args()
+
+# Start print time info
+start_time = str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+print_header("Running List IPSecTunnels")
+print("Starts at " + str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")))
+print("Written By Adi Zohar, June 2020")
+print("Command Line : " + ' '.join(x for x in sys.argv[1:]))
+
+# Identity extract compartments
+config, signer = create_signer(cmd.config_profile, cmd.is_instance_principals, cmd.is_delegation_token)
+compartments = []
+tenancy = None
+try:
+    print("\nConnecting to Identity Service...")
+    identity = oci.identity.IdentityClient(config, signer=signer)
+    if cmd.proxy:
+        identity.base_client.session.proxies = {'https': cmd.proxy}
+
+    tenancy = identity.get_tenancy(config["tenancy"]).data
+    regions = identity.list_region_subscriptions(tenancy.id).data
+
+    print("Tenant Name : " + str(tenancy.name))
+    print("Tenant Id   : " + tenancy.id)
+    print("")
+
+    compartments = identity_read_compartments(identity, tenancy)
+
+except Exception as e:
+    raise RuntimeError("\nError extracting compartments section - " + str(e))
+
+
+############################################
+# Loop on all regions
+############################################
+print("\nLoading IPSEC Tunnels...")
+data = []
+warnings = 0
+for region_name in [str(es.region_name) for es in regions]:
+
+    print("\nRegion " + region_name + "...")
+
+    # set the region in the config and signer
+    config['region'] = region_name
+    signer.region = region_name
+
+    # connect to virtual_network
+    virtual_network = oci.core.VirtualNetworkClient(config, signer=signer)
+    if cmd.proxy:
+        virtual_network.base_client.session.proxies = {'https': cmd.proxy}
+
+    ############################################
+    # Loop on all compartments
+    ############################################
+    try:
+        for compartment in compartments:
+            if compartment.id != tenancy.id and compartment.lifecycle_state != oci.identity.models.Compartment.LIFECYCLE_STATE_ACTIVE:
+                continue
+
+            print("    Compartment " + (str(compartment.name) + "... ").ljust(35), end="")
+            cnt = 0
+
+            ############################################
+            # Retrieve ip sec connections
+            ############################################
+            ipsec_connnections = []
+            try:
+                ipsec_connnections = oci.pagination.list_call_get_all_results(
+                    virtual_network.list_ip_sec_connections,
+                    compartment.id
+                ).data
+
+            except oci.exceptions.ServiceError as e:
+                if check_service_error(e.code):
+                    warnings += 1
+                    print("Warnings ")
+                    continue
+                raise
+
+            # loop on array,
+            # ipsec_conn = oci.core.models.IPSecConnection
+            for ipsec_conn in ipsec_connnections:
+                if ipsec_conn.lifecycle_state != oci.core.models.IPSecConnection.LIFECYCLE_STATE_AVAILABLE:
+                    continue
+
+                ############################################
+                # Retrieve DRG Redundancy
+                ############################################
+                drg_redundancy = ""
+                try:
+                    # redundancy = oci.core.models.DrgRedundancyStatus
+                    redundancy = virtual_network.get_drg_redundancy_status(ipsec_conn.drg_id).data
+                    if redundancy:
+                        drg_redundancy = str(redundancy.status)
+                except oci.exceptions.ServiceError as e:
+                    if check_service_error(e.code):
+                        print("DRG-Redun-Err ", end="")
+                    pass
+
+                ############################################
+                # Get IPSEC connection tunnels
+                ############################################
+                data_tunnel = []
+                try:
+                    tunnels = virtual_network.list_ip_sec_connection_tunnels(ipsec_conn.id).data
+                    # tunnel = oci.core.models.IPSecConnectionTunnel
+                    for tunnel in tunnels:
+
+                        # get bgp tunnel info
+                        tunnel_bgp_info = ""
+                        if tunnel.bgp_session_info:
+                            bs = tunnel.bgp_session_info
+                            tunnel_bgp_info = "BGP Status = " + str(bs.bgp_state) + ", Cust: " + str(bs.customer_interface_ip) + " (ASN = " + str(bs.customer_bgp_asn) + "), Oracle: " + str(bs.oracle_interface_ip) + " (ASN = " + str(bs.oracle_bgp_asn) + ")"
+
+                        # append the data to data_tunnel
+                        data_tunnel.append(
+                            {'id': str(tunnel.id),
+                             'status': str(tunnel.status),
+                             'lifecycle_state': str(tunnel.lifecycle_state),
+                             'status_date': tunnel.time_status_updated.strftime("%Y-%m-%d %H:%M"),
+                             'display_name': str(tunnel.display_name),
+                             'routing': str(tunnel.routing),
+                             'cpe_ip': str(tunnel.cpe_ip),
+                             'vpn_ip': str(tunnel.vpn_ip),
+                             'bgp_info': tunnel_bgp_info}
+                        )
+
+                        cnt += 1
+                except Exception as e:
+                    print("Error (" + str(e) + ") ", end="")
+                    pass
+
+                # Add all data to the data array
+                data.append({
+                    'region_name': region_name,
+                    'compartment_name': str(compartment.name),
+                    'compartment_id': str(compartment.id),
+                    'id': str(ipsec_conn.id),
+                    'name': str(ipsec_conn.display_name),
+                    'drg_id': str(ipsec_conn.drg_id),
+                    'drg_redundancy': drg_redundancy,
+                    'cpe_id': str(ipsec_conn.cpe_id),
+                    'time_created': str(ipsec_conn.time_created),
+                    'static_routes': [str(es) for es in ipsec_conn.static_routes],
+                    'tunnels': data_tunnel
+                })
+
+            # print tunnels for the compartment
+            if cnt == 0:
+                print("(-)")
+            else:
+                print("(" + str(cnt) + " Tunnels)")
+
+    except Exception as e:
+        raise RuntimeError("\nError extracting IPSEC tunnels - " + str(e))
+
+############################################
+# Print Output as JSON
+############################################
+print_header("Output")
+print(json.dumps(data, indent=4, sort_keys=False))
+
+if warnings > 0:
+    print_header(str(warnings) + " Warnings appeared")
+print_header("Completed at " + str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")))

--- a/examples/list_resources_in_tenancy/list_all_virtual_circuits_in_tenancy.py
+++ b/examples/list_resources_in_tenancy/list_all_virtual_circuits_in_tenancy.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+##########################################################################
+# Copyright(c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+# list_all_virtual_circuits_in_tenancy.py
+#
+# @author: Adi Zohar
+#
+# Supports Python 2 and 3
+#
+# coding: utf-8
+##########################################################################
+# Info:
+#    List all Virtual Circuits in Tenancy including DRG redundancy
+#
+# Connectivity:
+#    Option 1 - User Authentication
+#       $HOME/.oci/config, please follow - https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm
+#       OCI user part of ListIPsecGroup group with below Policy rules:
+#          Allow group ListIPsecGroup to inspect compartments in tenancy
+#          Allow group ListIPsecGroup to inspect tenancies in tenancy
+#          Allow group ListIPsecGroup to inspect virtual-circuits in tenancy
+#          Allow group ListIPsecGroup to inspect drgs in tenancy
+#
+#    Option 2 - Instance Principle
+#       Compute instance part of DynListIPsecGroup dynamic group with policy rules:
+#          Allow dynamic group DynListIPsecGroup to inspect compartments in tenancy
+#          Allow dynamic group DynListIPsecGroup to inspect tenancies in tenancy
+#          Allow dynamic group DynListIPsecGroup to inspect virtual-circuits in tenancy
+#          Allow dynamic group DynListIPsecGroup to inspect drgs in tenancy
+#
+##########################################################################
+# Modules Included:
+# - oci.identity.IdentityClient
+#
+# APIs Used:
+# - IdentityClient.list_compartments         - Policy COMPARTMENT_INSPECT
+# - IdentityClient.get_tenancy               - Policy TENANCY_INSPECT
+# - IdentityClient.list_region_subscriptions - Policy TENANCY_INSPECT
+# - VirtualNetworkClient.list_virtual_circuits      - Policy VIRTUAL_CIRCUIT_READ
+# - VirtualNetworkClient.get_drg_redundancy_status  - Policy DRG_READ
+#
+##########################################################################
+# Application Command line parameters
+#
+#   -t config - Config file section to use (tenancy profile)
+#   -p proxy  - Set Proxy (i.e. www-proxy-server.com:80)
+#   -ip       - Use Instance Principals for Authentication
+#   -dt       - Use Instance Principals with delegation token for cloud shell
+##########################################################################
+from __future__ import print_function
+import sys
+import argparse
+import datetime
+import oci
+import json
+import os
+
+
+##########################################################################
+# Print header centered
+##########################################################################
+def print_header(name):
+    chars = int(90)
+    print("")
+    print('#' * chars)
+    print("#" + name.center(chars - 2, " ") + "#")
+    print('#' * chars)
+
+
+##########################################################################
+# check service error to warn instead of error
+##########################################################################
+def check_service_error(code):
+    return ('max retries exceeded' in str(code).lower() or
+            'auth' in str(code).lower() or
+            'notfound' in str(code).lower() or
+            code == 'Forbidden' or
+            code == 'TooManyRequests' or
+            code == 'IncorrectState' or
+            code == 'LimitExceeded'
+            )
+
+
+##########################################################################
+# Create signer for Authentication
+# Input - config_profile and is_instance_principals and is_delegation_token
+# Output - config and signer objects
+##########################################################################
+def create_signer(config_profile, is_instance_principals, is_delegation_token):
+
+    # if instance principals authentications
+    if is_instance_principals:
+        try:
+            signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+            config = {'region': signer.region, 'tenancy': signer.tenancy_id}
+            return config, signer
+
+        except Exception:
+            print_header("Error obtaining instance principals certificate, aborting")
+            raise SystemExit
+
+    # -----------------------------
+    # Delegation Token
+    # -----------------------------
+    elif is_delegation_token:
+
+        try:
+            # check if env variables OCI_CONFIG_FILE, OCI_CONFIG_PROFILE exist and use them
+            env_config_file = os.environ.get('OCI_CONFIG_FILE')
+            env_config_section = os.environ.get('OCI_CONFIG_PROFILE')
+
+            # check if file exist
+            if env_config_file is None or env_config_section is None:
+                print("*** OCI_CONFIG_FILE and OCI_CONFIG_PROFILE env variables not found, abort. ***")
+                print("")
+                raise SystemExit
+
+            config = oci.config.from_file(env_config_file, env_config_section)
+            delegation_token_location = config["delegation_token_file"]
+
+            with open(delegation_token_location, 'r') as delegation_token_file:
+                delegation_token = delegation_token_file.read().strip()
+                # get signer from delegation token
+                signer = oci.auth.signers.InstancePrincipalsDelegationTokenSigner(delegation_token=delegation_token)
+
+                return config, signer
+
+        except KeyError:
+            print("* Key Error obtaining delegation_token_file")
+            raise SystemExit
+
+        except Exception:
+            raise
+
+    # -----------------------------
+    # config file authentication
+    # -----------------------------
+    else:
+        config = oci.config.from_file(
+            oci.config.DEFAULT_LOCATION,
+            (config_profile if config_profile else oci.config.DEFAULT_PROFILE)
+        )
+        signer = oci.signer.Signer(
+            tenancy=config["tenancy"],
+            user=config["user"],
+            fingerprint=config["fingerprint"],
+            private_key_file_location=config.get("key_file"),
+            pass_phrase=oci.config.get_config_value_or_default(config, "pass_phrase"),
+            private_key_content=config.get("key_content")
+        )
+        return config, signer
+
+
+##########################################################################
+# Load compartments
+##########################################################################
+def identity_read_compartments(identity, tenancy):
+
+    print("Loading Compartments...")
+    try:
+        compartments = oci.pagination.list_call_get_all_results(
+            identity.list_compartments,
+            tenancy.id,
+            compartment_id_in_subtree=True
+        ).data
+
+        # Add root compartment which is not part of the list_compartments
+        compartments.append(tenancy)
+
+        print("    Total " + str(len(compartments)) + " compartments loaded.")
+        return compartments
+
+    except Exception as e:
+        raise RuntimeError("Error in identity_read_compartments: " + str(e.args))
+
+
+##########################################################################
+# Main
+##########################################################################
+
+# Get Command Line Parser
+parser = argparse.ArgumentParser()
+parser.add_argument('-t', default="", dest='config_profile', help='Config file section to use (tenancy profile)')
+parser.add_argument('-p', default="", dest='proxy', help='Set Proxy (i.e. www-proxy-server.com:80) ')
+parser.add_argument('-ip', action='store_true', default=False, dest='is_instance_principals', help='Use Instance Principals for Authentication')
+parser.add_argument('-dt', action='store_true', default=False, dest='is_delegation_token', help='Use Delegation Token for Authentication')
+cmd = parser.parse_args()
+
+# Start print time info
+start_time = str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+print_header("Running List Virtual Circuits")
+print("Written By Adi Zohar, June 2020")
+print("Starts at " + str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")))
+print("Command Line : " + ' '.join(x for x in sys.argv[1:]))
+
+# Identity extract compartments
+config, signer = create_signer(cmd.config_profile, cmd.is_instance_principals, cmd.is_delegation_token)
+compartments = []
+tenancy = None
+try:
+    print("\nConnecting to Identity Service...")
+    identity = oci.identity.IdentityClient(config, signer=signer)
+    if cmd.proxy:
+        identity.base_client.session.proxies = {'https': cmd.proxy}
+
+    tenancy = identity.get_tenancy(config["tenancy"]).data
+    regions = identity.list_region_subscriptions(tenancy.id).data
+
+    print("Tenant Name : " + str(tenancy.name))
+    print("Tenant Id   : " + tenancy.id)
+    print("")
+
+    compartments = identity_read_compartments(identity, tenancy)
+
+except Exception as e:
+    raise RuntimeError("\nError extracting compartments section - " + str(e))
+
+############################################
+# Loop on all regions
+############################################
+print("\nLoading Virtual Circuits...")
+data = []
+warnings = 0
+for region_name in [str(es.region_name) for es in regions]:
+
+    print("\nRegion " + region_name + "...")
+
+    # set the region in the config and signer
+    config['region'] = region_name
+    signer.region = region_name
+
+    # connect to virtual_network
+    virtual_network = oci.core.VirtualNetworkClient(config, signer=signer)
+    if cmd.proxy:
+        virtual_network.base_client.session.proxies = {'https': cmd.proxy}
+
+    ############################################
+    # Loop on all compartments
+    ############################################
+    try:
+        for compartment in compartments:
+            if compartment.id != tenancy.id and compartment.lifecycle_state != oci.identity.models.Compartment.LIFECYCLE_STATE_ACTIVE:
+                continue
+
+            print("    Compartment " + (str(compartment.name) + "... ").ljust(35), end="")
+            cnt = 0
+
+            ############################################
+            # Retrieve virtual circuits
+            ############################################
+            virtual_circuits = []
+            try:
+                virtual_circuits = oci.pagination.list_call_get_all_results(
+                    virtual_network.list_virtual_circuits,
+                    compartment.id
+                ).data
+
+            except oci.exceptions.ServiceError as e:
+                if check_service_error(e.code):
+                    warnings += 1
+                    print("Warnings ")
+                    continue
+                raise
+
+            # loop on virtual_circuits array
+            # virtual_circuit = oci.core.models.VirtualCircuit
+            for virtual_circuit in virtual_circuits:
+                if (virtual_circuit.lifecycle_state == oci.core.models.VirtualCircuit.LIFECYCLE_STATE_TERMINATED or
+                        virtual_circuit.lifecycle_state == oci.core.models.VirtualCircuit.LIFECYCLE_STATE_TERMINATING):
+                    continue
+
+                ############################################
+                # get the cross connect mapping
+                ############################################
+                data_cross_connect = []
+                for cc in virtual_circuit.cross_connect_mappings:
+                    data_cross_connect.append({
+                        'customer_bgp_peering_ip': str(cc.customer_bgp_peering_ip),
+                        'oracle_bgp_peering_ip': str(cc.oracle_bgp_peering_ip),
+                        'vlan': str(cc.vlan)
+                    })
+
+                ############################################
+                # Retrieve DRG Redundancy
+                ############################################
+                drg_redundancy = ""
+                try:
+                    # redundancy = oci.core.models.DrgRedundancyStatus
+                    redundancy = virtual_network.get_drg_redundancy_status(virtual_circuit.gateway_id).data
+                    if redundancy:
+                        drg_redundancy = str(redundancy.status)
+                except oci.exceptions.ServiceError as e:
+                    if check_service_error(e.code):
+                        print("DRG-Redun-Err ", end="")
+                    pass
+
+                ############################################
+                # Add the info to the data array
+                ############################################
+                data.append({
+                    'region_name': region_name,
+                    'compartment_name': str(compartment.name),
+                    'compartment_id': str(compartment.id),
+                    'id': str(virtual_circuit.id),
+                    'name': str(virtual_circuit.display_name),
+                    'bandwidth_shape_name': str(virtual_circuit.bandwidth_shape_name),
+                    'bgp_management': str(virtual_circuit.bgp_management),
+                    'bgp_session_state': str(virtual_circuit.bgp_session_state),
+                    'customer_bgp_asn': str(virtual_circuit.customer_bgp_asn),
+                    'drg_id': str(virtual_circuit.gateway_id),
+                    'drg_redundancy': drg_redundancy,
+                    'lifecycle_state': str(virtual_circuit.lifecycle_state),
+                    'oracle_bgp_asn': str(virtual_circuit.oracle_bgp_asn),
+                    'provider_name': str(virtual_circuit.provider_name),
+                    'provider_service_name': str(virtual_circuit.provider_service_name),
+                    'provider_state': str(virtual_circuit.provider_state),
+                    'reference_comment': str(virtual_circuit.reference_comment),
+                    'service_type': str(virtual_circuit.service_type),
+                    'cross_connect_mappings': data_cross_connect,
+                    'type': str(virtual_circuit.type),
+                    'time_created': str(virtual_circuit.time_created)
+                })
+                cnt += 1
+
+            # print circuits for the compartment
+            if cnt == 0:
+                print("(-)")
+            else:
+                print("(" + str(cnt) + " Circuits)")
+
+    except Exception as e:
+        raise RuntimeError("\nError extracting Virtual Circuits - " + str(e))
+
+############################################
+# Print Output as JSON
+############################################
+print_header("Output")
+print(json.dumps(data, indent=4, sort_keys=False))
+
+if warnings > 0:
+    print_header(str(warnings) + " Warnings appeared")
+print_header("Completed at " + str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")))

--- a/examples/showoci/CHANGELOG.rst
+++ b/examples/showoci/CHANGELOG.rst
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 =====================
+20.06.09 - 2020-06-09
+=====================
+* Added file storage to the csv file
+* Added network sources
+* Added pagination call for the list_policies (Thank you Shyam)
+* Added more info for the images in the summary
+
+=====================
 20.06.02 - 2020-06-02
 =====================
 * Added image to the summary if it is custom image (from the marketplace)

--- a/examples/showoci/showoci.py
+++ b/examples/showoci/showoci.py
@@ -80,7 +80,7 @@ import sys
 import argparse
 import datetime
 
-version = "20.05.18"
+version = "20.06.09"
 
 ##########################################################################
 # check OCI version

--- a/examples/showoci/showoci_data.py
+++ b/examples/showoci/showoci_data.py
@@ -1376,10 +1376,12 @@ class ShowOCIData(object):
 
                 # fix the shape image for the summary
                 sum_shape = ""
-                if instance['image'] == "Not Found" or instance['image'] == "Custom" or instance['image_os'] == "Oracle Linux":
+                if instance['image'] == "Not Found" or instance['image'] == "Custom" or "Oracle-Linux" in instance['image']:
                     sum_shape = instance['image_os'][0:35]
                 elif 'Windows-Server' in instance['image']:
                     sum_shape = instance['image'][0:19]
+                elif instance['image_os'] == "PaaS Image":
+                    sum_shape = "PaaS Image - " + instance['display_name'].split("|", 2)[1] if len(instance['display_name'].split("|", 2)) >= 2 else instance['image_os']
                 else:
                     sum_shape = instance['image'][0:35]
 
@@ -1865,6 +1867,7 @@ class ShowOCIData(object):
                          'backup_subnet_id': dbs['backup_subnet_id'],
                          'scan_dns': dbs['scan_dns_record_id'],
                          'scan_ips': dbs['scan_ips'],
+                         'scan_dns_name': dbs['hostname'] + "-scan." + dbs['domain'],
                          'data_storage_size_in_gbs': dbs['data_storage_size_in_gbs'],
                          'reco_storage_size_in_gb': dbs['reco_storage_size_in_gb'],
                          'sparse_diskgroup': dbs['sparse_diskgroup'],

--- a/examples/usage_reports_to_adw/CHANGELOG.rst
+++ b/examples/usage_reports_to_adw/CHANGELOG.rst
@@ -7,6 +7,11 @@ The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 =====================
 20.06.02 - 2020-06-02
 =====================
+* Added Hourly cost over time
+
+=====================
+20.06.02 - 2020-06-02
+=====================
 * Added Summary cost per day to the Data Statistics - if you manage many tenants, it is a great view to see them all
 * Added Cost by SKU to the Cost Over Time - Daily/Weekly and Monthly
 

--- a/examples/usage_reports_to_adw/apex_demo_app/usage.demo.apex.sql
+++ b/examples/usage_reports_to_adw/apex_demo_app/usage.demo.apex.sql
@@ -28,7 +28,7 @@ prompt APPLICATION 100 - OCI Usage and Cost Report
 -- Application Export:
 --   Application:     100
 --   Name:            OCI Usage and Cost Report
---   Date and Time:   15:20 Wednesday May 20, 2020
+--   Date and Time:   14:08 Monday June 1, 2020
 --   Exported By:     ADIZOHAR
 --   Flashback:       0
 --   Export Type:     Application Export
@@ -36,9 +36,9 @@ prompt APPLICATION 100 - OCI Usage and Cost Report
 --       Items:                   77
 --       Computations:            21
 --       Processes:                4
---       Regions:                 57
+--       Regions:                 59
 --       Buttons:                  5
---       Dynamic Actions:         29
+--       Dynamic Actions:         31
 --     Shared Components:
 --       Logic:
 --         App Settings:           1
@@ -105,7 +105,7 @@ wwv_flow_api.create_flow(
 ,p_public_user=>'APEX_PUBLIC_USER'
 ,p_proxy_server=>nvl(wwv_flow_application_install.get_proxy,'')
 ,p_no_proxy_domains=>nvl(wwv_flow_application_install.get_no_proxy_domains,'')
-,p_flow_version=>'Release 20.06.02'
+,p_flow_version=>'Release 20.06.09'
 ,p_flow_status=>'AVAILABLE_W_EDIT_LINK'
 ,p_flow_unavailable_text=>'This application is currently unavailable at this time.'
 ,p_exact_substitutions_only=>'Y'
@@ -119,7 +119,7 @@ wwv_flow_api.create_flow(
 ,p_substitution_string_01=>'APP_NAME'
 ,p_substitution_value_01=>'OCI Usage and Cost Report'
 ,p_last_updated_by=>'ADIZOHAR'
-,p_last_upd_yyyymmddhh24miss=>'20200520151207'
+,p_last_upd_yyyymmddhh24miss=>'20200601140841'
 ,p_file_prefix => nvl(wwv_flow_application_install.get_static_app_file_prefix,'')
 ,p_files_version=>3
 ,p_ui_type_name => null
@@ -15342,7 +15342,7 @@ wwv_flow_api.create_page(
 '#P5_REPORT_SELECTOR { background-color: #F5FBB4; font-weight: bold; font-size: 13px;}'))
 ,p_page_template_options=>'#DEFAULT#'
 ,p_last_updated_by=>'ADIZOHAR'
-,p_last_upd_yyyymmddhh24miss=>'20200520151207'
+,p_last_upd_yyyymmddhh24miss=>'20200601140811'
 );
 wwv_flow_api.create_page_plug(
  p_id=>wwv_flow_api.id(22846551592241693)
@@ -16329,7 +16329,7 @@ wwv_flow_api.create_report_region(
 ,p_name=>'Weekly Report'
 ,p_parent_plug_id=>wwv_flow_api.id(33638842014589649)
 ,p_template=>wwv_flow_api.id(9765042323688020)
-,p_display_sequence=>140
+,p_display_sequence=>160
 ,p_region_template_options=>'#DEFAULT#:t-Region--scrollBody'
 ,p_component_template_options=>'#DEFAULT#:t-Report--altRowsDefault:t-Report--rowHighlight'
 ,p_display_point=>'BODY'
@@ -17184,7 +17184,7 @@ wwv_flow_api.create_report_region(
 ,p_name=>'Daily Product Unit Report - Single'
 ,p_parent_plug_id=>wwv_flow_api.id(33638842014589649)
 ,p_template=>wwv_flow_api.id(9765042323688020)
-,p_display_sequence=>120
+,p_display_sequence=>130
 ,p_region_template_options=>'#DEFAULT#:t-Region--scrollBody'
 ,p_component_template_options=>'#DEFAULT#:t-Report--altRowsDefault:t-Report--rowHighlight'
 ,p_display_point=>'BODY'
@@ -17802,6 +17802,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_data_source=>wwv_flow_string.join(wwv_flow_t_varchar2(
 'select ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -17817,11 +17818,13 @@ wwv_flow_api.create_jet_chart_series(
 '    (:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
 '    (:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
 '    (:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') and',
-'    (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'    (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YY'
+||'YY'') = :P5_PERIOD_RANGE) and',
 '    not (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null) and',
-'    :P5_REPORT_SELECTOR in (''Daily Cost Over Time - Total'',''Weekly Cost Over Time - Total'',''Monthly Cost Over Time - Total'')    ',
+'    :P5_REPORT_SELECTOR in (''Hourly Cost Over Time - Total'',''Daily Cost Over Time - Total'',''Weekly Cost Over Time - Total'',''Monthly Cost Over Time - Total'')    ',
 '    group by ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -17829,6 +17832,7 @@ wwv_flow_api.create_jet_chart_series(
 'union all',
 'select ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -17837,11 +17841,13 @@ wwv_flow_api.create_jet_chart_series(
 'from oci_cost_stats',
 'where ',
 '    tenant_name=:P5_TENANT_NAME and',
-'    (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'    (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YY'
+||'YY'') = :P5_PERIOD_RANGE) and',
 '    (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null) and',
-'    :P5_REPORT_SELECTOR in (''Daily Cost Over Time - Total'',''Weekly Cost Over Time - Total'',''Monthly Cost Over Time - Total'')    ',
+'    :P5_REPORT_SELECTOR in (''Hourly Cost Over Time - Total'',''Daily Cost Over Time - Total'',''Weekly Cost Over Time - Total'',''Monthly Cost Over Time - Total'')    ',
 '    group by ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -17857,9 +17863,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_assigned_to_y2=>'off'
 ,p_items_label_rendered=>true
 ,p_items_label_position=>'center'
-,p_items_label_display_as=>'PERCENT'
 ,p_items_label_font_size=>'10'
-,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(13977108905041448)
@@ -17968,6 +17972,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_data_source=>wwv_flow_string.join(wwv_flow_t_varchar2(
 'select ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -17984,10 +17989,12 @@ wwv_flow_api.create_jet_chart_series(
 '    (:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
 '    (:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
 '    (:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') and',
-'    (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
-'    :P5_REPORT_SELECTOR in (''Daily Cost By Region'',''Weekly Cost By Region'',''Monthly Cost By Region'')    ',
+'    (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YY'
+||'YY'') = :P5_PERIOD_RANGE) and',
+'    :P5_REPORT_SELECTOR in (''Hourly Cost By Region'',''Daily Cost By Region'',''Weekly Cost By Region'',''Monthly Cost By Region'')    ',
 '    group by ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -18000,9 +18007,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_assigned_to_y2=>'off'
 ,p_items_label_rendered=>true
 ,p_items_label_position=>'center'
-,p_items_label_display_as=>'PERCENT'
 ,p_items_label_font_size=>'10'
-,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(14186775683270008)
@@ -18064,6 +18069,9 @@ wwv_flow_api.create_page_plug(
 ,p_plug_query_num_rows=>15
 ,p_plug_query_options=>'DERIVED_REPORT_COLUMNS'
 );
+end;
+/
+begin
 wwv_flow_api.create_jet_chart(
  p_id=>wwv_flow_api.id(15051010405989902)
 ,p_region_id=>wwv_flow_api.id(15050972044989901)
@@ -18098,6 +18106,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_data_source=>wwv_flow_string.join(wwv_flow_t_varchar2(
 'select ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -18114,10 +18123,12 @@ wwv_flow_api.create_jet_chart_series(
 '    (:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
 '    (:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
 '    (:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') and',
-'    (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
-'    :P5_REPORT_SELECTOR in (''Daily Cost By Service'',''Weekly Cost By Service'',''Monthly Cost By Service'')    ',
+'    (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YY'
+||'YY'') = :P5_PERIOD_RANGE) and',
+'    :P5_REPORT_SELECTOR in (''Hourly Cost By Service'',''Daily Cost By Service'',''Weekly Cost By Service'',''Monthly Cost By Service'')    ',
 '    group by ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -18132,9 +18143,6 @@ wwv_flow_api.create_jet_chart_series(
 ,p_items_label_position=>'center'
 ,p_items_label_font_size=>'10'
 );
-end;
-/
-begin
 wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(15051263494989904)
 ,p_chart_id=>wwv_flow_api.id(15051010405989902)
@@ -18229,6 +18237,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_data_source=>wwv_flow_string.join(wwv_flow_t_varchar2(
 'select ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -18245,10 +18254,12 @@ wwv_flow_api.create_jet_chart_series(
 '    (:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
 '    (:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
 '    (:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') and',
-'    (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
-'    :P5_REPORT_SELECTOR in (''Daily Cost By Compartment'',''Weekly Cost By Compartment'',''Monthly Cost By Compartment'')    ',
+'    (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YY'
+||'YY'') = :P5_PERIOD_RANGE) and',
+'    :P5_REPORT_SELECTOR in (''Hourly Cost By Compartment'',''Daily Cost By Compartment'',''Weekly Cost By Compartment'',''Monthly Cost By Compartment'')    ',
 '    group by ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -18261,9 +18272,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_assigned_to_y2=>'off'
 ,p_items_label_rendered=>true
 ,p_items_label_position=>'center'
-,p_items_label_display_as=>'PERCENT'
 ,p_items_label_font_size=>'10'
-,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(15052096900989912)
@@ -18372,6 +18381,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_data_source=>wwv_flow_string.join(wwv_flow_t_varchar2(
 'select ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -18388,10 +18398,12 @@ wwv_flow_api.create_jet_chart_series(
 '    (:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
 '    (:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
 '    (:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') and',
-'    (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
-'    :P5_REPORT_SELECTOR in (''Daily Cost By Top Compartment'',''Weekly Cost By Top Compartment'',''Monthly Cost By Compartment'')    ',
+'    (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YY'
+||'YY'') = :P5_PERIOD_RANGE) and',
+'    :P5_REPORT_SELECTOR in (''Hourly Cost By Top Compartment'',''Daily Cost By Top Compartment'',''Weekly Cost By Top Compartment'',''Monthly Cost By Compartment'')    ',
 '    group by ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -18404,9 +18416,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_assigned_to_y2=>'off'
 ,p_items_label_rendered=>true
 ,p_items_label_position=>'center'
-,p_items_label_display_as=>'PERCENT'
 ,p_items_label_font_size=>'10'
-,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(15052897038989920)
@@ -18460,7 +18470,7 @@ wwv_flow_api.create_report_region(
 ,p_name=>'Daily Product Unit Report - Total'
 ,p_parent_plug_id=>wwv_flow_api.id(33638842014589649)
 ,p_template=>wwv_flow_api.id(9765042323688020)
-,p_display_sequence=>130
+,p_display_sequence=>140
 ,p_region_template_options=>'#DEFAULT#:t-Region--scrollBody'
 ,p_component_template_options=>'#DEFAULT#:t-Report--altRowsDefault:t-Report--rowHighlight'
 ,p_display_point=>'BODY'
@@ -18944,6 +18954,9 @@ wwv_flow_api.create_report_columns(
 ,p_derived_column=>'N'
 ,p_include_in_export=>'Y'
 );
+end;
+/
+begin
 wwv_flow_api.create_report_columns(
  p_id=>wwv_flow_api.id(15082822849497503)
 ,p_query_column_id=>28
@@ -19019,7 +19032,7 @@ wwv_flow_api.create_report_region(
 ,p_name=>'Weekly Product Unit Report'
 ,p_parent_plug_id=>wwv_flow_api.id(33638842014589649)
 ,p_template=>wwv_flow_api.id(9765042323688020)
-,p_display_sequence=>150
+,p_display_sequence=>170
 ,p_region_template_options=>'#DEFAULT#:t-Region--scrollBody'
 ,p_component_template_options=>'#DEFAULT#:t-Report--altRowsDefault:t-Report--rowHighlight'
 ,p_display_point=>'BODY'
@@ -19141,9 +19154,6 @@ wwv_flow_api.create_report_region(
 ,p_sort_null=>'L'
 ,p_plug_query_strip_html=>'N'
 );
-end;
-/
-begin
 wwv_flow_api.create_report_columns(
  p_id=>wwv_flow_api.id(15083882458497513)
 ,p_query_column_id=>1
@@ -19972,6 +19982,9 @@ wwv_flow_api.create_report_region(
 ,p_sort_null=>'L'
 ,p_plug_query_strip_html=>'N'
 );
+end;
+/
+begin
 wwv_flow_api.create_report_columns(
  p_id=>wwv_flow_api.id(15102928440532017)
 ,p_query_column_id=>1
@@ -20200,6 +20213,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_data_source=>wwv_flow_string.join(wwv_flow_t_varchar2(
 'select ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -20216,10 +20230,12 @@ wwv_flow_api.create_jet_chart_series(
 '    (:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
 '    (:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
 '    (:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') and',
-'    (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
-'    :P5_REPORT_SELECTOR in (''Daily Cost By SKU'',''Weekly Cost By SKU'',''Monthly Cost By SKU'')    ',
+'    (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YY'
+||'YY'') = :P5_PERIOD_RANGE) and',
+'    :P5_REPORT_SELECTOR in (''Hourly Cost By SKU'',''Daily Cost By SKU'',''Weekly Cost By SKU'',''Monthly Cost By SKU'')    ',
 '    group by ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -20234,9 +20250,6 @@ wwv_flow_api.create_jet_chart_series(
 ,p_items_label_position=>'center'
 ,p_items_label_font_size=>'10'
 );
-end;
-/
-begin
 wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(16360289843490327)
 ,p_chart_id=>wwv_flow_api.id(16360042364490325)
@@ -20267,6 +20280,898 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_tick_label_rendered=>'on'
 ,p_tick_label_rotation=>'auto'
 ,p_tick_label_position=>'outside'
+);
+wwv_flow_api.create_report_region(
+ p_id=>wwv_flow_api.id(16361917406490344)
+,p_name=>'Hourly Cost Report'
+,p_parent_plug_id=>wwv_flow_api.id(33638842014589649)
+,p_template=>wwv_flow_api.id(9765042323688020)
+,p_display_sequence=>120
+,p_region_template_options=>'#DEFAULT#:t-Region--scrollBody'
+,p_component_template_options=>'#DEFAULT#:t-Report--altRowsDefault:t-Report--rowHighlight'
+,p_display_point=>'BODY'
+,p_source_type=>'NATIVE_SQL_REPORT'
+,p_query_type=>'SQL'
+,p_source=>wwv_flow_string.join(wwv_flow_t_varchar2(
+'SELECT ',
+'	case ',
+'		when :P5_REPORT_GROUP = ''Product'' or :P5_REPORT_GROUP is null then COST_PRODUCT_SKU || '' '' || replace(replace(PRD_DESCRIPTION,COST_PRODUCT_SKU||'' - '',''''),''Oracle Cloud Infrastructure'',''OCI'')',
+'		when :P5_REPORT_GROUP = ''Region'' then prd_region',
+'		when :P5_REPORT_GROUP = ''Top Compartment'' then ',
+'			case ',
+'                when prd_compartment_path is null then ''No Compartment''',
+'                when prd_compartment_path like ''%/%'' then nvl(substr(prd_compartment_path,1,instr(prd_compartment_path,'' /'')-1) ,''(Root)'')',
+'                else prd_compartment_path ',
+'            end ',
+'		when :P5_REPORT_GROUP = ''Compartment'' then nvl(prd_compartment_name,''No Compartment'')',
+'	end product_name,',
+'    sum(COST_MY_COST) TOTAL,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''00'' then COST_MY_COST else null end) H00,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''01'' then COST_MY_COST else null end) H01,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''02'' then COST_MY_COST else null end) H02,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''03'' then COST_MY_COST else null end) H03,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''04'' then COST_MY_COST else null end) H04,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''05'' then COST_MY_COST else null end) H05,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''06'' then COST_MY_COST else null end) H06,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''07'' then COST_MY_COST else null end) H07,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''08'' then COST_MY_COST else null end) H08,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''09'' then COST_MY_COST else null end) H09,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''10'' then COST_MY_COST else null end) H10,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''11'' then COST_MY_COST else null end) H11,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''12'' then COST_MY_COST else null end) H12,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''13'' then COST_MY_COST else null end) H13,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''14'' then COST_MY_COST else null end) H14,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''15'' then COST_MY_COST else null end) H15,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''16'' then COST_MY_COST else null end) H16,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''17'' then COST_MY_COST else null end) H17,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''18'' then COST_MY_COST else null end) H18,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''19'' then COST_MY_COST else null end) H19,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''20'' then COST_MY_COST else null end) H20,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''21'' then COST_MY_COST else null end) H21,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''22'' then COST_MY_COST else null end) H22,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''23'' then COST_MY_COST else null end) H23',
+'FROM ',
+'    oci_cost ',
+'WHERE ',
+'    tenant_name=:P5_TENANT_NAME and',
+'    :P5_PERIOD=''Hourly'' and ',
+'	to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE and',
+'    (:P5_COMPARTMENT_NAME is null or prd_compartment_name = :P5_COMPARTMENT_NAME) and',
+'    (:P5_COMPARTMENT_TOP is null or prd_compartment_path like :P5_COMPARTMENT_TOP ||''%'') and',
+'    (:P5_PRODUCT_SERVICE is null or prd_service = :P5_PRODUCT_SERVICE) and',
+'    (:P5_PRODUCT_REGION is null or prd_region = :P5_PRODUCT_REGION) and',
+'    (:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
+'    (:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
+'    (:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') and',
+'    :P5_REPORT_SELECTOR = ''Hourly Cost Report''',
+'GROUP BY ',
+'	case ',
+'		when :P5_REPORT_GROUP = ''Product'' or :P5_REPORT_GROUP is null then COST_PRODUCT_SKU || '' '' || replace(replace(PRD_DESCRIPTION,COST_PRODUCT_SKU||'' - '',''''),''Oracle Cloud Infrastructure'',''OCI'')',
+'		when :P5_REPORT_GROUP = ''Region'' then prd_region',
+'		when :P5_REPORT_GROUP = ''Top Compartment'' then ',
+'			case ',
+'                when prd_compartment_path is null then ''No Compartment''',
+'                when prd_compartment_path like ''%/%'' then nvl(substr(prd_compartment_path,1,instr(prd_compartment_path,'' /'')-1) ,''(Root)'')',
+'                else prd_compartment_path ',
+'            end ',
+'		when :P5_REPORT_GROUP = ''Compartment'' then nvl(prd_compartment_name,''No Compartment'')',
+'	end',
+'having sum(COST_MY_COST)>0;'))
+,p_ajax_enabled=>'Y'
+,p_query_row_template=>wwv_flow_api.id(9790776953688052)
+,p_query_num_rows=>9999
+,p_query_options=>'DERIVED_REPORT_COLUMNS'
+,p_query_show_nulls_as=>'-'
+,p_query_num_rows_type=>'NEXT_PREVIOUS_LINKS'
+,p_pagination_display_position=>'BOTTOM_RIGHT'
+,p_csv_output=>'Y'
+,p_csv_output_link_text=>'Download'
+,p_prn_output=>'Y'
+,p_prn_format=>'PDF'
+,p_prn_output_link_text=>'Print'
+,p_prn_content_disposition=>'ATTACHMENT'
+,p_prn_document_header=>'APEX'
+,p_prn_units=>'INCHES'
+,p_prn_paper_size=>'LETTER'
+,p_prn_width_units=>'PERCENTAGE'
+,p_prn_width=>8.5
+,p_prn_height=>11
+,p_prn_orientation=>'HORIZONTAL'
+,p_prn_page_header_font_color=>'#000000'
+,p_prn_page_header_font_family=>'Helvetica'
+,p_prn_page_header_font_weight=>'normal'
+,p_prn_page_header_font_size=>'12'
+,p_prn_page_footer_font_color=>'#000000'
+,p_prn_page_footer_font_family=>'Helvetica'
+,p_prn_page_footer_font_weight=>'normal'
+,p_prn_page_footer_font_size=>'12'
+,p_prn_header_bg_color=>'#9bafde'
+,p_prn_header_font_color=>'#000000'
+,p_prn_header_font_family=>'Helvetica'
+,p_prn_header_font_weight=>'normal'
+,p_prn_header_font_size=>'10'
+,p_prn_body_bg_color=>'#efefef'
+,p_prn_body_font_color=>'#000000'
+,p_prn_body_font_family=>'Helvetica'
+,p_prn_body_font_weight=>'normal'
+,p_prn_body_font_size=>'10'
+,p_prn_border_width=>.5
+,p_prn_page_header_alignment=>'CENTER'
+,p_prn_page_footer_alignment=>'CENTER'
+,p_sort_null=>'L'
+,p_plug_query_strip_html=>'N'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16763274047834718)
+,p_query_column_id=>1
+,p_column_alias=>'PRODUCT_NAME'
+,p_column_display_sequence=>1
+,p_column_heading=>'&P5_REPORT_GROUP.'
+,p_use_as_row_header=>'N'
+,p_column_html_expression=>'<span style="white-space:nowrap;">#PRODUCT_NAME#</span>'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16763364024834719)
+,p_query_column_id=>2
+,p_column_alias=>'TOTAL'
+,p_column_display_sequence=>2
+,p_column_heading=>'Total'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_default_sort_column_sequence=>1
+,p_disable_sort_column=>'N'
+,p_sum_column=>'Y'
+,p_report_column_width=>85
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16770511516841241)
+,p_query_column_id=>3
+,p_column_alias=>'H00'
+,p_column_display_sequence=>3
+,p_column_heading=>'H00'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16770689428841242)
+,p_query_column_id=>4
+,p_column_alias=>'H01'
+,p_column_display_sequence=>4
+,p_column_heading=>'H01'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16770737453841243)
+,p_query_column_id=>5
+,p_column_alias=>'H02'
+,p_column_display_sequence=>5
+,p_column_heading=>'H02'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16770854563841244)
+,p_query_column_id=>6
+,p_column_alias=>'H03'
+,p_column_display_sequence=>6
+,p_column_heading=>'H03'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16770997460841245)
+,p_query_column_id=>7
+,p_column_alias=>'H04'
+,p_column_display_sequence=>7
+,p_column_heading=>'H04'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16771031468841246)
+,p_query_column_id=>8
+,p_column_alias=>'H05'
+,p_column_display_sequence=>8
+,p_column_heading=>'H05'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16771118519841247)
+,p_query_column_id=>9
+,p_column_alias=>'H06'
+,p_column_display_sequence=>9
+,p_column_heading=>'H06'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16771262419841248)
+,p_query_column_id=>10
+,p_column_alias=>'H07'
+,p_column_display_sequence=>10
+,p_column_heading=>'H07'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16771329063841249)
+,p_query_column_id=>11
+,p_column_alias=>'H08'
+,p_column_display_sequence=>11
+,p_column_heading=>'H08'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16771441103841250)
+,p_query_column_id=>12
+,p_column_alias=>'H09'
+,p_column_display_sequence=>12
+,p_column_heading=>'H09'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16826879267029001)
+,p_query_column_id=>13
+,p_column_alias=>'H10'
+,p_column_display_sequence=>13
+,p_column_heading=>'H10'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16826933010029002)
+,p_query_column_id=>14
+,p_column_alias=>'H11'
+,p_column_display_sequence=>14
+,p_column_heading=>'H11'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16827089785029003)
+,p_query_column_id=>15
+,p_column_alias=>'H12'
+,p_column_display_sequence=>15
+,p_column_heading=>'H12'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16827116573029004)
+,p_query_column_id=>16
+,p_column_alias=>'H13'
+,p_column_display_sequence=>16
+,p_column_heading=>'H13'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16827224833029005)
+,p_query_column_id=>17
+,p_column_alias=>'H14'
+,p_column_display_sequence=>17
+,p_column_heading=>'H14'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16827303340029006)
+,p_query_column_id=>18
+,p_column_alias=>'H15'
+,p_column_display_sequence=>18
+,p_column_heading=>'H15'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16827496080029007)
+,p_query_column_id=>19
+,p_column_alias=>'H16'
+,p_column_display_sequence=>19
+,p_column_heading=>'H16'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16827516268029008)
+,p_query_column_id=>20
+,p_column_alias=>'H17'
+,p_column_display_sequence=>20
+,p_column_heading=>'H17'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16827614635029009)
+,p_query_column_id=>21
+,p_column_alias=>'H18'
+,p_column_display_sequence=>21
+,p_column_heading=>'H18'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16827749905029010)
+,p_query_column_id=>22
+,p_column_alias=>'H19'
+,p_column_display_sequence=>22
+,p_column_heading=>'H19'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16827896907029011)
+,p_query_column_id=>23
+,p_column_alias=>'H20'
+,p_column_display_sequence=>23
+,p_column_heading=>'H20'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16827934142029012)
+,p_query_column_id=>24
+,p_column_alias=>'H21'
+,p_column_display_sequence=>24
+,p_column_heading=>'H21'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16828081124029013)
+,p_query_column_id=>25
+,p_column_alias=>'H22'
+,p_column_display_sequence=>25
+,p_column_heading=>'H22'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16828165381029014)
+,p_query_column_id=>26
+,p_column_alias=>'H23'
+,p_column_display_sequence=>26
+,p_column_heading=>'H23'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_region(
+ p_id=>wwv_flow_api.id(16766903294841205)
+,p_name=>'Hourly Product Unit Report'
+,p_parent_plug_id=>wwv_flow_api.id(33638842014589649)
+,p_template=>wwv_flow_api.id(9765042323688020)
+,p_display_sequence=>150
+,p_region_template_options=>'#DEFAULT#:t-Region--scrollBody'
+,p_component_template_options=>'#DEFAULT#:t-Report--altRowsDefault:t-Report--rowHighlight'
+,p_display_point=>'BODY'
+,p_source_type=>'NATIVE_SQL_REPORT'
+,p_query_type=>'SQL'
+,p_source=>wwv_flow_string.join(wwv_flow_t_varchar2(
+' SELECT ',
+'	product_name,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''00'' then USG_BILLED_QUANTITY else null end) D00,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''01'' then USG_BILLED_QUANTITY else null end) D01,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''02'' then USG_BILLED_QUANTITY else null end) D02,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''03'' then USG_BILLED_QUANTITY else null end) D03,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''04'' then USG_BILLED_QUANTITY else null end) D04,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''05'' then USG_BILLED_QUANTITY else null end) D05,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''06'' then USG_BILLED_QUANTITY else null end) D06,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''07'' then USG_BILLED_QUANTITY else null end) D07,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''08'' then USG_BILLED_QUANTITY else null end) D08,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''09'' then USG_BILLED_QUANTITY else null end) D09,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''10'' then USG_BILLED_QUANTITY else null end) D10,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''11'' then USG_BILLED_QUANTITY else null end) D11,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''12'' then USG_BILLED_QUANTITY else null end) D12,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''13'' then USG_BILLED_QUANTITY else null end) D13,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''14'' then USG_BILLED_QUANTITY else null end) D14,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''15'' then USG_BILLED_QUANTITY else null end) D15,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''16'' then USG_BILLED_QUANTITY else null end) D16,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''17'' then USG_BILLED_QUANTITY else null end) D17,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''18'' then USG_BILLED_QUANTITY else null end) D18,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''19'' then USG_BILLED_QUANTITY else null end) D19,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''20'' then USG_BILLED_QUANTITY else null end) D20,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''21'' then USG_BILLED_QUANTITY else null end) D21,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''22'' then USG_BILLED_QUANTITY else null end) D22,',
+'    sum(case when to_char(USAGE_INTERVAL_START,''HH24'') = ''23'' then USG_BILLED_QUANTITY else null end) D23',
+'FROM ',
+'(',
+'	SELECT ',
+'		COST_PRODUCT_SKU || '' '' || replace(replace(PRD_DESCRIPTION,COST_PRODUCT_SKU||'' - '',''''),''Oracle Cloud Infrastructure'',''OCI'') PRODUCT_NAME,',
+'		USAGE_INTERVAL_START,',
+'		USG_BILLED_QUANTITY',
+'	FROM',
+'    	oci_cost ',
+'	WHERE ',
+'		tenant_name=:P5_TENANT_NAME and',
+'		:P5_PERIOD=''Hourly'' and ',
+'		to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE and',
+'		(:P5_COMPARTMENT_NAME is null or prd_compartment_name = :P5_COMPARTMENT_NAME) and',
+'		(:P5_COMPARTMENT_TOP is null or prd_compartment_path like :P5_COMPARTMENT_TOP ||''%'') and',
+'		(:P5_PRODUCT_SERVICE is null or prd_service = :P5_PRODUCT_SERVICE) and',
+'		(:P5_PRODUCT_REGION is null or prd_region = :P5_PRODUCT_REGION) and',
+'		(:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
+'		(:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
+'		(:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') AND',
+'        :P5_REPORT_SELECTOR = ''Hourly Product Unit Report''',
+')',
+'GROUP BY PRODUCT_NAME',
+'having sum(USG_BILLED_QUANTITY)>0;'))
+,p_ajax_enabled=>'Y'
+,p_query_row_template=>wwv_flow_api.id(9790776953688052)
+,p_query_num_rows=>9999
+,p_query_options=>'DERIVED_REPORT_COLUMNS'
+,p_query_show_nulls_as=>'-'
+,p_query_num_rows_type=>'NEXT_PREVIOUS_LINKS'
+,p_pagination_display_position=>'BOTTOM_RIGHT'
+,p_csv_output=>'Y'
+,p_csv_output_link_text=>'Download'
+,p_prn_output=>'Y'
+,p_prn_format=>'PDF'
+,p_prn_output_link_text=>'Print'
+,p_prn_content_disposition=>'ATTACHMENT'
+,p_prn_document_header=>'APEX'
+,p_prn_units=>'INCHES'
+,p_prn_paper_size=>'LETTER'
+,p_prn_width_units=>'PERCENTAGE'
+,p_prn_width=>8.5
+,p_prn_height=>11
+,p_prn_orientation=>'HORIZONTAL'
+,p_prn_page_header_font_color=>'#000000'
+,p_prn_page_header_font_family=>'Helvetica'
+,p_prn_page_header_font_weight=>'normal'
+,p_prn_page_header_font_size=>'12'
+,p_prn_page_footer_font_color=>'#000000'
+,p_prn_page_footer_font_family=>'Helvetica'
+,p_prn_page_footer_font_weight=>'normal'
+,p_prn_page_footer_font_size=>'12'
+,p_prn_header_bg_color=>'#9bafde'
+,p_prn_header_font_color=>'#000000'
+,p_prn_header_font_family=>'Helvetica'
+,p_prn_header_font_weight=>'normal'
+,p_prn_header_font_size=>'10'
+,p_prn_body_bg_color=>'#efefef'
+,p_prn_body_font_color=>'#000000'
+,p_prn_body_font_family=>'Helvetica'
+,p_prn_body_font_weight=>'normal'
+,p_prn_body_font_size=>'10'
+,p_prn_border_width=>.5
+,p_prn_page_header_alignment=>'CENTER'
+,p_prn_page_footer_alignment=>'CENTER'
+,p_sort_null=>'L'
+,p_plug_query_strip_html=>'N'
+);
+end;
+/
+begin
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16767038146841206)
+,p_query_column_id=>1
+,p_column_alias=>'PRODUCT_NAME'
+,p_column_display_sequence=>1
+,p_column_heading=>'&P5_REPORT_GROUP.'
+,p_use_as_row_header=>'N'
+,p_column_html_expression=>'<span style="white-space:nowrap;">#PRODUCT_NAME#</span>'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16828243172029015)
+,p_query_column_id=>2
+,p_column_alias=>'D00'
+,p_column_display_sequence=>2
+,p_column_heading=>'D00'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16828372110029016)
+,p_query_column_id=>3
+,p_column_alias=>'D01'
+,p_column_display_sequence=>3
+,p_column_heading=>'D01'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16828437615029017)
+,p_query_column_id=>4
+,p_column_alias=>'D02'
+,p_column_display_sequence=>4
+,p_column_heading=>'D02'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16828549991029018)
+,p_query_column_id=>5
+,p_column_alias=>'D03'
+,p_column_display_sequence=>5
+,p_column_heading=>'D03'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16828631498029019)
+,p_query_column_id=>6
+,p_column_alias=>'D04'
+,p_column_display_sequence=>6
+,p_column_heading=>'D04'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16828793554029020)
+,p_query_column_id=>7
+,p_column_alias=>'D05'
+,p_column_display_sequence=>7
+,p_column_heading=>'D05'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16828813690029021)
+,p_query_column_id=>8
+,p_column_alias=>'D06'
+,p_column_display_sequence=>8
+,p_column_heading=>'D06'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16828917414029022)
+,p_query_column_id=>9
+,p_column_alias=>'D07'
+,p_column_display_sequence=>9
+,p_column_heading=>'D07'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16829061684029023)
+,p_query_column_id=>10
+,p_column_alias=>'D08'
+,p_column_display_sequence=>10
+,p_column_heading=>'D08'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16829112352029024)
+,p_query_column_id=>11
+,p_column_alias=>'D09'
+,p_column_display_sequence=>11
+,p_column_heading=>'D09'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16829239676029025)
+,p_query_column_id=>12
+,p_column_alias=>'D10'
+,p_column_display_sequence=>12
+,p_column_heading=>'D10'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16829374140029026)
+,p_query_column_id=>13
+,p_column_alias=>'D11'
+,p_column_display_sequence=>13
+,p_column_heading=>'D11'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16829409576029027)
+,p_query_column_id=>14
+,p_column_alias=>'D12'
+,p_column_display_sequence=>14
+,p_column_heading=>'D12'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16829515328029028)
+,p_query_column_id=>15
+,p_column_alias=>'D13'
+,p_column_display_sequence=>15
+,p_column_heading=>'D13'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16829664941029029)
+,p_query_column_id=>16
+,p_column_alias=>'D14'
+,p_column_display_sequence=>16
+,p_column_heading=>'D14'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16829724269029030)
+,p_query_column_id=>17
+,p_column_alias=>'D15'
+,p_column_display_sequence=>17
+,p_column_heading=>'D15'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16829802026029031)
+,p_query_column_id=>18
+,p_column_alias=>'D16'
+,p_column_display_sequence=>18
+,p_column_heading=>'D16'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16829959305029032)
+,p_query_column_id=>19
+,p_column_alias=>'D17'
+,p_column_display_sequence=>19
+,p_column_heading=>'D17'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16830085321029033)
+,p_query_column_id=>20
+,p_column_alias=>'D18'
+,p_column_display_sequence=>20
+,p_column_heading=>'D18'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16830195992029034)
+,p_query_column_id=>21
+,p_column_alias=>'D19'
+,p_column_display_sequence=>21
+,p_column_heading=>'D19'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16830202018029035)
+,p_query_column_id=>22
+,p_column_alias=>'D20'
+,p_column_display_sequence=>22
+,p_column_heading=>'D20'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16830368840029036)
+,p_query_column_id=>23
+,p_column_alias=>'D21'
+,p_column_display_sequence=>23
+,p_column_heading=>'D21'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16830480806029037)
+,p_query_column_id=>24
+,p_column_alias=>'D22'
+,p_column_display_sequence=>24
+,p_column_heading=>'D22'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
+);
+wwv_flow_api.create_report_columns(
+ p_id=>wwv_flow_api.id(16830548503029038)
+,p_query_column_id=>25
+,p_column_alias=>'D23'
+,p_column_display_sequence=>25
+,p_column_heading=>'D23'
+,p_use_as_row_header=>'N'
+,p_column_format=>'999G999G999G999G990D00'
+,p_column_alignment=>'RIGHT'
+,p_disable_sort_column=>'N'
+,p_derived_column=>'N'
+,p_include_in_export=>'Y'
 );
 wwv_flow_api.create_page_plug(
  p_id=>wwv_flow_api.id(23961814581267567)
@@ -20327,6 +21232,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_data_source=>wwv_flow_string.join(wwv_flow_t_varchar2(
 'select ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -20342,11 +21248,13 @@ wwv_flow_api.create_jet_chart_series(
 '    (:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
 '    (:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
 '    (:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') and',
-'    (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'    (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YY'
+||'YY'') = :P5_PERIOD_RANGE) and',
 '    not (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null) and',
-'    :P5_REPORT_SELECTOR in (''Daily Cost Over Time'',''Weekly Cost Over Time'',''Monthly Cost Over Time'')    ',
+'    :P5_REPORT_SELECTOR in (''Hourly Cost Over Time'',''Daily Cost Over Time'',''Weekly Cost Over Time'',''Monthly Cost Over Time'')    ',
 '    group by ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -20354,6 +21262,7 @@ wwv_flow_api.create_jet_chart_series(
 'union all',
 'select ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -20362,11 +21271,13 @@ wwv_flow_api.create_jet_chart_series(
 'from oci_cost_stats',
 'where ',
 '    tenant_name=:P5_TENANT_NAME and',
-'    (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'    (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YY'
+||'YY'') = :P5_PERIOD_RANGE) and',
 '    (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null) and',
-'    :P5_REPORT_SELECTOR in (''Daily Cost Over Time'',''Weekly Cost Over Time'',''Monthly Cost Over Time'')    ',
+'    :P5_REPORT_SELECTOR in (''Hourly Cost Over Time'',''Daily Cost Over Time'',''Weekly Cost Over Time'',''Monthly Cost Over Time'')    ',
 '    group by ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -20382,9 +21293,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_assigned_to_y2=>'off'
 ,p_items_label_rendered=>true
 ,p_items_label_position=>'center'
-,p_items_label_display_as=>'PERCENT'
 ,p_items_label_font_size=>'10'
-,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_series(
  p_id=>wwv_flow_api.id(11933638002191629)
@@ -20395,6 +21304,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_data_source=>wwv_flow_string.join(wwv_flow_t_varchar2(
 'select ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -20410,11 +21320,13 @@ wwv_flow_api.create_jet_chart_series(
 '    (:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
 '    (:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
 '    (:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') and',
-'    (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'    (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YY'
+||'YY'') = :P5_PERIOD_RANGE) and',
 '    not (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null) and',
-'    :P5_REPORT_SELECTOR in (''Daily Cost Over Time'',''Weekly Cost Over Time'',''Monthly Cost Over Time'')    ',
+'    :P5_REPORT_SELECTOR in (''Hourly Cost Over Time'',''Daily Cost Over Time'',''Weekly Cost Over Time'',''Monthly Cost Over Time'')    ',
 '    group by ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -20422,6 +21334,7 @@ wwv_flow_api.create_jet_chart_series(
 'union all',
 'select ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -20430,11 +21343,13 @@ wwv_flow_api.create_jet_chart_series(
 'from oci_cost_stats',
 'where ',
 '    tenant_name=:P5_TENANT_NAME and',
-'    (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'    (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YY'
+||'YY'') = :P5_PERIOD_RANGE) and',
 '    (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null) and',
-'    :P5_REPORT_SELECTOR in (''Daily Cost Over Time'',''Weekly Cost Over Time'',''Monthly Cost Over Time'')    ',
+'    :P5_REPORT_SELECTOR in (''Hourly Cost Over Time'',''Daily Cost Over Time'',''Weekly Cost Over Time'',''Monthly Cost Over Time'')    ',
 '    group by ',
 '    case ',
+'        when :P5_PERIOD=''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD HH24'') ',
 '        when :P5_PERIOD=''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '        when :P5_PERIOD=''Weekly'' then to_char(USAGE_INTERVAL_START,''YYYY-WW'') ',
 '        when :P5_PERIOD=''Monthly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-MON'')',
@@ -20450,9 +21365,7 @@ wwv_flow_api.create_jet_chart_series(
 ,p_assigned_to_y2=>'off'
 ,p_items_label_rendered=>true
 ,p_items_label_position=>'center'
-,p_items_label_display_as=>'PERCENT'
 ,p_items_label_font_size=>'10'
-,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(12036986078075984)
@@ -20547,7 +21460,7 @@ wwv_flow_api.create_page_item(
 ,p_item_plug_id=>wwv_flow_api.id(22846551592241693)
 ,p_prompt=>'Report Period'
 ,p_display_as=>'NATIVE_SELECT_LIST'
-,p_lov=>'STATIC2:Daily;Daily,Weekly;Weekly,Monthly;Monthly'
+,p_lov=>'STATIC2:Hourly;Hourly,Daily;Daily,Weekly;Weekly,Monthly;Monthly'
 ,p_lov_display_null=>'YES'
 ,p_lov_null_text=>'Please Choose'
 ,p_cHeight=>1
@@ -20567,30 +21480,50 @@ wwv_flow_api.create_page_item(
 ,p_item_default=>wwv_flow_string.join(wwv_flow_t_varchar2(
 'select max(',
 '          case ',
+'              when :P5_PERIOD = ''Hourly'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
 '              when :P5_PERIOD = ''Daily'' or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY-MM'') ',
 '              when :P5_PERIOD in (''Monthly'',''Weekly'') then to_char(USAGE_INTERVAL_START,''YYYY'') ',
 '          end) period',
 '     from ',
 '         oci_cost_stats',
 '     where',
-'     tenant_name=:P5_TENANT_NAME ',
+'     tenant_name=:P5_TENANT_NAME and (:P5_PERIOD <> ''Hourly'' or USAGE_INTERVAL_START<trunc(sysdate)-2)',
 ''))
 ,p_item_default_type=>'SQL_QUERY'
-,p_prompt=>'Year / Month'
+,p_prompt=>'Year / Month / Day'
 ,p_display_as=>'NATIVE_SELECT_LIST'
 ,p_lov=>wwv_flow_string.join(wwv_flow_t_varchar2(
-'select period o, period r',
+'select ',
+'    case when :P5_PERIOD = ''Hourly'' then period_d else period_r end o, period_r r',
 'from ',
 '(',
-'     select distinct ',
+'     select ',
 '          case ',
+'              when :P5_PERIOD = ''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD DY'') ',
 '              when :P5_PERIOD = ''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM'') ',
 '              when :P5_PERIOD in (''Monthly'',''Weekly'') or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY'') ',
-'          end period',
+'          end||'' - ''||to_char(sum(COST_MY_COST),''999,999,999.9'') period_d,',
+'          case ',
+'              when :P5_PERIOD = ''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
+'              when :P5_PERIOD = ''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM'') ',
+'              when :P5_PERIOD in (''Monthly'',''Weekly'') or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY'') ',
+'          end period_r',
 '     from ',
 '         oci_cost_stats',
 '     where',
-'     tenant_name=:P5_TENANT_NAME and :P5_PERIOD is not null',
+'         tenant_name=:P5_TENANT_NAME and :P5_PERIOD is not null',
+'         and (:P5_PERIOD <> ''Hourly'' or USAGE_INTERVAL_START>trunc(sysdate)-90 and USAGE_INTERVAL_START<trunc(sysdate)-2)',
+'     group by ',
+'          case ',
+'              when :P5_PERIOD = ''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD DY'') ',
+'              when :P5_PERIOD = ''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM'') ',
+'              when :P5_PERIOD in (''Monthly'',''Weekly'') or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY'') ',
+'          end ,',
+'          case ',
+'              when :P5_PERIOD = ''Hourly'' then to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') ',
+'              when :P5_PERIOD = ''Daily'' then to_char(USAGE_INTERVAL_START,''YYYY-MM'') ',
+'              when :P5_PERIOD in (''Monthly'',''Weekly'') or :P5_PERIOD is null then to_char(USAGE_INTERVAL_START,''YYYY'') ',
+'          end ',
 '     order by 1',
 ')'))
 ,p_lov_cascade_parent_items=>'P5_PERIOD,P5_TENANT_NAME'
@@ -20822,6 +21755,9 @@ wwv_flow_api.create_page_item(
 ,p_attribute_04=>'TEXT'
 ,p_attribute_05=>'BOTH'
 );
+end;
+/
+begin
 wwv_flow_api.create_page_item(
  p_id=>wwv_flow_api.id(12054081919076067)
 ,p_name=>'P5_COST'
@@ -20845,14 +21781,16 @@ wwv_flow_api.create_page_item(
 '        (:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
 '        (:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') and',
 '        (:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
-'        (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'        (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START'
+||',''YYYY'') = :P5_PERIOD_RANGE) and',
 '        not (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null)',
 '    union all',
 '    select sum(COST_MY_COST) COST_MY_COST, min(COST_CURRENCY_CODE) COST_CURRENCY_CODE',
 '    from oci_cost_stats',
 '    where ',
 '        tenant_name=:P5_TENANT_NAME and',
-'        (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'        (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START'
+||',''YYYY'') = :P5_PERIOD_RANGE) and',
 '        (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null)',
 ')'))
 ,p_source_type=>'QUERY'
@@ -20888,14 +21826,16 @@ wwv_flow_api.create_page_item(
 '        (:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
 '        (:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') and',
 '        (:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
-'        (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'        (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START'
+||',''YYYY'') = :P5_PERIOD_RANGE) and',
 '        not (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null)',
 '    union all',
 '    select sum(COST_MY_COST_OVERAGE) COST_MY_COST_OVERAGE, min(COST_CURRENCY_CODE) COST_CURRENCY_CODE',
 '    from oci_cost_stats',
 '    where ',
 '        tenant_name=:P5_TENANT_NAME and',
-'        (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'        (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START'
+||',''YYYY'') = :P5_PERIOD_RANGE) and',
 '        (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null)',
 ')'))
 ,p_source_type=>'QUERY'
@@ -20932,7 +21872,8 @@ wwv_flow_api.create_page_item(
 '        (:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
 '        (:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') and',
 '        (:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
-'        (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'        (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START'
+||',''YYYY'') = :P5_PERIOD_RANGE) and',
 '        not (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null)',
 '    union all',
 '    select ',
@@ -20940,7 +21881,8 @@ wwv_flow_api.create_page_item(
 '    from oci_cost_stats',
 '    where ',
 '        tenant_name=:P5_TENANT_NAME and',
-'        (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'        (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START'
+||',''YYYY'') = :P5_PERIOD_RANGE) and',
 '        (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null)',
 ')'))
 ,p_source_type=>'QUERY'
@@ -21005,6 +21947,24 @@ wwv_flow_api.create_page_item(
 ,p_lov=>wwv_flow_string.join(wwv_flow_t_varchar2(
 'with data as',
 '(',
+'    select ''Hourly Cost Over Time'' report_name from dual where :P5_PERIOD=''Hourly''',
+'    union all',
+'    select ''Hourly Cost Over Time - Total'' report_name from dual where :P5_PERIOD=''Hourly''',
+'    union all',
+'    select ''Hourly Cost By Service'' report_name from dual where :P5_PERIOD=''Hourly''',
+'    union all',
+'    select ''Hourly Cost By SKU'' report_name from dual where :P5_PERIOD=''Hourly''',
+'    union all',
+'    select ''Hourly Cost By Region'' report_name from dual where :P5_PERIOD=''Hourly''',
+'    union all',
+'    select ''Hourly Cost By Compartment'' report_name from dual where :P5_PERIOD=''Hourly''',
+'    union all',
+'    select ''Hourly Cost By Top Compartment'' report_name from dual where :P5_PERIOD=''Hourly''',
+'    union all',
+'    select ''Hourly Cost Report'' report_name from dual where :P5_PERIOD=''Hourly''',
+'    union all',
+'    select ''Hourly Product Unit Report'' report_name from dual where :P5_PERIOD=''Hourly''',
+'    union all',
 '    select ''Daily Cost Over Time'' report_name from dual where :P5_PERIOD=''Daily''',
 '    union all',
 '    select ''Daily Cost Over Time - Total'' report_name from dual where :P5_PERIOD=''Daily''',
@@ -21075,9 +22035,6 @@ wwv_flow_api.create_page_item(
 ,p_attribute_01=>'NONE'
 ,p_attribute_02=>'N'
 );
-end;
-/
-begin
 wwv_flow_api.create_page_item(
  p_id=>wwv_flow_api.id(14186230501270003)
 ,p_name=>'P5_YEARLY'
@@ -21103,7 +22060,8 @@ wwv_flow_api.create_page_item(
 '        (:P5_TAG_KEY is null or tags_data like ''%#'' || :P5_TAG_KEY || ''=%'') and',
 '        (:P5_TAG_DATA is null or tags_data like ''%#'' || nvl(:P5_TAG_KEY,''%'') || ''=%'' || :P5_TAG_DATA || ''#'') and',
 '        (:P5_COST_PRODUCT_SKU is null or COST_PRODUCT_SKU = :P5_COST_PRODUCT_SKU) and',
-'        (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'        (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START'
+||',''YYYY'') = :P5_PERIOD_RANGE) and',
 '        not (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null)',
 '    union all',
 '    select ',
@@ -21112,7 +22070,8 @@ wwv_flow_api.create_page_item(
 '    from oci_cost_stats',
 '    where ',
 '        tenant_name=:P5_TENANT_NAME and',
-'        (:P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START,''YYYY'') = :P5_PERIOD_RANGE) and',
+'        (:P5_PERIOD=''Hourly'' and to_char(USAGE_INTERVAL_START,''YYYY-MM-DD'') = :P5_PERIOD_RANGE or :P5_PERIOD=''Daily'' and to_char(USAGE_INTERVAL_START,''YYYY-MM'') = :P5_PERIOD_RANGE or :P5_PERIOD in (''Monthly'',''Weekly'') and to_char(USAGE_INTERVAL_START'
+||',''YYYY'') = :P5_PERIOD_RANGE) and',
 '        (:P5_COMPARTMENT_NAME is null and :P5_PRODUCT_SERVICE is null and :P5_PRODUCT_REGION is null and :P5_COMPARTMENT_TOP is null and :P5_TAG_KEY is null and :P5_TAG_DATA is null and :P5_COST_PRODUCT_SKU is null)',
 ')'))
 ,p_source_type=>'QUERY'
@@ -21305,7 +22264,7 @@ wwv_flow_api.create_page_da_event(
 ,p_event_sequence=>60
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'IN_LIST'
-,p_triggering_expression=>'Daily Cost Over Time,Weekly Cost Over Time,Monthly Cost Over Time'
+,p_triggering_expression=>'Hourly Cost Over Time,Daily Cost Over Time,Weekly Cost Over Time,Monthly Cost Over Time'
 ,p_bind_type=>'bind'
 ,p_bind_event_type=>'ready'
 );
@@ -21335,7 +22294,7 @@ wwv_flow_api.create_page_da_event(
 ,p_event_sequence=>70
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'IN_LIST'
-,p_triggering_expression=>'Daily Cost Over Time - Total,Weekly Cost Over Time - Total,Monthly Cost Over Time - Total'
+,p_triggering_expression=>'Hourly Cost Over Time - Total,Daily Cost Over Time - Total,Weekly Cost Over Time - Total,Monthly Cost Over Time - Total'
 ,p_bind_type=>'bind'
 ,p_bind_event_type=>'ready'
 );
@@ -21365,7 +22324,7 @@ wwv_flow_api.create_page_da_event(
 ,p_event_sequence=>80
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'IN_LIST'
-,p_triggering_expression=>'Daily Cost By Service,Weekly Cost By Service,Monthly Cost By Service'
+,p_triggering_expression=>'Hourly Cost By Service,Daily Cost By Service,Weekly Cost By Service,Monthly Cost By Service'
 ,p_bind_type=>'bind'
 ,p_bind_event_type=>'ready'
 );
@@ -21395,7 +22354,7 @@ wwv_flow_api.create_page_da_event(
 ,p_event_sequence=>90
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'IN_LIST'
-,p_triggering_expression=>'Daily Cost By SKU,Weekly Cost By SKU,Monthly Cost By SKU'
+,p_triggering_expression=>'Hourly Cost By SKU,Daily Cost By SKU,Weekly Cost By SKU,Monthly Cost By SKU'
 ,p_bind_type=>'bind'
 ,p_bind_event_type=>'ready'
 );
@@ -21425,7 +22384,7 @@ wwv_flow_api.create_page_da_event(
 ,p_event_sequence=>100
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'IN_LIST'
-,p_triggering_expression=>'Daily Cost By Compartment,Weekly Cost By Compartment,Monthly Cost By Compartment'
+,p_triggering_expression=>'Hourly Cost By Compartment,Daily Cost By Compartment,Weekly Cost By Compartment,Monthly Cost By Compartment'
 ,p_bind_type=>'bind'
 ,p_bind_event_type=>'ready'
 );
@@ -21455,7 +22414,7 @@ wwv_flow_api.create_page_da_event(
 ,p_event_sequence=>110
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'IN_LIST'
-,p_triggering_expression=>'Daily Cost By Region,Weekly Cost By Region,Monthly Cost By Region'
+,p_triggering_expression=>'Hourly Cost By Region,Daily Cost By Region,Weekly Cost By Region,Monthly Cost By Region'
 ,p_bind_type=>'bind'
 ,p_bind_event_type=>'ready'
 );
@@ -21485,7 +22444,7 @@ wwv_flow_api.create_page_da_event(
 ,p_event_sequence=>120
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'IN_LIST'
-,p_triggering_expression=>'Daily Cost By Top Compartment,Weekly Cost By Top Compartment,Monthly Cost By Top Compartment'
+,p_triggering_expression=>'Hourly Cost By Top Compartment,Daily Cost By Top Compartment,Weekly Cost By Top Compartment,Monthly Cost By Top Compartment'
 ,p_bind_type=>'bind'
 ,p_bind_event_type=>'ready'
 );
@@ -21508,6 +22467,69 @@ wwv_flow_api.create_page_da_action(
 ,p_action=>'NATIVE_SHOW'
 ,p_affected_elements_type=>'REGION'
 ,p_affected_region_id=>wwv_flow_api.id(15052505519989917)
+);
+wwv_flow_api.create_page_da_event(
+ p_id=>wwv_flow_api.id(16766694642841202)
+,p_name=>'ShowHourlyCostReport'
+,p_event_sequence=>125
+,p_condition_element=>'P5_REPORT_SELECTOR'
+,p_triggering_condition_type=>'EQUALS'
+,p_triggering_expression=>'Hourly Cost Report'
+,p_bind_type=>'bind'
+,p_bind_event_type=>'ready'
+);
+wwv_flow_api.create_page_da_action(
+ p_id=>wwv_flow_api.id(16766754682841203)
+,p_event_id=>wwv_flow_api.id(16766694642841202)
+,p_event_result=>'TRUE'
+,p_action_sequence=>10
+,p_execute_on_page_init=>'Y'
+,p_action=>'NATIVE_SHOW'
+,p_affected_elements_type=>'REGION'
+,p_affected_region_id=>wwv_flow_api.id(16361917406490344)
+);
+wwv_flow_api.create_page_da_action(
+ p_id=>wwv_flow_api.id(16766823504841204)
+,p_event_id=>wwv_flow_api.id(16766694642841202)
+,p_event_result=>'FALSE'
+,p_action_sequence=>10
+,p_execute_on_page_init=>'Y'
+,p_action=>'NATIVE_HIDE'
+,p_affected_elements_type=>'REGION'
+,p_affected_region_id=>wwv_flow_api.id(16361917406490344)
+);
+wwv_flow_api.create_page_da_event(
+ p_id=>wwv_flow_api.id(16770229606841238)
+,p_name=>'ShowHourlyProductUnitReport'
+,p_event_sequence=>126
+,p_condition_element=>'P5_REPORT_SELECTOR'
+,p_triggering_condition_type=>'EQUALS'
+,p_triggering_expression=>'Hourly Product Unit Report'
+,p_bind_type=>'bind'
+,p_bind_event_type=>'ready'
+);
+end;
+/
+begin
+wwv_flow_api.create_page_da_action(
+ p_id=>wwv_flow_api.id(16770332721841239)
+,p_event_id=>wwv_flow_api.id(16770229606841238)
+,p_event_result=>'TRUE'
+,p_action_sequence=>10
+,p_execute_on_page_init=>'Y'
+,p_action=>'NATIVE_SHOW'
+,p_affected_elements_type=>'REGION'
+,p_affected_region_id=>wwv_flow_api.id(16766903294841205)
+);
+wwv_flow_api.create_page_da_action(
+ p_id=>wwv_flow_api.id(16770414224841240)
+,p_event_id=>wwv_flow_api.id(16770229606841238)
+,p_event_result=>'FALSE'
+,p_action_sequence=>10
+,p_execute_on_page_init=>'Y'
+,p_action=>'NATIVE_HIDE'
+,p_affected_elements_type=>'REGION'
+,p_affected_region_id=>wwv_flow_api.id(16766903294841205)
 );
 wwv_flow_api.create_page_da_event(
  p_id=>wwv_flow_api.id(13975055917041427)
@@ -21542,7 +22564,7 @@ wwv_flow_api.create_page_da_action(
 wwv_flow_api.create_page_da_event(
  p_id=>wwv_flow_api.id(13975348835041430)
 ,p_name=>'ShowDailyProductUnitReportSingle'
-,p_event_sequence=>140
+,p_event_sequence=>150
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'EQUALS'
 ,p_triggering_expression=>'Daily Product Unit Report - Single'
@@ -21572,7 +22594,7 @@ wwv_flow_api.create_page_da_action(
 wwv_flow_api.create_page_da_event(
  p_id=>wwv_flow_api.id(15083319206497508)
 ,p_name=>'ShowDailyProductUnitReportTotal'
-,p_event_sequence=>150
+,p_event_sequence=>170
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'EQUALS'
 ,p_triggering_expression=>'Daily Product Unit Report - Total'
@@ -21602,7 +22624,7 @@ wwv_flow_api.create_page_da_action(
 wwv_flow_api.create_page_da_event(
  p_id=>wwv_flow_api.id(13975688110041433)
 ,p_name=>'ShowWeeklyCostReport'
-,p_event_sequence=>160
+,p_event_sequence=>180
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'EQUALS'
 ,p_triggering_expression=>'Weekly Cost Report'
@@ -21632,7 +22654,7 @@ wwv_flow_api.create_page_da_action(
 wwv_flow_api.create_page_da_event(
  p_id=>wwv_flow_api.id(15104375728532031)
 ,p_name=>'ShowWeeklyProductUnitReport'
-,p_event_sequence=>170
+,p_event_sequence=>190
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'EQUALS'
 ,p_triggering_expression=>'Weekly Product Unit Report'
@@ -21662,7 +22684,7 @@ wwv_flow_api.create_page_da_action(
 wwv_flow_api.create_page_da_event(
  p_id=>wwv_flow_api.id(15104677803532034)
 ,p_name=>'ShowMonthlyProductUnitReport'
-,p_event_sequence=>180
+,p_event_sequence=>200
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'EQUALS'
 ,p_triggering_expression=>'Monthly Product Unit Report'
@@ -21692,7 +22714,7 @@ wwv_flow_api.create_page_da_action(
 wwv_flow_api.create_page_da_event(
  p_id=>wwv_flow_api.id(13975972745041436)
 ,p_name=>'ShowMonthlyCostReport'
-,p_event_sequence=>190
+,p_event_sequence=>210
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'EQUALS'
 ,p_triggering_expression=>'Monthly Cost Report'
@@ -21722,7 +22744,7 @@ wwv_flow_api.create_page_da_action(
 wwv_flow_api.create_page_da_event(
  p_id=>wwv_flow_api.id(13976243106041439)
 ,p_name=>'ShowReportGroupOption'
-,p_event_sequence=>200
+,p_event_sequence=>220
 ,p_condition_element=>'P5_REPORT_SELECTOR'
 ,p_triggering_condition_type=>'IN_LIST'
 ,p_triggering_expression=>'Daily Cost Report,Weekly Cost Report,Monthly Cost Report'
@@ -21766,7 +22788,7 @@ wwv_flow_api.create_page(
 '}'))
 ,p_page_template_options=>'#DEFAULT#'
 ,p_last_updated_by=>'ADIZOHAR'
-,p_last_upd_yyyymmddhh24miss=>'20200520121531'
+,p_last_upd_yyyymmddhh24miss=>'20200601123606'
 );
 wwv_flow_api.create_page_plug(
  p_id=>wwv_flow_api.id(12552815670313326)
@@ -22197,7 +23219,7 @@ wwv_flow_api.create_worksheet_rpt(
 wwv_flow_api.create_page_plug(
  p_id=>wwv_flow_api.id(14188632778270027)
 ,p_plug_name=>'Cost Summary Last 7 Days'
-,p_region_template_options=>'#DEFAULT#:t-Region--accent15:t-Region--scrollBody'
+,p_region_template_options=>'#DEFAULT#:t-Region--noPadding:t-Region--accent15:t-Region--scrollBody:margin-top-none:margin-bottom-none:margin-left-none:margin-right-none'
 ,p_component_template_options=>'#DEFAULT#'
 ,p_plug_template=>wwv_flow_api.id(9765042323688020)
 ,p_plug_display_sequence=>30
@@ -22205,7 +23227,23 @@ wwv_flow_api.create_page_plug(
 ,p_plug_display_point=>'BODY'
 ,p_query_type=>'SQL'
 ,p_plug_source=>wwv_flow_string.join(wwv_flow_t_varchar2(
-'select tenant_name, day7, day6, day5, day4, day3, day2, day1, greatest(day1,day2,day3,day4,day5,day6,day7)*365 year',
+'select ',
+'	tenant_name, ',
+'	day7, ',
+'	day6, ',
+'	day5, ',
+'	day4, ',
+'	day3, ',
+'	day2, ',
+'	day1, ',
+'	greatest(day1,day2,day3,day4,day5,day6,day7)*365 year,',
+'	case when trunc(greatest(day1,day2,day3,day4,day5,day6,day7)) = trunc(day1) then ''background-color:#CCFFCC;font-weight:bold;'' else ''background-color:#FFFFFF'' END as day1_color,',
+'	case when trunc(greatest(day1,day2,day3,day4,day5,day6,day7)) = trunc(day2) then ''background-color:#CCFFCC;font-weight:bold;'' else ''background-color:#FFFFFF'' END as day2_color,',
+'	case when trunc(greatest(day1,day2,day3,day4,day5,day6,day7)) = trunc(day3) then ''background-color:#CCFFCC;font-weight:bold;'' else ''background-color:#FFFFFF'' END as day3_color,',
+'	case when trunc(greatest(day1,day2,day3,day4,day5,day6,day7)) = trunc(day4) then ''background-color:#CCFFCC;font-weight:bold;'' else ''background-color:#FFFFFF'' END as day4_color,',
+'	case when trunc(greatest(day1,day2,day3,day4,day5,day6,day7)) = trunc(day5) then ''background-color:#CCFFCC;font-weight:bold;'' else ''background-color:#FFFFFF'' END as day5_color,',
+'	case when trunc(greatest(day1,day2,day3,day4,day5,day6,day7)) = trunc(day6) then ''background-color:#CCFFCC;font-weight:bold;'' else ''background-color:#FFFFFF'' END as day6_color,',
+'	case when trunc(greatest(day1,day2,day3,day4,day5,day6,day7)) = trunc(day7) then ''background-color:#CCFFCC;font-weight:bold;'' else ''background-color:#FFFFFF'' END as day7_color',
 'from',
 '(',
 '    select ',
@@ -22224,8 +23262,7 @@ wwv_flow_api.create_page_plug(
 '        USAGE_INTERVAL_START > trunc(sysdate-8)',
 '    group by tenant_name',
 ')',
-'order by 1',
-''))
+'order by 1'))
 ,p_plug_source_type=>'NATIVE_IR'
 ,p_plug_query_options=>'DERIVED_REPORT_COLUMNS'
 ,p_prn_content_disposition=>'ATTACHMENT'
@@ -22282,6 +23319,7 @@ wwv_flow_api.create_worksheet_column(
 ,p_display_order=>20
 ,p_column_identifier=>'B'
 ,p_column_label=>'&P6_DAY7.'
+,p_column_html_expression=>'<span style="#DAY7_COLOR#">#DAY7#</span>'
 ,p_column_type=>'NUMBER'
 ,p_column_alignment=>'RIGHT'
 ,p_format_mask=>'999G999G999G999G990D00'
@@ -22292,6 +23330,7 @@ wwv_flow_api.create_worksheet_column(
 ,p_display_order=>30
 ,p_column_identifier=>'C'
 ,p_column_label=>'&P6_DAY6.'
+,p_column_html_expression=>'<span  style="#DAY6_COLOR#">#DAY6#</span>'
 ,p_column_type=>'NUMBER'
 ,p_column_alignment=>'RIGHT'
 ,p_format_mask=>'999G999G999G999G990D00'
@@ -22302,6 +23341,7 @@ wwv_flow_api.create_worksheet_column(
 ,p_display_order=>40
 ,p_column_identifier=>'D'
 ,p_column_label=>'&P6_DAY5.'
+,p_column_html_expression=>'<span  style="#DAY5_COLOR#">#DAY5#</span>'
 ,p_column_type=>'NUMBER'
 ,p_column_alignment=>'RIGHT'
 ,p_format_mask=>'999G999G999G999G990D00'
@@ -22312,6 +23352,7 @@ wwv_flow_api.create_worksheet_column(
 ,p_display_order=>50
 ,p_column_identifier=>'E'
 ,p_column_label=>'&P6_DAY4.'
+,p_column_html_expression=>'<span style="#DAY4_COLOR#">#DAY4#</span>'
 ,p_column_type=>'NUMBER'
 ,p_column_alignment=>'RIGHT'
 ,p_format_mask=>'999G999G999G999G990D00'
@@ -22322,6 +23363,7 @@ wwv_flow_api.create_worksheet_column(
 ,p_display_order=>60
 ,p_column_identifier=>'F'
 ,p_column_label=>'&P6_DAY3.'
+,p_column_html_expression=>'<span  style="#DAY3_COLOR#">#DAY3#</span>'
 ,p_column_type=>'NUMBER'
 ,p_column_alignment=>'RIGHT'
 ,p_format_mask=>'999G999G999G999G990D00'
@@ -22332,6 +23374,7 @@ wwv_flow_api.create_worksheet_column(
 ,p_display_order=>70
 ,p_column_identifier=>'G'
 ,p_column_label=>'&P6_DAY2.'
+,p_column_html_expression=>'<span style="#DAY2_COLOR#">#DAY2#</span>'
 ,p_column_type=>'NUMBER'
 ,p_column_alignment=>'RIGHT'
 ,p_format_mask=>'999G999G999G999G990D00'
@@ -22342,6 +23385,7 @@ wwv_flow_api.create_worksheet_column(
 ,p_display_order=>80
 ,p_column_identifier=>'H'
 ,p_column_label=>'&P6_DAY1.'
+,p_column_html_expression=>'<span style="#DAY1_COLOR#">#DAY1#</span>'
 ,p_column_type=>'NUMBER'
 ,p_column_alignment=>'RIGHT'
 ,p_format_mask=>'999G999G999G999G990D00'
@@ -22357,6 +23401,69 @@ wwv_flow_api.create_worksheet_column(
 ,p_format_mask=>'999G999G999G999G990'
 ,p_static_id=>'rep_col_grey'
 );
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(16361027290490335)
+,p_db_column_name=>'DAY1_COLOR'
+,p_display_order=>100
+,p_column_identifier=>'K'
+,p_column_label=>'Day1 Color'
+,p_column_type=>'STRING'
+,p_display_text_as=>'HIDDEN'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(16361147368490336)
+,p_db_column_name=>'DAY2_COLOR'
+,p_display_order=>110
+,p_column_identifier=>'L'
+,p_column_label=>'Day2 Color'
+,p_column_type=>'STRING'
+,p_display_text_as=>'HIDDEN'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(16361232740490337)
+,p_db_column_name=>'DAY3_COLOR'
+,p_display_order=>120
+,p_column_identifier=>'M'
+,p_column_label=>'Day3 Color'
+,p_column_type=>'STRING'
+,p_display_text_as=>'HIDDEN'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(16361395035490338)
+,p_db_column_name=>'DAY4_COLOR'
+,p_display_order=>130
+,p_column_identifier=>'N'
+,p_column_label=>'Day4 Color'
+,p_column_type=>'STRING'
+,p_display_text_as=>'HIDDEN'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(16361499830490339)
+,p_db_column_name=>'DAY5_COLOR'
+,p_display_order=>140
+,p_column_identifier=>'O'
+,p_column_label=>'Day5 Color'
+,p_column_type=>'STRING'
+,p_display_text_as=>'HIDDEN'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(16361540378490340)
+,p_db_column_name=>'DAY6_COLOR'
+,p_display_order=>150
+,p_column_identifier=>'P'
+,p_column_label=>'Day6 Color'
+,p_column_type=>'STRING'
+,p_display_text_as=>'HIDDEN'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(16361639231490341)
+,p_db_column_name=>'DAY7_COLOR'
+,p_display_order=>160
+,p_column_identifier=>'Q'
+,p_column_label=>'Day7 Color'
+,p_column_type=>'STRING'
+,p_display_text_as=>'HIDDEN'
+);
 wwv_flow_api.create_worksheet_rpt(
  p_id=>wwv_flow_api.id(16669557578557119)
 ,p_application_user=>'APXWS_DEFAULT'
@@ -22364,7 +23471,7 @@ wwv_flow_api.create_worksheet_rpt(
 ,p_report_alias=>'166696'
 ,p_status=>'PUBLIC'
 ,p_is_default=>'Y'
-,p_report_columns=>'TENANT_NAME:DAY7:DAY6:DAY5:DAY4:DAY3:DAY2:DAY1:YEAR:'
+,p_report_columns=>'TENANT_NAME:DAY7:DAY6:DAY5:DAY4:DAY3:DAY2:DAY1:YEAR::DAY1_COLOR:DAY2_COLOR:DAY3_COLOR:DAY4_COLOR:DAY5_COLOR:DAY6_COLOR:DAY7_COLOR'
 );
 wwv_flow_api.create_page_item(
  p_id=>wwv_flow_api.id(12555202081313350)

--- a/src/oci/database/database_client.py
+++ b/src/oci/database/database_client.py
@@ -1631,7 +1631,7 @@ class DatabaseClient(object):
 
     def create_database(self, create_new_database_details, **kwargs):
         """
-        Creates a new database in the specified Database Home. If the database version is provided, it must match the version of the Database Home. Applies only to Exadata DB systems.
+        Creates a new database in the specified Database Home. If the database version is provided, it must match the version of the Database Home. Applies to Exadata DB systems and Exadata Cloud at Customer.
 
 
         :param CreateDatabaseBase create_new_database_details: (required)
@@ -1704,7 +1704,7 @@ class DatabaseClient(object):
 
     def create_db_home(self, create_db_home_with_db_system_id_details, **kwargs):
         """
-        Creates a new Database Home in the specified DB system based on the request parameters you provide. Applies only to bare metal and Exadata DB systems.
+        Creates a new Database Home in the specified DB system based on the request parameters you provide. Applies to bare metal DB systems, Exadata DB systems, and Exadata Cloud at Customer systems.
 
 
         :param CreateDbHomeBase create_db_home_with_db_system_id_details: (required)
@@ -2671,11 +2671,9 @@ class DatabaseClient(object):
 
     def delete_db_home(self, db_home_id, **kwargs):
         """
-        Deletes a Database Home. Applies only to bare metal and Exadata DB systems.
+        Deletes a Database Home. Applies to bare metal DB systems, Exadata DB systems, and Exadata Cloud at Customer systems.
 
-        The Database Home and its database data are local to the DB system, and on a bare metal DB system, both are lost when you delete the Database Home. Oracle recommends that you back up any data on the DB system before you delete it. You can use the `performFinalBackup` parameter with this operation on bare metal DB systems.
-
-        On an Exadata DB system, the delete request is rejected if the Database Home is not empty. You must terminate all databases in the Database Home before you delete the home. The `performFinalBackup` parameter is not used with this operation on Exadata DB systems.
+        Oracle recommends that you use the `performFinalBackup` parameter to back up any data on a bare metal DB system before you delete a Database Home. On an Exadata Cloud at Customer system or an Exadata DB system, you can delete a Database Home only when there are no databases in it and therefore you cannot use the `performFinalBackup` parameter to back up data.
 
 
         :param str db_home_id: (required)
@@ -5485,6 +5483,148 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="VmClusterNetwork")
 
+    def get_vm_cluster_patch(self, vm_cluster_id, patch_id, **kwargs):
+        """
+        Gets information about a specified patch package.
+
+
+        :param str vm_cluster_id: (required)
+            The VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str patch_id: (required)
+            The `OCID`__ of the patch.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.Patch`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vmClusters/{vmClusterId}/patches/{patchId}"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_vm_cluster_patch got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "vmClusterId": vm_cluster_id,
+            "patchId": patch_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Patch")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Patch")
+
+    def get_vm_cluster_patch_history_entry(self, vm_cluster_id, patch_history_entry_id, **kwargs):
+        """
+        Gets the patch history details for the specified patchHistoryEntryId.
+
+
+        :param str vm_cluster_id: (required)
+            The VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str patch_history_entry_id: (required)
+            The `OCID`__ of the patch history entry.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.PatchHistoryEntry`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vmClusters/{vmClusterId}/patchHistoryEntries/{patchHistoryEntryId}"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_vm_cluster_patch_history_entry got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "vmClusterId": vm_cluster_id,
+            "patchHistoryEntryId": patch_history_entry_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="PatchHistoryEntry")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="PatchHistoryEntry")
+
     def launch_autonomous_exadata_infrastructure(self, launch_autonomous_exadata_infrastructure_details, **kwargs):
         """
         Launches a new Autonomous Exadata Infrastructure in the specified compartment and availability domain.
@@ -8141,7 +8281,7 @@ class DatabaseClient(object):
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the given lifecycle state exactly.
 
-            Allowed values are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE"
+            Allowed values are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "DISCONNECTED"
 
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
@@ -8191,7 +8331,7 @@ class DatabaseClient(object):
                 )
 
         if 'lifecycle_state' in kwargs:
-            lifecycle_state_allowed_values = ["CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE"]
+            lifecycle_state_allowed_values = ["CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "DISCONNECTED"]
             if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
                 raise ValueError(
                     "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
@@ -8625,6 +8765,174 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="list[VmClusterNetworkSummary]")
 
+    def list_vm_cluster_patch_history_entries(self, vm_cluster_id, **kwargs):
+        """
+        Gets the history of the patch actions performed on the specified Vm cluster.
+
+
+        :param str vm_cluster_id: (required)
+            The VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.PatchHistoryEntrySummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vmClusters/{vmClusterId}/patchHistoryEntries"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_vm_cluster_patch_history_entries got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "vmClusterId": vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[PatchHistoryEntrySummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[PatchHistoryEntrySummary]")
+
+    def list_vm_cluster_patches(self, vm_cluster_id, **kwargs):
+        """
+        Lists the patches applicable to the requested Vm cluster.
+
+
+        :param str vm_cluster_id: (required)
+            The VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.PatchSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vmClusters/{vmClusterId}/patches"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_vm_cluster_patches got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "vmClusterId": vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[PatchSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[PatchSummary]")
+
     def list_vm_clusters(self, compartment_id, **kwargs):
         """
         Gets a list of the VM clusters in the specified compartment.
@@ -8998,7 +9306,7 @@ class DatabaseClient(object):
 
     def restart_autonomous_database(self, autonomous_database_id, **kwargs):
         """
-        Restarts the specified Autonomous Database. Restart supported only for databases using dedicated Exadata infrastructure.
+        Restarts the specified Autonomous Database.
 
 
         :param str autonomous_database_id: (required)

--- a/src/oci/database/models/backup.py
+++ b/src/oci/database/models/backup.py
@@ -128,6 +128,10 @@ class Backup(object):
             The value to assign to the shape property of this Backup.
         :type shape: str
 
+        :param version:
+            The value to assign to the version property of this Backup.
+        :type version: str
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -142,7 +146,8 @@ class Backup(object):
             'lifecycle_state': 'str',
             'database_edition': 'str',
             'database_size_in_gbs': 'float',
-            'shape': 'str'
+            'shape': 'str',
+            'version': 'str'
         }
 
         self.attribute_map = {
@@ -158,7 +163,8 @@ class Backup(object):
             'lifecycle_state': 'lifecycleState',
             'database_edition': 'databaseEdition',
             'database_size_in_gbs': 'databaseSizeInGBs',
-            'shape': 'shape'
+            'shape': 'shape',
+            'version': 'version'
         }
 
         self._id = None
@@ -174,6 +180,7 @@ class Backup(object):
         self._database_edition = None
         self._database_size_in_gbs = None
         self._shape = None
+        self._version = None
 
     @property
     def id(self):
@@ -516,6 +523,30 @@ class Backup(object):
         :type: str
         """
         self._shape = shape
+
+    @property
+    def version(self):
+        """
+        Gets the version of this Backup.
+        Version of the backup's source database
+
+
+        :return: The version of this Backup.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this Backup.
+        Version of the backup's source database
+
+
+        :param version: The version of this Backup.
+        :type: str
+        """
+        self._version = version
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/backup_summary.py
+++ b/src/oci/database/models/backup_summary.py
@@ -133,6 +133,10 @@ class BackupSummary(object):
             The value to assign to the shape property of this BackupSummary.
         :type shape: str
 
+        :param version:
+            The value to assign to the version property of this BackupSummary.
+        :type version: str
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -147,7 +151,8 @@ class BackupSummary(object):
             'lifecycle_state': 'str',
             'database_edition': 'str',
             'database_size_in_gbs': 'float',
-            'shape': 'str'
+            'shape': 'str',
+            'version': 'str'
         }
 
         self.attribute_map = {
@@ -163,7 +168,8 @@ class BackupSummary(object):
             'lifecycle_state': 'lifecycleState',
             'database_edition': 'databaseEdition',
             'database_size_in_gbs': 'databaseSizeInGBs',
-            'shape': 'shape'
+            'shape': 'shape',
+            'version': 'version'
         }
 
         self._id = None
@@ -179,6 +185,7 @@ class BackupSummary(object):
         self._database_edition = None
         self._database_size_in_gbs = None
         self._shape = None
+        self._version = None
 
     @property
     def id(self):
@@ -521,6 +528,30 @@ class BackupSummary(object):
         :type: str
         """
         self._shape = shape
+
+    @property
+    def version(self):
+        """
+        Gets the version of this BackupSummary.
+        Version of the backup's source database
+
+
+        :return: The version of this BackupSummary.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this BackupSummary.
+        Version of the backup's source database
+
+
+        :param version: The version of this BackupSummary.
+        :type: str
+        """
+        self._version = version
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/create_vm_cluster_details.py
+++ b/src/oci/database/models/create_vm_cluster_details.py
@@ -42,6 +42,18 @@ class CreateVmClusterDetails(object):
             The value to assign to the cpu_core_count property of this CreateVmClusterDetails.
         :type cpu_core_count: int
 
+        :param memory_size_in_gbs:
+            The value to assign to the memory_size_in_gbs property of this CreateVmClusterDetails.
+        :type memory_size_in_gbs: int
+
+        :param db_node_storage_size_in_gbs:
+            The value to assign to the db_node_storage_size_in_gbs property of this CreateVmClusterDetails.
+        :type db_node_storage_size_in_gbs: int
+
+        :param data_storage_size_in_tbs:
+            The value to assign to the data_storage_size_in_tbs property of this CreateVmClusterDetails.
+        :type data_storage_size_in_tbs: float
+
         :param ssh_public_keys:
             The value to assign to the ssh_public_keys property of this CreateVmClusterDetails.
         :type ssh_public_keys: list[str]
@@ -85,6 +97,9 @@ class CreateVmClusterDetails(object):
             'display_name': 'str',
             'exadata_infrastructure_id': 'str',
             'cpu_core_count': 'int',
+            'memory_size_in_gbs': 'int',
+            'db_node_storage_size_in_gbs': 'int',
+            'data_storage_size_in_tbs': 'float',
             'ssh_public_keys': 'list[str]',
             'vm_cluster_network_id': 'str',
             'license_model': 'str',
@@ -101,6 +116,9 @@ class CreateVmClusterDetails(object):
             'display_name': 'displayName',
             'exadata_infrastructure_id': 'exadataInfrastructureId',
             'cpu_core_count': 'cpuCoreCount',
+            'memory_size_in_gbs': 'memorySizeInGBs',
+            'db_node_storage_size_in_gbs': 'dbNodeStorageSizeInGBs',
+            'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'ssh_public_keys': 'sshPublicKeys',
             'vm_cluster_network_id': 'vmClusterNetworkId',
             'license_model': 'licenseModel',
@@ -116,6 +134,9 @@ class CreateVmClusterDetails(object):
         self._display_name = None
         self._exadata_infrastructure_id = None
         self._cpu_core_count = None
+        self._memory_size_in_gbs = None
+        self._db_node_storage_size_in_gbs = None
+        self._data_storage_size_in_tbs = None
         self._ssh_public_keys = None
         self._vm_cluster_network_id = None
         self._license_model = None
@@ -229,6 +250,78 @@ class CreateVmClusterDetails(object):
         :type: int
         """
         self._cpu_core_count = cpu_core_count
+
+    @property
+    def memory_size_in_gbs(self):
+        """
+        Gets the memory_size_in_gbs of this CreateVmClusterDetails.
+        The memory to be allocated in GBs.
+
+
+        :return: The memory_size_in_gbs of this CreateVmClusterDetails.
+        :rtype: int
+        """
+        return self._memory_size_in_gbs
+
+    @memory_size_in_gbs.setter
+    def memory_size_in_gbs(self, memory_size_in_gbs):
+        """
+        Sets the memory_size_in_gbs of this CreateVmClusterDetails.
+        The memory to be allocated in GBs.
+
+
+        :param memory_size_in_gbs: The memory_size_in_gbs of this CreateVmClusterDetails.
+        :type: int
+        """
+        self._memory_size_in_gbs = memory_size_in_gbs
+
+    @property
+    def db_node_storage_size_in_gbs(self):
+        """
+        Gets the db_node_storage_size_in_gbs of this CreateVmClusterDetails.
+        The local node storage to be allocated in GBs.
+
+
+        :return: The db_node_storage_size_in_gbs of this CreateVmClusterDetails.
+        :rtype: int
+        """
+        return self._db_node_storage_size_in_gbs
+
+    @db_node_storage_size_in_gbs.setter
+    def db_node_storage_size_in_gbs(self, db_node_storage_size_in_gbs):
+        """
+        Sets the db_node_storage_size_in_gbs of this CreateVmClusterDetails.
+        The local node storage to be allocated in GBs.
+
+
+        :param db_node_storage_size_in_gbs: The db_node_storage_size_in_gbs of this CreateVmClusterDetails.
+        :type: int
+        """
+        self._db_node_storage_size_in_gbs = db_node_storage_size_in_gbs
+
+    @property
+    def data_storage_size_in_tbs(self):
+        """
+        Gets the data_storage_size_in_tbs of this CreateVmClusterDetails.
+        The data disk group size to be allocated in TBs.
+
+
+        :return: The data_storage_size_in_tbs of this CreateVmClusterDetails.
+        :rtype: float
+        """
+        return self._data_storage_size_in_tbs
+
+    @data_storage_size_in_tbs.setter
+    def data_storage_size_in_tbs(self, data_storage_size_in_tbs):
+        """
+        Sets the data_storage_size_in_tbs of this CreateVmClusterDetails.
+        The data disk group size to be allocated in TBs.
+
+
+        :param data_storage_size_in_tbs: The data_storage_size_in_tbs of this CreateVmClusterDetails.
+        :type: float
+        """
+        self._data_storage_size_in_tbs = data_storage_size_in_tbs
 
     @property
     def ssh_public_keys(self):

--- a/src/oci/database/models/db_node.py
+++ b/src/oci/database/models/db_node.py
@@ -403,7 +403,7 @@ class DbNode(object):
     def maintenance_type(self):
         """
         Gets the maintenance_type of this DbNode.
-        The type of maintenance of dbNode.
+        The type of database node maintenance.
 
         Allowed values for this property are: "VMDB_REBOOT_MIGRATION", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -418,7 +418,7 @@ class DbNode(object):
     def maintenance_type(self, maintenance_type):
         """
         Sets the maintenance_type of this DbNode.
-        The type of maintenance of dbNode.
+        The type of database node maintenance.
 
 
         :param maintenance_type: The maintenance_type of this DbNode.
@@ -481,7 +481,7 @@ class DbNode(object):
     def additional_details(self):
         """
         Gets the additional_details of this DbNode.
-        Additional information like a message to customer about the maintenance.
+        Additional information about the planned maintenance.
 
 
         :return: The additional_details of this DbNode.
@@ -493,7 +493,7 @@ class DbNode(object):
     def additional_details(self, additional_details):
         """
         Sets the additional_details of this DbNode.
-        Additional information like a message to customer about the maintenance.
+        Additional information about the planned maintenance.
 
 
         :param additional_details: The additional_details of this DbNode.

--- a/src/oci/database/models/db_node_summary.py
+++ b/src/oci/database/models/db_node_summary.py
@@ -409,7 +409,7 @@ class DbNodeSummary(object):
     def maintenance_type(self):
         """
         Gets the maintenance_type of this DbNodeSummary.
-        The type of maintenance of dbNode.
+        The type of database node maintenance.
 
         Allowed values for this property are: "VMDB_REBOOT_MIGRATION", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -424,7 +424,7 @@ class DbNodeSummary(object):
     def maintenance_type(self, maintenance_type):
         """
         Sets the maintenance_type of this DbNodeSummary.
-        The type of maintenance of dbNode.
+        The type of database node maintenance.
 
 
         :param maintenance_type: The maintenance_type of this DbNodeSummary.
@@ -487,7 +487,7 @@ class DbNodeSummary(object):
     def additional_details(self):
         """
         Gets the additional_details of this DbNodeSummary.
-        Additional information like a message to customer about the maintenance.
+        Additional information about the planned maintenance.
 
 
         :return: The additional_details of this DbNodeSummary.
@@ -499,7 +499,7 @@ class DbNodeSummary(object):
     def additional_details(self, additional_details):
         """
         Sets the additional_details of this DbNodeSummary.
-        Additional information like a message to customer about the maintenance.
+        Additional information about the planned maintenance.
 
 
         :param additional_details: The additional_details of this DbNodeSummary.

--- a/src/oci/database/models/db_system_shape_summary.py
+++ b/src/oci/database/models/db_system_shape_summary.py
@@ -49,6 +49,34 @@ class DbSystemShapeSummary(object):
             The value to assign to the core_count_increment property of this DbSystemShapeSummary.
         :type core_count_increment: int
 
+        :param min_core_count_per_node:
+            The value to assign to the min_core_count_per_node property of this DbSystemShapeSummary.
+        :type min_core_count_per_node: int
+
+        :param available_memory_in_gbs:
+            The value to assign to the available_memory_in_gbs property of this DbSystemShapeSummary.
+        :type available_memory_in_gbs: int
+
+        :param min_memory_per_node_in_g_bs:
+            The value to assign to the min_memory_per_node_in_g_bs property of this DbSystemShapeSummary.
+        :type min_memory_per_node_in_g_bs: int
+
+        :param available_db_node_storage_in_g_bs:
+            The value to assign to the available_db_node_storage_in_g_bs property of this DbSystemShapeSummary.
+        :type available_db_node_storage_in_g_bs: int
+
+        :param min_db_node_storage_per_node_in_g_bs:
+            The value to assign to the min_db_node_storage_per_node_in_g_bs property of this DbSystemShapeSummary.
+        :type min_db_node_storage_per_node_in_g_bs: int
+
+        :param available_data_storage_in_t_bs:
+            The value to assign to the available_data_storage_in_t_bs property of this DbSystemShapeSummary.
+        :type available_data_storage_in_t_bs: int
+
+        :param min_data_storage_in_t_bs:
+            The value to assign to the min_data_storage_in_t_bs property of this DbSystemShapeSummary.
+        :type min_data_storage_in_t_bs: int
+
         :param minimum_node_count:
             The value to assign to the minimum_node_count property of this DbSystemShapeSummary.
         :type minimum_node_count: int
@@ -65,6 +93,13 @@ class DbSystemShapeSummary(object):
             'available_core_count': 'int',
             'minimum_core_count': 'int',
             'core_count_increment': 'int',
+            'min_core_count_per_node': 'int',
+            'available_memory_in_gbs': 'int',
+            'min_memory_per_node_in_g_bs': 'int',
+            'available_db_node_storage_in_g_bs': 'int',
+            'min_db_node_storage_per_node_in_g_bs': 'int',
+            'available_data_storage_in_t_bs': 'int',
+            'min_data_storage_in_t_bs': 'int',
             'minimum_node_count': 'int',
             'maximum_node_count': 'int'
         }
@@ -76,6 +111,13 @@ class DbSystemShapeSummary(object):
             'available_core_count': 'availableCoreCount',
             'minimum_core_count': 'minimumCoreCount',
             'core_count_increment': 'coreCountIncrement',
+            'min_core_count_per_node': 'minCoreCountPerNode',
+            'available_memory_in_gbs': 'availableMemoryInGBs',
+            'min_memory_per_node_in_g_bs': 'minMemoryPerNodeInGBs',
+            'available_db_node_storage_in_g_bs': 'availableDbNodeStorageInGBs',
+            'min_db_node_storage_per_node_in_g_bs': 'minDbNodeStoragePerNodeInGBs',
+            'available_data_storage_in_t_bs': 'availableDataStorageInTBs',
+            'min_data_storage_in_t_bs': 'minDataStorageInTBs',
             'minimum_node_count': 'minimumNodeCount',
             'maximum_node_count': 'maximumNodeCount'
         }
@@ -86,6 +128,13 @@ class DbSystemShapeSummary(object):
         self._available_core_count = None
         self._minimum_core_count = None
         self._core_count_increment = None
+        self._min_core_count_per_node = None
+        self._available_memory_in_gbs = None
+        self._min_memory_per_node_in_g_bs = None
+        self._available_db_node_storage_in_g_bs = None
+        self._min_db_node_storage_per_node_in_g_bs = None
+        self._available_data_storage_in_t_bs = None
+        self._min_data_storage_in_t_bs = None
         self._minimum_node_count = None
         self._maximum_node_count = None
 
@@ -232,6 +281,174 @@ class DbSystemShapeSummary(object):
         :type: int
         """
         self._core_count_increment = core_count_increment
+
+    @property
+    def min_core_count_per_node(self):
+        """
+        Gets the min_core_count_per_node of this DbSystemShapeSummary.
+        The minimum number of CPU cores that can be enabled per node for this shape.
+
+
+        :return: The min_core_count_per_node of this DbSystemShapeSummary.
+        :rtype: int
+        """
+        return self._min_core_count_per_node
+
+    @min_core_count_per_node.setter
+    def min_core_count_per_node(self, min_core_count_per_node):
+        """
+        Sets the min_core_count_per_node of this DbSystemShapeSummary.
+        The minimum number of CPU cores that can be enabled per node for this shape.
+
+
+        :param min_core_count_per_node: The min_core_count_per_node of this DbSystemShapeSummary.
+        :type: int
+        """
+        self._min_core_count_per_node = min_core_count_per_node
+
+    @property
+    def available_memory_in_gbs(self):
+        """
+        Gets the available_memory_in_gbs of this DbSystemShapeSummary.
+        The maximum memory that can be enabled for this shape.
+
+
+        :return: The available_memory_in_gbs of this DbSystemShapeSummary.
+        :rtype: int
+        """
+        return self._available_memory_in_gbs
+
+    @available_memory_in_gbs.setter
+    def available_memory_in_gbs(self, available_memory_in_gbs):
+        """
+        Sets the available_memory_in_gbs of this DbSystemShapeSummary.
+        The maximum memory that can be enabled for this shape.
+
+
+        :param available_memory_in_gbs: The available_memory_in_gbs of this DbSystemShapeSummary.
+        :type: int
+        """
+        self._available_memory_in_gbs = available_memory_in_gbs
+
+    @property
+    def min_memory_per_node_in_g_bs(self):
+        """
+        Gets the min_memory_per_node_in_g_bs of this DbSystemShapeSummary.
+        The minimum memory that need be allocated per node for this shape.
+
+
+        :return: The min_memory_per_node_in_g_bs of this DbSystemShapeSummary.
+        :rtype: int
+        """
+        return self._min_memory_per_node_in_g_bs
+
+    @min_memory_per_node_in_g_bs.setter
+    def min_memory_per_node_in_g_bs(self, min_memory_per_node_in_g_bs):
+        """
+        Sets the min_memory_per_node_in_g_bs of this DbSystemShapeSummary.
+        The minimum memory that need be allocated per node for this shape.
+
+
+        :param min_memory_per_node_in_g_bs: The min_memory_per_node_in_g_bs of this DbSystemShapeSummary.
+        :type: int
+        """
+        self._min_memory_per_node_in_g_bs = min_memory_per_node_in_g_bs
+
+    @property
+    def available_db_node_storage_in_g_bs(self):
+        """
+        Gets the available_db_node_storage_in_g_bs of this DbSystemShapeSummary.
+        The maximum Db Node storage that can be enabled for this shape.
+
+
+        :return: The available_db_node_storage_in_g_bs of this DbSystemShapeSummary.
+        :rtype: int
+        """
+        return self._available_db_node_storage_in_g_bs
+
+    @available_db_node_storage_in_g_bs.setter
+    def available_db_node_storage_in_g_bs(self, available_db_node_storage_in_g_bs):
+        """
+        Sets the available_db_node_storage_in_g_bs of this DbSystemShapeSummary.
+        The maximum Db Node storage that can be enabled for this shape.
+
+
+        :param available_db_node_storage_in_g_bs: The available_db_node_storage_in_g_bs of this DbSystemShapeSummary.
+        :type: int
+        """
+        self._available_db_node_storage_in_g_bs = available_db_node_storage_in_g_bs
+
+    @property
+    def min_db_node_storage_per_node_in_g_bs(self):
+        """
+        Gets the min_db_node_storage_per_node_in_g_bs of this DbSystemShapeSummary.
+        The minimum Db Node storage that need be allocated per node for this shape.
+
+
+        :return: The min_db_node_storage_per_node_in_g_bs of this DbSystemShapeSummary.
+        :rtype: int
+        """
+        return self._min_db_node_storage_per_node_in_g_bs
+
+    @min_db_node_storage_per_node_in_g_bs.setter
+    def min_db_node_storage_per_node_in_g_bs(self, min_db_node_storage_per_node_in_g_bs):
+        """
+        Sets the min_db_node_storage_per_node_in_g_bs of this DbSystemShapeSummary.
+        The minimum Db Node storage that need be allocated per node for this shape.
+
+
+        :param min_db_node_storage_per_node_in_g_bs: The min_db_node_storage_per_node_in_g_bs of this DbSystemShapeSummary.
+        :type: int
+        """
+        self._min_db_node_storage_per_node_in_g_bs = min_db_node_storage_per_node_in_g_bs
+
+    @property
+    def available_data_storage_in_t_bs(self):
+        """
+        Gets the available_data_storage_in_t_bs of this DbSystemShapeSummary.
+        The maximum DATA storage that can be enabled for this shape.
+
+
+        :return: The available_data_storage_in_t_bs of this DbSystemShapeSummary.
+        :rtype: int
+        """
+        return self._available_data_storage_in_t_bs
+
+    @available_data_storage_in_t_bs.setter
+    def available_data_storage_in_t_bs(self, available_data_storage_in_t_bs):
+        """
+        Sets the available_data_storage_in_t_bs of this DbSystemShapeSummary.
+        The maximum DATA storage that can be enabled for this shape.
+
+
+        :param available_data_storage_in_t_bs: The available_data_storage_in_t_bs of this DbSystemShapeSummary.
+        :type: int
+        """
+        self._available_data_storage_in_t_bs = available_data_storage_in_t_bs
+
+    @property
+    def min_data_storage_in_t_bs(self):
+        """
+        Gets the min_data_storage_in_t_bs of this DbSystemShapeSummary.
+        The minimum data storage that need be allocated for this shape.
+
+
+        :return: The min_data_storage_in_t_bs of this DbSystemShapeSummary.
+        :rtype: int
+        """
+        return self._min_data_storage_in_t_bs
+
+    @min_data_storage_in_t_bs.setter
+    def min_data_storage_in_t_bs(self, min_data_storage_in_t_bs):
+        """
+        Sets the min_data_storage_in_t_bs of this DbSystemShapeSummary.
+        The minimum data storage that need be allocated for this shape.
+
+
+        :param min_data_storage_in_t_bs: The min_data_storage_in_t_bs of this DbSystemShapeSummary.
+        :type: int
+        """
+        self._min_data_storage_in_t_bs = min_data_storage_in_t_bs
 
     @property
     def minimum_node_count(self):

--- a/src/oci/database/models/exadata_infrastructure.py
+++ b/src/oci/database/models/exadata_infrastructure.py
@@ -50,8 +50,8 @@ class ExadataInfrastructure(object):
     LIFECYCLE_STATE_DELETED = "DELETED"
 
     #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructure.
-    #: This constant has a value of "OFFLINE"
-    LIFECYCLE_STATE_OFFLINE = "OFFLINE"
+    #: This constant has a value of "DISCONNECTED"
+    LIFECYCLE_STATE_DISCONNECTED = "DISCONNECTED"
 
     def __init__(self, **kwargs):
         """
@@ -68,7 +68,7 @@ class ExadataInfrastructure(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this ExadataInfrastructure.
-            Allowed values for this property are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "DISCONNECTED", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -88,9 +88,33 @@ class ExadataInfrastructure(object):
             The value to assign to the cpus_enabled property of this ExadataInfrastructure.
         :type cpus_enabled: int
 
+        :param max_cpu_count:
+            The value to assign to the max_cpu_count property of this ExadataInfrastructure.
+        :type max_cpu_count: int
+
+        :param memory_size_in_gbs:
+            The value to assign to the memory_size_in_gbs property of this ExadataInfrastructure.
+        :type memory_size_in_gbs: int
+
+        :param max_memory_in_gbs:
+            The value to assign to the max_memory_in_gbs property of this ExadataInfrastructure.
+        :type max_memory_in_gbs: int
+
+        :param db_node_storage_size_in_gbs:
+            The value to assign to the db_node_storage_size_in_gbs property of this ExadataInfrastructure.
+        :type db_node_storage_size_in_gbs: int
+
+        :param max_db_node_storage_in_g_bs:
+            The value to assign to the max_db_node_storage_in_g_bs property of this ExadataInfrastructure.
+        :type max_db_node_storage_in_g_bs: int
+
         :param data_storage_size_in_tbs:
             The value to assign to the data_storage_size_in_tbs property of this ExadataInfrastructure.
-        :type data_storage_size_in_tbs: int
+        :type data_storage_size_in_tbs: float
+
+        :param max_data_storage_in_t_bs:
+            The value to assign to the max_data_storage_in_t_bs property of this ExadataInfrastructure.
+        :type max_data_storage_in_t_bs: float
 
         :param cloud_control_plane_server1:
             The value to assign to the cloud_control_plane_server1 property of this ExadataInfrastructure.
@@ -153,7 +177,13 @@ class ExadataInfrastructure(object):
             'shape': 'str',
             'time_zone': 'str',
             'cpus_enabled': 'int',
-            'data_storage_size_in_tbs': 'int',
+            'max_cpu_count': 'int',
+            'memory_size_in_gbs': 'int',
+            'max_memory_in_gbs': 'int',
+            'db_node_storage_size_in_gbs': 'int',
+            'max_db_node_storage_in_g_bs': 'int',
+            'data_storage_size_in_tbs': 'float',
+            'max_data_storage_in_t_bs': 'float',
             'cloud_control_plane_server1': 'str',
             'cloud_control_plane_server2': 'str',
             'netmask': 'str',
@@ -177,7 +207,13 @@ class ExadataInfrastructure(object):
             'shape': 'shape',
             'time_zone': 'timeZone',
             'cpus_enabled': 'cpusEnabled',
+            'max_cpu_count': 'maxCpuCount',
+            'memory_size_in_gbs': 'memorySizeInGBs',
+            'max_memory_in_gbs': 'maxMemoryInGBs',
+            'db_node_storage_size_in_gbs': 'dbNodeStorageSizeInGBs',
+            'max_db_node_storage_in_g_bs': 'maxDbNodeStorageInGBs',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
+            'max_data_storage_in_t_bs': 'maxDataStorageInTBs',
             'cloud_control_plane_server1': 'cloudControlPlaneServer1',
             'cloud_control_plane_server2': 'cloudControlPlaneServer2',
             'netmask': 'netmask',
@@ -200,7 +236,13 @@ class ExadataInfrastructure(object):
         self._shape = None
         self._time_zone = None
         self._cpus_enabled = None
+        self._max_cpu_count = None
+        self._memory_size_in_gbs = None
+        self._max_memory_in_gbs = None
+        self._db_node_storage_size_in_gbs = None
+        self._max_db_node_storage_in_g_bs = None
         self._data_storage_size_in_tbs = None
+        self._max_data_storage_in_t_bs = None
         self._cloud_control_plane_server1 = None
         self._cloud_control_plane_server2 = None
         self._netmask = None
@@ -277,7 +319,7 @@ class ExadataInfrastructure(object):
         **[Required]** Gets the lifecycle_state of this ExadataInfrastructure.
         The current lifecycle state of the Exadata infrastructure.
 
-        Allowed values for this property are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "DISCONNECTED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -296,7 +338,7 @@ class ExadataInfrastructure(object):
         :param lifecycle_state: The lifecycle_state of this ExadataInfrastructure.
         :type: str
         """
-        allowed_values = ["CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE"]
+        allowed_values = ["CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "DISCONNECTED"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
@@ -402,6 +444,126 @@ class ExadataInfrastructure(object):
         self._cpus_enabled = cpus_enabled
 
     @property
+    def max_cpu_count(self):
+        """
+        Gets the max_cpu_count of this ExadataInfrastructure.
+        The total number of CPU cores available.
+
+
+        :return: The max_cpu_count of this ExadataInfrastructure.
+        :rtype: int
+        """
+        return self._max_cpu_count
+
+    @max_cpu_count.setter
+    def max_cpu_count(self, max_cpu_count):
+        """
+        Sets the max_cpu_count of this ExadataInfrastructure.
+        The total number of CPU cores available.
+
+
+        :param max_cpu_count: The max_cpu_count of this ExadataInfrastructure.
+        :type: int
+        """
+        self._max_cpu_count = max_cpu_count
+
+    @property
+    def memory_size_in_gbs(self):
+        """
+        Gets the memory_size_in_gbs of this ExadataInfrastructure.
+        The memory allocated in GBs.
+
+
+        :return: The memory_size_in_gbs of this ExadataInfrastructure.
+        :rtype: int
+        """
+        return self._memory_size_in_gbs
+
+    @memory_size_in_gbs.setter
+    def memory_size_in_gbs(self, memory_size_in_gbs):
+        """
+        Sets the memory_size_in_gbs of this ExadataInfrastructure.
+        The memory allocated in GBs.
+
+
+        :param memory_size_in_gbs: The memory_size_in_gbs of this ExadataInfrastructure.
+        :type: int
+        """
+        self._memory_size_in_gbs = memory_size_in_gbs
+
+    @property
+    def max_memory_in_gbs(self):
+        """
+        Gets the max_memory_in_gbs of this ExadataInfrastructure.
+        The total memory available in GBs.
+
+
+        :return: The max_memory_in_gbs of this ExadataInfrastructure.
+        :rtype: int
+        """
+        return self._max_memory_in_gbs
+
+    @max_memory_in_gbs.setter
+    def max_memory_in_gbs(self, max_memory_in_gbs):
+        """
+        Sets the max_memory_in_gbs of this ExadataInfrastructure.
+        The total memory available in GBs.
+
+
+        :param max_memory_in_gbs: The max_memory_in_gbs of this ExadataInfrastructure.
+        :type: int
+        """
+        self._max_memory_in_gbs = max_memory_in_gbs
+
+    @property
+    def db_node_storage_size_in_gbs(self):
+        """
+        Gets the db_node_storage_size_in_gbs of this ExadataInfrastructure.
+        The local node storage allocated in GBs.
+
+
+        :return: The db_node_storage_size_in_gbs of this ExadataInfrastructure.
+        :rtype: int
+        """
+        return self._db_node_storage_size_in_gbs
+
+    @db_node_storage_size_in_gbs.setter
+    def db_node_storage_size_in_gbs(self, db_node_storage_size_in_gbs):
+        """
+        Sets the db_node_storage_size_in_gbs of this ExadataInfrastructure.
+        The local node storage allocated in GBs.
+
+
+        :param db_node_storage_size_in_gbs: The db_node_storage_size_in_gbs of this ExadataInfrastructure.
+        :type: int
+        """
+        self._db_node_storage_size_in_gbs = db_node_storage_size_in_gbs
+
+    @property
+    def max_db_node_storage_in_g_bs(self):
+        """
+        Gets the max_db_node_storage_in_g_bs of this ExadataInfrastructure.
+        The total local node storage available in GBs.
+
+
+        :return: The max_db_node_storage_in_g_bs of this ExadataInfrastructure.
+        :rtype: int
+        """
+        return self._max_db_node_storage_in_g_bs
+
+    @max_db_node_storage_in_g_bs.setter
+    def max_db_node_storage_in_g_bs(self, max_db_node_storage_in_g_bs):
+        """
+        Sets the max_db_node_storage_in_g_bs of this ExadataInfrastructure.
+        The total local node storage available in GBs.
+
+
+        :param max_db_node_storage_in_g_bs: The max_db_node_storage_in_g_bs of this ExadataInfrastructure.
+        :type: int
+        """
+        self._max_db_node_storage_in_g_bs = max_db_node_storage_in_g_bs
+
+    @property
     def data_storage_size_in_tbs(self):
         """
         Gets the data_storage_size_in_tbs of this ExadataInfrastructure.
@@ -409,7 +571,7 @@ class ExadataInfrastructure(object):
 
 
         :return: The data_storage_size_in_tbs of this ExadataInfrastructure.
-        :rtype: int
+        :rtype: float
         """
         return self._data_storage_size_in_tbs
 
@@ -421,9 +583,33 @@ class ExadataInfrastructure(object):
 
 
         :param data_storage_size_in_tbs: The data_storage_size_in_tbs of this ExadataInfrastructure.
-        :type: int
+        :type: float
         """
         self._data_storage_size_in_tbs = data_storage_size_in_tbs
+
+    @property
+    def max_data_storage_in_t_bs(self):
+        """
+        Gets the max_data_storage_in_t_bs of this ExadataInfrastructure.
+        The total available DATA disk group size.
+
+
+        :return: The max_data_storage_in_t_bs of this ExadataInfrastructure.
+        :rtype: float
+        """
+        return self._max_data_storage_in_t_bs
+
+    @max_data_storage_in_t_bs.setter
+    def max_data_storage_in_t_bs(self, max_data_storage_in_t_bs):
+        """
+        Sets the max_data_storage_in_t_bs of this ExadataInfrastructure.
+        The total available DATA disk group size.
+
+
+        :param max_data_storage_in_t_bs: The max_data_storage_in_t_bs of this ExadataInfrastructure.
+        :type: float
+        """
+        self._max_data_storage_in_t_bs = max_data_storage_in_t_bs
 
     @property
     def cloud_control_plane_server1(self):

--- a/src/oci/database/models/exadata_infrastructure_summary.py
+++ b/src/oci/database/models/exadata_infrastructure_summary.py
@@ -50,8 +50,8 @@ class ExadataInfrastructureSummary(object):
     LIFECYCLE_STATE_DELETED = "DELETED"
 
     #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructureSummary.
-    #: This constant has a value of "OFFLINE"
-    LIFECYCLE_STATE_OFFLINE = "OFFLINE"
+    #: This constant has a value of "DISCONNECTED"
+    LIFECYCLE_STATE_DISCONNECTED = "DISCONNECTED"
 
     def __init__(self, **kwargs):
         """
@@ -68,7 +68,7 @@ class ExadataInfrastructureSummary(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this ExadataInfrastructureSummary.
-            Allowed values for this property are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "DISCONNECTED", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -88,9 +88,33 @@ class ExadataInfrastructureSummary(object):
             The value to assign to the cpus_enabled property of this ExadataInfrastructureSummary.
         :type cpus_enabled: int
 
+        :param max_cpu_count:
+            The value to assign to the max_cpu_count property of this ExadataInfrastructureSummary.
+        :type max_cpu_count: int
+
+        :param memory_size_in_gbs:
+            The value to assign to the memory_size_in_gbs property of this ExadataInfrastructureSummary.
+        :type memory_size_in_gbs: int
+
+        :param max_memory_in_gbs:
+            The value to assign to the max_memory_in_gbs property of this ExadataInfrastructureSummary.
+        :type max_memory_in_gbs: int
+
+        :param db_node_storage_size_in_gbs:
+            The value to assign to the db_node_storage_size_in_gbs property of this ExadataInfrastructureSummary.
+        :type db_node_storage_size_in_gbs: int
+
+        :param max_db_node_storage_in_g_bs:
+            The value to assign to the max_db_node_storage_in_g_bs property of this ExadataInfrastructureSummary.
+        :type max_db_node_storage_in_g_bs: int
+
         :param data_storage_size_in_tbs:
             The value to assign to the data_storage_size_in_tbs property of this ExadataInfrastructureSummary.
-        :type data_storage_size_in_tbs: int
+        :type data_storage_size_in_tbs: float
+
+        :param max_data_storage_in_t_bs:
+            The value to assign to the max_data_storage_in_t_bs property of this ExadataInfrastructureSummary.
+        :type max_data_storage_in_t_bs: float
 
         :param cloud_control_plane_server1:
             The value to assign to the cloud_control_plane_server1 property of this ExadataInfrastructureSummary.
@@ -153,7 +177,13 @@ class ExadataInfrastructureSummary(object):
             'shape': 'str',
             'time_zone': 'str',
             'cpus_enabled': 'int',
-            'data_storage_size_in_tbs': 'int',
+            'max_cpu_count': 'int',
+            'memory_size_in_gbs': 'int',
+            'max_memory_in_gbs': 'int',
+            'db_node_storage_size_in_gbs': 'int',
+            'max_db_node_storage_in_g_bs': 'int',
+            'data_storage_size_in_tbs': 'float',
+            'max_data_storage_in_t_bs': 'float',
             'cloud_control_plane_server1': 'str',
             'cloud_control_plane_server2': 'str',
             'netmask': 'str',
@@ -177,7 +207,13 @@ class ExadataInfrastructureSummary(object):
             'shape': 'shape',
             'time_zone': 'timeZone',
             'cpus_enabled': 'cpusEnabled',
+            'max_cpu_count': 'maxCpuCount',
+            'memory_size_in_gbs': 'memorySizeInGBs',
+            'max_memory_in_gbs': 'maxMemoryInGBs',
+            'db_node_storage_size_in_gbs': 'dbNodeStorageSizeInGBs',
+            'max_db_node_storage_in_g_bs': 'maxDbNodeStorageInGBs',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
+            'max_data_storage_in_t_bs': 'maxDataStorageInTBs',
             'cloud_control_plane_server1': 'cloudControlPlaneServer1',
             'cloud_control_plane_server2': 'cloudControlPlaneServer2',
             'netmask': 'netmask',
@@ -200,7 +236,13 @@ class ExadataInfrastructureSummary(object):
         self._shape = None
         self._time_zone = None
         self._cpus_enabled = None
+        self._max_cpu_count = None
+        self._memory_size_in_gbs = None
+        self._max_memory_in_gbs = None
+        self._db_node_storage_size_in_gbs = None
+        self._max_db_node_storage_in_g_bs = None
         self._data_storage_size_in_tbs = None
+        self._max_data_storage_in_t_bs = None
         self._cloud_control_plane_server1 = None
         self._cloud_control_plane_server2 = None
         self._netmask = None
@@ -277,7 +319,7 @@ class ExadataInfrastructureSummary(object):
         **[Required]** Gets the lifecycle_state of this ExadataInfrastructureSummary.
         The current lifecycle state of the Exadata infrastructure.
 
-        Allowed values for this property are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "DISCONNECTED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -296,7 +338,7 @@ class ExadataInfrastructureSummary(object):
         :param lifecycle_state: The lifecycle_state of this ExadataInfrastructureSummary.
         :type: str
         """
-        allowed_values = ["CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "OFFLINE"]
+        allowed_values = ["CREATING", "REQUIRES_ACTIVATION", "ACTIVATING", "ACTIVE", "ACTIVATION_FAILED", "FAILED", "UPDATING", "DELETING", "DELETED", "DISCONNECTED"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
@@ -402,6 +444,126 @@ class ExadataInfrastructureSummary(object):
         self._cpus_enabled = cpus_enabled
 
     @property
+    def max_cpu_count(self):
+        """
+        Gets the max_cpu_count of this ExadataInfrastructureSummary.
+        The total number of CPU cores available.
+
+
+        :return: The max_cpu_count of this ExadataInfrastructureSummary.
+        :rtype: int
+        """
+        return self._max_cpu_count
+
+    @max_cpu_count.setter
+    def max_cpu_count(self, max_cpu_count):
+        """
+        Sets the max_cpu_count of this ExadataInfrastructureSummary.
+        The total number of CPU cores available.
+
+
+        :param max_cpu_count: The max_cpu_count of this ExadataInfrastructureSummary.
+        :type: int
+        """
+        self._max_cpu_count = max_cpu_count
+
+    @property
+    def memory_size_in_gbs(self):
+        """
+        Gets the memory_size_in_gbs of this ExadataInfrastructureSummary.
+        The memory allocated in GBs.
+
+
+        :return: The memory_size_in_gbs of this ExadataInfrastructureSummary.
+        :rtype: int
+        """
+        return self._memory_size_in_gbs
+
+    @memory_size_in_gbs.setter
+    def memory_size_in_gbs(self, memory_size_in_gbs):
+        """
+        Sets the memory_size_in_gbs of this ExadataInfrastructureSummary.
+        The memory allocated in GBs.
+
+
+        :param memory_size_in_gbs: The memory_size_in_gbs of this ExadataInfrastructureSummary.
+        :type: int
+        """
+        self._memory_size_in_gbs = memory_size_in_gbs
+
+    @property
+    def max_memory_in_gbs(self):
+        """
+        Gets the max_memory_in_gbs of this ExadataInfrastructureSummary.
+        The total memory available in GBs.
+
+
+        :return: The max_memory_in_gbs of this ExadataInfrastructureSummary.
+        :rtype: int
+        """
+        return self._max_memory_in_gbs
+
+    @max_memory_in_gbs.setter
+    def max_memory_in_gbs(self, max_memory_in_gbs):
+        """
+        Sets the max_memory_in_gbs of this ExadataInfrastructureSummary.
+        The total memory available in GBs.
+
+
+        :param max_memory_in_gbs: The max_memory_in_gbs of this ExadataInfrastructureSummary.
+        :type: int
+        """
+        self._max_memory_in_gbs = max_memory_in_gbs
+
+    @property
+    def db_node_storage_size_in_gbs(self):
+        """
+        Gets the db_node_storage_size_in_gbs of this ExadataInfrastructureSummary.
+        The local node storage allocated in GBs.
+
+
+        :return: The db_node_storage_size_in_gbs of this ExadataInfrastructureSummary.
+        :rtype: int
+        """
+        return self._db_node_storage_size_in_gbs
+
+    @db_node_storage_size_in_gbs.setter
+    def db_node_storage_size_in_gbs(self, db_node_storage_size_in_gbs):
+        """
+        Sets the db_node_storage_size_in_gbs of this ExadataInfrastructureSummary.
+        The local node storage allocated in GBs.
+
+
+        :param db_node_storage_size_in_gbs: The db_node_storage_size_in_gbs of this ExadataInfrastructureSummary.
+        :type: int
+        """
+        self._db_node_storage_size_in_gbs = db_node_storage_size_in_gbs
+
+    @property
+    def max_db_node_storage_in_g_bs(self):
+        """
+        Gets the max_db_node_storage_in_g_bs of this ExadataInfrastructureSummary.
+        The total local node storage available in GBs.
+
+
+        :return: The max_db_node_storage_in_g_bs of this ExadataInfrastructureSummary.
+        :rtype: int
+        """
+        return self._max_db_node_storage_in_g_bs
+
+    @max_db_node_storage_in_g_bs.setter
+    def max_db_node_storage_in_g_bs(self, max_db_node_storage_in_g_bs):
+        """
+        Sets the max_db_node_storage_in_g_bs of this ExadataInfrastructureSummary.
+        The total local node storage available in GBs.
+
+
+        :param max_db_node_storage_in_g_bs: The max_db_node_storage_in_g_bs of this ExadataInfrastructureSummary.
+        :type: int
+        """
+        self._max_db_node_storage_in_g_bs = max_db_node_storage_in_g_bs
+
+    @property
     def data_storage_size_in_tbs(self):
         """
         Gets the data_storage_size_in_tbs of this ExadataInfrastructureSummary.
@@ -409,7 +571,7 @@ class ExadataInfrastructureSummary(object):
 
 
         :return: The data_storage_size_in_tbs of this ExadataInfrastructureSummary.
-        :rtype: int
+        :rtype: float
         """
         return self._data_storage_size_in_tbs
 
@@ -421,9 +583,33 @@ class ExadataInfrastructureSummary(object):
 
 
         :param data_storage_size_in_tbs: The data_storage_size_in_tbs of this ExadataInfrastructureSummary.
-        :type: int
+        :type: float
         """
         self._data_storage_size_in_tbs = data_storage_size_in_tbs
+
+    @property
+    def max_data_storage_in_t_bs(self):
+        """
+        Gets the max_data_storage_in_t_bs of this ExadataInfrastructureSummary.
+        The total available DATA disk group size.
+
+
+        :return: The max_data_storage_in_t_bs of this ExadataInfrastructureSummary.
+        :rtype: float
+        """
+        return self._max_data_storage_in_t_bs
+
+    @max_data_storage_in_t_bs.setter
+    def max_data_storage_in_t_bs(self, max_data_storage_in_t_bs):
+        """
+        Sets the max_data_storage_in_t_bs of this ExadataInfrastructureSummary.
+        The total available DATA disk group size.
+
+
+        :param max_data_storage_in_t_bs: The max_data_storage_in_t_bs of this ExadataInfrastructureSummary.
+        :type: float
+        """
+        self._max_data_storage_in_t_bs = max_data_storage_in_t_bs
 
     @property
     def cloud_control_plane_server1(self):

--- a/src/oci/database/models/update_autonomous_database_details.py
+++ b/src/oci/database/models/update_autonomous_database_details.py
@@ -60,10 +60,6 @@ class UpdateAutonomousDatabaseDetails(object):
             The value to assign to the defined_tags property of this UpdateAutonomousDatabaseDetails.
         :type defined_tags: dict(str, dict(str, object))
 
-        :param nsg_ids:
-            The value to assign to the nsg_ids property of this UpdateAutonomousDatabaseDetails.
-        :type nsg_ids: list[str]
-
         :param license_model:
             The value to assign to the license_model property of this UpdateAutonomousDatabaseDetails.
             Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
@@ -81,6 +77,10 @@ class UpdateAutonomousDatabaseDetails(object):
             The value to assign to the db_version property of this UpdateAutonomousDatabaseDetails.
         :type db_version: str
 
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this UpdateAutonomousDatabaseDetails.
+        :type nsg_ids: list[str]
+
         """
         self.swagger_types = {
             'cpu_core_count': 'int',
@@ -91,11 +91,11 @@ class UpdateAutonomousDatabaseDetails(object):
             'db_name': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
-            'nsg_ids': 'list[str]',
             'license_model': 'str',
             'whitelisted_ips': 'list[str]',
             'is_auto_scaling_enabled': 'bool',
-            'db_version': 'str'
+            'db_version': 'str',
+            'nsg_ids': 'list[str]'
         }
 
         self.attribute_map = {
@@ -107,11 +107,11 @@ class UpdateAutonomousDatabaseDetails(object):
             'db_name': 'dbName',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
-            'nsg_ids': 'nsgIds',
             'license_model': 'licenseModel',
             'whitelisted_ips': 'whitelistedIps',
             'is_auto_scaling_enabled': 'isAutoScalingEnabled',
-            'db_version': 'dbVersion'
+            'db_version': 'dbVersion',
+            'nsg_ids': 'nsgIds'
         }
 
         self._cpu_core_count = None
@@ -122,11 +122,11 @@ class UpdateAutonomousDatabaseDetails(object):
         self._db_name = None
         self._freeform_tags = None
         self._defined_tags = None
-        self._nsg_ids = None
         self._license_model = None
         self._whitelisted_ips = None
         self._is_auto_scaling_enabled = None
         self._db_version = None
+        self._nsg_ids = None
 
     @property
     def cpu_core_count(self):
@@ -180,7 +180,8 @@ class UpdateAutonomousDatabaseDetails(object):
     def display_name(self):
         """
         Gets the display_name of this UpdateAutonomousDatabaseDetails.
-        The user-friendly name for the Autonomous Database. The name does not have to be unique.
+        The user-friendly name for the Autonomous Database. The name does not have to be unique. Can only be updated for Autonomous Databases
+        using dedicated Exadata infrastructure.
 
 
         :return: The display_name of this UpdateAutonomousDatabaseDetails.
@@ -192,7 +193,8 @@ class UpdateAutonomousDatabaseDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this UpdateAutonomousDatabaseDetails.
-        The user-friendly name for the Autonomous Database. The name does not have to be unique.
+        The user-friendly name for the Autonomous Database. The name does not have to be unique. Can only be updated for Autonomous Databases
+        using dedicated Exadata infrastructure.
 
 
         :param display_name: The display_name of this UpdateAutonomousDatabaseDetails.
@@ -341,40 +343,6 @@ class UpdateAutonomousDatabaseDetails(object):
         self._defined_tags = defined_tags
 
     @property
-    def nsg_ids(self):
-        """
-        Gets the nsg_ids of this UpdateAutonomousDatabaseDetails.
-        A list of the `OCIDs`__ of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
-        **NsgIds restrictions:**
-        - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
-
-        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
-        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
-
-
-        :return: The nsg_ids of this UpdateAutonomousDatabaseDetails.
-        :rtype: list[str]
-        """
-        return self._nsg_ids
-
-    @nsg_ids.setter
-    def nsg_ids(self, nsg_ids):
-        """
-        Sets the nsg_ids of this UpdateAutonomousDatabaseDetails.
-        A list of the `OCIDs`__ of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
-        **NsgIds restrictions:**
-        - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
-
-        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
-        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
-
-
-        :param nsg_ids: The nsg_ids of this UpdateAutonomousDatabaseDetails.
-        :type: list[str]
-        """
-        self._nsg_ids = nsg_ids
-
-    @property
     def license_model(self):
         """
         Gets the license_model of this UpdateAutonomousDatabaseDetails.
@@ -499,6 +467,40 @@ class UpdateAutonomousDatabaseDetails(object):
         :type: str
         """
         self._db_version = db_version
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this UpdateAutonomousDatabaseDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+        **NsgIds restrictions:**
+        - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :return: The nsg_ids of this UpdateAutonomousDatabaseDetails.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this UpdateAutonomousDatabaseDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+        **NsgIds restrictions:**
+        - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :param nsg_ids: The nsg_ids of this UpdateAutonomousDatabaseDetails.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/update_backup_destination_details.py
+++ b/src/oci/database/models/update_backup_destination_details.py
@@ -11,7 +11,7 @@ from oci.decorators import init_model_state_from_kwargs
 class UpdateBackupDestinationDetails(object):
     """
     For a RECOVERY_APPLIANCE backup destination, used to update the connection string and/or the list of VPC users.
-    For an NFS backup destination, used to update the NFS location.
+    For an NFS backup destination, there are 2 mount types - Self mount used for non-autonomous ExaCC and automated mount used for autonomous on ExaCC.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/database/models/update_vm_cluster_details.py
+++ b/src/oci/database/models/update_vm_cluster_details.py
@@ -30,6 +30,18 @@ class UpdateVmClusterDetails(object):
             The value to assign to the cpu_core_count property of this UpdateVmClusterDetails.
         :type cpu_core_count: int
 
+        :param memory_size_in_gbs:
+            The value to assign to the memory_size_in_gbs property of this UpdateVmClusterDetails.
+        :type memory_size_in_gbs: int
+
+        :param db_node_storage_size_in_gbs:
+            The value to assign to the db_node_storage_size_in_gbs property of this UpdateVmClusterDetails.
+        :type db_node_storage_size_in_gbs: int
+
+        :param data_storage_size_in_tbs:
+            The value to assign to the data_storage_size_in_tbs property of this UpdateVmClusterDetails.
+        :type data_storage_size_in_tbs: float
+
         :param license_model:
             The value to assign to the license_model property of this UpdateVmClusterDetails.
             Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
@@ -38,6 +50,10 @@ class UpdateVmClusterDetails(object):
         :param ssh_public_keys:
             The value to assign to the ssh_public_keys property of this UpdateVmClusterDetails.
         :type ssh_public_keys: list[str]
+
+        :param version:
+            The value to assign to the version property of this UpdateVmClusterDetails.
+        :type version: PatchDetails
 
         :param freeform_tags:
             The value to assign to the freeform_tags property of this UpdateVmClusterDetails.
@@ -50,23 +66,35 @@ class UpdateVmClusterDetails(object):
         """
         self.swagger_types = {
             'cpu_core_count': 'int',
+            'memory_size_in_gbs': 'int',
+            'db_node_storage_size_in_gbs': 'int',
+            'data_storage_size_in_tbs': 'float',
             'license_model': 'str',
             'ssh_public_keys': 'list[str]',
+            'version': 'PatchDetails',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
 
         self.attribute_map = {
             'cpu_core_count': 'cpuCoreCount',
+            'memory_size_in_gbs': 'memorySizeInGBs',
+            'db_node_storage_size_in_gbs': 'dbNodeStorageSizeInGBs',
+            'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'license_model': 'licenseModel',
             'ssh_public_keys': 'sshPublicKeys',
+            'version': 'version',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
 
         self._cpu_core_count = None
+        self._memory_size_in_gbs = None
+        self._db_node_storage_size_in_gbs = None
+        self._data_storage_size_in_tbs = None
         self._license_model = None
         self._ssh_public_keys = None
+        self._version = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -93,6 +121,78 @@ class UpdateVmClusterDetails(object):
         :type: int
         """
         self._cpu_core_count = cpu_core_count
+
+    @property
+    def memory_size_in_gbs(self):
+        """
+        Gets the memory_size_in_gbs of this UpdateVmClusterDetails.
+        The memory to be allocated in GBs.
+
+
+        :return: The memory_size_in_gbs of this UpdateVmClusterDetails.
+        :rtype: int
+        """
+        return self._memory_size_in_gbs
+
+    @memory_size_in_gbs.setter
+    def memory_size_in_gbs(self, memory_size_in_gbs):
+        """
+        Sets the memory_size_in_gbs of this UpdateVmClusterDetails.
+        The memory to be allocated in GBs.
+
+
+        :param memory_size_in_gbs: The memory_size_in_gbs of this UpdateVmClusterDetails.
+        :type: int
+        """
+        self._memory_size_in_gbs = memory_size_in_gbs
+
+    @property
+    def db_node_storage_size_in_gbs(self):
+        """
+        Gets the db_node_storage_size_in_gbs of this UpdateVmClusterDetails.
+        The local node storage to be allocated in GBs.
+
+
+        :return: The db_node_storage_size_in_gbs of this UpdateVmClusterDetails.
+        :rtype: int
+        """
+        return self._db_node_storage_size_in_gbs
+
+    @db_node_storage_size_in_gbs.setter
+    def db_node_storage_size_in_gbs(self, db_node_storage_size_in_gbs):
+        """
+        Sets the db_node_storage_size_in_gbs of this UpdateVmClusterDetails.
+        The local node storage to be allocated in GBs.
+
+
+        :param db_node_storage_size_in_gbs: The db_node_storage_size_in_gbs of this UpdateVmClusterDetails.
+        :type: int
+        """
+        self._db_node_storage_size_in_gbs = db_node_storage_size_in_gbs
+
+    @property
+    def data_storage_size_in_tbs(self):
+        """
+        Gets the data_storage_size_in_tbs of this UpdateVmClusterDetails.
+        The data disk group size to be allocated in TBs.
+
+
+        :return: The data_storage_size_in_tbs of this UpdateVmClusterDetails.
+        :rtype: float
+        """
+        return self._data_storage_size_in_tbs
+
+    @data_storage_size_in_tbs.setter
+    def data_storage_size_in_tbs(self, data_storage_size_in_tbs):
+        """
+        Sets the data_storage_size_in_tbs of this UpdateVmClusterDetails.
+        The data disk group size to be allocated in TBs.
+
+
+        :param data_storage_size_in_tbs: The data_storage_size_in_tbs of this UpdateVmClusterDetails.
+        :type: float
+        """
+        self._data_storage_size_in_tbs = data_storage_size_in_tbs
 
     @property
     def license_model(self):
@@ -149,6 +249,26 @@ class UpdateVmClusterDetails(object):
         :type: list[str]
         """
         self._ssh_public_keys = ssh_public_keys
+
+    @property
+    def version(self):
+        """
+        Gets the version of this UpdateVmClusterDetails.
+
+        :return: The version of this UpdateVmClusterDetails.
+        :rtype: PatchDetails
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this UpdateVmClusterDetails.
+
+        :param version: The version of this UpdateVmClusterDetails.
+        :type: PatchDetails
+        """
+        self._version = version
 
     @property
     def freeform_tags(self):

--- a/src/oci/database/models/vm_cluster.py
+++ b/src/oci/database/models/vm_cluster.py
@@ -58,6 +58,10 @@ class VmCluster(object):
             The value to assign to the compartment_id property of this VmCluster.
         :type compartment_id: str
 
+        :param last_patch_history_entry_id:
+            The value to assign to the last_patch_history_entry_id property of this VmCluster.
+        :type last_patch_history_entry_id: str
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this VmCluster.
             Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
@@ -100,9 +104,17 @@ class VmCluster(object):
             The value to assign to the cpus_enabled property of this VmCluster.
         :type cpus_enabled: int
 
+        :param memory_size_in_gbs:
+            The value to assign to the memory_size_in_gbs property of this VmCluster.
+        :type memory_size_in_gbs: int
+
+        :param db_node_storage_size_in_gbs:
+            The value to assign to the db_node_storage_size_in_gbs property of this VmCluster.
+        :type db_node_storage_size_in_gbs: int
+
         :param data_storage_size_in_tbs:
             The value to assign to the data_storage_size_in_tbs property of this VmCluster.
-        :type data_storage_size_in_tbs: int
+        :type data_storage_size_in_tbs: float
 
         :param shape:
             The value to assign to the shape property of this VmCluster.
@@ -134,6 +146,7 @@ class VmCluster(object):
         self.swagger_types = {
             'id': 'str',
             'compartment_id': 'str',
+            'last_patch_history_entry_id': 'str',
             'lifecycle_state': 'str',
             'display_name': 'str',
             'time_created': 'datetime',
@@ -144,7 +157,9 @@ class VmCluster(object):
             'is_sparse_diskgroup_enabled': 'bool',
             'vm_cluster_network_id': 'str',
             'cpus_enabled': 'int',
-            'data_storage_size_in_tbs': 'int',
+            'memory_size_in_gbs': 'int',
+            'db_node_storage_size_in_gbs': 'int',
+            'data_storage_size_in_tbs': 'float',
             'shape': 'str',
             'gi_version': 'str',
             'ssh_public_keys': 'list[str]',
@@ -156,6 +171,7 @@ class VmCluster(object):
         self.attribute_map = {
             'id': 'id',
             'compartment_id': 'compartmentId',
+            'last_patch_history_entry_id': 'lastPatchHistoryEntryId',
             'lifecycle_state': 'lifecycleState',
             'display_name': 'displayName',
             'time_created': 'timeCreated',
@@ -166,6 +182,8 @@ class VmCluster(object):
             'is_sparse_diskgroup_enabled': 'isSparseDiskgroupEnabled',
             'vm_cluster_network_id': 'vmClusterNetworkId',
             'cpus_enabled': 'cpusEnabled',
+            'memory_size_in_gbs': 'memorySizeInGBs',
+            'db_node_storage_size_in_gbs': 'dbNodeStorageSizeInGBs',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'shape': 'shape',
             'gi_version': 'giVersion',
@@ -177,6 +195,7 @@ class VmCluster(object):
 
         self._id = None
         self._compartment_id = None
+        self._last_patch_history_entry_id = None
         self._lifecycle_state = None
         self._display_name = None
         self._time_created = None
@@ -187,6 +206,8 @@ class VmCluster(object):
         self._is_sparse_diskgroup_enabled = None
         self._vm_cluster_network_id = None
         self._cpus_enabled = None
+        self._memory_size_in_gbs = None
+        self._db_node_storage_size_in_gbs = None
         self._data_storage_size_in_tbs = None
         self._shape = None
         self._gi_version = None
@@ -250,6 +271,34 @@ class VmCluster(object):
         :type: str
         """
         self._compartment_id = compartment_id
+
+    @property
+    def last_patch_history_entry_id(self):
+        """
+        Gets the last_patch_history_entry_id of this VmCluster.
+        The `OCID`__ of the last patch history. This value is updated as soon as a patch operation starts.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The last_patch_history_entry_id of this VmCluster.
+        :rtype: str
+        """
+        return self._last_patch_history_entry_id
+
+    @last_patch_history_entry_id.setter
+    def last_patch_history_entry_id(self, last_patch_history_entry_id):
+        """
+        Sets the last_patch_history_entry_id of this VmCluster.
+        The `OCID`__ of the last patch history. This value is updated as soon as a patch operation starts.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param last_patch_history_entry_id: The last_patch_history_entry_id of this VmCluster.
+        :type: str
+        """
+        self._last_patch_history_entry_id = last_patch_history_entry_id
 
     @property
     def lifecycle_state(self):
@@ -510,6 +559,54 @@ class VmCluster(object):
         self._cpus_enabled = cpus_enabled
 
     @property
+    def memory_size_in_gbs(self):
+        """
+        Gets the memory_size_in_gbs of this VmCluster.
+        The memory allocated in GBs.
+
+
+        :return: The memory_size_in_gbs of this VmCluster.
+        :rtype: int
+        """
+        return self._memory_size_in_gbs
+
+    @memory_size_in_gbs.setter
+    def memory_size_in_gbs(self, memory_size_in_gbs):
+        """
+        Sets the memory_size_in_gbs of this VmCluster.
+        The memory allocated in GBs.
+
+
+        :param memory_size_in_gbs: The memory_size_in_gbs of this VmCluster.
+        :type: int
+        """
+        self._memory_size_in_gbs = memory_size_in_gbs
+
+    @property
+    def db_node_storage_size_in_gbs(self):
+        """
+        Gets the db_node_storage_size_in_gbs of this VmCluster.
+        The local node storage allocated in GBs.
+
+
+        :return: The db_node_storage_size_in_gbs of this VmCluster.
+        :rtype: int
+        """
+        return self._db_node_storage_size_in_gbs
+
+    @db_node_storage_size_in_gbs.setter
+    def db_node_storage_size_in_gbs(self, db_node_storage_size_in_gbs):
+        """
+        Sets the db_node_storage_size_in_gbs of this VmCluster.
+        The local node storage allocated in GBs.
+
+
+        :param db_node_storage_size_in_gbs: The db_node_storage_size_in_gbs of this VmCluster.
+        :type: int
+        """
+        self._db_node_storage_size_in_gbs = db_node_storage_size_in_gbs
+
+    @property
     def data_storage_size_in_tbs(self):
         """
         Gets the data_storage_size_in_tbs of this VmCluster.
@@ -517,7 +614,7 @@ class VmCluster(object):
 
 
         :return: The data_storage_size_in_tbs of this VmCluster.
-        :rtype: int
+        :rtype: float
         """
         return self._data_storage_size_in_tbs
 
@@ -529,7 +626,7 @@ class VmCluster(object):
 
 
         :param data_storage_size_in_tbs: The data_storage_size_in_tbs of this VmCluster.
-        :type: int
+        :type: float
         """
         self._data_storage_size_in_tbs = data_storage_size_in_tbs
 

--- a/src/oci/database/models/vm_cluster_summary.py
+++ b/src/oci/database/models/vm_cluster_summary.py
@@ -58,6 +58,10 @@ class VmClusterSummary(object):
             The value to assign to the compartment_id property of this VmClusterSummary.
         :type compartment_id: str
 
+        :param last_patch_history_entry_id:
+            The value to assign to the last_patch_history_entry_id property of this VmClusterSummary.
+        :type last_patch_history_entry_id: str
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this VmClusterSummary.
             Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
@@ -100,9 +104,17 @@ class VmClusterSummary(object):
             The value to assign to the cpus_enabled property of this VmClusterSummary.
         :type cpus_enabled: int
 
+        :param memory_size_in_gbs:
+            The value to assign to the memory_size_in_gbs property of this VmClusterSummary.
+        :type memory_size_in_gbs: int
+
+        :param db_node_storage_size_in_gbs:
+            The value to assign to the db_node_storage_size_in_gbs property of this VmClusterSummary.
+        :type db_node_storage_size_in_gbs: int
+
         :param data_storage_size_in_tbs:
             The value to assign to the data_storage_size_in_tbs property of this VmClusterSummary.
-        :type data_storage_size_in_tbs: int
+        :type data_storage_size_in_tbs: float
 
         :param shape:
             The value to assign to the shape property of this VmClusterSummary.
@@ -134,6 +146,7 @@ class VmClusterSummary(object):
         self.swagger_types = {
             'id': 'str',
             'compartment_id': 'str',
+            'last_patch_history_entry_id': 'str',
             'lifecycle_state': 'str',
             'display_name': 'str',
             'time_created': 'datetime',
@@ -144,7 +157,9 @@ class VmClusterSummary(object):
             'is_sparse_diskgroup_enabled': 'bool',
             'vm_cluster_network_id': 'str',
             'cpus_enabled': 'int',
-            'data_storage_size_in_tbs': 'int',
+            'memory_size_in_gbs': 'int',
+            'db_node_storage_size_in_gbs': 'int',
+            'data_storage_size_in_tbs': 'float',
             'shape': 'str',
             'gi_version': 'str',
             'ssh_public_keys': 'list[str]',
@@ -156,6 +171,7 @@ class VmClusterSummary(object):
         self.attribute_map = {
             'id': 'id',
             'compartment_id': 'compartmentId',
+            'last_patch_history_entry_id': 'lastPatchHistoryEntryId',
             'lifecycle_state': 'lifecycleState',
             'display_name': 'displayName',
             'time_created': 'timeCreated',
@@ -166,6 +182,8 @@ class VmClusterSummary(object):
             'is_sparse_diskgroup_enabled': 'isSparseDiskgroupEnabled',
             'vm_cluster_network_id': 'vmClusterNetworkId',
             'cpus_enabled': 'cpusEnabled',
+            'memory_size_in_gbs': 'memorySizeInGBs',
+            'db_node_storage_size_in_gbs': 'dbNodeStorageSizeInGBs',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'shape': 'shape',
             'gi_version': 'giVersion',
@@ -177,6 +195,7 @@ class VmClusterSummary(object):
 
         self._id = None
         self._compartment_id = None
+        self._last_patch_history_entry_id = None
         self._lifecycle_state = None
         self._display_name = None
         self._time_created = None
@@ -187,6 +206,8 @@ class VmClusterSummary(object):
         self._is_sparse_diskgroup_enabled = None
         self._vm_cluster_network_id = None
         self._cpus_enabled = None
+        self._memory_size_in_gbs = None
+        self._db_node_storage_size_in_gbs = None
         self._data_storage_size_in_tbs = None
         self._shape = None
         self._gi_version = None
@@ -250,6 +271,34 @@ class VmClusterSummary(object):
         :type: str
         """
         self._compartment_id = compartment_id
+
+    @property
+    def last_patch_history_entry_id(self):
+        """
+        Gets the last_patch_history_entry_id of this VmClusterSummary.
+        The `OCID`__ of the last patch history. This value is updated as soon as a patch operation starts.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The last_patch_history_entry_id of this VmClusterSummary.
+        :rtype: str
+        """
+        return self._last_patch_history_entry_id
+
+    @last_patch_history_entry_id.setter
+    def last_patch_history_entry_id(self, last_patch_history_entry_id):
+        """
+        Sets the last_patch_history_entry_id of this VmClusterSummary.
+        The `OCID`__ of the last patch history. This value is updated as soon as a patch operation starts.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param last_patch_history_entry_id: The last_patch_history_entry_id of this VmClusterSummary.
+        :type: str
+        """
+        self._last_patch_history_entry_id = last_patch_history_entry_id
 
     @property
     def lifecycle_state(self):
@@ -510,6 +559,54 @@ class VmClusterSummary(object):
         self._cpus_enabled = cpus_enabled
 
     @property
+    def memory_size_in_gbs(self):
+        """
+        Gets the memory_size_in_gbs of this VmClusterSummary.
+        The memory allocated in GBs.
+
+
+        :return: The memory_size_in_gbs of this VmClusterSummary.
+        :rtype: int
+        """
+        return self._memory_size_in_gbs
+
+    @memory_size_in_gbs.setter
+    def memory_size_in_gbs(self, memory_size_in_gbs):
+        """
+        Sets the memory_size_in_gbs of this VmClusterSummary.
+        The memory allocated in GBs.
+
+
+        :param memory_size_in_gbs: The memory_size_in_gbs of this VmClusterSummary.
+        :type: int
+        """
+        self._memory_size_in_gbs = memory_size_in_gbs
+
+    @property
+    def db_node_storage_size_in_gbs(self):
+        """
+        Gets the db_node_storage_size_in_gbs of this VmClusterSummary.
+        The local node storage allocated in GBs.
+
+
+        :return: The db_node_storage_size_in_gbs of this VmClusterSummary.
+        :rtype: int
+        """
+        return self._db_node_storage_size_in_gbs
+
+    @db_node_storage_size_in_gbs.setter
+    def db_node_storage_size_in_gbs(self, db_node_storage_size_in_gbs):
+        """
+        Sets the db_node_storage_size_in_gbs of this VmClusterSummary.
+        The local node storage allocated in GBs.
+
+
+        :param db_node_storage_size_in_gbs: The db_node_storage_size_in_gbs of this VmClusterSummary.
+        :type: int
+        """
+        self._db_node_storage_size_in_gbs = db_node_storage_size_in_gbs
+
+    @property
     def data_storage_size_in_tbs(self):
         """
         Gets the data_storage_size_in_tbs of this VmClusterSummary.
@@ -517,7 +614,7 @@ class VmClusterSummary(object):
 
 
         :return: The data_storage_size_in_tbs of this VmClusterSummary.
-        :rtype: int
+        :rtype: float
         """
         return self._data_storage_size_in_tbs
 
@@ -529,7 +626,7 @@ class VmClusterSummary(object):
 
 
         :param data_storage_size_in_tbs: The data_storage_size_in_tbs of this VmClusterSummary.
-        :type: int
+        :type: float
         """
         self._data_storage_size_in_tbs = data_storage_size_in_tbs
 

--- a/src/oci/identity/identity_client.py
+++ b/src/oci/identity/identity_client.py
@@ -323,6 +323,381 @@ class IdentityClient(object):
                 header_params=header_params,
                 response_type="list[TagDefaultSummary]")
 
+    def bulk_delete_resources(self, compartment_id, bulk_delete_resources_details, **kwargs):
+        """
+        Bulk delete resources in the compartment. All resources must be in the same compartment.
+        This API can only be invoked from tenancy's home region.
+
+
+        :param str compartment_id: (required)
+            The OCID of the compartment.
+
+        :param BulkDeleteResourcesDetails bulk_delete_resources_details: (required)
+            Request object for bulk delete resources in a compartment.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/compartments/{compartmentId}/actions/bulkDeleteResources"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "bulk_delete_resources got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "compartmentId": compartment_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=bulk_delete_resources_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=bulk_delete_resources_details)
+
+    def bulk_delete_tags(self, bulk_delete_tags_details, **kwargs):
+        """
+        Deletes the specified tag key definitions. This operation triggers a process that removes the
+        tags from all resources in your tenancy.
+
+        The following actions happen immediately:
+        \u00A0
+          * If the tag is a cost-tracking tag, the tag no longer counts against your
+          10 cost-tracking tags limit, even if you do not disable the tag before running this operation.
+          * If the tag is used with dynamic groups, the rules that contain the tag are no longer
+          evaluated against the tag.
+
+        After you start this operation, the state of the tag changes to DELETING, and tag removal
+        from resources begins. This process can take up to 48 hours depending on the number of resources that
+        are tagged and the regions in which those resources reside.
+
+        When all tags have been removed, the state changes to DELETED. You cannot restore a deleted tag. After the tag state
+        changes to DELETED, you can use the same tag name again.
+
+        After you start this operation, you cannot start either the :func:`delete_tag` or the :func:`cascade_delete_tag_namespace` operation until this process completes.
+
+        In order to delete tags, you must first retire the tags. Use :func:`update_tag`
+        to retire a tag.
+
+
+        :param BulkDeleteTagsDetails bulk_delete_tags_details: (required)
+            Request object for deleting tags in bulk.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/tags/actions/bulkDelete"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "bulk_delete_tags got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=bulk_delete_tags_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=bulk_delete_tags_details)
+
+    def bulk_move_resources(self, compartment_id, bulk_move_resources_details, **kwargs):
+        """
+        Bulk move resources in the compartment. All resources must be in the same compartment.
+        This API can only be invoked from tenancy's home region.
+
+
+        :param str compartment_id: (required)
+            The OCID of the compartment.
+
+        :param BulkMoveResourcesDetails bulk_move_resources_details: (required)
+            Request object for bulk move resources in the compartment.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/compartments/{compartmentId}/actions/bulkMoveResources"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "bulk_move_resources got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "compartmentId": compartment_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=bulk_move_resources_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=bulk_move_resources_details)
+
+    def cascade_delete_tag_namespace(self, tag_namespace_id, **kwargs):
+        """
+        Deletes the specified tag namespace. This operation triggers a process that removes all of the tags
+        defined in the specified tag namespace from all resources in your tenancy and then deletes the tag namespace.
+
+        After you start the delete operation:
+
+          * New tag key definitions cannot be created under the namespace.
+          * The state of the tag namespace changes to DELETING.
+          * Tag removal from the resources begins.
+
+        This process can take up to 48 hours depending on the number of tag definitions in the namespace, the number of resources
+        that are tagged, and the locations of the regions in which those resources reside.
+
+        After all tags are removed, the state changes to DELETED. You cannot restore a deleted tag namespace. After the deleted tag namespace
+        changes its state to DELETED, you can use the name of the deleted tag namespace again.
+
+        After you start this operation, you cannot start either the :func:`delete_tag` or the :func:`bulk_delete_tags` operation until this process completes.
+
+        To delete a tag namespace, you must first retire it. Use :func:`update_tag_namespace`
+        to retire a tag namespace.
+
+
+        :param str tag_namespace_id: (required)
+            The OCID of the tag namespace.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/tagNamespaces/{tagNamespaceId}/actions/cascadeDelete"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "cascade_delete_tag_namespace got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "tagNamespaceId": tag_namespace_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
     def change_tag_namespace_compartment(self, tag_namespace_id, change_tag_namespace_compartment_detail, **kwargs):
         """
         Moves the specified tag namespace to the specified compartment within the same tenancy.
@@ -1139,8 +1514,12 @@ class IdentityClient(object):
         After you send your request, the new object's `lifecycleState` will temporarily be CREATING. Before using the
         object, first make sure its `lifecycleState` has changed to ACTIVE.
 
+        After your network resource is created, you can use it in policy to restrict access to only requests made from an allowed
+        IP address specified in your network source. For more information, see `Managing Network Sources`__.
+
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
         __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm
+        __ https://docs.cloud.oracle.com/Content/Identity/Tasks/managingnetworksources.htm
 
 
         :param CreateNetworkSourceDetails create_network_source_details: (required)
@@ -3164,11 +3543,14 @@ class IdentityClient(object):
           * If the tag was used with dynamic groups, none of the rules that contain the tag will
           be evaluated against the tag.
 
-        Once you start the delete operation, the state of the tag changes to DELETING and tag removal
+        When you start the delete operation, the state of the tag changes to DELETING and tag removal
         from resources begins. This can take up to 48 hours depending on the number of resources that
-        were tagged as well as the regions in which those resources reside. When all tags have been
-        removed, the state changes to DELETED. You cannot restore a deleted tag. Once the deleted tag
+        were tagged as well as the regions in which those resources reside.
+
+        When all tags have been removed, the state changes to DELETED. You cannot restore a deleted tag. Once the deleted tag
         changes its state to DELETED, you can use the same tag name again.
+
+        After you start this operation, you cannot start either the :func:`bulk_delete_tags` or the :func:`cascade_delete_tag_namespace` operation until this process completes.
 
         To delete a tag, you must first retire it. Use :func:`update_tag`
         to retire a tag.
@@ -3325,8 +3707,11 @@ class IdentityClient(object):
 
     def delete_tag_namespace(self, tag_namespace_id, **kwargs):
         """
-        Deletes the specified tag namespace. Only an empty tag namespace can be deleted. To delete
-        a tag namespace, first delete all its tag definitions.
+        Deletes the specified tag namespace. Only an empty tag namespace can be deleted with this operation. To use this operation
+        to delete a tag namespace that contains tag definitions, first delete all of its tag definitions.
+
+        Use :func:`cascade_delete_tag_namespace` to delete a tag namespace along with all of
+        the tag definitions contained within that namespace.
 
         Use :func:`delete_tag` to delete a tag definition.
 
@@ -4908,6 +5293,85 @@ class IdentityClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="list[AvailabilityDomain]")
+
+    def list_bulk_action_resource_types(self, bulk_action_type, **kwargs):
+        """
+        Lists the resource types supported by compartment bulk actions.
+
+
+        :param str bulk_action_type: (required)
+            The type of the bulk action.
+
+            Allowed values are: "BULK_MOVE_RESOURCES", "BULK_DELETE_RESOURCES"
+
+        :param str page: (optional)
+            The value of the `opc-next-page` response header from the previous \"List\" call.
+
+        :param int limit: (optional)
+            The maximum number of items to return in a paginated \"List\" call.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.identity.models.BulkActionResourceTypeCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/compartments/bulkActionResourceTypes"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "page",
+            "limit"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_bulk_action_resource_types got unknown kwargs: {!r}".format(extra_kwargs))
+
+        bulk_action_type_allowed_values = ["BULK_MOVE_RESOURCES", "BULK_DELETE_RESOURCES"]
+        if bulk_action_type not in bulk_action_type_allowed_values:
+            raise ValueError(
+                "Invalid value for `bulk_action_type`, must be one of {0}".format(bulk_action_type_allowed_values)
+            )
+
+        query_params = {
+            "bulkActionType": bulk_action_type,
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="BulkActionResourceTypeCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="BulkActionResourceTypeCollection")
 
     def list_compartments(self, compartment_id, **kwargs):
         """

--- a/src/oci/identity/identity_client_composite_operations.py
+++ b/src/oci/identity/identity_client_composite_operations.py
@@ -61,6 +61,164 @@ class IdentityClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def bulk_delete_resources_and_wait_for_state(self, compartment_id, bulk_delete_resources_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.identity.IdentityClient.bulk_delete_resources` and waits for the :py:class:`~oci.identity.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str compartment_id: (required)
+            The OCID of the compartment.
+
+        :param BulkDeleteResourcesDetails bulk_delete_resources_details: (required)
+            Request object for bulk delete resources in a compartment.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.identity.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.identity.IdentityClient.bulk_delete_resources`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.bulk_delete_resources(compartment_id, bulk_delete_resources_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def bulk_delete_tags_and_wait_for_state(self, bulk_delete_tags_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.identity.IdentityClient.bulk_delete_tags` and waits for the :py:class:`~oci.identity.models.WorkRequest`
+        to enter the given state(s).
+
+        :param BulkDeleteTagsDetails bulk_delete_tags_details: (required)
+            Request object for deleting tags in bulk.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.identity.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.identity.IdentityClient.bulk_delete_tags`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.bulk_delete_tags(bulk_delete_tags_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def bulk_move_resources_and_wait_for_state(self, compartment_id, bulk_move_resources_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.identity.IdentityClient.bulk_move_resources` and waits for the :py:class:`~oci.identity.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str compartment_id: (required)
+            The OCID of the compartment.
+
+        :param BulkMoveResourcesDetails bulk_move_resources_details: (required)
+            Request object for bulk move resources in the compartment.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.identity.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.identity.IdentityClient.bulk_move_resources`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.bulk_move_resources(compartment_id, bulk_move_resources_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def cascade_delete_tag_namespace_and_wait_for_state(self, tag_namespace_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.identity.IdentityClient.cascade_delete_tag_namespace` and waits for the :py:class:`~oci.identity.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str tag_namespace_id: (required)
+            The OCID of the tag namespace.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.identity.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.identity.IdentityClient.cascade_delete_tag_namespace`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.cascade_delete_tag_namespace(tag_namespace_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_compartment_and_wait_for_state(self, create_compartment_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.identity.IdentityClient.create_compartment` and waits for the :py:class:`~oci.identity.models.Compartment` acted upon

--- a/src/oci/identity/models/__init__.py
+++ b/src/oci/identity/models/__init__.py
@@ -10,6 +10,12 @@ from .auth_token import AuthToken
 from .authentication_policy import AuthenticationPolicy
 from .availability_domain import AvailabilityDomain
 from .base_tag_definition_validator import BaseTagDefinitionValidator
+from .bulk_action_resource import BulkActionResource
+from .bulk_action_resource_type import BulkActionResourceType
+from .bulk_action_resource_type_collection import BulkActionResourceTypeCollection
+from .bulk_delete_resources_details import BulkDeleteResourcesDetails
+from .bulk_delete_tags_details import BulkDeleteTagsDetails
+from .bulk_move_resources_details import BulkMoveResourcesDetails
 from .change_tag_namespace_compartment_detail import ChangeTagNamespaceCompartmentDetail
 from .compartment import Compartment
 from .create_api_key_details import CreateApiKeyDetails
@@ -110,6 +116,12 @@ identity_type_mapping = {
     "AuthenticationPolicy": AuthenticationPolicy,
     "AvailabilityDomain": AvailabilityDomain,
     "BaseTagDefinitionValidator": BaseTagDefinitionValidator,
+    "BulkActionResource": BulkActionResource,
+    "BulkActionResourceType": BulkActionResourceType,
+    "BulkActionResourceTypeCollection": BulkActionResourceTypeCollection,
+    "BulkDeleteResourcesDetails": BulkDeleteResourcesDetails,
+    "BulkDeleteTagsDetails": BulkDeleteTagsDetails,
+    "BulkMoveResourcesDetails": BulkMoveResourcesDetails,
     "ChangeTagNamespaceCompartmentDetail": ChangeTagNamespaceCompartmentDetail,
     "Compartment": Compartment,
     "CreateApiKeyDetails": CreateApiKeyDetails,

--- a/src/oci/identity/models/bulk_action_resource.py
+++ b/src/oci/identity/models/bulk_action_resource.py
@@ -1,0 +1,144 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class BulkActionResource(object):
+    """
+    The bulk action resource entity.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new BulkActionResource object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param identifier:
+            The value to assign to the identifier property of this BulkActionResource.
+        :type identifier: str
+
+        :param entity_type:
+            The value to assign to the entity_type property of this BulkActionResource.
+        :type entity_type: str
+
+        :param metadata:
+            The value to assign to the metadata property of this BulkActionResource.
+        :type metadata: dict(str, str)
+
+        """
+        self.swagger_types = {
+            'identifier': 'str',
+            'entity_type': 'str',
+            'metadata': 'dict(str, str)'
+        }
+
+        self.attribute_map = {
+            'identifier': 'identifier',
+            'entity_type': 'entityType',
+            'metadata': 'metadata'
+        }
+
+        self._identifier = None
+        self._entity_type = None
+        self._metadata = None
+
+    @property
+    def identifier(self):
+        """
+        **[Required]** Gets the identifier of this BulkActionResource.
+        The resource identifier.
+
+
+        :return: The identifier of this BulkActionResource.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this BulkActionResource.
+        The resource identifier.
+
+
+        :param identifier: The identifier of this BulkActionResource.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def entity_type(self):
+        """
+        **[Required]** Gets the entity_type of this BulkActionResource.
+        The resource type.
+
+
+        :return: The entity_type of this BulkActionResource.
+        :rtype: str
+        """
+        return self._entity_type
+
+    @entity_type.setter
+    def entity_type(self, entity_type):
+        """
+        Sets the entity_type of this BulkActionResource.
+        The resource type.
+
+
+        :param entity_type: The entity_type of this BulkActionResource.
+        :type: str
+        """
+        self._entity_type = entity_type
+
+    @property
+    def metadata(self):
+        """
+        Gets the metadata of this BulkActionResource.
+        Additional information that helps to identity the resource for bulk action.
+
+        DELETE and UPDATE APIs for most resource types only require the resource identifier(ocid).
+        But additional metadata is required for some resource types.
+
+        This information is provided in the resource's public API document. It is also
+        available through the ListBulkActionResourceTypes API.
+
+
+        :return: The metadata of this BulkActionResource.
+        :rtype: dict(str, str)
+        """
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        """
+        Sets the metadata of this BulkActionResource.
+        Additional information that helps to identity the resource for bulk action.
+
+        DELETE and UPDATE APIs for most resource types only require the resource identifier(ocid).
+        But additional metadata is required for some resource types.
+
+        This information is provided in the resource's public API document. It is also
+        available through the ListBulkActionResourceTypes API.
+
+
+        :param metadata: The metadata of this BulkActionResource.
+        :type: dict(str, str)
+        """
+        self._metadata = metadata
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/identity/models/bulk_action_resource_type.py
+++ b/src/oci/identity/models/bulk_action_resource_type.py
@@ -1,0 +1,107 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class BulkActionResourceType(object):
+    """
+    BulkActionResourceType model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new BulkActionResourceType object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this BulkActionResourceType.
+        :type name: str
+
+        :param metadata_keys:
+            The value to assign to the metadata_keys property of this BulkActionResourceType.
+        :type metadata_keys: list[str]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'metadata_keys': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'metadata_keys': 'metadataKeys'
+        }
+
+        self._name = None
+        self._metadata_keys = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this BulkActionResourceType.
+        The unique name of the resource type.
+
+
+        :return: The name of this BulkActionResourceType.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this BulkActionResourceType.
+        The unique name of the resource type.
+
+
+        :param name: The name of this BulkActionResourceType.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def metadata_keys(self):
+        """
+        Gets the metadata_keys of this BulkActionResourceType.
+        List of metadata keys required to identify the resource.
+        E.g. for bucket, metadataKeys will be [\"namespaceName\", \"bucketName\"].
+        This informatino will match the public API document:
+        https://docs.cloud.oracle.com/en-us/iaas/api/#/en/objectstorage/20160918/Bucket/GetBucket
+
+
+        :return: The metadata_keys of this BulkActionResourceType.
+        :rtype: list[str]
+        """
+        return self._metadata_keys
+
+    @metadata_keys.setter
+    def metadata_keys(self, metadata_keys):
+        """
+        Sets the metadata_keys of this BulkActionResourceType.
+        List of metadata keys required to identify the resource.
+        E.g. for bucket, metadataKeys will be [\"namespaceName\", \"bucketName\"].
+        This informatino will match the public API document:
+        https://docs.cloud.oracle.com/en-us/iaas/api/#/en/objectstorage/20160918/Bucket/GetBucket
+
+
+        :param metadata_keys: The metadata_keys of this BulkActionResourceType.
+        :type: list[str]
+        """
+        self._metadata_keys = metadata_keys
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/identity/models/bulk_action_resource_type_collection.py
+++ b/src/oci/identity/models/bulk_action_resource_type_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class BulkActionResourceTypeCollection(object):
+    """
+    Collection of resource types supported by bulk action.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new BulkActionResourceTypeCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this BulkActionResourceTypeCollection.
+        :type items: list[BulkActionResourceType]
+
+        """
+        self.swagger_types = {
+            'items': 'list[BulkActionResourceType]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this BulkActionResourceTypeCollection.
+        Collection of resource types supported by bulk action.
+
+
+        :return: The items of this BulkActionResourceTypeCollection.
+        :rtype: list[BulkActionResourceType]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this BulkActionResourceTypeCollection.
+        Collection of resource types supported by bulk action.
+
+
+        :param items: The items of this BulkActionResourceTypeCollection.
+        :type: list[BulkActionResourceType]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/identity/models/bulk_delete_resources_details.py
+++ b/src/oci/identity/models/bulk_delete_resources_details.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class BulkDeleteResourcesDetails(object):
+    """
+    BulkDeleteResourcesDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new BulkDeleteResourcesDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param resources:
+            The value to assign to the resources property of this BulkDeleteResourcesDetails.
+        :type resources: list[BulkActionResource]
+
+        """
+        self.swagger_types = {
+            'resources': 'list[BulkActionResource]'
+        }
+
+        self.attribute_map = {
+            'resources': 'resources'
+        }
+
+        self._resources = None
+
+    @property
+    def resources(self):
+        """
+        **[Required]** Gets the resources of this BulkDeleteResourcesDetails.
+        The resources to be deleted.
+
+
+        :return: The resources of this BulkDeleteResourcesDetails.
+        :rtype: list[BulkActionResource]
+        """
+        return self._resources
+
+    @resources.setter
+    def resources(self, resources):
+        """
+        Sets the resources of this BulkDeleteResourcesDetails.
+        The resources to be deleted.
+
+
+        :param resources: The resources of this BulkDeleteResourcesDetails.
+        :type: list[BulkActionResource]
+        """
+        self._resources = resources
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/identity/models/bulk_delete_tags_details.py
+++ b/src/oci/identity/models/bulk_delete_tags_details.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class BulkDeleteTagsDetails(object):
+    """
+    Properties for deleting tags in bulk
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new BulkDeleteTagsDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param tag_definition_ids:
+            The value to assign to the tag_definition_ids property of this BulkDeleteTagsDetails.
+        :type tag_definition_ids: list[str]
+
+        """
+        self.swagger_types = {
+            'tag_definition_ids': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'tag_definition_ids': 'tagDefinitionIds'
+        }
+
+        self._tag_definition_ids = None
+
+    @property
+    def tag_definition_ids(self):
+        """
+        **[Required]** Gets the tag_definition_ids of this BulkDeleteTagsDetails.
+        The OCIDs of the tag definitions to delete
+
+
+        :return: The tag_definition_ids of this BulkDeleteTagsDetails.
+        :rtype: list[str]
+        """
+        return self._tag_definition_ids
+
+    @tag_definition_ids.setter
+    def tag_definition_ids(self, tag_definition_ids):
+        """
+        Sets the tag_definition_ids of this BulkDeleteTagsDetails.
+        The OCIDs of the tag definitions to delete
+
+
+        :param tag_definition_ids: The tag_definition_ids of this BulkDeleteTagsDetails.
+        :type: list[str]
+        """
+        self._tag_definition_ids = tag_definition_ids
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/identity/models/bulk_move_resources_details.py
+++ b/src/oci/identity/models/bulk_move_resources_details.py
@@ -1,0 +1,107 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class BulkMoveResourcesDetails(object):
+    """
+    BulkMoveResourcesDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new BulkMoveResourcesDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param resources:
+            The value to assign to the resources property of this BulkMoveResourcesDetails.
+        :type resources: list[BulkActionResource]
+
+        :param target_compartment_id:
+            The value to assign to the target_compartment_id property of this BulkMoveResourcesDetails.
+        :type target_compartment_id: str
+
+        """
+        self.swagger_types = {
+            'resources': 'list[BulkActionResource]',
+            'target_compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'resources': 'resources',
+            'target_compartment_id': 'targetCompartmentId'
+        }
+
+        self._resources = None
+        self._target_compartment_id = None
+
+    @property
+    def resources(self):
+        """
+        **[Required]** Gets the resources of this BulkMoveResourcesDetails.
+        The resources to be moved.
+
+
+        :return: The resources of this BulkMoveResourcesDetails.
+        :rtype: list[BulkActionResource]
+        """
+        return self._resources
+
+    @resources.setter
+    def resources(self, resources):
+        """
+        Sets the resources of this BulkMoveResourcesDetails.
+        The resources to be moved.
+
+
+        :param resources: The resources of this BulkMoveResourcesDetails.
+        :type: list[BulkActionResource]
+        """
+        self._resources = resources
+
+    @property
+    def target_compartment_id(self):
+        """
+        **[Required]** Gets the target_compartment_id of this BulkMoveResourcesDetails.
+        The `OCID`__ of the destination compartment
+        into which to move the resources.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The target_compartment_id of this BulkMoveResourcesDetails.
+        :rtype: str
+        """
+        return self._target_compartment_id
+
+    @target_compartment_id.setter
+    def target_compartment_id(self, target_compartment_id):
+        """
+        Sets the target_compartment_id of this BulkMoveResourcesDetails.
+        The `OCID`__ of the destination compartment
+        into which to move the resources.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param target_compartment_id: The target_compartment_id of this BulkMoveResourcesDetails.
+        :type: str
+        """
+        self._target_compartment_id = target_compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/identity/models/create_network_source_details.py
+++ b/src/oci/identity/models/create_network_source_details.py
@@ -86,7 +86,7 @@ class CreateNetworkSourceDetails(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this CreateNetworkSourceDetails.
-        The OCID of the tenancy containing the network source object.
+        The OCID of the tenancy (root compartment) containing the network source object.
 
 
         :return: The compartment_id of this CreateNetworkSourceDetails.
@@ -98,7 +98,7 @@ class CreateNetworkSourceDetails(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this CreateNetworkSourceDetails.
-        The OCID of the tenancy containing the network source object.
+        The OCID of the tenancy (root compartment) containing the network source object.
 
 
         :param compartment_id: The compartment_id of this CreateNetworkSourceDetails.
@@ -136,7 +136,7 @@ class CreateNetworkSourceDetails(object):
     def public_source_list(self):
         """
         Gets the public_source_list of this CreateNetworkSourceDetails.
-        A list of allowed public IPs and CIDR ranges
+        A list of allowed public IP addresses and CIDR ranges.
 
 
         :return: The public_source_list of this CreateNetworkSourceDetails.
@@ -148,7 +148,7 @@ class CreateNetworkSourceDetails(object):
     def public_source_list(self, public_source_list):
         """
         Sets the public_source_list of this CreateNetworkSourceDetails.
-        A list of allowed public IPs and CIDR ranges
+        A list of allowed public IP addresses and CIDR ranges.
 
 
         :param public_source_list: The public_source_list of this CreateNetworkSourceDetails.
@@ -160,7 +160,8 @@ class CreateNetworkSourceDetails(object):
     def virtual_source_list(self):
         """
         Gets the virtual_source_list of this CreateNetworkSourceDetails.
-        A list of allowed VCN ocid/IP range pairs
+        A list of allowed VCN OCID and IP range pairs.
+        Example:`\"vcnId\": \"ocid1.vcn.oc1.iad.aaaaaaaaexampleuniqueID\", \"ipRanges\": [ \"129.213.39.0/24\" ]`
 
 
         :return: The virtual_source_list of this CreateNetworkSourceDetails.
@@ -172,7 +173,8 @@ class CreateNetworkSourceDetails(object):
     def virtual_source_list(self, virtual_source_list):
         """
         Sets the virtual_source_list of this CreateNetworkSourceDetails.
-        A list of allowed VCN ocid/IP range pairs
+        A list of allowed VCN OCID and IP range pairs.
+        Example:`\"vcnId\": \"ocid1.vcn.oc1.iad.aaaaaaaaexampleuniqueID\", \"ipRanges\": [ \"129.213.39.0/24\" ]`
 
 
         :param virtual_source_list: The virtual_source_list of this CreateNetworkSourceDetails.
@@ -184,8 +186,9 @@ class CreateNetworkSourceDetails(object):
     def services(self):
         """
         Gets the services of this CreateNetworkSourceDetails.
-        A list of OCIservices allowed to make on behalf of requests which may have different source ips.
-        At this time only the values of all or none are supported.
+        A list of services allowed to make on-behalf-of requests. These requests can have different source IP addresses
+        than those listed in the network source.
+        Currently, only `all` and `none` are supported. The default is `all`.
 
 
         :return: The services of this CreateNetworkSourceDetails.
@@ -197,8 +200,9 @@ class CreateNetworkSourceDetails(object):
     def services(self, services):
         """
         Sets the services of this CreateNetworkSourceDetails.
-        A list of OCIservices allowed to make on behalf of requests which may have different source ips.
-        At this time only the values of all or none are supported.
+        A list of services allowed to make on-behalf-of requests. These requests can have different source IP addresses
+        than those listed in the network source.
+        Currently, only `all` and `none` are supported. The default is `all`.
 
 
         :param services: The services of this CreateNetworkSourceDetails.

--- a/src/oci/identity/models/create_region_subscription_details.py
+++ b/src/oci/identity/models/create_region_subscription_details.py
@@ -37,18 +37,12 @@ class CreateRegionSubscriptionDetails(object):
     def region_key(self):
         """
         **[Required]** Gets the region_key of this CreateRegionSubscriptionDetails.
-        The regions's key.
-
-        Allowed values are:
-        - `PHX`
-        - `IAD`
-        - `FRA`
-        - `LHR`
-        - `YYZ`
-        - `NRT`
-        - `ICN`
+        The regions's key. See `Regions and Availability Domains`__ for
+        the full list of supported 3-letter region codes.
 
         Example: `PHX`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
 
 
         :return: The region_key of this CreateRegionSubscriptionDetails.
@@ -60,18 +54,12 @@ class CreateRegionSubscriptionDetails(object):
     def region_key(self, region_key):
         """
         Sets the region_key of this CreateRegionSubscriptionDetails.
-        The regions's key.
-
-        Allowed values are:
-        - `PHX`
-        - `IAD`
-        - `FRA`
-        - `LHR`
-        - `YYZ`
-        - `NRT`
-        - `ICN`
+        The regions's key. See `Regions and Availability Domains`__ for
+        the full list of supported 3-letter region codes.
 
         Example: `PHX`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
 
 
         :param region_key: The region_key of this CreateRegionSubscriptionDetails.

--- a/src/oci/identity/models/network_sources.py
+++ b/src/oci/identity/models/network_sources.py
@@ -10,8 +10,11 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class NetworkSources(object):
     """
-    A network source defines a list of source IPs that are allowed to make auth requests
-    More info needed here
+    A network source specifies a list of source IP addresses that are allowed to make authorization requests.
+    Use the network source in policy statements to restrict access to only requests that come from the specified IPs.
+    For more information, see `Managing Network Sources`__.
+
+    __ https://docs.cloud.oracle.com/Content/Identity/Tasks/managingnetworksources.htm
     """
 
     #: A constant which can be used with the lifecycle_state property of a NetworkSources.
@@ -161,7 +164,7 @@ class NetworkSources(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this NetworkSources.
-        The OCID of the tenancy containing the network source.
+        The OCID of the tenancy containing the network source. The tenancy is the root compartment.
 
 
         :return: The compartment_id of this NetworkSources.
@@ -173,7 +176,7 @@ class NetworkSources(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this NetworkSources.
-        The OCID of the tenancy containing the network source.
+        The OCID of the tenancy containing the network source. The tenancy is the root compartment.
 
 
         :param compartment_id: The compartment_id of this NetworkSources.
@@ -235,7 +238,7 @@ class NetworkSources(object):
     def public_source_list(self):
         """
         Gets the public_source_list of this NetworkSources.
-        A list of allowed public IPs and CIDR ranges
+        A list of allowed public IPs and CIDR ranges.
 
 
         :return: The public_source_list of this NetworkSources.
@@ -247,7 +250,7 @@ class NetworkSources(object):
     def public_source_list(self, public_source_list):
         """
         Sets the public_source_list of this NetworkSources.
-        A list of allowed public IPs and CIDR ranges
+        A list of allowed public IPs and CIDR ranges.
 
 
         :param public_source_list: The public_source_list of this NetworkSources.
@@ -259,7 +262,8 @@ class NetworkSources(object):
     def virtual_source_list(self):
         """
         Gets the virtual_source_list of this NetworkSources.
-        A list of allowed VCN ocid/IP range pairs
+        A list of allowed VCN OCID and IP range pairs.
+        Example:`\"vcnId\": \"ocid1.vcn.oc1.iad.aaaaaaaaexampleuniqueID\", \"ipRanges\": [ \"129.213.39.0/24\" ]`
 
 
         :return: The virtual_source_list of this NetworkSources.
@@ -271,7 +275,8 @@ class NetworkSources(object):
     def virtual_source_list(self, virtual_source_list):
         """
         Sets the virtual_source_list of this NetworkSources.
-        A list of allowed VCN ocid/IP range pairs
+        A list of allowed VCN OCID and IP range pairs.
+        Example:`\"vcnId\": \"ocid1.vcn.oc1.iad.aaaaaaaaexampleuniqueID\", \"ipRanges\": [ \"129.213.39.0/24\" ]`
 
 
         :param virtual_source_list: The virtual_source_list of this NetworkSources.
@@ -283,8 +288,9 @@ class NetworkSources(object):
     def services(self):
         """
         Gets the services of this NetworkSources.
-        A list of OCIservices allowed to make on behalf of requests which may have different source ips.
-        At this time only the values of all or none are supported.
+        A list of services allowed to make on-behalf-of requests. These requests can have different source IPs than
+        those specified in the network source.
+        Currently, only `all` and `none` are supported. The default is `all`.
 
 
         :return: The services of this NetworkSources.
@@ -296,8 +302,9 @@ class NetworkSources(object):
     def services(self, services):
         """
         Sets the services of this NetworkSources.
-        A list of OCIservices allowed to make on behalf of requests which may have different source ips.
-        At this time only the values of all or none are supported.
+        A list of services allowed to make on-behalf-of requests. These requests can have different source IPs than
+        those specified in the network source.
+        Currently, only `all` and `none` are supported. The default is `all`.
 
 
         :param services: The services of this NetworkSources.

--- a/src/oci/identity/models/network_sources_summary.py
+++ b/src/oci/identity/models/network_sources_summary.py
@@ -10,8 +10,11 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class NetworkSourcesSummary(object):
     """
-    A network source defines a list of source IPs that are allowed to make auth requests
-    More info needed here
+    A network source specifies a list of source IP addresses that are allowed to make authorization requests.
+    Use the network source in policy statements to restrict access to only requests that come from the specified IPs.
+    For more information, see `Managing Network Sources`__.
+
+    __ https://docs.cloud.oracle.com/Content/Identity/Tasks/managingnetworksources.htm
     """
 
     def __init__(self, **kwargs):
@@ -111,7 +114,7 @@ class NetworkSourcesSummary(object):
     def compartment_id(self):
         """
         Gets the compartment_id of this NetworkSourcesSummary.
-        The OCID of the tenancy containing the network source.
+        The OCID of the tenancy (root compartment) containing the network source.
 
 
         :return: The compartment_id of this NetworkSourcesSummary.
@@ -123,7 +126,7 @@ class NetworkSourcesSummary(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this NetworkSourcesSummary.
-        The OCID of the tenancy containing the network source.
+        The OCID of the tenancy (root compartment) containing the network source.
 
 
         :param compartment_id: The compartment_id of this NetworkSourcesSummary.
@@ -185,7 +188,7 @@ class NetworkSourcesSummary(object):
     def public_source_list(self):
         """
         Gets the public_source_list of this NetworkSourcesSummary.
-        A list of allowed public IPs and CIDR ranges
+        A list of allowed public IP addresses and CIDR ranges.
 
 
         :return: The public_source_list of this NetworkSourcesSummary.
@@ -197,7 +200,7 @@ class NetworkSourcesSummary(object):
     def public_source_list(self, public_source_list):
         """
         Sets the public_source_list of this NetworkSourcesSummary.
-        A list of allowed public IPs and CIDR ranges
+        A list of allowed public IP addresses and CIDR ranges.
 
 
         :param public_source_list: The public_source_list of this NetworkSourcesSummary.
@@ -209,7 +212,8 @@ class NetworkSourcesSummary(object):
     def virtual_source_list(self):
         """
         Gets the virtual_source_list of this NetworkSourcesSummary.
-        A list of allowed VCN ocid/IP range pairs
+        A list of allowed VCN OCID and IP range pairs.
+        Example:`\"vcnId\": \"ocid1.vcn.oc1.iad.aaaaaaaaexampleuniqueID\", \"ipRanges\": [ \"129.213.39.0/24\" ]`
 
 
         :return: The virtual_source_list of this NetworkSourcesSummary.
@@ -221,7 +225,8 @@ class NetworkSourcesSummary(object):
     def virtual_source_list(self, virtual_source_list):
         """
         Sets the virtual_source_list of this NetworkSourcesSummary.
-        A list of allowed VCN ocid/IP range pairs
+        A list of allowed VCN OCID and IP range pairs.
+        Example:`\"vcnId\": \"ocid1.vcn.oc1.iad.aaaaaaaaexampleuniqueID\", \"ipRanges\": [ \"129.213.39.0/24\" ]`
 
 
         :param virtual_source_list: The virtual_source_list of this NetworkSourcesSummary.
@@ -233,8 +238,8 @@ class NetworkSourcesSummary(object):
     def services(self):
         """
         Gets the services of this NetworkSourcesSummary.
-        A list of OCIservices allowed to make on behalf of requests which may have different source ips.
-        At this time only the values of all or none are supported.
+        A list of services allowed to make on-behalf-of requests. These requests can have different source IPs than
+        those specified in the network source. Currently, only `all` and `none` are supported. The default is `all`.
 
 
         :return: The services of this NetworkSourcesSummary.
@@ -246,8 +251,8 @@ class NetworkSourcesSummary(object):
     def services(self, services):
         """
         Sets the services of this NetworkSourcesSummary.
-        A list of OCIservices allowed to make on behalf of requests which may have different source ips.
-        At this time only the values of all or none are supported.
+        A list of services allowed to make on-behalf-of requests. These requests can have different source IPs than
+        those specified in the network source. Currently, only `all` and `none` are supported. The default is `all`.
 
 
         :param services: The services of this NetworkSourcesSummary.

--- a/src/oci/identity/models/region.py
+++ b/src/oci/identity/models/region.py
@@ -53,16 +53,12 @@ class Region(object):
     def key(self):
         """
         Gets the key of this Region.
-        The key of the region.
+        The key of the region. See `Regions and Availability Domains`__ for
+        the full list of supported 3-letter region codes.
 
-        Allowed values are:
-        - `PHX`
-        - `IAD`
-        - `FRA`
-        - `LHR`
-        - `YYZ`
-        - `NRT`
-        - `ICN`
+        Example: `PHX`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
 
 
         :return: The key of this Region.
@@ -74,16 +70,12 @@ class Region(object):
     def key(self, key):
         """
         Sets the key of this Region.
-        The key of the region.
+        The key of the region. See `Regions and Availability Domains`__ for
+        the full list of supported 3-letter region codes.
 
-        Allowed values are:
-        - `PHX`
-        - `IAD`
-        - `FRA`
-        - `LHR`
-        - `YYZ`
-        - `NRT`
-        - `ICN`
+        Example: `PHX`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
 
 
         :param key: The key of this Region.
@@ -95,16 +87,12 @@ class Region(object):
     def name(self):
         """
         Gets the name of this Region.
-        The name of the region.
+        The name of the region. See `Regions and Availability Domains`__
+        for the full list of supported region names.
 
-        Allowed values are:
-        - `ap-seoul-1`
-        - `ap-tokyo-1`
-        - `ca-toronto-1`
-        - `eu-frankurt-1`
-        - `uk-london-1`
-        - `us-ashburn-1`
-        - `us-phoenix-1`
+        Example: `us-phoenix-1`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
 
 
         :return: The name of this Region.
@@ -116,16 +104,12 @@ class Region(object):
     def name(self, name):
         """
         Sets the name of this Region.
-        The name of the region.
+        The name of the region. See `Regions and Availability Domains`__
+        for the full list of supported region names.
 
-        Allowed values are:
-        - `ap-seoul-1`
-        - `ap-tokyo-1`
-        - `ca-toronto-1`
-        - `eu-frankurt-1`
-        - `uk-london-1`
-        - `us-ashburn-1`
-        - `us-phoenix-1`
+        Example: `us-phoenix-1`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
 
 
         :param name: The name of this Region.

--- a/src/oci/identity/models/region_subscription.py
+++ b/src/oci/identity/models/region_subscription.py
@@ -76,16 +76,12 @@ class RegionSubscription(object):
     def region_key(self):
         """
         **[Required]** Gets the region_key of this RegionSubscription.
-        The region's key.
+        The region's key. See `Regions and Availability Domains`__
+        for the full list of supported 3-letter region codes.
 
-        Allowed values are:
-        - `PHX`
-        - `IAD`
-        - `FRA`
-        - `LHR`
-        - `YYZ`
-        - `NRT`
-        - `ICN`
+        Example: `PHX`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
 
 
         :return: The region_key of this RegionSubscription.
@@ -97,16 +93,12 @@ class RegionSubscription(object):
     def region_key(self, region_key):
         """
         Sets the region_key of this RegionSubscription.
-        The region's key.
+        The region's key. See `Regions and Availability Domains`__
+        for the full list of supported 3-letter region codes.
 
-        Allowed values are:
-        - `PHX`
-        - `IAD`
-        - `FRA`
-        - `LHR`
-        - `YYZ`
-        - `NRT`
-        - `ICN`
+        Example: `PHX`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
 
 
         :param region_key: The region_key of this RegionSubscription.
@@ -118,16 +110,12 @@ class RegionSubscription(object):
     def region_name(self):
         """
         **[Required]** Gets the region_name of this RegionSubscription.
-        The region's name.
+        The region's name. See `Regions and Availability Domains`__
+        for the full list of supported region names.
 
-        Allowed values are:
-        - `ap-seoul-1`
-        - `ap-tokyo-1`
-        - `ca-toronto-1`
-        - `eu-frankurt-1`
-        - `uk-london-1`
-        - `us-ashburn-1`
-        - `us-phoenix-1`
+        Example: `us-phoenix-1`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
 
 
         :return: The region_name of this RegionSubscription.
@@ -139,16 +127,12 @@ class RegionSubscription(object):
     def region_name(self, region_name):
         """
         Sets the region_name of this RegionSubscription.
-        The region's name.
+        The region's name. See `Regions and Availability Domains`__
+        for the full list of supported region names.
 
-        Allowed values are:
-        - `ap-seoul-1`
-        - `ap-tokyo-1`
-        - `ca-toronto-1`
-        - `eu-frankurt-1`
-        - `uk-london-1`
-        - `us-ashburn-1`
-        - `us-phoenix-1`
+        Example: `us-phoenix-1`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
 
 
         :param region_name: The region_name of this RegionSubscription.

--- a/src/oci/identity/models/tenancy.py
+++ b/src/oci/identity/models/tenancy.py
@@ -160,17 +160,10 @@ class Tenancy(object):
     def home_region_key(self):
         """
         Gets the home_region_key of this Tenancy.
-        The region key for the tenancy's home region. For more information about regions, see
+        The region key for the tenancy's home region. For the full list of supported regions, see
         `Regions and Availability Domains`__.
 
-        Allowed values are:
-        - `IAD`
-        - `PHX`
-        - `FRA`
-        - `LHR`
-        - `ICN`
-        - `YYZ`
-        - `NRT`
+        Example: `PHX`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
 
@@ -184,17 +177,10 @@ class Tenancy(object):
     def home_region_key(self, home_region_key):
         """
         Sets the home_region_key of this Tenancy.
-        The region key for the tenancy's home region. For more information about regions, see
+        The region key for the tenancy's home region. For the full list of supported regions, see
         `Regions and Availability Domains`__.
 
-        Allowed values are:
-        - `IAD`
-        - `PHX`
-        - `FRA`
-        - `LHR`
-        - `ICN`
-        - `YYZ`
-        - `NRT`
+        Example: `PHX`
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
 

--- a/src/oci/identity/models/update_network_source_details.py
+++ b/src/oci/identity/models/update_network_source_details.py
@@ -96,7 +96,7 @@ class UpdateNetworkSourceDetails(object):
     def public_source_list(self):
         """
         Gets the public_source_list of this UpdateNetworkSourceDetails.
-        A list of allowed public IPs and CIDR ranges
+        A list of allowed public IP addresses and CIDR ranges.
 
 
         :return: The public_source_list of this UpdateNetworkSourceDetails.
@@ -108,7 +108,7 @@ class UpdateNetworkSourceDetails(object):
     def public_source_list(self, public_source_list):
         """
         Sets the public_source_list of this UpdateNetworkSourceDetails.
-        A list of allowed public IPs and CIDR ranges
+        A list of allowed public IP addresses and CIDR ranges.
 
 
         :param public_source_list: The public_source_list of this UpdateNetworkSourceDetails.
@@ -120,7 +120,8 @@ class UpdateNetworkSourceDetails(object):
     def virtual_source_list(self):
         """
         Gets the virtual_source_list of this UpdateNetworkSourceDetails.
-        A list of allowed VCN ocid/IP range pairs
+        A list of allowed VCN OCID and IP range pairs.
+        Example:`\"vcnId\": \"ocid1.vcn.oc1.iad.aaaaaaaaexampleuniqueID\", \"ipRanges\": [ \"129.213.39.0/24\" ]`
 
 
         :return: The virtual_source_list of this UpdateNetworkSourceDetails.
@@ -132,7 +133,8 @@ class UpdateNetworkSourceDetails(object):
     def virtual_source_list(self, virtual_source_list):
         """
         Sets the virtual_source_list of this UpdateNetworkSourceDetails.
-        A list of allowed VCN ocid/IP range pairs
+        A list of allowed VCN OCID and IP range pairs.
+        Example:`\"vcnId\": \"ocid1.vcn.oc1.iad.aaaaaaaaexampleuniqueID\", \"ipRanges\": [ \"129.213.39.0/24\" ]`
 
 
         :param virtual_source_list: The virtual_source_list of this UpdateNetworkSourceDetails.
@@ -144,8 +146,8 @@ class UpdateNetworkSourceDetails(object):
     def services(self):
         """
         Gets the services of this UpdateNetworkSourceDetails.
-        A list of OCIservices allowed to make on behalf of requests which may have different source ips.
-        At this time only the values of all or none are supported.
+        A list of services allowed to make on-behalf-of requests. These requests can have different source IPs than
+        those specified in the network source. Currently, only `all` and `none` are supported. The default is `all`.
 
 
         :return: The services of this UpdateNetworkSourceDetails.
@@ -157,8 +159,8 @@ class UpdateNetworkSourceDetails(object):
     def services(self, services):
         """
         Sets the services of this UpdateNetworkSourceDetails.
-        A list of OCIservices allowed to make on behalf of requests which may have different source ips.
-        At this time only the values of all or none are supported.
+        A list of services allowed to make on-behalf-of requests. These requests can have different source IPs than
+        those specified in the network source. Currently, only `all` and `none` are supported. The default is `all`.
 
 
         :param services: The services of this UpdateNetworkSourceDetails.

--- a/src/oci/identity/models/user.py
+++ b/src/oci/identity/models/user.py
@@ -31,7 +31,7 @@ class User(object):
     **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values
     using the API.
 
-    __ https://docs.cloud.oracle.com/Content/API/Concepts/usercredentials.htm
+    __ https://docs.cloud.oracle.com/Content/Identity/Concepts/usercredentials.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/federation.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm

--- a/src/oci/integration/models/create_integration_instance_details.py
+++ b/src/oci/integration/models/create_integration_instance_details.py
@@ -59,6 +59,10 @@ class CreateIntegrationInstanceDetails(object):
             The value to assign to the message_packs property of this CreateIntegrationInstanceDetails.
         :type message_packs: int
 
+        :param is_file_server_enabled:
+            The value to assign to the is_file_server_enabled property of this CreateIntegrationInstanceDetails.
+        :type is_file_server_enabled: bool
+
         """
         self.swagger_types = {
             'display_name': 'str',
@@ -68,7 +72,8 @@ class CreateIntegrationInstanceDetails(object):
             'defined_tags': 'dict(str, dict(str, object))',
             'is_byol': 'bool',
             'idcs_at': 'str',
-            'message_packs': 'int'
+            'message_packs': 'int',
+            'is_file_server_enabled': 'bool'
         }
 
         self.attribute_map = {
@@ -79,7 +84,8 @@ class CreateIntegrationInstanceDetails(object):
             'defined_tags': 'definedTags',
             'is_byol': 'isByol',
             'idcs_at': 'idcsAt',
-            'message_packs': 'messagePacks'
+            'message_packs': 'messagePacks',
+            'is_file_server_enabled': 'isFileServerEnabled'
         }
 
         self._display_name = None
@@ -90,6 +96,7 @@ class CreateIntegrationInstanceDetails(object):
         self._is_byol = None
         self._idcs_at = None
         self._message_packs = None
+        self._is_file_server_enabled = None
 
     @property
     def display_name(self):
@@ -298,6 +305,30 @@ class CreateIntegrationInstanceDetails(object):
         :type: int
         """
         self._message_packs = message_packs
+
+    @property
+    def is_file_server_enabled(self):
+        """
+        Gets the is_file_server_enabled of this CreateIntegrationInstanceDetails.
+        The file server is enabled or not.
+
+
+        :return: The is_file_server_enabled of this CreateIntegrationInstanceDetails.
+        :rtype: bool
+        """
+        return self._is_file_server_enabled
+
+    @is_file_server_enabled.setter
+    def is_file_server_enabled(self, is_file_server_enabled):
+        """
+        Sets the is_file_server_enabled of this CreateIntegrationInstanceDetails.
+        The file server is enabled or not.
+
+
+        :param is_file_server_enabled: The is_file_server_enabled of this CreateIntegrationInstanceDetails.
+        :type: bool
+        """
+        self._is_file_server_enabled = is_file_server_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/integration/models/integration_instance.py
+++ b/src/oci/integration/models/integration_instance.py
@@ -110,6 +110,10 @@ class IntegrationInstance(object):
             The value to assign to the message_packs property of this IntegrationInstance.
         :type message_packs: int
 
+        :param is_file_server_enabled:
+            The value to assign to the is_file_server_enabled property of this IntegrationInstance.
+        :type is_file_server_enabled: bool
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -124,7 +128,8 @@ class IntegrationInstance(object):
             'defined_tags': 'dict(str, dict(str, object))',
             'is_byol': 'bool',
             'instance_url': 'str',
-            'message_packs': 'int'
+            'message_packs': 'int',
+            'is_file_server_enabled': 'bool'
         }
 
         self.attribute_map = {
@@ -140,7 +145,8 @@ class IntegrationInstance(object):
             'defined_tags': 'definedTags',
             'is_byol': 'isByol',
             'instance_url': 'instanceUrl',
-            'message_packs': 'messagePacks'
+            'message_packs': 'messagePacks',
+            'is_file_server_enabled': 'isFileServerEnabled'
         }
 
         self._id = None
@@ -156,6 +162,7 @@ class IntegrationInstance(object):
         self._is_byol = None
         self._instance_url = None
         self._message_packs = None
+        self._is_file_server_enabled = None
 
     @property
     def id(self):
@@ -488,6 +495,30 @@ class IntegrationInstance(object):
         :type: int
         """
         self._message_packs = message_packs
+
+    @property
+    def is_file_server_enabled(self):
+        """
+        Gets the is_file_server_enabled of this IntegrationInstance.
+        The file server is enabled or not.
+
+
+        :return: The is_file_server_enabled of this IntegrationInstance.
+        :rtype: bool
+        """
+        return self._is_file_server_enabled
+
+    @is_file_server_enabled.setter
+    def is_file_server_enabled(self, is_file_server_enabled):
+        """
+        Sets the is_file_server_enabled of this IntegrationInstance.
+        The file server is enabled or not.
+
+
+        :param is_file_server_enabled: The is_file_server_enabled of this IntegrationInstance.
+        :type: bool
+        """
+        self._is_file_server_enabled = is_file_server_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/integration/models/integration_instance_summary.py
+++ b/src/oci/integration/models/integration_instance_summary.py
@@ -102,6 +102,10 @@ class IntegrationInstanceSummary(object):
             The value to assign to the message_packs property of this IntegrationInstanceSummary.
         :type message_packs: int
 
+        :param is_file_server_enabled:
+            The value to assign to the is_file_server_enabled property of this IntegrationInstanceSummary.
+        :type is_file_server_enabled: bool
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -114,7 +118,8 @@ class IntegrationInstanceSummary(object):
             'state_message': 'str',
             'is_byol': 'bool',
             'instance_url': 'str',
-            'message_packs': 'int'
+            'message_packs': 'int',
+            'is_file_server_enabled': 'bool'
         }
 
         self.attribute_map = {
@@ -128,7 +133,8 @@ class IntegrationInstanceSummary(object):
             'state_message': 'stateMessage',
             'is_byol': 'isByol',
             'instance_url': 'instanceUrl',
-            'message_packs': 'messagePacks'
+            'message_packs': 'messagePacks',
+            'is_file_server_enabled': 'isFileServerEnabled'
         }
 
         self._id = None
@@ -142,6 +148,7 @@ class IntegrationInstanceSummary(object):
         self._is_byol = None
         self._instance_url = None
         self._message_packs = None
+        self._is_file_server_enabled = None
 
     @property
     def id(self):
@@ -418,6 +425,30 @@ class IntegrationInstanceSummary(object):
         :type: int
         """
         self._message_packs = message_packs
+
+    @property
+    def is_file_server_enabled(self):
+        """
+        Gets the is_file_server_enabled of this IntegrationInstanceSummary.
+        The file server is enabled or not.
+
+
+        :return: The is_file_server_enabled of this IntegrationInstanceSummary.
+        :rtype: bool
+        """
+        return self._is_file_server_enabled
+
+    @is_file_server_enabled.setter
+    def is_file_server_enabled(self, is_file_server_enabled):
+        """
+        Sets the is_file_server_enabled of this IntegrationInstanceSummary.
+        The file server is enabled or not.
+
+
+        :param is_file_server_enabled: The is_file_server_enabled of this IntegrationInstanceSummary.
+        :type: bool
+        """
+        self._is_file_server_enabled = is_file_server_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/integration/models/update_integration_instance_details.py
+++ b/src/oci/integration/models/update_integration_instance_details.py
@@ -51,6 +51,10 @@ class UpdateIntegrationInstanceDetails(object):
             The value to assign to the message_packs property of this UpdateIntegrationInstanceDetails.
         :type message_packs: int
 
+        :param is_file_server_enabled:
+            The value to assign to the is_file_server_enabled property of this UpdateIntegrationInstanceDetails.
+        :type is_file_server_enabled: bool
+
         """
         self.swagger_types = {
             'display_name': 'str',
@@ -58,7 +62,8 @@ class UpdateIntegrationInstanceDetails(object):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'is_byol': 'bool',
-            'message_packs': 'int'
+            'message_packs': 'int',
+            'is_file_server_enabled': 'bool'
         }
 
         self.attribute_map = {
@@ -67,7 +72,8 @@ class UpdateIntegrationInstanceDetails(object):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'is_byol': 'isByol',
-            'message_packs': 'messagePacks'
+            'message_packs': 'messagePacks',
+            'is_file_server_enabled': 'isFileServerEnabled'
         }
 
         self._display_name = None
@@ -76,6 +82,7 @@ class UpdateIntegrationInstanceDetails(object):
         self._defined_tags = None
         self._is_byol = None
         self._message_packs = None
+        self._is_file_server_enabled = None
 
     @property
     def display_name(self):
@@ -236,6 +243,30 @@ class UpdateIntegrationInstanceDetails(object):
         :type: int
         """
         self._message_packs = message_packs
+
+    @property
+    def is_file_server_enabled(self):
+        """
+        Gets the is_file_server_enabled of this UpdateIntegrationInstanceDetails.
+        The file server is enabled or not.
+
+
+        :return: The is_file_server_enabled of this UpdateIntegrationInstanceDetails.
+        :rtype: bool
+        """
+        return self._is_file_server_enabled
+
+    @is_file_server_enabled.setter
+    def is_file_server_enabled(self, is_file_server_enabled):
+        """
+        Sets the is_file_server_enabled of this UpdateIntegrationInstanceDetails.
+        The file server is enabled or not.
+
+
+        :param is_file_server_enabled: The is_file_server_enabled of this UpdateIntegrationInstanceDetails.
+        :type: bool
+        """
+        self._is_file_server_enabled = is_file_server_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/oda/models/oda_instance.py
+++ b/src/oci/oda/models/oda_instance.py
@@ -50,8 +50,32 @@ class OdaInstance(object):
     LIFECYCLE_STATE_FAILED = "FAILED"
 
     #: A constant which can be used with the lifecycle_sub_state property of a OdaInstance.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_SUB_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_sub_state property of a OdaInstance.
+    #: This constant has a value of "STARTING"
+    LIFECYCLE_SUB_STATE_STARTING = "STARTING"
+
+    #: A constant which can be used with the lifecycle_sub_state property of a OdaInstance.
+    #: This constant has a value of "STOPPING"
+    LIFECYCLE_SUB_STATE_STOPPING = "STOPPING"
+
+    #: A constant which can be used with the lifecycle_sub_state property of a OdaInstance.
+    #: This constant has a value of "CHANGING_COMPARTMENT"
+    LIFECYCLE_SUB_STATE_CHANGING_COMPARTMENT = "CHANGING_COMPARTMENT"
+
+    #: A constant which can be used with the lifecycle_sub_state property of a OdaInstance.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_SUB_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_sub_state property of a OdaInstance.
     #: This constant has a value of "DELETE_PENDING"
     LIFECYCLE_SUB_STATE_DELETE_PENDING = "DELETE_PENDING"
+
+    #: A constant which can be used with the lifecycle_sub_state property of a OdaInstance.
+    #: This constant has a value of "RECOVERING"
+    LIFECYCLE_SUB_STATE_RECOVERING = "RECOVERING"
 
     #: A constant which can be used with the lifecycle_sub_state property of a OdaInstance.
     #: This constant has a value of "PURGING"
@@ -112,7 +136,7 @@ class OdaInstance(object):
 
         :param lifecycle_sub_state:
             The value to assign to the lifecycle_sub_state property of this OdaInstance.
-            Allowed values for this property are: "DELETE_PENDING", "PURGING", "QUEUED", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATING", "STARTING", "STOPPING", "CHANGING_COMPARTMENT", "DELETING", "DELETE_PENDING", "RECOVERING", "PURGING", "QUEUED", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_sub_state: str
 
@@ -446,7 +470,7 @@ class OdaInstance(object):
         Gets the lifecycle_sub_state of this OdaInstance.
         The current sub-state of the Digital Assistant instance.
 
-        Allowed values for this property are: "DELETE_PENDING", "PURGING", "QUEUED", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATING", "STARTING", "STOPPING", "CHANGING_COMPARTMENT", "DELETING", "DELETE_PENDING", "RECOVERING", "PURGING", "QUEUED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -465,7 +489,7 @@ class OdaInstance(object):
         :param lifecycle_sub_state: The lifecycle_sub_state of this OdaInstance.
         :type: str
         """
-        allowed_values = ["DELETE_PENDING", "PURGING", "QUEUED"]
+        allowed_values = ["CREATING", "STARTING", "STOPPING", "CHANGING_COMPARTMENT", "DELETING", "DELETE_PENDING", "RECOVERING", "PURGING", "QUEUED"]
         if not value_allowed_none_or_none_sentinel(lifecycle_sub_state, allowed_values):
             lifecycle_sub_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_sub_state = lifecycle_sub_state

--- a/src/oci/oda/models/oda_instance_summary.py
+++ b/src/oci/oda/models/oda_instance_summary.py
@@ -50,8 +50,32 @@ class OdaInstanceSummary(object):
     LIFECYCLE_STATE_FAILED = "FAILED"
 
     #: A constant which can be used with the lifecycle_sub_state property of a OdaInstanceSummary.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_SUB_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_sub_state property of a OdaInstanceSummary.
+    #: This constant has a value of "STARTING"
+    LIFECYCLE_SUB_STATE_STARTING = "STARTING"
+
+    #: A constant which can be used with the lifecycle_sub_state property of a OdaInstanceSummary.
+    #: This constant has a value of "STOPPING"
+    LIFECYCLE_SUB_STATE_STOPPING = "STOPPING"
+
+    #: A constant which can be used with the lifecycle_sub_state property of a OdaInstanceSummary.
+    #: This constant has a value of "CHANGING_COMPARTMENT"
+    LIFECYCLE_SUB_STATE_CHANGING_COMPARTMENT = "CHANGING_COMPARTMENT"
+
+    #: A constant which can be used with the lifecycle_sub_state property of a OdaInstanceSummary.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_SUB_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_sub_state property of a OdaInstanceSummary.
     #: This constant has a value of "DELETE_PENDING"
     LIFECYCLE_SUB_STATE_DELETE_PENDING = "DELETE_PENDING"
+
+    #: A constant which can be used with the lifecycle_sub_state property of a OdaInstanceSummary.
+    #: This constant has a value of "RECOVERING"
+    LIFECYCLE_SUB_STATE_RECOVERING = "RECOVERING"
 
     #: A constant which can be used with the lifecycle_sub_state property of a OdaInstanceSummary.
     #: This constant has a value of "PURGING"
@@ -104,7 +128,7 @@ class OdaInstanceSummary(object):
 
         :param lifecycle_sub_state:
             The value to assign to the lifecycle_sub_state property of this OdaInstanceSummary.
-            Allowed values for this property are: "DELETE_PENDING", "PURGING", "QUEUED", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATING", "STARTING", "STOPPING", "CHANGING_COMPARTMENT", "DELETING", "DELETE_PENDING", "RECOVERING", "PURGING", "QUEUED", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_sub_state: str
 
@@ -382,7 +406,7 @@ class OdaInstanceSummary(object):
         Gets the lifecycle_sub_state of this OdaInstanceSummary.
         The current sub-state of the Digital Assistant instance.
 
-        Allowed values for this property are: "DELETE_PENDING", "PURGING", "QUEUED", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATING", "STARTING", "STOPPING", "CHANGING_COMPARTMENT", "DELETING", "DELETE_PENDING", "RECOVERING", "PURGING", "QUEUED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -401,7 +425,7 @@ class OdaInstanceSummary(object):
         :param lifecycle_sub_state: The lifecycle_sub_state of this OdaInstanceSummary.
         :type: str
         """
-        allowed_values = ["DELETE_PENDING", "PURGING", "QUEUED"]
+        allowed_values = ["CREATING", "STARTING", "STOPPING", "CHANGING_COMPARTMENT", "DELETING", "DELETE_PENDING", "RECOVERING", "PURGING", "QUEUED"]
         if not value_allowed_none_or_none_sentinel(lifecycle_sub_state, allowed_values):
             lifecycle_sub_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_sub_state = lifecycle_sub_state

--- a/src/oci/regions.py
+++ b/src/oci/regions.py
@@ -127,10 +127,11 @@ REGIONS_CONFIG_FILE_PATH = os.path.join('~', '.oci', 'regions-config.json')
 ExternalSources = Enum('ExternalSources', ['REGIONS_CFG_FILE', 'ENV_VAR', 'IMDS'])
 
 # Dict to track if we have read the ExternalSources
+# Reading from IMDS is opt-in and can be enabled by calling enable_instance_metadata_service()
 _has_been_read_external_sources = {
     ExternalSources.REGIONS_CFG_FILE: False,
     ExternalSources.ENV_VAR: False,
-    ExternalSources.IMDS: False
+    ExternalSources.IMDS: True
 }
 
 logger = logging.getLogger(__name__)
@@ -195,6 +196,8 @@ def endpoint_for(service, region=None, endpoint=None, service_endpoint_template=
     2. Region Metadata Environment variable
     3. Instance Metadata Service
 
+    Lookup from Instance Metadata Service is disabled by default. To enable, call enable_instance_metadata_service()
+
     The region metadata schema is:
     {
         "realmKey" : string,
@@ -228,11 +231,17 @@ def endpoint_for(service, region=None, endpoint=None, service_endpoint_template=
 
 
 def skip_instance_metadata_service():
+    logger.debug("Disabling region metadata lookup from IMDS")
     _set_source_has_been_read(ExternalSources.IMDS)
 
 
-def _set_source_has_been_read(source):
-    _has_been_read_external_sources[source] = True
+def enable_instance_metadata_service():
+    logger.debug("Enabling region metadata lookup from IMDS")
+    _set_source_has_been_read(ExternalSources.IMDS, False)
+
+
+def _set_source_has_been_read(source, value=True):
+    _has_been_read_external_sources[source] = value
 
 
 def _get_source_has_been_read(source):

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.15.0"
+__version__ = "2.16.0"


### PR DESCRIPTION
## Added

* Support for returning the database version of backups in the Database service

* Support for patching on Exadata Cloud at Customer resources in the Database service

* Support for new lifecycle substates on instances in the Digital Assistant service

* Support for file servers in the Integration service

* Support for deleting non-empty tag namespaces and bulk deleting tags in the Identity service

* Support for bulk move and bulk delete of resources by compartment in the Identity service



## Breaking

* Data type for paramater `data_storage_size_in_tbs` changed from int to float in the Database service

* Parameter `lifecycle_state` removed state `OFFLINE` and added `DISCONNECTED` in the Database service
