### PR TITLE
Releasing version 2.16.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.16.1 - 2020-06-16
+====================
+
+Added
+-----
+* Support for creating a new database from an existing database based on a given timestamp in the Database service
+* Support for enabling archive log backups of databases in the Database service
+* Support for returning the database version on autonomous container databases in the Database service
+* Support for the new DNS format of the Data Transfer service
+* Support for scheduled autoscaling, which allows for scaling actions triggered at particular times based on CRON expressions, in the Compute Autoscaling service
+* Support for filtering of list APIs for groups, identity providers, identity provider groups, compartments, dynamic groups, network sources, policies, and users by name or lifecycle state in the Identity Service
+
+====================
 2.16.0 - 2020-06-09
 ====================
 

--- a/docs/api/autoscaling.rst
+++ b/docs/api/autoscaling.rst
@@ -29,13 +29,18 @@ Autoscaling
     oci.autoscaling.models.CreateAutoScalingConfigurationDetails
     oci.autoscaling.models.CreateAutoScalingPolicyDetails
     oci.autoscaling.models.CreateConditionDetails
+    oci.autoscaling.models.CreateScheduledPolicyDetails
     oci.autoscaling.models.CreateThresholdPolicyDetails
+    oci.autoscaling.models.CronExecutionSchedule
+    oci.autoscaling.models.ExecutionSchedule
     oci.autoscaling.models.InstancePoolResource
     oci.autoscaling.models.Metric
     oci.autoscaling.models.Resource
+    oci.autoscaling.models.ScheduledPolicy
     oci.autoscaling.models.Threshold
     oci.autoscaling.models.ThresholdPolicy
     oci.autoscaling.models.UpdateAutoScalingConfigurationDetails
     oci.autoscaling.models.UpdateAutoScalingPolicyDetails
     oci.autoscaling.models.UpdateConditionDetails
+    oci.autoscaling.models.UpdateScheduledPolicyDetails
     oci.autoscaling.models.UpdateThresholdPolicyDetails

--- a/docs/api/autoscaling/models/oci.autoscaling.models.CreateScheduledPolicyDetails.rst
+++ b/docs/api/autoscaling/models/oci.autoscaling.models.CreateScheduledPolicyDetails.rst
@@ -1,0 +1,11 @@
+CreateScheduledPolicyDetails
+============================
+
+.. currentmodule:: oci.autoscaling.models
+
+.. autoclass:: CreateScheduledPolicyDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/autoscaling/models/oci.autoscaling.models.CronExecutionSchedule.rst
+++ b/docs/api/autoscaling/models/oci.autoscaling.models.CronExecutionSchedule.rst
@@ -1,0 +1,11 @@
+CronExecutionSchedule
+=====================
+
+.. currentmodule:: oci.autoscaling.models
+
+.. autoclass:: CronExecutionSchedule
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/autoscaling/models/oci.autoscaling.models.ExecutionSchedule.rst
+++ b/docs/api/autoscaling/models/oci.autoscaling.models.ExecutionSchedule.rst
@@ -1,0 +1,11 @@
+ExecutionSchedule
+=================
+
+.. currentmodule:: oci.autoscaling.models
+
+.. autoclass:: ExecutionSchedule
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/autoscaling/models/oci.autoscaling.models.ScheduledPolicy.rst
+++ b/docs/api/autoscaling/models/oci.autoscaling.models.ScheduledPolicy.rst
@@ -1,0 +1,11 @@
+ScheduledPolicy
+===============
+
+.. currentmodule:: oci.autoscaling.models
+
+.. autoclass:: ScheduledPolicy
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/autoscaling/models/oci.autoscaling.models.UpdateScheduledPolicyDetails.rst
+++ b/docs/api/autoscaling/models/oci.autoscaling.models.UpdateScheduledPolicyDetails.rst
@@ -1,0 +1,11 @@
+UpdateScheduledPolicyDetails
+============================
+
+.. currentmodule:: oci.autoscaling.models
+
+.. autoclass:: UpdateScheduledPolicyDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -70,13 +70,16 @@ Database
     oci.database.models.CreateDataGuardAssociationWithNewDbSystemDetails
     oci.database.models.CreateDatabaseBase
     oci.database.models.CreateDatabaseDetails
+    oci.database.models.CreateDatabaseFromAnotherDatabaseDetails
     oci.database.models.CreateDatabaseFromBackup
     oci.database.models.CreateDatabaseFromBackupDetails
     oci.database.models.CreateDbHomeBase
     oci.database.models.CreateDbHomeDetails
     oci.database.models.CreateDbHomeFromBackupDetails
+    oci.database.models.CreateDbHomeFromDatabaseDetails
     oci.database.models.CreateDbHomeWithDbSystemIdDetails
     oci.database.models.CreateDbHomeWithDbSystemIdFromBackupDetails
+    oci.database.models.CreateDbHomeWithDbSystemIdFromDatabaseDetails
     oci.database.models.CreateDbHomeWithVmClusterIdDetails
     oci.database.models.CreateExadataInfrastructureDetails
     oci.database.models.CreateExternalBackupJobDetails
@@ -117,6 +120,7 @@ Database
     oci.database.models.LaunchDbSystemBase
     oci.database.models.LaunchDbSystemDetails
     oci.database.models.LaunchDbSystemFromBackupDetails
+    oci.database.models.LaunchDbSystemFromDatabaseDetails
     oci.database.models.MaintenanceRun
     oci.database.models.MaintenanceRunSummary
     oci.database.models.MaintenanceWindow

--- a/docs/api/database/models/oci.database.models.CreateDatabaseFromAnotherDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateDatabaseFromAnotherDatabaseDetails.rst
@@ -1,0 +1,11 @@
+CreateDatabaseFromAnotherDatabaseDetails
+========================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateDatabaseFromAnotherDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateDbHomeFromDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateDbHomeFromDatabaseDetails.rst
@@ -1,0 +1,11 @@
+CreateDbHomeFromDatabaseDetails
+===============================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateDbHomeFromDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateDbHomeWithDbSystemIdFromDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateDbHomeWithDbSystemIdFromDatabaseDetails.rst
@@ -1,0 +1,11 @@
+CreateDbHomeWithDbSystemIdFromDatabaseDetails
+=============================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateDbHomeWithDbSystemIdFromDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.LaunchDbSystemFromDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.LaunchDbSystemFromDatabaseDetails.rst
@@ -1,0 +1,11 @@
+LaunchDbSystemFromDatabaseDetails
+=================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: LaunchDbSystemFromDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/list_resources_in_tenancy/list_all_ipsec_tunnels_in_tenancy.py
+++ b/examples/list_resources_in_tenancy/list_all_ipsec_tunnels_in_tenancy.py
@@ -1,13 +1,12 @@
-#!/usr/bin/env python3
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 ##########################################################################
-# Copyright(c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
 # list_all_ipsec_tunnels_in_tenancy.py
 #
 # @author: Adi Zohar
 #
-# Supports Python 2 and 3
-#
-# coding: utf-8
+# Supports Python 3
 ##########################################################################
 # Info:
 #    List all IPSEC tunnels in Tenancy including DRG redundancy

--- a/examples/list_resources_in_tenancy/list_all_virtual_circuits_in_tenancy.py
+++ b/examples/list_resources_in_tenancy/list_all_virtual_circuits_in_tenancy.py
@@ -1,13 +1,12 @@
-#!/usr/bin/env python3
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 ##########################################################################
-# Copyright(c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
 # list_all_virtual_circuits_in_tenancy.py
 #
 # @author: Adi Zohar
 #
-# Supports Python 2 and 3
-#
-# coding: utf-8
+# Supports Python 3
 ##########################################################################
 # Info:
 #    List all Virtual Circuits in Tenancy including DRG redundancy

--- a/examples/list_resources_in_tenancy/list_compute_tags_in_tenancy.py
+++ b/examples/list_resources_in_tenancy/list_compute_tags_in_tenancy.py
@@ -1,13 +1,12 @@
-#!/usr/bin/env python3
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 ##########################################################################
-# Copyright(c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
 # list_compute_tags_in_tenancy.py
 #
 # @author: Adi Zohar
 #
 # Supports Python  3
-#
-# coding: utf-8
 ##########################################################################
 # Info:
 #    List all compute tags in Tenancy

--- a/examples/list_resources_in_tenancy/list_dbsystem_with_maintenance_in_tenancy.py
+++ b/examples/list_resources_in_tenancy/list_dbsystem_with_maintenance_in_tenancy.py
@@ -1,13 +1,12 @@
-#!/usr/bin/env python3
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 ##########################################################################
-# Copyright(c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
 # list_dbsystem_with_maintenance_in_tenancy.py
 #
 # @author: Adi Zohar
 #
 # Supports Python 3
-#
-# coding: utf-8
 ##########################################################################
 # Info:
 #    List all dbsystems including maintenance in Tenancy

--- a/examples/showoci/CHANGELOG.rst
+++ b/examples/showoci/CHANGELOG.rst
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 =====================
+20.06.15 - 2020-06-15
+=====================
+* Added Maintatance for DBSystem including alert if maintenance is less than 14 days
+* Added -nobackups flags
+
+=====================
 20.06.09 - 2020-06-09
 =====================
 * Added file storage to the csv file

--- a/examples/showoci/README.md
+++ b/examples/showoci/README.md
@@ -146,14 +146,10 @@ Execute
 ```
 $ ./showoci.py  
 
-usage: showoci.py [-h] [-a] [-ani] [-an] [-api] [-b] [-c] [-cn] [-d] [-e]
-                  [-edge] [-f] [-fun] [-i] [-ic] [-l] [-lq] [-m] [-n] [-o]
-                  [-paas] [-dataai] [-rm] [-s] [-so] [-mc] [-nr] [-ip]
-                  [-t PROFILE] [-p PROXY] [-rg REGION] [-cp COMPART]
-                  [-cpr COMPART_RECUR] [-cpath COMPARTPATH]
-                  [-tenantid TENANTID] [-cf CONFIG] [-csv CSV] [-jf JOUTFILE]
-                  [-js] [-sjf SJOUTFILE] [-cachef SERVICEFILE] [-caches]
-                  [--version]
+usage: showoci.py [-h] [-a] [-ani] [-an] [-api] [-b] [-c] [-cn] [-d] [-e] [-edge] [-f] [-fun] [-i] [-ic] [-isc] [-l] [-lq] [-m] [-n] [-o]
+                  [-paas] [-dataai] [-rm] [-s] [-nobackups] [-so] [-mc] [-nr] [-ip] [-dt] [-t PROFILE] [-p PROXY] [-rg REGION]
+                  [-cp COMPART] [-cpr COMPART_RECUR] [-cpath COMPARTPATH] [-tenantid TENANTID] [-cf CONFIG] [-csv CSV] [-jf JOUTFILE]
+                  [-js] [-sjf SJOUTFILE] [-cachef SERVICEFILE] [-caches] [--version]
 
 optional arguments:
   -h, --help           show this help message and exit
@@ -178,22 +174,23 @@ optional arguments:
   -n                   Print Network
   -o                   Print Object Storage
   -paas                Print PaaS Platform Services - OIC OAC OCE
-  -dataai              Print D.Science, D.Catalog, D.Flow, ODA or BDS
+  -dataai              Print - D.Science, D.Catalog, D.Flow, ODA and BDS
   -rm                  Print Resource management
   -s                   Print Streams
+  -nobackups           Do not process backups
   -so                  Print Summary Only
   -mc                  exclude ManagedCompartmentForPaaS
   -nr                  Not include root compartment
   -ip                  Use Instance Principals for Authentication
-  -dt                  Use Delegation Token for Authentication
+  -dt                  Use Delegation Token (Cloud shell)
   -t PROFILE           Config file section to use (tenancy profile)
   -p PROXY             Set Proxy (i.e. www-proxy-server.com:80)
   -rg REGION           Filter by Region
   -cp COMPART          Filter by Compartment Name or OCID
-  -cpr COMPART_RECUR   Filter by Comp Name or OCID Recursive
+  -cpr COMPART_RECUR   Filter by Comp Name Recursive
   -cpath COMPARTPATH   Filter by Compartment path ,(i.e. -cpath "Adi / Sub"
   -tenantid TENANTID   Override confile file tenancy_id
-  -cf CONFIG           Config File
+  -cf CONFIG           Config File (~/.oci/config)
   -csv CSV             Output to CSV files, Input as file header
   -jf JOUTFILE         Output to file (JSON format)
   -js                  Output to screen (JSON format)

--- a/examples/showoci/showoci.py
+++ b/examples/showoci/showoci.py
@@ -80,7 +80,7 @@ import sys
 import argparse
 import datetime
 
-version = "20.06.09"
+version = "20.06.16"
 
 ##########################################################################
 # check OCI version
@@ -214,6 +214,12 @@ def execute_extract():
     if data.get_service_reboot_migration() > 0:
         output.print_header(str(data.get_service_reboot_migration()) + " Reboot Migration Alert for Compute or DB Node", 0)
 
+    # if dbsystem maintenance
+    if data.get_service_dbsystem_maintenance():
+        output.print_header("DB System Maintenance", 0)
+        for alert in data.get_service_dbsystem_maintenance():
+            print(alert)
+
     # print completion
     output.print_header("Completed " + complete_message + " at " + str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")), 0)
 
@@ -269,6 +275,7 @@ def set_parser_arguments():
     parser.add_argument('-rm', action='store_true', default=False, dest='orm', help='Print Resource management')
     parser.add_argument('-s', action='store_true', default=False, dest='streams', help='Print Streams')
 
+    parser.add_argument('-nobackups', action='store_true', default=False, dest='skip_backups', help='Do not process backups')
     parser.add_argument('-so', action='store_true', default=False, dest='sumonly', help='Print Summary Only')
     parser.add_argument('-mc', action='store_true', default=False, dest='mgdcompart', help='exclude ManagedCompartmentForPaaS')
     parser.add_argument('-nr', action='store_true', default=False, dest='noroot', help='Not include root compartment')
@@ -389,6 +396,9 @@ def set_service_extract_flags(cmd):
 
     if cmd.noroot:
         prm.read_root_compartment = False
+
+    if cmd.skip_backups:
+        prm.skip_backups = True
 
     if cmd.config:
         if cmd.config.name:

--- a/examples/showoci/showoci_data.py
+++ b/examples/showoci/showoci_data.py
@@ -156,6 +156,13 @@ class ShowOCIData(object):
         return self.service.reboot_migration_counter
 
     ##########################################################################
+    # get service reboot migration
+    ##########################################################################
+    def get_service_dbsystem_maintenance(self):
+
+        return self.service.dbsystem_maintenance
+
+    ##########################################################################
     # print print error
     ##########################################################################
     def __print_error(self, msg, e):
@@ -1704,7 +1711,7 @@ class ShowOCIData(object):
                 value = {'name': (str(db['db_name']) + " - " + str(db['db_unique_name']) + " - " + pdb_name +
                                   str(db['db_workload']) + " - " +
                                   str(db['character_set']) + " - " + str(db['lifecycle_state']) + backupstr),
-                         'backups': self.__get_database_db_backups(db['backups']),
+                         'backups': self.__get_database_db_backups(db['backups']) if 'backups' in db else [],
                          'time_created': db['time_created'],
                          'defined_tags': db['defined_tags'],
                          'dataguard': self.__get_database_db_dataguard(db['dataguard']),
@@ -1828,7 +1835,7 @@ class ShowOCIData(object):
     #
     # class oci.database.DatabaseClient(config, **kwargs)
     #
-    # Below APIs not yet done (TBD):
+    # Below APIs not done:
     # list_db_home_patch_history_entries
     # list_db_system_patch_history_entries
     # list_data_guard_associations
@@ -1875,14 +1882,18 @@ class ShowOCIData(object):
                          'vip_ips': dbs['vip_ips'],
                          'compartment_name': dbs['compartment_name'],
                          'compartment_id': dbs['compartment_id'],
-                         'patches': self.__get_database_db_patches(dbs['patches']),
-                         'listener_port': dbs['listener_port'],
-                         'db_homes': self.__get_database_db_homes(dbs['db_homes']),
-                         'db_nodes': self.__get_database_db_nodes(dbs['db_nodes']),
                          'cluster_name': dbs['cluster_name'],
                          'time_created': dbs['time_created'],
                          'defined_tags': dbs['defined_tags'],
-                         'freeform_tags': dbs['freeform_tags']}
+                         'freeform_tags': dbs['freeform_tags'],
+                         'listener_port': dbs['listener_port'],
+                         'last_maintenance_run': dbs['last_maintenance_run'],
+                         'next_maintenance_run': dbs['next_maintenance_run'],
+                         'maintenance_window': dbs['maintenance_window'],
+                         'patches': self.__get_database_db_patches(dbs['patches']),
+                         'db_homes': self.__get_database_db_homes(dbs['db_homes']),
+                         'db_nodes': self.__get_database_db_nodes(dbs['db_nodes'])
+                         }
 
                 if dbs['data_storage_size_in_gbs']:
                     value['data'] = str(dbs['data_storage_size_in_gbs']) + "GB - " + str(dbs['data_storage_percentage']) + "%" + (" - " + dbs['storage_management'] if dbs['storage_management'] else "")

--- a/examples/showoci/showoci_output.py
+++ b/examples/showoci/showoci_output.py
@@ -37,13 +37,16 @@ class ShowOCIOutput(object):
     ##########################################################################
     # Print header centered
     ##########################################################################
-    def print_header(self, name, category):
+    def print_header(self, name, category, topBorder=True, bottomBorder=True, printText=True):
         options = {0: 90, 1: 60, 2: 30, 3: 75}
         chars = int(options[category])
-        print("")
-        print('#' * chars)
-        print("#" + name.center(chars - 2, " ") + "#")
-        print('#' * chars)
+        if topBorder:
+            print("")
+            print('#' * chars)
+        if printText:
+            print("#" + name.center(chars - 2, " ") + "#")
+        if bottomBorder:
+            print('#' * chars)
 
     ##########################################################################
     # print_oci_main
@@ -874,6 +877,22 @@ class ShowOCIOutput(object):
             if 'patches' in dbs:
                 for p in dbs['patches']:
                     print(self.tabs + "Patches : " + p)
+
+            if 'maintenance_window' in dbs:
+                if dbs['maintenance_window']:
+                    print(self.tabs + "Maint   : Window : " + dbs['maintenance_window']['display'])
+
+            if 'last_maintenance_run' in dbs:
+                if dbs['last_maintenance_run']:
+                    print(self.tabs + "Maint   : Last   : " + dbs['last_maintenance_run']['description'])
+                    print(self.tabs + "                 : " + dbs['last_maintenance_run']['maintenance_display'])
+
+            if 'next_maintenance_run' in dbs:
+                if dbs['next_maintenance_run']:
+                    print(self.tabs + "Maint   : Next   : " + dbs['next_maintenance_run']['description'])
+                    print(self.tabs + "                 : " + dbs['next_maintenance_run']['maintenance_display'])
+                    if dbs['next_maintenance_run']['maintenance_alert']:
+                        print(self.tabs + "          Alert  : " + dbs['next_maintenance_run']['maintenance_alert'])
 
             print(self.tabs + "        : " + '-' * 90)
 
@@ -2840,8 +2859,18 @@ class ShowOCICSV(object):
                         'db_nodes': str(', '.join(x['desc'] for x in dbs['db_nodes'])),
                         'freeform_tags': str(', '.join(key + "=" + dbs['freeform_tags'][key] for key in dbs['freeform_tags'].keys())),
                         'defined_tags': self.__get_defined_tags(dbs['defined_tags']),
+                        'maintenance_window': "",
+                        'last_maintenance_run': "",
+                        'next_maintenance_run': "",
                         'dbsystem_id': dbs['id']
                         }
+                if dbs['maintenance_window']:
+                    dbsd['maintenance_window'] = dbs['maintenance_window']['display']
+                if dbs['last_maintenance_run']:
+                    dbsd['last_maintenance_run'] = dbs['last_maintenance_run']['maintenance_display']
+                if dbs['next_maintenance_run']:
+                    dbsd['next_maintenance_run'] = dbs['next_maintenance_run']['maintenance_display']
+
                 self.csv_db_system.append(dbsd)
 
                 # Build the database CSV

--- a/src/oci/autoscaling/auto_scaling_client.py
+++ b/src/oci/autoscaling/auto_scaling_client.py
@@ -18,8 +18,12 @@ missing = Sentinel("Missing")
 
 class AutoScalingClient(object):
     """
-    APIs for dynamically scaling Compute resources to meet application requirements.
-    For information about the Compute service, see [Overview of the Compute Service](/Content/Compute/Concepts/computeoverview.htm).
+    APIs for dynamically scaling Compute resources to meet application requirements. For more information about
+    autoscaling, see [Autoscaling](/Content/Compute/Tasks/autoscalinginstancepools.htm). For information about the
+    Compute service, see [Overview of the Compute Service](/Content/Compute/Concepts/computeoverview.htm).
+
+    **Note:** Autoscaling is not available in US Government Cloud tenancies. For more information, see
+    [Oracle Cloud Infrastructure US Government Cloud](/Content/General/Concepts/govoverview.htm).
     """
 
     def __init__(self, config, **kwargs):

--- a/src/oci/autoscaling/models/__init__.py
+++ b/src/oci/autoscaling/models/__init__.py
@@ -15,15 +15,20 @@ from .condition import Condition
 from .create_auto_scaling_configuration_details import CreateAutoScalingConfigurationDetails
 from .create_auto_scaling_policy_details import CreateAutoScalingPolicyDetails
 from .create_condition_details import CreateConditionDetails
+from .create_scheduled_policy_details import CreateScheduledPolicyDetails
 from .create_threshold_policy_details import CreateThresholdPolicyDetails
+from .cron_execution_schedule import CronExecutionSchedule
+from .execution_schedule import ExecutionSchedule
 from .instance_pool_resource import InstancePoolResource
 from .metric import Metric
 from .resource import Resource
+from .scheduled_policy import ScheduledPolicy
 from .threshold import Threshold
 from .threshold_policy import ThresholdPolicy
 from .update_auto_scaling_configuration_details import UpdateAutoScalingConfigurationDetails
 from .update_auto_scaling_policy_details import UpdateAutoScalingPolicyDetails
 from .update_condition_details import UpdateConditionDetails
+from .update_scheduled_policy_details import UpdateScheduledPolicyDetails
 from .update_threshold_policy_details import UpdateThresholdPolicyDetails
 
 # Maps type names to classes for autoscaling services.
@@ -39,14 +44,19 @@ autoscaling_type_mapping = {
     "CreateAutoScalingConfigurationDetails": CreateAutoScalingConfigurationDetails,
     "CreateAutoScalingPolicyDetails": CreateAutoScalingPolicyDetails,
     "CreateConditionDetails": CreateConditionDetails,
+    "CreateScheduledPolicyDetails": CreateScheduledPolicyDetails,
     "CreateThresholdPolicyDetails": CreateThresholdPolicyDetails,
+    "CronExecutionSchedule": CronExecutionSchedule,
+    "ExecutionSchedule": ExecutionSchedule,
     "InstancePoolResource": InstancePoolResource,
     "Metric": Metric,
     "Resource": Resource,
+    "ScheduledPolicy": ScheduledPolicy,
     "Threshold": Threshold,
     "ThresholdPolicy": ThresholdPolicy,
     "UpdateAutoScalingConfigurationDetails": UpdateAutoScalingConfigurationDetails,
     "UpdateAutoScalingPolicyDetails": UpdateAutoScalingPolicyDetails,
     "UpdateConditionDetails": UpdateConditionDetails,
+    "UpdateScheduledPolicyDetails": UpdateScheduledPolicyDetails,
     "UpdateThresholdPolicyDetails": UpdateThresholdPolicyDetails
 }

--- a/src/oci/autoscaling/models/auto_scaling_configuration.py
+++ b/src/oci/autoscaling/models/auto_scaling_configuration.py
@@ -61,6 +61,14 @@ class AutoScalingConfiguration(object):
             The value to assign to the time_created property of this AutoScalingConfiguration.
         :type time_created: datetime
 
+        :param max_resource_count:
+            The value to assign to the max_resource_count property of this AutoScalingConfiguration.
+        :type max_resource_count: int
+
+        :param min_resource_count:
+            The value to assign to the min_resource_count property of this AutoScalingConfiguration.
+        :type min_resource_count: int
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
@@ -72,7 +80,9 @@ class AutoScalingConfiguration(object):
             'is_enabled': 'bool',
             'resource': 'Resource',
             'policies': 'list[AutoScalingPolicy]',
-            'time_created': 'datetime'
+            'time_created': 'datetime',
+            'max_resource_count': 'int',
+            'min_resource_count': 'int'
         }
 
         self.attribute_map = {
@@ -85,7 +95,9 @@ class AutoScalingConfiguration(object):
             'is_enabled': 'isEnabled',
             'resource': 'resource',
             'policies': 'policies',
-            'time_created': 'timeCreated'
+            'time_created': 'timeCreated',
+            'max_resource_count': 'maxResourceCount',
+            'min_resource_count': 'minResourceCount'
         }
 
         self._compartment_id = None
@@ -98,6 +110,8 @@ class AutoScalingConfiguration(object):
         self._resource = None
         self._policies = None
         self._time_created = None
+        self._max_resource_count = None
+        self._min_resource_count = None
 
     @property
     def compartment_id(self):
@@ -374,6 +388,54 @@ class AutoScalingConfiguration(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def max_resource_count(self):
+        """
+        Gets the max_resource_count of this AutoScalingConfiguration.
+        The maximum number of resources to scale out to.
+
+
+        :return: The max_resource_count of this AutoScalingConfiguration.
+        :rtype: int
+        """
+        return self._max_resource_count
+
+    @max_resource_count.setter
+    def max_resource_count(self, max_resource_count):
+        """
+        Sets the max_resource_count of this AutoScalingConfiguration.
+        The maximum number of resources to scale out to.
+
+
+        :param max_resource_count: The max_resource_count of this AutoScalingConfiguration.
+        :type: int
+        """
+        self._max_resource_count = max_resource_count
+
+    @property
+    def min_resource_count(self):
+        """
+        Gets the min_resource_count of this AutoScalingConfiguration.
+        The minimum number of resources to scale in to.
+
+
+        :return: The min_resource_count of this AutoScalingConfiguration.
+        :rtype: int
+        """
+        return self._min_resource_count
+
+    @min_resource_count.setter
+    def min_resource_count(self, min_resource_count):
+        """
+        Sets the min_resource_count of this AutoScalingConfiguration.
+        The minimum number of resources to scale in to.
+
+
+        :param min_resource_count: The min_resource_count of this AutoScalingConfiguration.
+        :type: int
+        """
+        self._min_resource_count = min_resource_count
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/autoscaling/models/auto_scaling_configuration_summary.py
+++ b/src/oci/autoscaling/models/auto_scaling_configuration_summary.py
@@ -222,7 +222,7 @@ class AutoScalingConfigurationSummary(object):
     @property
     def resource(self):
         """
-        Gets the resource of this AutoScalingConfigurationSummary.
+        **[Required]** Gets the resource of this AutoScalingConfigurationSummary.
 
         :return: The resource of this AutoScalingConfigurationSummary.
         :rtype: Resource

--- a/src/oci/autoscaling/models/auto_scaling_policy.py
+++ b/src/oci/autoscaling/models/auto_scaling_policy.py
@@ -23,6 +23,7 @@ class AutoScalingPolicy(object):
         Initializes a new AutoScalingPolicy object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.autoscaling.models.ScheduledPolicy`
         * :class:`~oci.autoscaling.models.ThresholdPolicy`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
@@ -47,13 +48,18 @@ class AutoScalingPolicy(object):
             The value to assign to the time_created property of this AutoScalingPolicy.
         :type time_created: datetime
 
+        :param is_enabled:
+            The value to assign to the is_enabled property of this AutoScalingPolicy.
+        :type is_enabled: bool
+
         """
         self.swagger_types = {
             'capacity': 'Capacity',
             'id': 'str',
             'display_name': 'str',
             'policy_type': 'str',
-            'time_created': 'datetime'
+            'time_created': 'datetime',
+            'is_enabled': 'bool'
         }
 
         self.attribute_map = {
@@ -61,7 +67,8 @@ class AutoScalingPolicy(object):
             'id': 'id',
             'display_name': 'displayName',
             'policy_type': 'policyType',
-            'time_created': 'timeCreated'
+            'time_created': 'timeCreated',
+            'is_enabled': 'isEnabled'
         }
 
         self._capacity = None
@@ -69,6 +76,7 @@ class AutoScalingPolicy(object):
         self._display_name = None
         self._policy_type = None
         self._time_created = None
+        self._is_enabled = None
 
     @staticmethod
     def get_subtype(object_dictionary):
@@ -77,6 +85,9 @@ class AutoScalingPolicy(object):
         use the info in the hash to return the class of the subtype.
         """
         type = object_dictionary['policyType']
+
+        if type == 'scheduled':
+            return 'ScheduledPolicy'
 
         if type == 'threshold':
             return 'ThresholdPolicy'
@@ -206,6 +217,30 @@ class AutoScalingPolicy(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this AutoScalingPolicy.
+        Boolean field indicating whether this policy is enabled or not.
+
+
+        :return: The is_enabled of this AutoScalingPolicy.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this AutoScalingPolicy.
+        Boolean field indicating whether this policy is enabled or not.
+
+
+        :param is_enabled: The is_enabled of this AutoScalingPolicy.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/autoscaling/models/auto_scaling_policy_summary.py
+++ b/src/oci/autoscaling/models/auto_scaling_policy_summary.py
@@ -30,22 +30,29 @@ class AutoScalingPolicySummary(object):
             The value to assign to the policy_type property of this AutoScalingPolicySummary.
         :type policy_type: str
 
+        :param is_enabled:
+            The value to assign to the is_enabled property of this AutoScalingPolicySummary.
+        :type is_enabled: bool
+
         """
         self.swagger_types = {
             'id': 'str',
             'display_name': 'str',
-            'policy_type': 'str'
+            'policy_type': 'str',
+            'is_enabled': 'bool'
         }
 
         self.attribute_map = {
             'id': 'id',
             'display_name': 'displayName',
-            'policy_type': 'policyType'
+            'policy_type': 'policyType',
+            'is_enabled': 'isEnabled'
         }
 
         self._id = None
         self._display_name = None
         self._policy_type = None
+        self._is_enabled = None
 
     @property
     def id(self):
@@ -118,6 +125,30 @@ class AutoScalingPolicySummary(object):
         :type: str
         """
         self._policy_type = policy_type
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this AutoScalingPolicySummary.
+        Boolean field indicated whether this policy is enabled or not.
+
+
+        :return: The is_enabled of this AutoScalingPolicySummary.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this AutoScalingPolicySummary.
+        Boolean field indicated whether this policy is enabled or not.
+
+
+        :param is_enabled: The is_enabled of this AutoScalingPolicySummary.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/autoscaling/models/capacity.py
+++ b/src/oci/autoscaling/models/capacity.py
@@ -50,7 +50,7 @@ class Capacity(object):
     @property
     def max(self):
         """
-        **[Required]** Gets the max of this Capacity.
+        Gets the max of this Capacity.
         The maximum number of instances the instance pool is allowed to increase to (scale out).
 
 
@@ -74,7 +74,7 @@ class Capacity(object):
     @property
     def min(self):
         """
-        **[Required]** Gets the min of this Capacity.
+        Gets the min of this Capacity.
         The minimum number of instances the instance pool is allowed to decrease to (scale in).
 
 
@@ -98,7 +98,7 @@ class Capacity(object):
     @property
     def initial(self):
         """
-        **[Required]** Gets the initial of this Capacity.
+        Gets the initial of this Capacity.
         The initial number of instances to launch in the instance pool immediately after autoscaling is
         enabled. After autoscaling retrieves performance metrics, the number of instances is automatically adjusted from this
         initial number to a number that is based on the limits that you set.

--- a/src/oci/autoscaling/models/create_auto_scaling_policy_details.py
+++ b/src/oci/autoscaling/models/create_auto_scaling_policy_details.py
@@ -23,6 +23,7 @@ class CreateAutoScalingPolicyDetails(object):
         Initializes a new CreateAutoScalingPolicyDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.autoscaling.models.CreateScheduledPolicyDetails`
         * :class:`~oci.autoscaling.models.CreateThresholdPolicyDetails`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
@@ -39,22 +40,29 @@ class CreateAutoScalingPolicyDetails(object):
             The value to assign to the policy_type property of this CreateAutoScalingPolicyDetails.
         :type policy_type: str
 
+        :param is_enabled:
+            The value to assign to the is_enabled property of this CreateAutoScalingPolicyDetails.
+        :type is_enabled: bool
+
         """
         self.swagger_types = {
             'capacity': 'Capacity',
             'display_name': 'str',
-            'policy_type': 'str'
+            'policy_type': 'str',
+            'is_enabled': 'bool'
         }
 
         self.attribute_map = {
             'capacity': 'capacity',
             'display_name': 'displayName',
-            'policy_type': 'policyType'
+            'policy_type': 'policyType',
+            'is_enabled': 'isEnabled'
         }
 
         self._capacity = None
         self._display_name = None
         self._policy_type = None
+        self._is_enabled = None
 
     @staticmethod
     def get_subtype(object_dictionary):
@@ -63,6 +71,9 @@ class CreateAutoScalingPolicyDetails(object):
         use the info in the hash to return the class of the subtype.
         """
         type = object_dictionary['policyType']
+
+        if type == 'scheduled':
+            return 'CreateScheduledPolicyDetails'
 
         if type == 'threshold':
             return 'CreateThresholdPolicyDetails'
@@ -140,6 +151,30 @@ class CreateAutoScalingPolicyDetails(object):
         :type: str
         """
         self._policy_type = policy_type
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this CreateAutoScalingPolicyDetails.
+        Boolean field indicating whether this policy is enabled or not.
+
+
+        :return: The is_enabled of this CreateAutoScalingPolicyDetails.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this CreateAutoScalingPolicyDetails.
+        Boolean field indicating whether this policy is enabled or not.
+
+
+        :param is_enabled: The is_enabled of this CreateAutoScalingPolicyDetails.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/autoscaling/models/create_scheduled_policy_details.py
+++ b/src/oci/autoscaling/models/create_scheduled_policy_details.py
@@ -1,0 +1,98 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_auto_scaling_policy_details import CreateAutoScalingPolicyDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateScheduledPolicyDetails(CreateAutoScalingPolicyDetails):
+    """
+    Creation details for a schedule-based autoscaling policy.
+
+    In a schedule-based autoscaling policy, an autoscaling action is triggered when execution time is current.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateScheduledPolicyDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.autoscaling.models.CreateScheduledPolicyDetails.policy_type` attribute
+        of this class is ``scheduled`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param capacity:
+            The value to assign to the capacity property of this CreateScheduledPolicyDetails.
+        :type capacity: Capacity
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateScheduledPolicyDetails.
+        :type display_name: str
+
+        :param policy_type:
+            The value to assign to the policy_type property of this CreateScheduledPolicyDetails.
+        :type policy_type: str
+
+        :param is_enabled:
+            The value to assign to the is_enabled property of this CreateScheduledPolicyDetails.
+        :type is_enabled: bool
+
+        :param execution_schedule:
+            The value to assign to the execution_schedule property of this CreateScheduledPolicyDetails.
+        :type execution_schedule: ExecutionSchedule
+
+        """
+        self.swagger_types = {
+            'capacity': 'Capacity',
+            'display_name': 'str',
+            'policy_type': 'str',
+            'is_enabled': 'bool',
+            'execution_schedule': 'ExecutionSchedule'
+        }
+
+        self.attribute_map = {
+            'capacity': 'capacity',
+            'display_name': 'displayName',
+            'policy_type': 'policyType',
+            'is_enabled': 'isEnabled',
+            'execution_schedule': 'executionSchedule'
+        }
+
+        self._capacity = None
+        self._display_name = None
+        self._policy_type = None
+        self._is_enabled = None
+        self._execution_schedule = None
+        self._policy_type = 'scheduled'
+
+    @property
+    def execution_schedule(self):
+        """
+        **[Required]** Gets the execution_schedule of this CreateScheduledPolicyDetails.
+
+        :return: The execution_schedule of this CreateScheduledPolicyDetails.
+        :rtype: ExecutionSchedule
+        """
+        return self._execution_schedule
+
+    @execution_schedule.setter
+    def execution_schedule(self, execution_schedule):
+        """
+        Sets the execution_schedule of this CreateScheduledPolicyDetails.
+
+        :param execution_schedule: The execution_schedule of this CreateScheduledPolicyDetails.
+        :type: ExecutionSchedule
+        """
+        self._execution_schedule = execution_schedule
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/autoscaling/models/create_threshold_policy_details.py
+++ b/src/oci/autoscaling/models/create_threshold_policy_details.py
@@ -34,6 +34,10 @@ class CreateThresholdPolicyDetails(CreateAutoScalingPolicyDetails):
             The value to assign to the policy_type property of this CreateThresholdPolicyDetails.
         :type policy_type: str
 
+        :param is_enabled:
+            The value to assign to the is_enabled property of this CreateThresholdPolicyDetails.
+        :type is_enabled: bool
+
         :param rules:
             The value to assign to the rules property of this CreateThresholdPolicyDetails.
         :type rules: list[CreateConditionDetails]
@@ -43,6 +47,7 @@ class CreateThresholdPolicyDetails(CreateAutoScalingPolicyDetails):
             'capacity': 'Capacity',
             'display_name': 'str',
             'policy_type': 'str',
+            'is_enabled': 'bool',
             'rules': 'list[CreateConditionDetails]'
         }
 
@@ -50,12 +55,14 @@ class CreateThresholdPolicyDetails(CreateAutoScalingPolicyDetails):
             'capacity': 'capacity',
             'display_name': 'displayName',
             'policy_type': 'policyType',
+            'is_enabled': 'isEnabled',
             'rules': 'rules'
         }
 
         self._capacity = None
         self._display_name = None
         self._policy_type = None
+        self._is_enabled = None
         self._rules = None
         self._policy_type = 'threshold'
 

--- a/src/oci/autoscaling/models/cron_execution_schedule.py
+++ b/src/oci/autoscaling/models/cron_execution_schedule.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .execution_schedule import ExecutionSchedule
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CronExecutionSchedule(ExecutionSchedule):
+    """
+    Specifies the execution schedule of CRON type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CronExecutionSchedule object with values from keyword arguments. The default value of the :py:attr:`~oci.autoscaling.models.CronExecutionSchedule.type` attribute
+        of this class is ``cron`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param type:
+            The value to assign to the type property of this CronExecutionSchedule.
+        :type type: str
+
+        :param timezone:
+            The value to assign to the timezone property of this CronExecutionSchedule.
+            Allowed values for this property are: "UTC"
+        :type timezone: str
+
+        :param expression:
+            The value to assign to the expression property of this CronExecutionSchedule.
+        :type expression: str
+
+        """
+        self.swagger_types = {
+            'type': 'str',
+            'timezone': 'str',
+            'expression': 'str'
+        }
+
+        self.attribute_map = {
+            'type': 'type',
+            'timezone': 'timezone',
+            'expression': 'expression'
+        }
+
+        self._type = None
+        self._timezone = None
+        self._expression = None
+        self._type = 'cron'
+
+    @property
+    def expression(self):
+        """
+        **[Required]** Gets the expression of this CronExecutionSchedule.
+        The value representing the execution schedule, as defined by cron format.
+
+
+        :return: The expression of this CronExecutionSchedule.
+        :rtype: str
+        """
+        return self._expression
+
+    @expression.setter
+    def expression(self, expression):
+        """
+        Sets the expression of this CronExecutionSchedule.
+        The value representing the execution schedule, as defined by cron format.
+
+
+        :param expression: The expression of this CronExecutionSchedule.
+        :type: str
+        """
+        self._expression = expression
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/autoscaling/models/execution_schedule.py
+++ b/src/oci/autoscaling/models/execution_schedule.py
@@ -1,0 +1,130 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExecutionSchedule(object):
+    """
+    Specifies the execution schedule for a policy.
+    """
+
+    #: A constant which can be used with the timezone property of a ExecutionSchedule.
+    #: This constant has a value of "UTC"
+    TIMEZONE_UTC = "UTC"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExecutionSchedule object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.autoscaling.models.CronExecutionSchedule`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param type:
+            The value to assign to the type property of this ExecutionSchedule.
+        :type type: str
+
+        :param timezone:
+            The value to assign to the timezone property of this ExecutionSchedule.
+            Allowed values for this property are: "UTC", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type timezone: str
+
+        """
+        self.swagger_types = {
+            'type': 'str',
+            'timezone': 'str'
+        }
+
+        self.attribute_map = {
+            'type': 'type',
+            'timezone': 'timezone'
+        }
+
+        self._type = None
+        self._timezone = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['type']
+
+        if type == 'cron':
+            return 'CronExecutionSchedule'
+        else:
+            return 'ExecutionSchedule'
+
+    @property
+    def type(self):
+        """
+        **[Required]** Gets the type of this ExecutionSchedule.
+        The type of ExecutionSchedule.
+
+
+        :return: The type of this ExecutionSchedule.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this ExecutionSchedule.
+        The type of ExecutionSchedule.
+
+
+        :param type: The type of this ExecutionSchedule.
+        :type: str
+        """
+        self._type = type
+
+    @property
+    def timezone(self):
+        """
+        **[Required]** Gets the timezone of this ExecutionSchedule.
+        Specifies the time zone the schedule is in.
+
+        Allowed values for this property are: "UTC", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The timezone of this ExecutionSchedule.
+        :rtype: str
+        """
+        return self._timezone
+
+    @timezone.setter
+    def timezone(self, timezone):
+        """
+        Sets the timezone of this ExecutionSchedule.
+        Specifies the time zone the schedule is in.
+
+
+        :param timezone: The timezone of this ExecutionSchedule.
+        :type: str
+        """
+        allowed_values = ["UTC"]
+        if not value_allowed_none_or_none_sentinel(timezone, allowed_values):
+            timezone = 'UNKNOWN_ENUM_VALUE'
+        self._timezone = timezone
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/autoscaling/models/scheduled_policy.py
+++ b/src/oci/autoscaling/models/scheduled_policy.py
@@ -8,44 +8,44 @@ from oci.decorators import init_model_state_from_kwargs
 
 
 @init_model_state_from_kwargs
-class ThresholdPolicy(AutoScalingPolicy):
+class ScheduledPolicy(AutoScalingPolicy):
     """
-    An autoscaling policy that defines threshold-based rules for an autoscaling configuration.
+    An autoscaling policy that defines execution schedules for an autoscaling configuration.
     """
 
     def __init__(self, **kwargs):
         """
-        Initializes a new ThresholdPolicy object with values from keyword arguments. The default value of the :py:attr:`~oci.autoscaling.models.ThresholdPolicy.policy_type` attribute
-        of this class is ``threshold`` and it should not be changed.
+        Initializes a new ScheduledPolicy object with values from keyword arguments. The default value of the :py:attr:`~oci.autoscaling.models.ScheduledPolicy.policy_type` attribute
+        of this class is ``scheduled`` and it should not be changed.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param capacity:
-            The value to assign to the capacity property of this ThresholdPolicy.
+            The value to assign to the capacity property of this ScheduledPolicy.
         :type capacity: Capacity
 
         :param id:
-            The value to assign to the id property of this ThresholdPolicy.
+            The value to assign to the id property of this ScheduledPolicy.
         :type id: str
 
         :param display_name:
-            The value to assign to the display_name property of this ThresholdPolicy.
+            The value to assign to the display_name property of this ScheduledPolicy.
         :type display_name: str
 
         :param policy_type:
-            The value to assign to the policy_type property of this ThresholdPolicy.
+            The value to assign to the policy_type property of this ScheduledPolicy.
         :type policy_type: str
 
         :param time_created:
-            The value to assign to the time_created property of this ThresholdPolicy.
+            The value to assign to the time_created property of this ScheduledPolicy.
         :type time_created: datetime
 
         :param is_enabled:
-            The value to assign to the is_enabled property of this ThresholdPolicy.
+            The value to assign to the is_enabled property of this ScheduledPolicy.
         :type is_enabled: bool
 
-        :param rules:
-            The value to assign to the rules property of this ThresholdPolicy.
-        :type rules: list[Condition]
+        :param execution_schedule:
+            The value to assign to the execution_schedule property of this ScheduledPolicy.
+        :type execution_schedule: ExecutionSchedule
 
         """
         self.swagger_types = {
@@ -55,7 +55,7 @@ class ThresholdPolicy(AutoScalingPolicy):
             'policy_type': 'str',
             'time_created': 'datetime',
             'is_enabled': 'bool',
-            'rules': 'list[Condition]'
+            'execution_schedule': 'ExecutionSchedule'
         }
 
         self.attribute_map = {
@@ -65,7 +65,7 @@ class ThresholdPolicy(AutoScalingPolicy):
             'policy_type': 'policyType',
             'time_created': 'timeCreated',
             'is_enabled': 'isEnabled',
-            'rules': 'rules'
+            'execution_schedule': 'executionSchedule'
         }
 
         self._capacity = None
@@ -74,28 +74,28 @@ class ThresholdPolicy(AutoScalingPolicy):
         self._policy_type = None
         self._time_created = None
         self._is_enabled = None
-        self._rules = None
-        self._policy_type = 'threshold'
+        self._execution_schedule = None
+        self._policy_type = 'scheduled'
 
     @property
-    def rules(self):
+    def execution_schedule(self):
         """
-        **[Required]** Gets the rules of this ThresholdPolicy.
+        **[Required]** Gets the execution_schedule of this ScheduledPolicy.
 
-        :return: The rules of this ThresholdPolicy.
-        :rtype: list[Condition]
+        :return: The execution_schedule of this ScheduledPolicy.
+        :rtype: ExecutionSchedule
         """
-        return self._rules
+        return self._execution_schedule
 
-    @rules.setter
-    def rules(self, rules):
+    @execution_schedule.setter
+    def execution_schedule(self, execution_schedule):
         """
-        Sets the rules of this ThresholdPolicy.
+        Sets the execution_schedule of this ScheduledPolicy.
 
-        :param rules: The rules of this ThresholdPolicy.
-        :type: list[Condition]
+        :param execution_schedule: The execution_schedule of this ScheduledPolicy.
+        :type: ExecutionSchedule
         """
-        self._rules = rules
+        self._execution_schedule = execution_schedule
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/autoscaling/models/update_auto_scaling_policy_details.py
+++ b/src/oci/autoscaling/models/update_auto_scaling_policy_details.py
@@ -19,6 +19,7 @@ class UpdateAutoScalingPolicyDetails(object):
         to a service operations then you should favor using a subclass over the base class:
 
         * :class:`~oci.autoscaling.models.UpdateThresholdPolicyDetails`
+        * :class:`~oci.autoscaling.models.UpdateScheduledPolicyDetails`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
@@ -34,22 +35,29 @@ class UpdateAutoScalingPolicyDetails(object):
             The value to assign to the policy_type property of this UpdateAutoScalingPolicyDetails.
         :type policy_type: str
 
+        :param is_enabled:
+            The value to assign to the is_enabled property of this UpdateAutoScalingPolicyDetails.
+        :type is_enabled: bool
+
         """
         self.swagger_types = {
             'display_name': 'str',
             'capacity': 'Capacity',
-            'policy_type': 'str'
+            'policy_type': 'str',
+            'is_enabled': 'bool'
         }
 
         self.attribute_map = {
             'display_name': 'displayName',
             'capacity': 'capacity',
-            'policy_type': 'policyType'
+            'policy_type': 'policyType',
+            'is_enabled': 'isEnabled'
         }
 
         self._display_name = None
         self._capacity = None
         self._policy_type = None
+        self._is_enabled = None
 
     @staticmethod
     def get_subtype(object_dictionary):
@@ -61,6 +69,9 @@ class UpdateAutoScalingPolicyDetails(object):
 
         if type == 'threshold':
             return 'UpdateThresholdPolicyDetails'
+
+        if type == 'scheduled':
+            return 'UpdateScheduledPolicyDetails'
         else:
             return 'UpdateAutoScalingPolicyDetails'
 
@@ -135,6 +146,30 @@ class UpdateAutoScalingPolicyDetails(object):
         :type: str
         """
         self._policy_type = policy_type
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this UpdateAutoScalingPolicyDetails.
+        Boolean field indicating whether this policy is enabled or not.
+
+
+        :return: The is_enabled of this UpdateAutoScalingPolicyDetails.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this UpdateAutoScalingPolicyDetails.
+        Boolean field indicating whether this policy is enabled or not.
+
+
+        :param is_enabled: The is_enabled of this UpdateAutoScalingPolicyDetails.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/autoscaling/models/update_scheduled_policy_details.py
+++ b/src/oci/autoscaling/models/update_scheduled_policy_details.py
@@ -8,36 +8,36 @@ from oci.decorators import init_model_state_from_kwargs
 
 
 @init_model_state_from_kwargs
-class UpdateThresholdPolicyDetails(UpdateAutoScalingPolicyDetails):
+class UpdateScheduledPolicyDetails(UpdateAutoScalingPolicyDetails):
     """
-    UpdateThresholdPolicyDetails model.
+    UpdateScheduledPolicyDetails model.
     """
 
     def __init__(self, **kwargs):
         """
-        Initializes a new UpdateThresholdPolicyDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.autoscaling.models.UpdateThresholdPolicyDetails.policy_type` attribute
-        of this class is ``threshold`` and it should not be changed.
+        Initializes a new UpdateScheduledPolicyDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.autoscaling.models.UpdateScheduledPolicyDetails.policy_type` attribute
+        of this class is ``scheduled`` and it should not be changed.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param display_name:
-            The value to assign to the display_name property of this UpdateThresholdPolicyDetails.
+            The value to assign to the display_name property of this UpdateScheduledPolicyDetails.
         :type display_name: str
 
         :param capacity:
-            The value to assign to the capacity property of this UpdateThresholdPolicyDetails.
+            The value to assign to the capacity property of this UpdateScheduledPolicyDetails.
         :type capacity: Capacity
 
         :param policy_type:
-            The value to assign to the policy_type property of this UpdateThresholdPolicyDetails.
+            The value to assign to the policy_type property of this UpdateScheduledPolicyDetails.
         :type policy_type: str
 
         :param is_enabled:
-            The value to assign to the is_enabled property of this UpdateThresholdPolicyDetails.
+            The value to assign to the is_enabled property of this UpdateScheduledPolicyDetails.
         :type is_enabled: bool
 
-        :param rules:
-            The value to assign to the rules property of this UpdateThresholdPolicyDetails.
-        :type rules: list[UpdateConditionDetails]
+        :param execution_schedule:
+            The value to assign to the execution_schedule property of this UpdateScheduledPolicyDetails.
+        :type execution_schedule: ExecutionSchedule
 
         """
         self.swagger_types = {
@@ -45,7 +45,7 @@ class UpdateThresholdPolicyDetails(UpdateAutoScalingPolicyDetails):
             'capacity': 'Capacity',
             'policy_type': 'str',
             'is_enabled': 'bool',
-            'rules': 'list[UpdateConditionDetails]'
+            'execution_schedule': 'ExecutionSchedule'
         }
 
         self.attribute_map = {
@@ -53,35 +53,35 @@ class UpdateThresholdPolicyDetails(UpdateAutoScalingPolicyDetails):
             'capacity': 'capacity',
             'policy_type': 'policyType',
             'is_enabled': 'isEnabled',
-            'rules': 'rules'
+            'execution_schedule': 'executionSchedule'
         }
 
         self._display_name = None
         self._capacity = None
         self._policy_type = None
         self._is_enabled = None
-        self._rules = None
-        self._policy_type = 'threshold'
+        self._execution_schedule = None
+        self._policy_type = 'scheduled'
 
     @property
-    def rules(self):
+    def execution_schedule(self):
         """
-        Gets the rules of this UpdateThresholdPolicyDetails.
+        Gets the execution_schedule of this UpdateScheduledPolicyDetails.
 
-        :return: The rules of this UpdateThresholdPolicyDetails.
-        :rtype: list[UpdateConditionDetails]
+        :return: The execution_schedule of this UpdateScheduledPolicyDetails.
+        :rtype: ExecutionSchedule
         """
-        return self._rules
+        return self._execution_schedule
 
-    @rules.setter
-    def rules(self, rules):
+    @execution_schedule.setter
+    def execution_schedule(self, execution_schedule):
         """
-        Sets the rules of this UpdateThresholdPolicyDetails.
+        Sets the execution_schedule of this UpdateScheduledPolicyDetails.
 
-        :param rules: The rules of this UpdateThresholdPolicyDetails.
-        :type: list[UpdateConditionDetails]
+        :param execution_schedule: The execution_schedule of this UpdateScheduledPolicyDetails.
+        :type: ExecutionSchedule
         """
-        self._rules = rules
+        self._execution_schedule = execution_schedule
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/__init__.py
+++ b/src/oci/database/models/__init__.py
@@ -56,13 +56,16 @@ from .create_data_guard_association_to_existing_db_system_details import CreateD
 from .create_data_guard_association_with_new_db_system_details import CreateDataGuardAssociationWithNewDbSystemDetails
 from .create_database_base import CreateDatabaseBase
 from .create_database_details import CreateDatabaseDetails
+from .create_database_from_another_database_details import CreateDatabaseFromAnotherDatabaseDetails
 from .create_database_from_backup import CreateDatabaseFromBackup
 from .create_database_from_backup_details import CreateDatabaseFromBackupDetails
 from .create_db_home_base import CreateDbHomeBase
 from .create_db_home_details import CreateDbHomeDetails
 from .create_db_home_from_backup_details import CreateDbHomeFromBackupDetails
+from .create_db_home_from_database_details import CreateDbHomeFromDatabaseDetails
 from .create_db_home_with_db_system_id_details import CreateDbHomeWithDbSystemIdDetails
 from .create_db_home_with_db_system_id_from_backup_details import CreateDbHomeWithDbSystemIdFromBackupDetails
+from .create_db_home_with_db_system_id_from_database_details import CreateDbHomeWithDbSystemIdFromDatabaseDetails
 from .create_db_home_with_vm_cluster_id_details import CreateDbHomeWithVmClusterIdDetails
 from .create_exadata_infrastructure_details import CreateExadataInfrastructureDetails
 from .create_external_backup_job_details import CreateExternalBackupJobDetails
@@ -103,6 +106,7 @@ from .launch_autonomous_exadata_infrastructure_details import LaunchAutonomousEx
 from .launch_db_system_base import LaunchDbSystemBase
 from .launch_db_system_details import LaunchDbSystemDetails
 from .launch_db_system_from_backup_details import LaunchDbSystemFromBackupDetails
+from .launch_db_system_from_database_details import LaunchDbSystemFromDatabaseDetails
 from .maintenance_run import MaintenanceRun
 from .maintenance_run_summary import MaintenanceRunSummary
 from .maintenance_window import MaintenanceWindow
@@ -195,13 +199,16 @@ database_type_mapping = {
     "CreateDataGuardAssociationWithNewDbSystemDetails": CreateDataGuardAssociationWithNewDbSystemDetails,
     "CreateDatabaseBase": CreateDatabaseBase,
     "CreateDatabaseDetails": CreateDatabaseDetails,
+    "CreateDatabaseFromAnotherDatabaseDetails": CreateDatabaseFromAnotherDatabaseDetails,
     "CreateDatabaseFromBackup": CreateDatabaseFromBackup,
     "CreateDatabaseFromBackupDetails": CreateDatabaseFromBackupDetails,
     "CreateDbHomeBase": CreateDbHomeBase,
     "CreateDbHomeDetails": CreateDbHomeDetails,
     "CreateDbHomeFromBackupDetails": CreateDbHomeFromBackupDetails,
+    "CreateDbHomeFromDatabaseDetails": CreateDbHomeFromDatabaseDetails,
     "CreateDbHomeWithDbSystemIdDetails": CreateDbHomeWithDbSystemIdDetails,
     "CreateDbHomeWithDbSystemIdFromBackupDetails": CreateDbHomeWithDbSystemIdFromBackupDetails,
+    "CreateDbHomeWithDbSystemIdFromDatabaseDetails": CreateDbHomeWithDbSystemIdFromDatabaseDetails,
     "CreateDbHomeWithVmClusterIdDetails": CreateDbHomeWithVmClusterIdDetails,
     "CreateExadataInfrastructureDetails": CreateExadataInfrastructureDetails,
     "CreateExternalBackupJobDetails": CreateExternalBackupJobDetails,
@@ -242,6 +249,7 @@ database_type_mapping = {
     "LaunchDbSystemBase": LaunchDbSystemBase,
     "LaunchDbSystemDetails": LaunchDbSystemDetails,
     "LaunchDbSystemFromBackupDetails": LaunchDbSystemFromBackupDetails,
+    "LaunchDbSystemFromDatabaseDetails": LaunchDbSystemFromDatabaseDetails,
     "MaintenanceRun": MaintenanceRun,
     "MaintenanceRunSummary": MaintenanceRunSummary,
     "MaintenanceWindow": MaintenanceWindow,

--- a/src/oci/database/models/autonomous_container_database.py
+++ b/src/oci/database/models/autonomous_container_database.py
@@ -144,6 +144,10 @@ class AutonomousContainerDatabase(object):
             The value to assign to the availability_domain property of this AutonomousContainerDatabase.
         :type availability_domain: str
 
+        :param db_version:
+            The value to assign to the db_version property of this AutonomousContainerDatabase.
+        :type db_version: str
+
         :param backup_config:
             The value to assign to the backup_config property of this AutonomousContainerDatabase.
         :type backup_config: AutonomousContainerDatabaseBackupConfig
@@ -165,6 +169,7 @@ class AutonomousContainerDatabase(object):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'availability_domain': 'str',
+            'db_version': 'str',
             'backup_config': 'AutonomousContainerDatabaseBackupConfig'
         }
 
@@ -184,6 +189,7 @@ class AutonomousContainerDatabase(object):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'availability_domain': 'availabilityDomain',
+            'db_version': 'dbVersion',
             'backup_config': 'backupConfig'
         }
 
@@ -202,6 +208,7 @@ class AutonomousContainerDatabase(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._availability_domain = None
+        self._db_version = None
         self._backup_config = None
 
     @property
@@ -601,6 +608,30 @@ class AutonomousContainerDatabase(object):
         :type: str
         """
         self._availability_domain = availability_domain
+
+    @property
+    def db_version(self):
+        """
+        Gets the db_version of this AutonomousContainerDatabase.
+        Oracle Database version of the Autonomous Container Database
+
+
+        :return: The db_version of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._db_version
+
+    @db_version.setter
+    def db_version(self, db_version):
+        """
+        Sets the db_version of this AutonomousContainerDatabase.
+        Oracle Database version of the Autonomous Container Database
+
+
+        :param db_version: The db_version of this AutonomousContainerDatabase.
+        :type: str
+        """
+        self._db_version = db_version
 
     @property
     def backup_config(self):

--- a/src/oci/database/models/autonomous_container_database_summary.py
+++ b/src/oci/database/models/autonomous_container_database_summary.py
@@ -144,6 +144,10 @@ class AutonomousContainerDatabaseSummary(object):
             The value to assign to the availability_domain property of this AutonomousContainerDatabaseSummary.
         :type availability_domain: str
 
+        :param db_version:
+            The value to assign to the db_version property of this AutonomousContainerDatabaseSummary.
+        :type db_version: str
+
         :param backup_config:
             The value to assign to the backup_config property of this AutonomousContainerDatabaseSummary.
         :type backup_config: AutonomousContainerDatabaseBackupConfig
@@ -165,6 +169,7 @@ class AutonomousContainerDatabaseSummary(object):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'availability_domain': 'str',
+            'db_version': 'str',
             'backup_config': 'AutonomousContainerDatabaseBackupConfig'
         }
 
@@ -184,6 +189,7 @@ class AutonomousContainerDatabaseSummary(object):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'availability_domain': 'availabilityDomain',
+            'db_version': 'dbVersion',
             'backup_config': 'backupConfig'
         }
 
@@ -202,6 +208,7 @@ class AutonomousContainerDatabaseSummary(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._availability_domain = None
+        self._db_version = None
         self._backup_config = None
 
     @property
@@ -601,6 +608,30 @@ class AutonomousContainerDatabaseSummary(object):
         :type: str
         """
         self._availability_domain = availability_domain
+
+    @property
+    def db_version(self):
+        """
+        Gets the db_version of this AutonomousContainerDatabaseSummary.
+        Oracle Database version of the Autonomous Container Database
+
+
+        :return: The db_version of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._db_version
+
+    @db_version.setter
+    def db_version(self, db_version):
+        """
+        Sets the db_version of this AutonomousContainerDatabaseSummary.
+        Oracle Database version of the Autonomous Container Database
+
+
+        :param db_version: The db_version of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        self._db_version = db_version
 
     @property
     def backup_config(self):

--- a/src/oci/database/models/create_database_from_another_database_details.py
+++ b/src/oci/database/models/create_database_from_another_database_details.py
@@ -1,0 +1,229 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDatabaseFromAnotherDatabaseDetails(object):
+    """
+    CreateDatabaseFromAnotherDatabaseDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDatabaseFromAnotherDatabaseDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param database_id:
+            The value to assign to the database_id property of this CreateDatabaseFromAnotherDatabaseDetails.
+        :type database_id: str
+
+        :param backup_tde_password:
+            The value to assign to the backup_tde_password property of this CreateDatabaseFromAnotherDatabaseDetails.
+        :type backup_tde_password: str
+
+        :param admin_password:
+            The value to assign to the admin_password property of this CreateDatabaseFromAnotherDatabaseDetails.
+        :type admin_password: str
+
+        :param db_unique_name:
+            The value to assign to the db_unique_name property of this CreateDatabaseFromAnotherDatabaseDetails.
+        :type db_unique_name: str
+
+        :param db_name:
+            The value to assign to the db_name property of this CreateDatabaseFromAnotherDatabaseDetails.
+        :type db_name: str
+
+        :param time_stamp_for_point_in_time_recovery:
+            The value to assign to the time_stamp_for_point_in_time_recovery property of this CreateDatabaseFromAnotherDatabaseDetails.
+        :type time_stamp_for_point_in_time_recovery: datetime
+
+        """
+        self.swagger_types = {
+            'database_id': 'str',
+            'backup_tde_password': 'str',
+            'admin_password': 'str',
+            'db_unique_name': 'str',
+            'db_name': 'str',
+            'time_stamp_for_point_in_time_recovery': 'datetime'
+        }
+
+        self.attribute_map = {
+            'database_id': 'databaseId',
+            'backup_tde_password': 'backupTDEPassword',
+            'admin_password': 'adminPassword',
+            'db_unique_name': 'dbUniqueName',
+            'db_name': 'dbName',
+            'time_stamp_for_point_in_time_recovery': 'timeStampForPointInTimeRecovery'
+        }
+
+        self._database_id = None
+        self._backup_tde_password = None
+        self._admin_password = None
+        self._db_unique_name = None
+        self._db_name = None
+        self._time_stamp_for_point_in_time_recovery = None
+
+    @property
+    def database_id(self):
+        """
+        **[Required]** Gets the database_id of this CreateDatabaseFromAnotherDatabaseDetails.
+        The database `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The database_id of this CreateDatabaseFromAnotherDatabaseDetails.
+        :rtype: str
+        """
+        return self._database_id
+
+    @database_id.setter
+    def database_id(self, database_id):
+        """
+        Sets the database_id of this CreateDatabaseFromAnotherDatabaseDetails.
+        The database `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param database_id: The database_id of this CreateDatabaseFromAnotherDatabaseDetails.
+        :type: str
+        """
+        self._database_id = database_id
+
+    @property
+    def backup_tde_password(self):
+        """
+        **[Required]** Gets the backup_tde_password of this CreateDatabaseFromAnotherDatabaseDetails.
+        The password to open the TDE wallet.
+
+
+        :return: The backup_tde_password of this CreateDatabaseFromAnotherDatabaseDetails.
+        :rtype: str
+        """
+        return self._backup_tde_password
+
+    @backup_tde_password.setter
+    def backup_tde_password(self, backup_tde_password):
+        """
+        Sets the backup_tde_password of this CreateDatabaseFromAnotherDatabaseDetails.
+        The password to open the TDE wallet.
+
+
+        :param backup_tde_password: The backup_tde_password of this CreateDatabaseFromAnotherDatabaseDetails.
+        :type: str
+        """
+        self._backup_tde_password = backup_tde_password
+
+    @property
+    def admin_password(self):
+        """
+        **[Required]** Gets the admin_password of this CreateDatabaseFromAnotherDatabaseDetails.
+        A strong password for SYS, SYSTEM, PDB Admin and TDE Wallet. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numbers, and two special characters. The special characters must be _, \\#, or -.
+
+
+        :return: The admin_password of this CreateDatabaseFromAnotherDatabaseDetails.
+        :rtype: str
+        """
+        return self._admin_password
+
+    @admin_password.setter
+    def admin_password(self, admin_password):
+        """
+        Sets the admin_password of this CreateDatabaseFromAnotherDatabaseDetails.
+        A strong password for SYS, SYSTEM, PDB Admin and TDE Wallet. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numbers, and two special characters. The special characters must be _, \\#, or -.
+
+
+        :param admin_password: The admin_password of this CreateDatabaseFromAnotherDatabaseDetails.
+        :type: str
+        """
+        self._admin_password = admin_password
+
+    @property
+    def db_unique_name(self):
+        """
+        Gets the db_unique_name of this CreateDatabaseFromAnotherDatabaseDetails.
+        The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+
+
+        :return: The db_unique_name of this CreateDatabaseFromAnotherDatabaseDetails.
+        :rtype: str
+        """
+        return self._db_unique_name
+
+    @db_unique_name.setter
+    def db_unique_name(self, db_unique_name):
+        """
+        Sets the db_unique_name of this CreateDatabaseFromAnotherDatabaseDetails.
+        The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+
+
+        :param db_unique_name: The db_unique_name of this CreateDatabaseFromAnotherDatabaseDetails.
+        :type: str
+        """
+        self._db_unique_name = db_unique_name
+
+    @property
+    def db_name(self):
+        """
+        Gets the db_name of this CreateDatabaseFromAnotherDatabaseDetails.
+        The display name of the database to be created from the backup. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted.
+
+
+        :return: The db_name of this CreateDatabaseFromAnotherDatabaseDetails.
+        :rtype: str
+        """
+        return self._db_name
+
+    @db_name.setter
+    def db_name(self, db_name):
+        """
+        Sets the db_name of this CreateDatabaseFromAnotherDatabaseDetails.
+        The display name of the database to be created from the backup. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted.
+
+
+        :param db_name: The db_name of this CreateDatabaseFromAnotherDatabaseDetails.
+        :type: str
+        """
+        self._db_name = db_name
+
+    @property
+    def time_stamp_for_point_in_time_recovery(self):
+        """
+        Gets the time_stamp_for_point_in_time_recovery of this CreateDatabaseFromAnotherDatabaseDetails.
+        The point in time of the original database from which the new database is created. If not specifed, the latest backup is used to create the database.
+
+
+        :return: The time_stamp_for_point_in_time_recovery of this CreateDatabaseFromAnotherDatabaseDetails.
+        :rtype: datetime
+        """
+        return self._time_stamp_for_point_in_time_recovery
+
+    @time_stamp_for_point_in_time_recovery.setter
+    def time_stamp_for_point_in_time_recovery(self, time_stamp_for_point_in_time_recovery):
+        """
+        Sets the time_stamp_for_point_in_time_recovery of this CreateDatabaseFromAnotherDatabaseDetails.
+        The point in time of the original database from which the new database is created. If not specifed, the latest backup is used to create the database.
+
+
+        :param time_stamp_for_point_in_time_recovery: The time_stamp_for_point_in_time_recovery of this CreateDatabaseFromAnotherDatabaseDetails.
+        :type: datetime
+        """
+        self._time_stamp_for_point_in_time_recovery = time_stamp_for_point_in_time_recovery
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_db_home_base.py
+++ b/src/oci/database/models/create_db_home_base.py
@@ -24,6 +24,10 @@ class CreateDbHomeBase(object):
     SOURCE_DB_BACKUP = "DB_BACKUP"
 
     #: A constant which can be used with the source property of a CreateDbHomeBase.
+    #: This constant has a value of "DATABASE"
+    SOURCE_DATABASE = "DATABASE"
+
+    #: A constant which can be used with the source property of a CreateDbHomeBase.
     #: This constant has a value of "VM_CLUSTER_NEW"
     SOURCE_VM_CLUSTER_NEW = "VM_CLUSTER_NEW"
 
@@ -32,6 +36,7 @@ class CreateDbHomeBase(object):
         Initializes a new CreateDbHomeBase object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.database.models.CreateDbHomeWithDbSystemIdFromDatabaseDetails`
         * :class:`~oci.database.models.CreateDbHomeWithDbSystemIdFromBackupDetails`
         * :class:`~oci.database.models.CreateDbHomeWithDbSystemIdDetails`
         * :class:`~oci.database.models.CreateDbHomeWithVmClusterIdDetails`
@@ -44,7 +49,7 @@ class CreateDbHomeBase(object):
 
         :param source:
             The value to assign to the source property of this CreateDbHomeBase.
-            Allowed values for this property are: "NONE", "DB_BACKUP", "VM_CLUSTER_NEW"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_NEW"
         :type source: str
 
         """
@@ -68,6 +73,9 @@ class CreateDbHomeBase(object):
         use the info in the hash to return the class of the subtype.
         """
         type = object_dictionary['source']
+
+        if type == 'DATABASE':
+            return 'CreateDbHomeWithDbSystemIdFromDatabaseDetails'
 
         if type == 'DB_BACKUP':
             return 'CreateDbHomeWithDbSystemIdFromBackupDetails'
@@ -110,7 +118,7 @@ class CreateDbHomeBase(object):
         Gets the source of this CreateDbHomeBase.
         The source of database: NONE for creating a new database. DB_BACKUP for creating a new database by restoring from a database backup.
 
-        Allowed values for this property are: "NONE", "DB_BACKUP", "VM_CLUSTER_NEW"
+        Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_NEW"
 
 
         :return: The source of this CreateDbHomeBase.
@@ -128,7 +136,7 @@ class CreateDbHomeBase(object):
         :param source: The source of this CreateDbHomeBase.
         :type: str
         """
-        allowed_values = ["NONE", "DB_BACKUP", "VM_CLUSTER_NEW"]
+        allowed_values = ["NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_NEW"]
         if not value_allowed_none_or_none_sentinel(source, allowed_values):
             raise ValueError(
                 "Invalid value for `source`, must be None or one of {0}"

--- a/src/oci/database/models/create_db_home_from_database_details.py
+++ b/src/oci/database/models/create_db_home_from_database_details.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDbHomeFromDatabaseDetails(object):
+    """
+    Details for creating a Database Home if you are creating a database by restoring from a database backup.
+
+    **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDbHomeFromDatabaseDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateDbHomeFromDatabaseDetails.
+        :type display_name: str
+
+        :param database:
+            The value to assign to the database property of this CreateDbHomeFromDatabaseDetails.
+        :type database: CreateDatabaseFromAnotherDatabaseDetails
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'database': 'CreateDatabaseFromAnotherDatabaseDetails'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'database': 'database'
+        }
+
+        self._display_name = None
+        self._database = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateDbHomeFromDatabaseDetails.
+        The user-provided name of the Database Home.
+
+
+        :return: The display_name of this CreateDbHomeFromDatabaseDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateDbHomeFromDatabaseDetails.
+        The user-provided name of the Database Home.
+
+
+        :param display_name: The display_name of this CreateDbHomeFromDatabaseDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def database(self):
+        """
+        **[Required]** Gets the database of this CreateDbHomeFromDatabaseDetails.
+
+        :return: The database of this CreateDbHomeFromDatabaseDetails.
+        :rtype: CreateDatabaseFromAnotherDatabaseDetails
+        """
+        return self._database
+
+    @database.setter
+    def database(self, database):
+        """
+        Sets the database of this CreateDbHomeFromDatabaseDetails.
+
+        :param database: The database of this CreateDbHomeFromDatabaseDetails.
+        :type: CreateDatabaseFromAnotherDatabaseDetails
+        """
+        self._database = database
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_db_home_with_db_system_id_details.py
+++ b/src/oci/database/models/create_db_home_with_db_system_id_details.py
@@ -25,7 +25,7 @@ class CreateDbHomeWithDbSystemIdDetails(CreateDbHomeBase):
 
         :param source:
             The value to assign to the source property of this CreateDbHomeWithDbSystemIdDetails.
-            Allowed values for this property are: "NONE", "DB_BACKUP", "VM_CLUSTER_NEW"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_NEW"
         :type source: str
 
         :param db_system_id:

--- a/src/oci/database/models/create_db_home_with_db_system_id_from_database_details.py
+++ b/src/oci/database/models/create_db_home_with_db_system_id_from_database_details.py
@@ -8,40 +8,40 @@ from oci.decorators import init_model_state_from_kwargs
 
 
 @init_model_state_from_kwargs
-class CreateDbHomeWithDbSystemIdFromBackupDetails(CreateDbHomeBase):
+class CreateDbHomeWithDbSystemIdFromDatabaseDetails(CreateDbHomeBase):
     """
-    Note that a valid `dbSystemId` value must be supplied for the `CreateDbHomeWithDbSystemIdFromBackup` API operation to successfully complete.
+    Note that a valid `dbSystemId` value must be supplied for the `CreateDbHomeWithDbSystemIdFromDatabase` API operation to successfully complete.
     """
 
     def __init__(self, **kwargs):
         """
-        Initializes a new CreateDbHomeWithDbSystemIdFromBackupDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.CreateDbHomeWithDbSystemIdFromBackupDetails.source` attribute
-        of this class is ``DB_BACKUP`` and it should not be changed.
+        Initializes a new CreateDbHomeWithDbSystemIdFromDatabaseDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.CreateDbHomeWithDbSystemIdFromDatabaseDetails.source` attribute
+        of this class is ``DATABASE`` and it should not be changed.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param display_name:
-            The value to assign to the display_name property of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+            The value to assign to the display_name property of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
         :type display_name: str
 
         :param source:
-            The value to assign to the source property of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+            The value to assign to the source property of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
             Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_NEW"
         :type source: str
 
         :param db_system_id:
-            The value to assign to the db_system_id property of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+            The value to assign to the db_system_id property of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
         :type db_system_id: str
 
         :param database:
-            The value to assign to the database property of this CreateDbHomeWithDbSystemIdFromBackupDetails.
-        :type database: CreateDatabaseFromBackupDetails
+            The value to assign to the database property of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
+        :type database: CreateDatabaseFromAnotherDatabaseDetails
 
         """
         self.swagger_types = {
             'display_name': 'str',
             'source': 'str',
             'db_system_id': 'str',
-            'database': 'CreateDatabaseFromBackupDetails'
+            'database': 'CreateDatabaseFromAnotherDatabaseDetails'
         }
 
         self.attribute_map = {
@@ -55,18 +55,18 @@ class CreateDbHomeWithDbSystemIdFromBackupDetails(CreateDbHomeBase):
         self._source = None
         self._db_system_id = None
         self._database = None
-        self._source = 'DB_BACKUP'
+        self._source = 'DATABASE'
 
     @property
     def db_system_id(self):
         """
-        **[Required]** Gets the db_system_id of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+        **[Required]** Gets the db_system_id of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
         The `OCID`__ of the DB system.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
-        :return: The db_system_id of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+        :return: The db_system_id of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
         :rtype: str
         """
         return self._db_system_id
@@ -74,13 +74,13 @@ class CreateDbHomeWithDbSystemIdFromBackupDetails(CreateDbHomeBase):
     @db_system_id.setter
     def db_system_id(self, db_system_id):
         """
-        Sets the db_system_id of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+        Sets the db_system_id of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
         The `OCID`__ of the DB system.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
-        :param db_system_id: The db_system_id of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+        :param db_system_id: The db_system_id of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
         :type: str
         """
         self._db_system_id = db_system_id
@@ -88,20 +88,20 @@ class CreateDbHomeWithDbSystemIdFromBackupDetails(CreateDbHomeBase):
     @property
     def database(self):
         """
-        **[Required]** Gets the database of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+        **[Required]** Gets the database of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
 
-        :return: The database of this CreateDbHomeWithDbSystemIdFromBackupDetails.
-        :rtype: CreateDatabaseFromBackupDetails
+        :return: The database of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
+        :rtype: CreateDatabaseFromAnotherDatabaseDetails
         """
         return self._database
 
     @database.setter
     def database(self, database):
         """
-        Sets the database of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+        Sets the database of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
 
-        :param database: The database of this CreateDbHomeWithDbSystemIdFromBackupDetails.
-        :type: CreateDatabaseFromBackupDetails
+        :param database: The database of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
+        :type: CreateDatabaseFromAnotherDatabaseDetails
         """
         self._database = database
 

--- a/src/oci/database/models/create_db_home_with_vm_cluster_id_details.py
+++ b/src/oci/database/models/create_db_home_with_vm_cluster_id_details.py
@@ -25,7 +25,7 @@ class CreateDbHomeWithVmClusterIdDetails(CreateDbHomeBase):
 
         :param source:
             The value to assign to the source property of this CreateDbHomeWithVmClusterIdDetails.
-            Allowed values for this property are: "NONE", "DB_BACKUP", "VM_CLUSTER_NEW"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_NEW"
         :type source: str
 
         :param vm_cluster_id:

--- a/src/oci/database/models/database.py
+++ b/src/oci/database/models/database.py
@@ -108,6 +108,10 @@ class Database(object):
             The value to assign to the time_created property of this Database.
         :type time_created: datetime
 
+        :param last_backup_timestamp:
+            The value to assign to the last_backup_timestamp property of this Database.
+        :type last_backup_timestamp: datetime
+
         :param db_backup_config:
             The value to assign to the db_backup_config property of this Database.
         :type db_backup_config: DbBackupConfig
@@ -140,6 +144,7 @@ class Database(object):
             'lifecycle_details': 'str',
             'lifecycle_state': 'str',
             'time_created': 'datetime',
+            'last_backup_timestamp': 'datetime',
             'db_backup_config': 'DbBackupConfig',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
@@ -161,6 +166,7 @@ class Database(object):
             'lifecycle_details': 'lifecycleDetails',
             'lifecycle_state': 'lifecycleState',
             'time_created': 'timeCreated',
+            'last_backup_timestamp': 'lastBackupTimestamp',
             'db_backup_config': 'dbBackupConfig',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
@@ -181,6 +187,7 @@ class Database(object):
         self._lifecycle_details = None
         self._lifecycle_state = None
         self._time_created = None
+        self._last_backup_timestamp = None
         self._db_backup_config = None
         self._freeform_tags = None
         self._defined_tags = None
@@ -547,6 +554,30 @@ class Database(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def last_backup_timestamp(self):
+        """
+        Gets the last_backup_timestamp of this Database.
+        The date and time when the latest database backup was created.
+
+
+        :return: The last_backup_timestamp of this Database.
+        :rtype: datetime
+        """
+        return self._last_backup_timestamp
+
+    @last_backup_timestamp.setter
+    def last_backup_timestamp(self, last_backup_timestamp):
+        """
+        Sets the last_backup_timestamp of this Database.
+        The date and time when the latest database backup was created.
+
+
+        :param last_backup_timestamp: The last_backup_timestamp of this Database.
+        :type: datetime
+        """
+        self._last_backup_timestamp = last_backup_timestamp
 
     @property
     def db_backup_config(self):

--- a/src/oci/database/models/database_summary.py
+++ b/src/oci/database/models/database_summary.py
@@ -115,6 +115,10 @@ class DatabaseSummary(object):
             The value to assign to the time_created property of this DatabaseSummary.
         :type time_created: datetime
 
+        :param last_backup_timestamp:
+            The value to assign to the last_backup_timestamp property of this DatabaseSummary.
+        :type last_backup_timestamp: datetime
+
         :param db_backup_config:
             The value to assign to the db_backup_config property of this DatabaseSummary.
         :type db_backup_config: DbBackupConfig
@@ -147,6 +151,7 @@ class DatabaseSummary(object):
             'lifecycle_details': 'str',
             'lifecycle_state': 'str',
             'time_created': 'datetime',
+            'last_backup_timestamp': 'datetime',
             'db_backup_config': 'DbBackupConfig',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
@@ -168,6 +173,7 @@ class DatabaseSummary(object):
             'lifecycle_details': 'lifecycleDetails',
             'lifecycle_state': 'lifecycleState',
             'time_created': 'timeCreated',
+            'last_backup_timestamp': 'lastBackupTimestamp',
             'db_backup_config': 'dbBackupConfig',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
@@ -188,6 +194,7 @@ class DatabaseSummary(object):
         self._lifecycle_details = None
         self._lifecycle_state = None
         self._time_created = None
+        self._last_backup_timestamp = None
         self._db_backup_config = None
         self._freeform_tags = None
         self._defined_tags = None
@@ -554,6 +561,30 @@ class DatabaseSummary(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def last_backup_timestamp(self):
+        """
+        Gets the last_backup_timestamp of this DatabaseSummary.
+        The date and time when the latest database backup was created.
+
+
+        :return: The last_backup_timestamp of this DatabaseSummary.
+        :rtype: datetime
+        """
+        return self._last_backup_timestamp
+
+    @last_backup_timestamp.setter
+    def last_backup_timestamp(self, last_backup_timestamp):
+        """
+        Sets the last_backup_timestamp of this DatabaseSummary.
+        The date and time when the latest database backup was created.
+
+
+        :param last_backup_timestamp: The last_backup_timestamp of this DatabaseSummary.
+        :type: datetime
+        """
+        self._last_backup_timestamp = last_backup_timestamp
 
     @property
     def db_backup_config(self):

--- a/src/oci/database/models/launch_db_system_base.py
+++ b/src/oci/database/models/launch_db_system_base.py
@@ -23,12 +23,17 @@ class LaunchDbSystemBase(object):
     #: This constant has a value of "DB_BACKUP"
     SOURCE_DB_BACKUP = "DB_BACKUP"
 
+    #: A constant which can be used with the source property of a LaunchDbSystemBase.
+    #: This constant has a value of "DATABASE"
+    SOURCE_DATABASE = "DATABASE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new LaunchDbSystemBase object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
         * :class:`~oci.database.models.LaunchDbSystemDetails`
+        * :class:`~oci.database.models.LaunchDbSystemFromDatabaseDetails`
         * :class:`~oci.database.models.LaunchDbSystemFromBackupDetails`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
@@ -123,7 +128,7 @@ class LaunchDbSystemBase(object):
 
         :param source:
             The value to assign to the source property of this LaunchDbSystemBase.
-            Allowed values for this property are: "NONE", "DB_BACKUP"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE"
         :type source: str
 
         """
@@ -213,6 +218,9 @@ class LaunchDbSystemBase(object):
 
         if type == 'NONE':
             return 'LaunchDbSystemDetails'
+
+        if type == 'DATABASE':
+            return 'LaunchDbSystemFromDatabaseDetails'
 
         if type == 'DB_BACKUP':
             return 'LaunchDbSystemFromBackupDetails'
@@ -906,9 +914,10 @@ class LaunchDbSystemBase(object):
         """
         Gets the source of this LaunchDbSystemBase.
         The source of the database:
-        Use `NONE` for creating a new database. Use `DB_BACKUP` for creating a new database by restoring from a backup. The default is `NONE`.
+        Use `NONE` for creating a new database. Use `DB_BACKUP` for creating a new database by restoring from a backup. Use `DATABASE` for creating
+        a new database from an existing database, including archive redo log data. The default is `NONE`.
 
-        Allowed values for this property are: "NONE", "DB_BACKUP"
+        Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE"
 
 
         :return: The source of this LaunchDbSystemBase.
@@ -921,13 +930,14 @@ class LaunchDbSystemBase(object):
         """
         Sets the source of this LaunchDbSystemBase.
         The source of the database:
-        Use `NONE` for creating a new database. Use `DB_BACKUP` for creating a new database by restoring from a backup. The default is `NONE`.
+        Use `NONE` for creating a new database. Use `DB_BACKUP` for creating a new database by restoring from a backup. Use `DATABASE` for creating
+        a new database from an existing database, including archive redo log data. The default is `NONE`.
 
 
         :param source: The source of this LaunchDbSystemBase.
         :type: str
         """
-        allowed_values = ["NONE", "DB_BACKUP"]
+        allowed_values = ["NONE", "DB_BACKUP", "DATABASE"]
         if not value_allowed_none_or_none_sentinel(source, allowed_values):
             raise ValueError(
                 "Invalid value for `source`, must be None or one of {0}"

--- a/src/oci/database/models/launch_db_system_from_backup_details.py
+++ b/src/oci/database/models/launch_db_system_from_backup_details.py
@@ -141,7 +141,7 @@ class LaunchDbSystemFromBackupDetails(LaunchDbSystemBase):
 
         :param source:
             The value to assign to the source property of this LaunchDbSystemFromBackupDetails.
-            Allowed values for this property are: "NONE", "DB_BACKUP"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE"
         :type source: str
 
         :param db_home:

--- a/src/oci/database/models/launch_db_system_from_database_details.py
+++ b/src/oci/database/models/launch_db_system_from_database_details.py
@@ -8,164 +8,160 @@ from oci.decorators import init_model_state_from_kwargs
 
 
 @init_model_state_from_kwargs
-class LaunchDbSystemDetails(LaunchDbSystemBase):
+class LaunchDbSystemFromDatabaseDetails(LaunchDbSystemBase):
     """
-    Used for creating a new DB system. Does not use backups or an existing database for the creation of the initial database.
+    Used for creating a new DB system from a database, including archived redo log data.
     """
 
-    #: A constant which can be used with the database_edition property of a LaunchDbSystemDetails.
+    #: A constant which can be used with the database_edition property of a LaunchDbSystemFromDatabaseDetails.
     #: This constant has a value of "STANDARD_EDITION"
     DATABASE_EDITION_STANDARD_EDITION = "STANDARD_EDITION"
 
-    #: A constant which can be used with the database_edition property of a LaunchDbSystemDetails.
+    #: A constant which can be used with the database_edition property of a LaunchDbSystemFromDatabaseDetails.
     #: This constant has a value of "ENTERPRISE_EDITION"
     DATABASE_EDITION_ENTERPRISE_EDITION = "ENTERPRISE_EDITION"
 
-    #: A constant which can be used with the database_edition property of a LaunchDbSystemDetails.
+    #: A constant which can be used with the database_edition property of a LaunchDbSystemFromDatabaseDetails.
     #: This constant has a value of "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
     DATABASE_EDITION_ENTERPRISE_EDITION_HIGH_PERFORMANCE = "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
 
-    #: A constant which can be used with the database_edition property of a LaunchDbSystemDetails.
+    #: A constant which can be used with the database_edition property of a LaunchDbSystemFromDatabaseDetails.
     #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
     DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
 
-    #: A constant which can be used with the disk_redundancy property of a LaunchDbSystemDetails.
+    #: A constant which can be used with the disk_redundancy property of a LaunchDbSystemFromDatabaseDetails.
     #: This constant has a value of "HIGH"
     DISK_REDUNDANCY_HIGH = "HIGH"
 
-    #: A constant which can be used with the disk_redundancy property of a LaunchDbSystemDetails.
+    #: A constant which can be used with the disk_redundancy property of a LaunchDbSystemFromDatabaseDetails.
     #: This constant has a value of "NORMAL"
     DISK_REDUNDANCY_NORMAL = "NORMAL"
 
-    #: A constant which can be used with the license_model property of a LaunchDbSystemDetails.
+    #: A constant which can be used with the license_model property of a LaunchDbSystemFromDatabaseDetails.
     #: This constant has a value of "LICENSE_INCLUDED"
     LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
 
-    #: A constant which can be used with the license_model property of a LaunchDbSystemDetails.
+    #: A constant which can be used with the license_model property of a LaunchDbSystemFromDatabaseDetails.
     #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
     LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
 
     def __init__(self, **kwargs):
         """
-        Initializes a new LaunchDbSystemDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.LaunchDbSystemDetails.source` attribute
-        of this class is ``NONE`` and it should not be changed.
+        Initializes a new LaunchDbSystemFromDatabaseDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.LaunchDbSystemFromDatabaseDetails.source` attribute
+        of this class is ``DATABASE`` and it should not be changed.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param compartment_id:
-            The value to assign to the compartment_id property of this LaunchDbSystemDetails.
+            The value to assign to the compartment_id property of this LaunchDbSystemFromDatabaseDetails.
         :type compartment_id: str
 
         :param fault_domains:
-            The value to assign to the fault_domains property of this LaunchDbSystemDetails.
+            The value to assign to the fault_domains property of this LaunchDbSystemFromDatabaseDetails.
         :type fault_domains: list[str]
 
         :param display_name:
-            The value to assign to the display_name property of this LaunchDbSystemDetails.
+            The value to assign to the display_name property of this LaunchDbSystemFromDatabaseDetails.
         :type display_name: str
 
         :param availability_domain:
-            The value to assign to the availability_domain property of this LaunchDbSystemDetails.
+            The value to assign to the availability_domain property of this LaunchDbSystemFromDatabaseDetails.
         :type availability_domain: str
 
         :param subnet_id:
-            The value to assign to the subnet_id property of this LaunchDbSystemDetails.
+            The value to assign to the subnet_id property of this LaunchDbSystemFromDatabaseDetails.
         :type subnet_id: str
 
         :param backup_subnet_id:
-            The value to assign to the backup_subnet_id property of this LaunchDbSystemDetails.
+            The value to assign to the backup_subnet_id property of this LaunchDbSystemFromDatabaseDetails.
         :type backup_subnet_id: str
 
         :param nsg_ids:
-            The value to assign to the nsg_ids property of this LaunchDbSystemDetails.
+            The value to assign to the nsg_ids property of this LaunchDbSystemFromDatabaseDetails.
         :type nsg_ids: list[str]
 
         :param backup_network_nsg_ids:
-            The value to assign to the backup_network_nsg_ids property of this LaunchDbSystemDetails.
+            The value to assign to the backup_network_nsg_ids property of this LaunchDbSystemFromDatabaseDetails.
         :type backup_network_nsg_ids: list[str]
 
         :param shape:
-            The value to assign to the shape property of this LaunchDbSystemDetails.
+            The value to assign to the shape property of this LaunchDbSystemFromDatabaseDetails.
         :type shape: str
 
         :param time_zone:
-            The value to assign to the time_zone property of this LaunchDbSystemDetails.
+            The value to assign to the time_zone property of this LaunchDbSystemFromDatabaseDetails.
         :type time_zone: str
 
         :param db_system_options:
-            The value to assign to the db_system_options property of this LaunchDbSystemDetails.
+            The value to assign to the db_system_options property of this LaunchDbSystemFromDatabaseDetails.
         :type db_system_options: DbSystemOptions
 
         :param sparse_diskgroup:
-            The value to assign to the sparse_diskgroup property of this LaunchDbSystemDetails.
+            The value to assign to the sparse_diskgroup property of this LaunchDbSystemFromDatabaseDetails.
         :type sparse_diskgroup: bool
 
         :param ssh_public_keys:
-            The value to assign to the ssh_public_keys property of this LaunchDbSystemDetails.
+            The value to assign to the ssh_public_keys property of this LaunchDbSystemFromDatabaseDetails.
         :type ssh_public_keys: list[str]
 
         :param hostname:
-            The value to assign to the hostname property of this LaunchDbSystemDetails.
+            The value to assign to the hostname property of this LaunchDbSystemFromDatabaseDetails.
         :type hostname: str
 
         :param domain:
-            The value to assign to the domain property of this LaunchDbSystemDetails.
+            The value to assign to the domain property of this LaunchDbSystemFromDatabaseDetails.
         :type domain: str
 
         :param cpu_core_count:
-            The value to assign to the cpu_core_count property of this LaunchDbSystemDetails.
+            The value to assign to the cpu_core_count property of this LaunchDbSystemFromDatabaseDetails.
         :type cpu_core_count: int
 
         :param cluster_name:
-            The value to assign to the cluster_name property of this LaunchDbSystemDetails.
+            The value to assign to the cluster_name property of this LaunchDbSystemFromDatabaseDetails.
         :type cluster_name: str
 
         :param data_storage_percentage:
-            The value to assign to the data_storage_percentage property of this LaunchDbSystemDetails.
+            The value to assign to the data_storage_percentage property of this LaunchDbSystemFromDatabaseDetails.
         :type data_storage_percentage: int
 
         :param initial_data_storage_size_in_gb:
-            The value to assign to the initial_data_storage_size_in_gb property of this LaunchDbSystemDetails.
+            The value to assign to the initial_data_storage_size_in_gb property of this LaunchDbSystemFromDatabaseDetails.
         :type initial_data_storage_size_in_gb: int
 
         :param node_count:
-            The value to assign to the node_count property of this LaunchDbSystemDetails.
+            The value to assign to the node_count property of this LaunchDbSystemFromDatabaseDetails.
         :type node_count: int
 
         :param freeform_tags:
-            The value to assign to the freeform_tags property of this LaunchDbSystemDetails.
+            The value to assign to the freeform_tags property of this LaunchDbSystemFromDatabaseDetails.
         :type freeform_tags: dict(str, str)
 
         :param defined_tags:
-            The value to assign to the defined_tags property of this LaunchDbSystemDetails.
+            The value to assign to the defined_tags property of this LaunchDbSystemFromDatabaseDetails.
         :type defined_tags: dict(str, dict(str, object))
 
         :param source:
-            The value to assign to the source property of this LaunchDbSystemDetails.
+            The value to assign to the source property of this LaunchDbSystemFromDatabaseDetails.
             Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE"
         :type source: str
 
         :param db_home:
-            The value to assign to the db_home property of this LaunchDbSystemDetails.
-        :type db_home: CreateDbHomeDetails
+            The value to assign to the db_home property of this LaunchDbSystemFromDatabaseDetails.
+        :type db_home: CreateDbHomeFromDatabaseDetails
 
         :param database_edition:
-            The value to assign to the database_edition property of this LaunchDbSystemDetails.
+            The value to assign to the database_edition property of this LaunchDbSystemFromDatabaseDetails.
             Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
         :type database_edition: str
 
         :param disk_redundancy:
-            The value to assign to the disk_redundancy property of this LaunchDbSystemDetails.
+            The value to assign to the disk_redundancy property of this LaunchDbSystemFromDatabaseDetails.
             Allowed values for this property are: "HIGH", "NORMAL"
         :type disk_redundancy: str
 
         :param license_model:
-            The value to assign to the license_model property of this LaunchDbSystemDetails.
+            The value to assign to the license_model property of this LaunchDbSystemFromDatabaseDetails.
             Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
         :type license_model: str
-
-        :param maintenance_window_details:
-            The value to assign to the maintenance_window_details property of this LaunchDbSystemDetails.
-        :type maintenance_window_details: MaintenanceWindow
 
         """
         self.swagger_types = {
@@ -192,11 +188,10 @@ class LaunchDbSystemDetails(LaunchDbSystemBase):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str',
-            'db_home': 'CreateDbHomeDetails',
+            'db_home': 'CreateDbHomeFromDatabaseDetails',
             'database_edition': 'str',
             'disk_redundancy': 'str',
-            'license_model': 'str',
-            'maintenance_window_details': 'MaintenanceWindow'
+            'license_model': 'str'
         }
 
         self.attribute_map = {
@@ -226,8 +221,7 @@ class LaunchDbSystemDetails(LaunchDbSystemBase):
             'db_home': 'dbHome',
             'database_edition': 'databaseEdition',
             'disk_redundancy': 'diskRedundancy',
-            'license_model': 'licenseModel',
-            'maintenance_window_details': 'maintenanceWindowDetails'
+            'license_model': 'licenseModel'
         }
 
         self._compartment_id = None
@@ -257,40 +251,39 @@ class LaunchDbSystemDetails(LaunchDbSystemBase):
         self._database_edition = None
         self._disk_redundancy = None
         self._license_model = None
-        self._maintenance_window_details = None
-        self._source = 'NONE'
+        self._source = 'DATABASE'
 
     @property
     def db_home(self):
         """
-        **[Required]** Gets the db_home of this LaunchDbSystemDetails.
+        **[Required]** Gets the db_home of this LaunchDbSystemFromDatabaseDetails.
 
-        :return: The db_home of this LaunchDbSystemDetails.
-        :rtype: CreateDbHomeDetails
+        :return: The db_home of this LaunchDbSystemFromDatabaseDetails.
+        :rtype: CreateDbHomeFromDatabaseDetails
         """
         return self._db_home
 
     @db_home.setter
     def db_home(self, db_home):
         """
-        Sets the db_home of this LaunchDbSystemDetails.
+        Sets the db_home of this LaunchDbSystemFromDatabaseDetails.
 
-        :param db_home: The db_home of this LaunchDbSystemDetails.
-        :type: CreateDbHomeDetails
+        :param db_home: The db_home of this LaunchDbSystemFromDatabaseDetails.
+        :type: CreateDbHomeFromDatabaseDetails
         """
         self._db_home = db_home
 
     @property
     def database_edition(self):
         """
-        **[Required]** Gets the database_edition of this LaunchDbSystemDetails.
+        **[Required]** Gets the database_edition of this LaunchDbSystemFromDatabaseDetails.
         The Oracle Database Edition that applies to all the databases on the DB system.
         Exadata DB systems and 2-node RAC DB systems require ENTERPRISE_EDITION_EXTREME_PERFORMANCE.
 
         Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
 
 
-        :return: The database_edition of this LaunchDbSystemDetails.
+        :return: The database_edition of this LaunchDbSystemFromDatabaseDetails.
         :rtype: str
         """
         return self._database_edition
@@ -298,12 +291,12 @@ class LaunchDbSystemDetails(LaunchDbSystemBase):
     @database_edition.setter
     def database_edition(self, database_edition):
         """
-        Sets the database_edition of this LaunchDbSystemDetails.
+        Sets the database_edition of this LaunchDbSystemFromDatabaseDetails.
         The Oracle Database Edition that applies to all the databases on the DB system.
         Exadata DB systems and 2-node RAC DB systems require ENTERPRISE_EDITION_EXTREME_PERFORMANCE.
 
 
-        :param database_edition: The database_edition of this LaunchDbSystemDetails.
+        :param database_edition: The database_edition of this LaunchDbSystemFromDatabaseDetails.
         :type: str
         """
         allowed_values = ["STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"]
@@ -317,15 +310,15 @@ class LaunchDbSystemDetails(LaunchDbSystemBase):
     @property
     def disk_redundancy(self):
         """
-        Gets the disk_redundancy of this LaunchDbSystemDetails.
+        Gets the disk_redundancy of this LaunchDbSystemFromDatabaseDetails.
         The type of redundancy configured for the DB system.
-        Normal is 2-way redundancy, recommended for test and development systems.
-        High is 3-way redundancy, recommended for production systems.
+        NORMAL 2-way redundancy, recommended for test and development systems.
+        HIGH is 3-way redundancy, recommended for production systems.
 
         Allowed values for this property are: "HIGH", "NORMAL"
 
 
-        :return: The disk_redundancy of this LaunchDbSystemDetails.
+        :return: The disk_redundancy of this LaunchDbSystemFromDatabaseDetails.
         :rtype: str
         """
         return self._disk_redundancy
@@ -333,13 +326,13 @@ class LaunchDbSystemDetails(LaunchDbSystemBase):
     @disk_redundancy.setter
     def disk_redundancy(self, disk_redundancy):
         """
-        Sets the disk_redundancy of this LaunchDbSystemDetails.
+        Sets the disk_redundancy of this LaunchDbSystemFromDatabaseDetails.
         The type of redundancy configured for the DB system.
-        Normal is 2-way redundancy, recommended for test and development systems.
-        High is 3-way redundancy, recommended for production systems.
+        NORMAL 2-way redundancy, recommended for test and development systems.
+        HIGH is 3-way redundancy, recommended for production systems.
 
 
-        :param disk_redundancy: The disk_redundancy of this LaunchDbSystemDetails.
+        :param disk_redundancy: The disk_redundancy of this LaunchDbSystemFromDatabaseDetails.
         :type: str
         """
         allowed_values = ["HIGH", "NORMAL"]
@@ -353,13 +346,13 @@ class LaunchDbSystemDetails(LaunchDbSystemBase):
     @property
     def license_model(self):
         """
-        Gets the license_model of this LaunchDbSystemDetails.
+        Gets the license_model of this LaunchDbSystemFromDatabaseDetails.
         The Oracle license model that applies to all the databases on the DB system. The default is LICENSE_INCLUDED.
 
         Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
 
 
-        :return: The license_model of this LaunchDbSystemDetails.
+        :return: The license_model of this LaunchDbSystemFromDatabaseDetails.
         :rtype: str
         """
         return self._license_model
@@ -367,11 +360,11 @@ class LaunchDbSystemDetails(LaunchDbSystemBase):
     @license_model.setter
     def license_model(self, license_model):
         """
-        Sets the license_model of this LaunchDbSystemDetails.
+        Sets the license_model of this LaunchDbSystemFromDatabaseDetails.
         The Oracle license model that applies to all the databases on the DB system. The default is LICENSE_INCLUDED.
 
 
-        :param license_model: The license_model of this LaunchDbSystemDetails.
+        :param license_model: The license_model of this LaunchDbSystemFromDatabaseDetails.
         :type: str
         """
         allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
@@ -381,26 +374,6 @@ class LaunchDbSystemDetails(LaunchDbSystemBase):
                 .format(allowed_values)
             )
         self._license_model = license_model
-
-    @property
-    def maintenance_window_details(self):
-        """
-        Gets the maintenance_window_details of this LaunchDbSystemDetails.
-
-        :return: The maintenance_window_details of this LaunchDbSystemDetails.
-        :rtype: MaintenanceWindow
-        """
-        return self._maintenance_window_details
-
-    @maintenance_window_details.setter
-    def maintenance_window_details(self, maintenance_window_details):
-        """
-        Sets the maintenance_window_details of this LaunchDbSystemDetails.
-
-        :param maintenance_window_details: The maintenance_window_details of this LaunchDbSystemDetails.
-        :type: MaintenanceWindow
-        """
-        self._maintenance_window_details = maintenance_window_details
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/dts/appliance_export_job_client.py
+++ b/src/oci/dts/appliance_export_job_client.py
@@ -75,7 +75,7 @@ class ApplianceExportJobClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
-            'service_endpoint_template': 'https://datatransfer.{region}.{secondLevelDomain}',
+            'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("appliance_export_job", config, signer, dts_type_mapping, **base_client_init_kwargs)

--- a/src/oci/dts/shipping_vendors_client.py
+++ b/src/oci/dts/shipping_vendors_client.py
@@ -75,7 +75,7 @@ class ShippingVendorsClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
-            'service_endpoint_template': 'https://datatransfer.{region}.{secondLevelDomain}',
+            'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("shipping_vendors", config, signer, dts_type_mapping, **base_client_init_kwargs)

--- a/src/oci/dts/transfer_appliance_client.py
+++ b/src/oci/dts/transfer_appliance_client.py
@@ -75,7 +75,7 @@ class TransferApplianceClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
-            'service_endpoint_template': 'https://datatransfer.{region}.{secondLevelDomain}',
+            'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("transfer_appliance", config, signer, dts_type_mapping, **base_client_init_kwargs)

--- a/src/oci/dts/transfer_appliance_entitlement_client.py
+++ b/src/oci/dts/transfer_appliance_entitlement_client.py
@@ -75,7 +75,7 @@ class TransferApplianceEntitlementClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
-            'service_endpoint_template': 'https://datatransfer.{region}.{secondLevelDomain}',
+            'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("transfer_appliance_entitlement", config, signer, dts_type_mapping, **base_client_init_kwargs)

--- a/src/oci/dts/transfer_device_client.py
+++ b/src/oci/dts/transfer_device_client.py
@@ -75,7 +75,7 @@ class TransferDeviceClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
-            'service_endpoint_template': 'https://datatransfer.{region}.{secondLevelDomain}',
+            'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("transfer_device", config, signer, dts_type_mapping, **base_client_init_kwargs)

--- a/src/oci/dts/transfer_job_client.py
+++ b/src/oci/dts/transfer_job_client.py
@@ -75,7 +75,7 @@ class TransferJobClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
-            'service_endpoint_template': 'https://datatransfer.{region}.{secondLevelDomain}',
+            'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("transfer_job", config, signer, dts_type_mapping, **base_client_init_kwargs)

--- a/src/oci/dts/transfer_package_client.py
+++ b/src/oci/dts/transfer_package_client.py
@@ -75,7 +75,7 @@ class TransferPackageClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
-            'service_endpoint_template': 'https://datatransfer.{region}.{secondLevelDomain}',
+            'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("transfer_package", config, signer, dts_type_mapping, **base_client_init_kwargs)

--- a/src/oci/identity/identity_client.py
+++ b/src/oci/identity/identity_client.py
@@ -5424,6 +5424,32 @@ class IdentityClient(object):
             and all compartments and subcompartments in the tenancy are
             returned depending on the the setting of `accessLevel`.
 
+        :param str name: (optional)
+            A filter to only return resources that match the given name exactly.
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+            TIMECREATED is descending. Default order for NAME is ascending. The NAME
+            sort order is case sensitive.
+
+            **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+            optionally filter by Availability Domain if the scope of the resource type is within a
+            single Availability Domain. If you call one of these \"List\" operations without specifying
+            an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+
+            Allowed values are: "TIMECREATED", "NAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+            is case sensitive.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+
+            Allowed values are: "CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -5444,7 +5470,11 @@ class IdentityClient(object):
             "page",
             "limit",
             "access_level",
-            "compartment_id_in_subtree"
+            "compartment_id_in_subtree",
+            "name",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -5458,12 +5488,37 @@ class IdentityClient(object):
                     "Invalid value for `access_level`, must be one of {0}".format(access_level_allowed_values)
                 )
 
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "NAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
         query_params = {
             "compartmentId": compartment_id,
             "page": kwargs.get("page", missing),
             "limit": kwargs.get("limit", missing),
             "accessLevel": kwargs.get("access_level", missing),
-            "compartmentIdInSubtree": kwargs.get("compartment_id_in_subtree", missing)
+            "compartmentIdInSubtree": kwargs.get("compartment_id_in_subtree", missing),
+            "name": kwargs.get("name", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -5648,6 +5703,32 @@ class IdentityClient(object):
         :param int limit: (optional)
             The maximum number of items to return in a paginated \"List\" call.
 
+        :param str name: (optional)
+            A filter to only return resources that match the given name exactly.
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+            TIMECREATED is descending. Default order for NAME is ascending. The NAME
+            sort order is case sensitive.
+
+            **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+            optionally filter by Availability Domain if the scope of the resource type is within a
+            single Availability Domain. If you call one of these \"List\" operations without specifying
+            an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+
+            Allowed values are: "TIMECREATED", "NAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+            is case sensitive.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+
+            Allowed values are: "CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -5666,17 +5747,46 @@ class IdentityClient(object):
         expected_kwargs = [
             "retry_strategy",
             "page",
-            "limit"
+            "limit",
+            "name",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
             raise ValueError(
                 "list_dynamic_groups got unknown kwargs: {!r}".format(extra_kwargs))
 
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "NAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
         query_params = {
             "compartmentId": compartment_id,
             "page": kwargs.get("page", missing),
-            "limit": kwargs.get("limit", missing)
+            "limit": kwargs.get("limit", missing),
+            "name": kwargs.get("name", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -5789,6 +5899,32 @@ class IdentityClient(object):
         :param int limit: (optional)
             The maximum number of items to return in a paginated \"List\" call.
 
+        :param str name: (optional)
+            A filter to only return resources that match the given name exactly.
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+            TIMECREATED is descending. Default order for NAME is ascending. The NAME
+            sort order is case sensitive.
+
+            **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+            optionally filter by Availability Domain if the scope of the resource type is within a
+            single Availability Domain. If you call one of these \"List\" operations without specifying
+            an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+
+            Allowed values are: "TIMECREATED", "NAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+            is case sensitive.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+
+            Allowed values are: "CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -5807,17 +5943,46 @@ class IdentityClient(object):
         expected_kwargs = [
             "retry_strategy",
             "page",
-            "limit"
+            "limit",
+            "name",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
             raise ValueError(
                 "list_groups got unknown kwargs: {!r}".format(extra_kwargs))
 
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "NAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
         query_params = {
             "compartmentId": compartment_id,
             "page": kwargs.get("page", missing),
-            "limit": kwargs.get("limit", missing)
+            "limit": kwargs.get("limit", missing),
+            "name": kwargs.get("name", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -5860,6 +6025,14 @@ class IdentityClient(object):
         :param int limit: (optional)
             The maximum number of items to return in a paginated \"List\" call.
 
+        :param str name: (optional)
+            A filter to only return resources that match the given name exactly.
+
+        :param str lifecycle_state: (optional)
+            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+
+            Allowed values are: "CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -5878,7 +6051,9 @@ class IdentityClient(object):
         expected_kwargs = [
             "retry_strategy",
             "page",
-            "limit"
+            "limit",
+            "name",
+            "lifecycle_state"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -5895,9 +6070,18 @@ class IdentityClient(object):
             if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
 
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
         query_params = {
             "page": kwargs.get("page", missing),
-            "limit": kwargs.get("limit", missing)
+            "limit": kwargs.get("limit", missing),
+            "name": kwargs.get("name", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -5952,6 +6136,32 @@ class IdentityClient(object):
         :param int limit: (optional)
             The maximum number of items to return in a paginated \"List\" call.
 
+        :param str name: (optional)
+            A filter to only return resources that match the given name exactly.
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+            TIMECREATED is descending. Default order for NAME is ascending. The NAME
+            sort order is case sensitive.
+
+            **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+            optionally filter by Availability Domain if the scope of the resource type is within a
+            single Availability Domain. If you call one of these \"List\" operations without specifying
+            an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+
+            Allowed values are: "TIMECREATED", "NAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+            is case sensitive.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+
+            Allowed values are: "CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -5970,18 +6180,47 @@ class IdentityClient(object):
         expected_kwargs = [
             "retry_strategy",
             "page",
-            "limit"
+            "limit",
+            "name",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
             raise ValueError(
                 "list_identity_providers got unknown kwargs: {!r}".format(extra_kwargs))
 
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "NAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
         query_params = {
             "protocol": protocol,
             "compartmentId": compartment_id,
             "page": kwargs.get("page", missing),
-            "limit": kwargs.get("limit", missing)
+            "limit": kwargs.get("limit", missing),
+            "name": kwargs.get("name", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -6229,6 +6468,32 @@ class IdentityClient(object):
         :param int limit: (optional)
             The maximum number of items to return in a paginated \"List\" call.
 
+        :param str name: (optional)
+            A filter to only return resources that match the given name exactly.
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+            TIMECREATED is descending. Default order for NAME is ascending. The NAME
+            sort order is case sensitive.
+
+            **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+            optionally filter by Availability Domain if the scope of the resource type is within a
+            single Availability Domain. If you call one of these \"List\" operations without specifying
+            an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+
+            Allowed values are: "TIMECREATED", "NAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+            is case sensitive.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+
+            Allowed values are: "CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -6247,17 +6512,46 @@ class IdentityClient(object):
         expected_kwargs = [
             "retry_strategy",
             "page",
-            "limit"
+            "limit",
+            "name",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
             raise ValueError(
                 "list_network_sources got unknown kwargs: {!r}".format(extra_kwargs))
 
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "NAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
         query_params = {
             "compartmentId": compartment_id,
             "page": kwargs.get("page", missing),
-            "limit": kwargs.get("limit", missing)
+            "limit": kwargs.get("limit", missing),
+            "name": kwargs.get("name", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -6402,6 +6696,32 @@ class IdentityClient(object):
         :param int limit: (optional)
             The maximum number of items to return in a paginated \"List\" call.
 
+        :param str name: (optional)
+            A filter to only return resources that match the given name exactly.
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+            TIMECREATED is descending. Default order for NAME is ascending. The NAME
+            sort order is case sensitive.
+
+            **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+            optionally filter by Availability Domain if the scope of the resource type is within a
+            single Availability Domain. If you call one of these \"List\" operations without specifying
+            an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+
+            Allowed values are: "TIMECREATED", "NAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+            is case sensitive.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+
+            Allowed values are: "CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -6420,17 +6740,46 @@ class IdentityClient(object):
         expected_kwargs = [
             "retry_strategy",
             "page",
-            "limit"
+            "limit",
+            "name",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
             raise ValueError(
                 "list_policies got unknown kwargs: {!r}".format(extra_kwargs))
 
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "NAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
         query_params = {
             "compartmentId": compartment_id,
             "page": kwargs.get("page", missing),
-            "limit": kwargs.get("limit", missing)
+            "limit": kwargs.get("limit", missing),
+            "name": kwargs.get("name", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -7339,6 +7688,32 @@ class IdentityClient(object):
         :param str external_identifier: (optional)
             The id of a user in the identity provider.
 
+        :param str name: (optional)
+            A filter to only return resources that match the given name exactly.
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+            TIMECREATED is descending. Default order for NAME is ascending. The NAME
+            sort order is case sensitive.
+
+            **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+            optionally filter by Availability Domain if the scope of the resource type is within a
+            single Availability Domain. If you call one of these \"List\" operations without specifying
+            an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+
+            Allowed values are: "TIMECREATED", "NAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+            is case sensitive.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+
+            Allowed values are: "CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -7359,19 +7734,48 @@ class IdentityClient(object):
             "page",
             "limit",
             "identity_provider_id",
-            "external_identifier"
+            "external_identifier",
+            "name",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
             raise ValueError(
                 "list_users got unknown kwargs: {!r}".format(extra_kwargs))
 
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "NAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
         query_params = {
             "compartmentId": compartment_id,
             "page": kwargs.get("page", missing),
             "limit": kwargs.get("limit", missing),
             "identityProviderId": kwargs.get("identity_provider_id", missing),
-            "externalIdentifier": kwargs.get("external_identifier", missing)
+            "externalIdentifier": kwargs.get("external_identifier", missing),
+            "name": kwargs.get("name", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 

--- a/src/oci/identity/models/user.py
+++ b/src/oci/identity/models/user.py
@@ -82,6 +82,10 @@ class User(object):
             The value to assign to the email property of this User.
         :type email: str
 
+        :param email_verified:
+            The value to assign to the email_verified property of this User.
+        :type email_verified: bool
+
         :param identity_provider_id:
             The value to assign to the identity_provider_id property of this User.
         :type identity_provider_id: str
@@ -127,6 +131,7 @@ class User(object):
             'name': 'str',
             'description': 'str',
             'email': 'str',
+            'email_verified': 'bool',
             'identity_provider_id': 'str',
             'external_identifier': 'str',
             'time_created': 'datetime',
@@ -144,6 +149,7 @@ class User(object):
             'name': 'name',
             'description': 'description',
             'email': 'email',
+            'email_verified': 'emailVerified',
             'identity_provider_id': 'identityProviderId',
             'external_identifier': 'externalIdentifier',
             'time_created': 'timeCreated',
@@ -160,6 +166,7 @@ class User(object):
         self._name = None
         self._description = None
         self._email = None
+        self._email_verified = None
         self._identity_provider_id = None
         self._external_identifier = None
         self._time_created = None
@@ -293,6 +300,30 @@ class User(object):
         :type: str
         """
         self._email = email
+
+    @property
+    def email_verified(self):
+        """
+        Gets the email_verified of this User.
+        Whether the email address has been validated.
+
+
+        :return: The email_verified of this User.
+        :rtype: bool
+        """
+        return self._email_verified
+
+    @email_verified.setter
+    def email_verified(self, email_verified):
+        """
+        Sets the email_verified of this User.
+        Whether the email address has been validated.
+
+
+        :param email_verified: The email_verified of this User.
+        :type: bool
+        """
+        self._email_verified = email_verified
 
     @property
     def identity_provider_id(self):

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.16.0"
+__version__ = "2.16.1"


### PR DESCRIPTION
## Added

* Support for creating a new database from an existing database based on a given timestamp in the Database service

* Support for enabling archive log backups of databases in the Database service

* Support for returning the database version on autonomous container databases in the Database service

* Support for the new DNS format of the Data Transfer service

* Support for scheduled autoscaling, which allows for scaling actions triggered at particular times based on CRON expressions, in the Compute Autoscaling service

* Support for filtering of list APIs for groups, identity providers, identity provider groups, compartments, dynamic groups, network sources, policies, and users by name or lifecycle state in the Identity Service
