### PR TITLE
Releasing version 2.17.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.17.1 - 2020-06-30
+====================
+
+Added
+-----
+* Support for the Usage service
+* Support for the VMware Provisioning service
+* Support for applying one-off patches to databases in the Database service
+* Support for layer-2 virtualization features on vlans in the Networking service
+* Support for all AttachVolumeDetails and ParavirtualizedAttachVolumeDetails properties on instance configurations in the Compute Management service
+* Support for setting HTTP header size and allowing invalid characters in HTTP request headers in the Load Balancing service
+* Support for enabling/disabling HTTP logging. Please see https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/logging.html
+
+====================
 2.17.0 - 2020-06-23
 ====================
 

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -80,6 +80,7 @@ Core Services
     oci.core.models.ChangeSubnetCompartmentDetails
     oci.core.models.ChangeVcnCompartmentDetails
     oci.core.models.ChangeVirtualCircuitCompartmentDetails
+    oci.core.models.ChangeVlanCompartmentDetails
     oci.core.models.ChangeVolumeBackupCompartmentDetails
     oci.core.models.ChangeVolumeCompartmentDetails
     oci.core.models.ChangeVolumeGroupBackupCompartmentDetails
@@ -136,6 +137,7 @@ Core Services
     oci.core.models.CreateVcnDetails
     oci.core.models.CreateVirtualCircuitDetails
     oci.core.models.CreateVirtualCircuitPublicPrefixDetails
+    oci.core.models.CreateVlanDetails
     oci.core.models.CreateVnicDetails
     oci.core.models.CreateVolumeBackupDetails
     oci.core.models.CreateVolumeBackupPolicyAssignmentDetails
@@ -301,6 +303,7 @@ Core Services
     oci.core.models.UpdateTunnelCpeDeviceConfigDetails
     oci.core.models.UpdateVcnDetails
     oci.core.models.UpdateVirtualCircuitDetails
+    oci.core.models.UpdateVlanDetails
     oci.core.models.UpdateVnicDetails
     oci.core.models.UpdateVolumeBackupDetails
     oci.core.models.UpdateVolumeBackupPolicyDetails
@@ -313,6 +316,7 @@ Core Services
     oci.core.models.VirtualCircuit
     oci.core.models.VirtualCircuitBandwidthShape
     oci.core.models.VirtualCircuitPublicPrefix
+    oci.core.models.Vlan
     oci.core.models.Vnic
     oci.core.models.VnicAttachment
     oci.core.models.Volume

--- a/docs/api/core/models/oci.core.models.ChangeVlanCompartmentDetails.rst
+++ b/docs/api/core/models/oci.core.models.ChangeVlanCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeVlanCompartmentDetails
+============================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: ChangeVlanCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.CreateVlanDetails.rst
+++ b/docs/api/core/models/oci.core.models.CreateVlanDetails.rst
@@ -1,0 +1,11 @@
+CreateVlanDetails
+=================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: CreateVlanDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.UpdateVlanDetails.rst
+++ b/docs/api/core/models/oci.core.models.UpdateVlanDetails.rst
@@ -1,0 +1,11 @@
+UpdateVlanDetails
+=================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: UpdateVlanDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.Vlan.rst
+++ b/docs/api/core/models/oci.core.models.Vlan.rst
@@ -1,0 +1,11 @@
+Vlan
+====
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: Vlan
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/landing.rst
+++ b/docs/api/landing.rst
@@ -56,6 +56,9 @@ API Reference
 * :doc:`Nosql <nosql/client/oci.nosql.NosqlClient>`
 * :doc:`Object Storage <object_storage/client/oci.object_storage.ObjectStorageClient>`
 * :doc:`Oce Instance <oce/client/oci.oce.OceInstanceClient>`
+* :doc:`Esxi Host <ocvp/client/oci.ocvp.EsxiHostClient>`
+* :doc:`Sddc <ocvp/client/oci.ocvp.SddcClient>`
+* :doc:`Work Request <work_requests/client/oci.work_requests.WorkRequestClient>`
 * :doc:`Oda <oda/client/oci.oda.OdaClient>`
 * :doc:`Notification Control Plane <ons/client/oci.ons.NotificationControlPlaneClient>`
 * :doc:`Notification Data Plane <ons/client/oci.ons.NotificationDataPlaneClient>`
@@ -65,6 +68,7 @@ API Reference
 * :doc:`Secrets <secrets/client/oci.secrets.SecretsClient>`
 * :doc:`Stream Admin <streaming/client/oci.streaming.StreamAdminClient>`
 * :doc:`Stream <streaming/client/oci.streaming.StreamClient>`
+* :doc:`Usageapi <usage_api/client/oci.usage_api.UsageapiClient>`
 * :doc:`Vaults <vault/client/oci.vault.VaultsClient>`
 * :doc:`Redirect <waas/client/oci.waas.RedirectClient>`
 * :doc:`Waas <waas/client/oci.waas.WaasClient>`
@@ -122,6 +126,7 @@ API Reference
     nosql
     object_storage
     oce
+    ocvp
     oda
     ons
     os_management
@@ -129,6 +134,7 @@ API Reference
     resource_search
     secrets
     streaming
+    usage_api
     vault
     waas
     work_requests

--- a/docs/api/load_balancer.rst
+++ b/docs/api/load_balancer.rst
@@ -47,6 +47,7 @@ Load Balancer
     oci.load_balancer.models.HealthCheckerDetails
     oci.load_balancer.models.Hostname
     oci.load_balancer.models.HostnameDetails
+    oci.load_balancer.models.HttpHeaderRule
     oci.load_balancer.models.IpAddress
     oci.load_balancer.models.LBCookieSessionPersistenceConfigurationDetails
     oci.load_balancer.models.Listener

--- a/docs/api/load_balancer/models/oci.load_balancer.models.HttpHeaderRule.rst
+++ b/docs/api/load_balancer/models/oci.load_balancer.models.HttpHeaderRule.rst
@@ -1,0 +1,11 @@
+HttpHeaderRule
+==============
+
+.. currentmodule:: oci.load_balancer.models
+
+.. autoclass:: HttpHeaderRule
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp.rst
+++ b/docs/api/ocvp.rst
@@ -1,0 +1,44 @@
+Ocvp 
+====
+
+.. autosummary::
+    :toctree: ocvp/client
+    :nosignatures:
+    :template: autosummary/service_client.rst
+
+    oci.ocvp.EsxiHostClient
+    oci.ocvp.SddcClient
+    oci.ocvp.WorkRequestClient
+    oci.ocvp.EsxiHostClientCompositeOperations
+    oci.ocvp.SddcClientCompositeOperations
+    oci.ocvp.WorkRequestClientCompositeOperations
+
+--------
+ Models
+--------
+
+.. autosummary::
+    :toctree: ocvp/models
+    :nosignatures:
+    :template: autosummary/model_class.rst
+
+    oci.ocvp.models.ChangeSddcCompartmentDetails
+    oci.ocvp.models.CreateEsxiHostDetails
+    oci.ocvp.models.CreateSddcDetails
+    oci.ocvp.models.EsxiHost
+    oci.ocvp.models.EsxiHostCollection
+    oci.ocvp.models.EsxiHostSummary
+    oci.ocvp.models.Sddc
+    oci.ocvp.models.SddcCollection
+    oci.ocvp.models.SddcSummary
+    oci.ocvp.models.SupportedVmwareSoftwareVersionCollection
+    oci.ocvp.models.SupportedVmwareSoftwareVersionSummary
+    oci.ocvp.models.UpdateEsxiHostDetails
+    oci.ocvp.models.UpdateSddcDetails
+    oci.ocvp.models.WorkRequest
+    oci.ocvp.models.WorkRequestCollection
+    oci.ocvp.models.WorkRequestError
+    oci.ocvp.models.WorkRequestErrorCollection
+    oci.ocvp.models.WorkRequestLogEntry
+    oci.ocvp.models.WorkRequestLogEntryCollection
+    oci.ocvp.models.WorkRequestResource

--- a/docs/api/ocvp/client/oci.ocvp.EsxiHostClient.rst
+++ b/docs/api/ocvp/client/oci.ocvp.EsxiHostClient.rst
@@ -1,0 +1,8 @@
+EsxiHostClient
+==============
+
+.. currentmodule:: oci.ocvp
+
+.. autoclass:: EsxiHostClient
+    :special-members: __init__
+    :members:

--- a/docs/api/ocvp/client/oci.ocvp.EsxiHostClientCompositeOperations.rst
+++ b/docs/api/ocvp/client/oci.ocvp.EsxiHostClientCompositeOperations.rst
@@ -1,0 +1,8 @@
+EsxiHostClientCompositeOperations
+=================================
+
+.. currentmodule:: oci.ocvp
+
+.. autoclass:: EsxiHostClientCompositeOperations
+    :special-members: __init__
+    :members:

--- a/docs/api/ocvp/client/oci.ocvp.SddcClient.rst
+++ b/docs/api/ocvp/client/oci.ocvp.SddcClient.rst
@@ -1,0 +1,8 @@
+SddcClient
+==========
+
+.. currentmodule:: oci.ocvp
+
+.. autoclass:: SddcClient
+    :special-members: __init__
+    :members:

--- a/docs/api/ocvp/client/oci.ocvp.SddcClientCompositeOperations.rst
+++ b/docs/api/ocvp/client/oci.ocvp.SddcClientCompositeOperations.rst
@@ -1,0 +1,8 @@
+SddcClientCompositeOperations
+=============================
+
+.. currentmodule:: oci.ocvp
+
+.. autoclass:: SddcClientCompositeOperations
+    :special-members: __init__
+    :members:

--- a/docs/api/ocvp/client/oci.ocvp.WorkRequestClient.rst
+++ b/docs/api/ocvp/client/oci.ocvp.WorkRequestClient.rst
@@ -1,0 +1,8 @@
+WorkRequestClient
+=================
+
+.. currentmodule:: oci.ocvp
+
+.. autoclass:: WorkRequestClient
+    :special-members: __init__
+    :members:

--- a/docs/api/ocvp/client/oci.ocvp.WorkRequestClientCompositeOperations.rst
+++ b/docs/api/ocvp/client/oci.ocvp.WorkRequestClientCompositeOperations.rst
@@ -1,0 +1,8 @@
+WorkRequestClientCompositeOperations
+====================================
+
+.. currentmodule:: oci.ocvp
+
+.. autoclass:: WorkRequestClientCompositeOperations
+    :special-members: __init__
+    :members:

--- a/docs/api/ocvp/models/oci.ocvp.models.ChangeSddcCompartmentDetails.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.ChangeSddcCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeSddcCompartmentDetails
+============================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: ChangeSddcCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.CreateEsxiHostDetails.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.CreateEsxiHostDetails.rst
@@ -1,0 +1,11 @@
+CreateEsxiHostDetails
+=====================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: CreateEsxiHostDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.CreateSddcDetails.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.CreateSddcDetails.rst
@@ -1,0 +1,11 @@
+CreateSddcDetails
+=================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: CreateSddcDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.EsxiHost.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.EsxiHost.rst
@@ -1,0 +1,11 @@
+EsxiHost
+========
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: EsxiHost
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.EsxiHostCollection.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.EsxiHostCollection.rst
@@ -1,0 +1,11 @@
+EsxiHostCollection
+==================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: EsxiHostCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.EsxiHostSummary.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.EsxiHostSummary.rst
@@ -1,0 +1,11 @@
+EsxiHostSummary
+===============
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: EsxiHostSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.Sddc.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.Sddc.rst
@@ -1,0 +1,11 @@
+Sddc
+====
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: Sddc
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.SddcCollection.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.SddcCollection.rst
@@ -1,0 +1,11 @@
+SddcCollection
+==============
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: SddcCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.SddcSummary.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.SddcSummary.rst
@@ -1,0 +1,11 @@
+SddcSummary
+===========
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: SddcSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.SupportedVmwareSoftwareVersionCollection.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.SupportedVmwareSoftwareVersionCollection.rst
@@ -1,0 +1,11 @@
+SupportedVmwareSoftwareVersionCollection
+========================================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: SupportedVmwareSoftwareVersionCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.SupportedVmwareSoftwareVersionSummary.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.SupportedVmwareSoftwareVersionSummary.rst
@@ -1,0 +1,11 @@
+SupportedVmwareSoftwareVersionSummary
+=====================================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: SupportedVmwareSoftwareVersionSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.UpdateEsxiHostDetails.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.UpdateEsxiHostDetails.rst
@@ -1,0 +1,11 @@
+UpdateEsxiHostDetails
+=====================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: UpdateEsxiHostDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.UpdateSddcDetails.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.UpdateSddcDetails.rst
@@ -1,0 +1,11 @@
+UpdateSddcDetails
+=================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: UpdateSddcDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.WorkRequest.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.WorkRequest.rst
@@ -1,0 +1,11 @@
+WorkRequest
+===========
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: WorkRequest
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.WorkRequestCollection.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.WorkRequestCollection.rst
@@ -1,0 +1,11 @@
+WorkRequestCollection
+=====================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: WorkRequestCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.WorkRequestError.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.WorkRequestError.rst
@@ -1,0 +1,11 @@
+WorkRequestError
+================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: WorkRequestError
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.WorkRequestErrorCollection.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.WorkRequestErrorCollection.rst
@@ -1,0 +1,11 @@
+WorkRequestErrorCollection
+==========================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: WorkRequestErrorCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.WorkRequestLogEntry.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.WorkRequestLogEntry.rst
@@ -1,0 +1,11 @@
+WorkRequestLogEntry
+===================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: WorkRequestLogEntry
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.WorkRequestLogEntryCollection.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.WorkRequestLogEntryCollection.rst
@@ -1,0 +1,11 @@
+WorkRequestLogEntryCollection
+=============================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: WorkRequestLogEntryCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/ocvp/models/oci.ocvp.models.WorkRequestResource.rst
+++ b/docs/api/ocvp/models/oci.ocvp.models.WorkRequestResource.rst
@@ -1,0 +1,11 @@
+WorkRequestResource
+===================
+
+.. currentmodule:: oci.ocvp.models
+
+.. autoclass:: WorkRequestResource
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/usage_api.rst
+++ b/docs/api/usage_api.rst
@@ -1,0 +1,28 @@
+Usage Api 
+=========
+
+.. autosummary::
+    :toctree: usage_api/client
+    :nosignatures:
+    :template: autosummary/service_client.rst
+
+    oci.usage_api.UsageapiClient
+    oci.usage_api.UsageapiClientCompositeOperations
+
+--------
+ Models
+--------
+
+.. autosummary::
+    :toctree: usage_api/models
+    :nosignatures:
+    :template: autosummary/model_class.rst
+
+    oci.usage_api.models.Configuration
+    oci.usage_api.models.ConfigurationAggregation
+    oci.usage_api.models.Dimension
+    oci.usage_api.models.Filter
+    oci.usage_api.models.RequestSummarizedUsagesDetails
+    oci.usage_api.models.Tag
+    oci.usage_api.models.UsageAggregation
+    oci.usage_api.models.UsageSummary

--- a/docs/api/usage_api/client/oci.usage_api.UsageapiClient.rst
+++ b/docs/api/usage_api/client/oci.usage_api.UsageapiClient.rst
@@ -1,0 +1,8 @@
+UsageapiClient
+==============
+
+.. currentmodule:: oci.usage_api
+
+.. autoclass:: UsageapiClient
+    :special-members: __init__
+    :members:

--- a/docs/api/usage_api/client/oci.usage_api.UsageapiClientCompositeOperations.rst
+++ b/docs/api/usage_api/client/oci.usage_api.UsageapiClientCompositeOperations.rst
@@ -1,0 +1,8 @@
+UsageapiClientCompositeOperations
+=================================
+
+.. currentmodule:: oci.usage_api
+
+.. autoclass:: UsageapiClientCompositeOperations
+    :special-members: __init__
+    :members:

--- a/docs/api/usage_api/models/oci.usage_api.models.Configuration.rst
+++ b/docs/api/usage_api/models/oci.usage_api.models.Configuration.rst
@@ -1,0 +1,11 @@
+Configuration
+=============
+
+.. currentmodule:: oci.usage_api.models
+
+.. autoclass:: Configuration
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/usage_api/models/oci.usage_api.models.ConfigurationAggregation.rst
+++ b/docs/api/usage_api/models/oci.usage_api.models.ConfigurationAggregation.rst
@@ -1,0 +1,11 @@
+ConfigurationAggregation
+========================
+
+.. currentmodule:: oci.usage_api.models
+
+.. autoclass:: ConfigurationAggregation
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/usage_api/models/oci.usage_api.models.Dimension.rst
+++ b/docs/api/usage_api/models/oci.usage_api.models.Dimension.rst
@@ -1,0 +1,11 @@
+Dimension
+=========
+
+.. currentmodule:: oci.usage_api.models
+
+.. autoclass:: Dimension
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/usage_api/models/oci.usage_api.models.Filter.rst
+++ b/docs/api/usage_api/models/oci.usage_api.models.Filter.rst
@@ -1,0 +1,11 @@
+Filter
+======
+
+.. currentmodule:: oci.usage_api.models
+
+.. autoclass:: Filter
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/usage_api/models/oci.usage_api.models.RequestSummarizedUsagesDetails.rst
+++ b/docs/api/usage_api/models/oci.usage_api.models.RequestSummarizedUsagesDetails.rst
@@ -1,0 +1,11 @@
+RequestSummarizedUsagesDetails
+==============================
+
+.. currentmodule:: oci.usage_api.models
+
+.. autoclass:: RequestSummarizedUsagesDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/usage_api/models/oci.usage_api.models.Tag.rst
+++ b/docs/api/usage_api/models/oci.usage_api.models.Tag.rst
@@ -1,0 +1,11 @@
+Tag
+===
+
+.. currentmodule:: oci.usage_api.models
+
+.. autoclass:: Tag
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/usage_api/models/oci.usage_api.models.UsageAggregation.rst
+++ b/docs/api/usage_api/models/oci.usage_api.models.UsageAggregation.rst
@@ -1,0 +1,11 @@
+UsageAggregation
+================
+
+.. currentmodule:: oci.usage_api.models
+
+.. autoclass:: UsageAggregation
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/usage_api/models/oci.usage_api.models.UsageSummary.rst
+++ b/docs/api/usage_api/models/oci.usage_api.models.UsageSummary.rst
@@ -1,0 +1,11 @@
+UsageSummary
+============
+
+.. currentmodule:: oci.usage_api.models
+
+.. autoclass:: UsageSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -55,7 +55,15 @@ Or programmatically, for example:
         "log_requests": True
     }
 
-Request logging enables debugging information in the Python http module.  This debugging information can be quite verbose and the output will go to standard out.  This http module does not use Python's logging module.
+Request logging enables debugging information in the Python http module.  This debugging information can be quite verbose and the output will go to standard out.  This http module does not use Python’s logging module, but can be enabled separately:
+
+.. code-block:: python
+
+    import oci
+    oci.base_client.is_http_log_enabled(True)
+    oci.base_client.is_http_log_enabled(False)
+
+Note that http module logging is enabled/disabled as Request Logging enabled/disabled:
 
 Once you have request logging in your config, you can create the appropriate logging handler(s) for your use case. For example to log to an output stream such as ``stderr`` you could do:
 
@@ -81,3 +89,30 @@ The oci module has logging at the following levels:
 
 
 The raw response body is not logged.
+
+Disable Logging
+================
+To disable particular client's logging, just need to disable the corresponding logger
+
+.. code-block:: python
+
+    import oci
+    import logging
+    # Disable particular client logging
+    logger = logging.getLogger('oci.base_client.{}'.format(id(client.base_client)))
+    logger.disabled = True
+    # Need to manually disable http logging
+    oci.base_client.is_http_log_enabled(False)
+
+To disable all Python SDK logging
+
+.. code-block:: python
+
+    import oci
+    import logging
+
+    # Disable logging
+    config['log_requests'] = False
+    client = oci.identity.IdentityClient(config)
+
+    # Rest of code ...

--- a/examples/showoci/CHANGELOG.rst
+++ b/examples/showoci/CHANGELOG.rst
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 =====================
+20.06.30 - 2020-06-30
+=====================
+* Added compute agent information
+* Added password policy to the tenant json (thanks to Josh)
+
+=====================
 20.06.15 - 2020-06-15
 =====================
 * Added Maintatance for DBSystem including alert if maintenance is less than 14 days

--- a/examples/showoci/showoci.py
+++ b/examples/showoci/showoci.py
@@ -69,6 +69,7 @@
 # - oci.secrets.SecretsClient
 # - oci.vault.VaultsClient
 # - oci.work_requests.WorkRequestClient
+# -
 ##########################################################################
 from __future__ import print_function
 from showoci_data import ShowOCIData
@@ -80,7 +81,7 @@ import sys
 import argparse
 import datetime
 
-version = "20.06.16"
+version = "20.06.30"
 
 ##########################################################################
 # check OCI version

--- a/examples/showoci/showoci_data.py
+++ b/examples/showoci/showoci_data.py
@@ -1417,7 +1417,11 @@ class ShowOCIData(object):
                         'lifecycle_state': instance['lifecycle_state'],
                         'console_id': instance['console_id'], 'console': instance['console'],
                         'time_created': instance['time_created'],
-                        'defined_tags': instance['defined_tags'], 'freeform_tags': instance['freeform_tags']}
+                        'agent_is_management_disabled': instance['agent_is_management_disabled'],
+                        'agent_is_monitoring_disabled': instance['agent_is_monitoring_disabled'],
+                        'defined_tags': instance['defined_tags'],
+                        'freeform_tags': instance['freeform_tags']
+                        }
 
                 # boot volumes attachments
                 boot_vol_attachement = self.service.search_multi_items(self.service.C_COMPUTE, self.service.C_COMPUTE_BOOT_VOL_ATTACH, 'instance_id', instance['id'])

--- a/examples/showoci/showoci_output.py
+++ b/examples/showoci/showoci_output.py
@@ -1551,6 +1551,9 @@ class ShowOCIOutput(object):
                     if instance['console']:
                         print(self.tabs2 + instance['console'])
 
+                if 'agent_is_management_disabled' in instance:
+                    print(self.tabs2 + "Agent: Is Management Disabled = " + instance['agent_is_management_disabled'] + ", Is Monitoring Disabled = " + instance['agent_is_monitoring_disabled'])
+
                 print("")
 
         except Exception as e:

--- a/src/oci/__init__.py
+++ b/src/oci/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-from . import analytics, announcements_service, apigateway, application_migration, audit, autoscaling, bds, budget, cims, container_engine, core, data_catalog, data_flow, data_integration, data_safe, data_science, database, dns, dts, email, events, file_storage, functions, healthchecks, identity, integration, key_management, limits, load_balancer, marketplace, monitoring, mysql, nosql, object_storage, oce, oda, ons, os_management, resource_manager, resource_search, secrets, streaming, vault, waas, work_requests
+from . import analytics, announcements_service, apigateway, application_migration, audit, autoscaling, bds, budget, cims, container_engine, core, data_catalog, data_flow, data_integration, data_safe, data_science, database, dns, dts, email, events, file_storage, functions, healthchecks, identity, integration, key_management, limits, load_balancer, marketplace, monitoring, mysql, nosql, object_storage, oce, ocvp, oda, ons, os_management, resource_manager, resource_search, secrets, streaming, usage_api, vault, waas, work_requests
 from . import auth, config, constants, decorators, exceptions, regions, pagination, retry, fips
 from .base_client import BaseClient
 from .request import Request
@@ -15,5 +15,5 @@ fips.enable_fips_mode()
 
 __all__ = [
     "BaseClient", "Error", "Request", "Response", "Signer", "config", "constants", "decorators", "exceptions", "regions", "wait_until", "pagination", "auth", "retry", "fips",
-    "analytics", "announcements_service", "apigateway", "application_migration", "audit", "autoscaling", "bds", "budget", "cims", "container_engine", "core", "data_catalog", "data_flow", "data_integration", "data_safe", "data_science", "database", "dns", "dts", "email", "events", "file_storage", "functions", "healthchecks", "identity", "integration", "key_management", "limits", "load_balancer", "marketplace", "monitoring", "mysql", "nosql", "object_storage", "oce", "oda", "ons", "os_management", "resource_manager", "resource_search", "secrets", "streaming", "vault", "waas", "work_requests"
+    "analytics", "announcements_service", "apigateway", "application_migration", "audit", "autoscaling", "bds", "budget", "cims", "container_engine", "core", "data_catalog", "data_flow", "data_integration", "data_safe", "data_science", "database", "dns", "dts", "email", "events", "file_storage", "functions", "healthchecks", "identity", "integration", "key_management", "limits", "load_balancer", "marketplace", "monitoring", "mysql", "nosql", "object_storage", "oce", "ocvp", "oda", "ons", "os_management", "resource_manager", "resource_search", "secrets", "streaming", "usage_api", "vault", "waas", "work_requests"
 ]

--- a/src/oci/base_client.py
+++ b/src/oci/base_client.py
@@ -59,6 +59,13 @@ def utc_now():
     return " " + str(datetime.utcnow()) + ": "
 
 
+def is_http_log_enabled(is_enabled):
+    if is_enabled:
+        six.moves.http_client.HTTPConnection.debuglevel = 1
+    else:
+        six.moves.http_client.HTTPConnection.debuglevel = 0
+
+
 STREAM_RESPONSE_TYPE = 'stream'
 BYTES_RESPONSE_TYPE = 'bytes'
 
@@ -135,10 +142,12 @@ class BaseClient(object):
         self.logger = logging.getLogger("{}.{}".format(__name__, id(self)))
         self.logger.addHandler(logging.NullHandler())
         if get_config_value_or_default(config, "log_requests"):
+            self.logger.disabled = False
             self.logger.setLevel(logging.DEBUG)
-            six.moves.http_client.HTTPConnection.debuglevel = 1
+            is_http_log_enabled(True)
         else:
-            six.moves.http_client.HTTPConnection.debuglevel = 0
+            self.logger.disabled = True
+            is_http_log_enabled(False)
 
         self.skip_deserialization = kwargs.get('skip_deserialization')
 

--- a/src/oci/core/compute_client.py
+++ b/src/oci/core/compute_client.py
@@ -4023,7 +4023,7 @@ class ComputeClient(object):
 
     def list_image_shape_compatibility_entries(self, image_id, **kwargs):
         """
-        Lists the shape compatibilities for the image.
+        Lists the compatible shapes for the specified image.
 
 
         :param str image_id: (required)

--- a/src/oci/core/models/__init__.py
+++ b/src/oci/core/models/__init__.py
@@ -60,6 +60,7 @@ from .change_service_gateway_compartment_details import ChangeServiceGatewayComp
 from .change_subnet_compartment_details import ChangeSubnetCompartmentDetails
 from .change_vcn_compartment_details import ChangeVcnCompartmentDetails
 from .change_virtual_circuit_compartment_details import ChangeVirtualCircuitCompartmentDetails
+from .change_vlan_compartment_details import ChangeVlanCompartmentDetails
 from .change_volume_backup_compartment_details import ChangeVolumeBackupCompartmentDetails
 from .change_volume_compartment_details import ChangeVolumeCompartmentDetails
 from .change_volume_group_backup_compartment_details import ChangeVolumeGroupBackupCompartmentDetails
@@ -116,6 +117,7 @@ from .create_subnet_details import CreateSubnetDetails
 from .create_vcn_details import CreateVcnDetails
 from .create_virtual_circuit_details import CreateVirtualCircuitDetails
 from .create_virtual_circuit_public_prefix_details import CreateVirtualCircuitPublicPrefixDetails
+from .create_vlan_details import CreateVlanDetails
 from .create_vnic_details import CreateVnicDetails
 from .create_volume_backup_details import CreateVolumeBackupDetails
 from .create_volume_backup_policy_assignment_details import CreateVolumeBackupPolicyAssignmentDetails
@@ -281,6 +283,7 @@ from .update_subnet_details import UpdateSubnetDetails
 from .update_tunnel_cpe_device_config_details import UpdateTunnelCpeDeviceConfigDetails
 from .update_vcn_details import UpdateVcnDetails
 from .update_virtual_circuit_details import UpdateVirtualCircuitDetails
+from .update_vlan_details import UpdateVlanDetails
 from .update_vnic_details import UpdateVnicDetails
 from .update_volume_backup_details import UpdateVolumeBackupDetails
 from .update_volume_backup_policy_details import UpdateVolumeBackupPolicyDetails
@@ -293,6 +296,7 @@ from .vcn import Vcn
 from .virtual_circuit import VirtualCircuit
 from .virtual_circuit_bandwidth_shape import VirtualCircuitBandwidthShape
 from .virtual_circuit_public_prefix import VirtualCircuitPublicPrefix
+from .vlan import Vlan
 from .vnic import Vnic
 from .vnic_attachment import VnicAttachment
 from .volume import Volume
@@ -370,6 +374,7 @@ core_type_mapping = {
     "ChangeSubnetCompartmentDetails": ChangeSubnetCompartmentDetails,
     "ChangeVcnCompartmentDetails": ChangeVcnCompartmentDetails,
     "ChangeVirtualCircuitCompartmentDetails": ChangeVirtualCircuitCompartmentDetails,
+    "ChangeVlanCompartmentDetails": ChangeVlanCompartmentDetails,
     "ChangeVolumeBackupCompartmentDetails": ChangeVolumeBackupCompartmentDetails,
     "ChangeVolumeCompartmentDetails": ChangeVolumeCompartmentDetails,
     "ChangeVolumeGroupBackupCompartmentDetails": ChangeVolumeGroupBackupCompartmentDetails,
@@ -426,6 +431,7 @@ core_type_mapping = {
     "CreateVcnDetails": CreateVcnDetails,
     "CreateVirtualCircuitDetails": CreateVirtualCircuitDetails,
     "CreateVirtualCircuitPublicPrefixDetails": CreateVirtualCircuitPublicPrefixDetails,
+    "CreateVlanDetails": CreateVlanDetails,
     "CreateVnicDetails": CreateVnicDetails,
     "CreateVolumeBackupDetails": CreateVolumeBackupDetails,
     "CreateVolumeBackupPolicyAssignmentDetails": CreateVolumeBackupPolicyAssignmentDetails,
@@ -591,6 +597,7 @@ core_type_mapping = {
     "UpdateTunnelCpeDeviceConfigDetails": UpdateTunnelCpeDeviceConfigDetails,
     "UpdateVcnDetails": UpdateVcnDetails,
     "UpdateVirtualCircuitDetails": UpdateVirtualCircuitDetails,
+    "UpdateVlanDetails": UpdateVlanDetails,
     "UpdateVnicDetails": UpdateVnicDetails,
     "UpdateVolumeBackupDetails": UpdateVolumeBackupDetails,
     "UpdateVolumeBackupPolicyDetails": UpdateVolumeBackupPolicyDetails,
@@ -603,6 +610,7 @@ core_type_mapping = {
     "VirtualCircuit": VirtualCircuit,
     "VirtualCircuitBandwidthShape": VirtualCircuitBandwidthShape,
     "VirtualCircuitPublicPrefix": VirtualCircuitPublicPrefix,
+    "Vlan": Vlan,
     "Vnic": Vnic,
     "VnicAttachment": VnicAttachment,
     "Volume": Volume,

--- a/src/oci/core/models/app_catalog_listing.py
+++ b/src/oci/core/models/app_catalog_listing.py
@@ -182,8 +182,10 @@ class AppCatalogListing(object):
     def time_published(self):
         """
         Gets the time_published of this AppCatalogListing.
-        Date and time the listing was published, in RFC3339 format.
+        Date and time the listing was published, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_published of this AppCatalogListing.
@@ -195,8 +197,10 @@ class AppCatalogListing(object):
     def time_published(self, time_published):
         """
         Sets the time_published of this AppCatalogListing.
-        Date and time the listing was published, in RFC3339 format.
+        Date and time the listing was published, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_published: The time_published of this AppCatalogListing.

--- a/src/oci/core/models/app_catalog_listing_resource_version.py
+++ b/src/oci/core/models/app_catalog_listing_resource_version.py
@@ -140,8 +140,10 @@ class AppCatalogListingResourceVersion(object):
     def time_published(self):
         """
         Gets the time_published of this AppCatalogListingResourceVersion.
-        Date and time the listing resource version was published, in RFC3339 format.
+        Date and time the listing resource version was published, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_published of this AppCatalogListingResourceVersion.
@@ -153,8 +155,10 @@ class AppCatalogListingResourceVersion(object):
     def time_published(self, time_published):
         """
         Sets the time_published of this AppCatalogListingResourceVersion.
-        Date and time the listing resource version was published, in RFC3339 format.
+        Date and time the listing resource version was published, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_published: The time_published of this AppCatalogListingResourceVersion.

--- a/src/oci/core/models/app_catalog_listing_resource_version_agreements.py
+++ b/src/oci/core/models/app_catalog_listing_resource_version_agreements.py
@@ -168,8 +168,10 @@ class AppCatalogListingResourceVersionAgreements(object):
     def time_retrieved(self):
         """
         Gets the time_retrieved of this AppCatalogListingResourceVersionAgreements.
-        Date and time the agreements were retrieved, in RFC3339 format.
+        Date and time the agreements were retrieved, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_retrieved of this AppCatalogListingResourceVersionAgreements.
@@ -181,8 +183,10 @@ class AppCatalogListingResourceVersionAgreements(object):
     def time_retrieved(self, time_retrieved):
         """
         Sets the time_retrieved of this AppCatalogListingResourceVersionAgreements.
-        Date and time the agreements were retrieved, in RFC3339 format.
+        Date and time the agreements were retrieved, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_retrieved: The time_retrieved of this AppCatalogListingResourceVersionAgreements.

--- a/src/oci/core/models/app_catalog_listing_resource_version_summary.py
+++ b/src/oci/core/models/app_catalog_listing_resource_version_summary.py
@@ -82,8 +82,10 @@ class AppCatalogListingResourceVersionSummary(object):
     def time_published(self):
         """
         Gets the time_published of this AppCatalogListingResourceVersionSummary.
-        Date and time the listing resource version was published, in RFC3339 format.
+        Date and time the listing resource version was published, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_published of this AppCatalogListingResourceVersionSummary.
@@ -95,8 +97,10 @@ class AppCatalogListingResourceVersionSummary(object):
     def time_published(self, time_published):
         """
         Sets the time_published of this AppCatalogListingResourceVersionSummary.
-        Date and time the listing resource version was published, in RFC3339 format.
+        Date and time the listing resource version was published, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_published: The time_published of this AppCatalogListingResourceVersionSummary.

--- a/src/oci/core/models/app_catalog_subscription.py
+++ b/src/oci/core/models/app_catalog_subscription.py
@@ -254,8 +254,10 @@ class AppCatalogSubscription(object):
     def time_created(self):
         """
         Gets the time_created of this AppCatalogSubscription.
-        Date and time at which the subscription was created, in RFC3339 format.
+        Date and time at which the subscription was created, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this AppCatalogSubscription.
@@ -267,8 +269,10 @@ class AppCatalogSubscription(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this AppCatalogSubscription.
-        Date and time at which the subscription was created, in RFC3339 format.
+        Date and time at which the subscription was created, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this AppCatalogSubscription.

--- a/src/oci/core/models/app_catalog_subscription_summary.py
+++ b/src/oci/core/models/app_catalog_subscription_summary.py
@@ -254,8 +254,10 @@ class AppCatalogSubscriptionSummary(object):
     def time_created(self):
         """
         Gets the time_created of this AppCatalogSubscriptionSummary.
-        Date and time at which the subscription was created, in RFC3339 format.
+        Date and time at which the subscription was created, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this AppCatalogSubscriptionSummary.
@@ -267,8 +269,10 @@ class AppCatalogSubscriptionSummary(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this AppCatalogSubscriptionSummary.
-        Date and time at which the subscription was created, in RFC3339 format.
+        Date and time at which the subscription was created, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this AppCatalogSubscriptionSummary.

--- a/src/oci/core/models/attach_volume_details.py
+++ b/src/oci/core/models/attach_volume_details.py
@@ -234,7 +234,7 @@ class AttachVolumeDetails(object):
     def type(self):
         """
         **[Required]** Gets the type of this AttachVolumeDetails.
-        The type of volume. The only supported value are \"iscsi\" and \"paravirtualized\".
+        The type of volume. The only supported values are \"iscsi\" and \"paravirtualized\".
 
 
         :return: The type of this AttachVolumeDetails.
@@ -246,7 +246,7 @@ class AttachVolumeDetails(object):
     def type(self, type):
         """
         Sets the type of this AttachVolumeDetails.
-        The type of volume. The only supported value are \"iscsi\" and \"paravirtualized\".
+        The type of volume. The only supported values are \"iscsi\" and \"paravirtualized\".
 
 
         :param type: The type of this AttachVolumeDetails.

--- a/src/oci/core/models/boot_volume.py
+++ b/src/oci/core/models/boot_volume.py
@@ -580,7 +580,10 @@ class BootVolume(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this BootVolume.
-        The date and time the boot volume was created. Format defined by RFC3339.
+        The date and time the boot volume was created. Format defined
+        by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this BootVolume.
@@ -592,7 +595,10 @@ class BootVolume(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this BootVolume.
-        The date and time the boot volume was created. Format defined by RFC3339.
+        The date and time the boot volume was created. Format defined
+        by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this BootVolume.

--- a/src/oci/core/models/boot_volume_attachment.py
+++ b/src/oci/core/models/boot_volume_attachment.py
@@ -298,9 +298,11 @@ class BootVolumeAttachment(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this BootVolumeAttachment.
-        The date and time the boot volume was created, in the format defined by RFC3339.
+        The date and time the boot volume was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this BootVolumeAttachment.
@@ -312,9 +314,11 @@ class BootVolumeAttachment(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this BootVolumeAttachment.
-        The date and time the boot volume was created, in the format defined by RFC3339.
+        The date and time the boot volume was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this BootVolumeAttachment.

--- a/src/oci/core/models/boot_volume_backup.py
+++ b/src/oci/core/models/boot_volume_backup.py
@@ -349,10 +349,12 @@ class BootVolumeBackup(object):
         """
         Gets the expiration_time of this BootVolumeBackup.
         The date and time the volume backup will expire and be automatically deleted.
-        Format defined by RFC3339. This parameter will always be present for backups that
+        Format defined by `RFC3339`__. This parameter will always be present for backups that
         were created automatically by a scheduled-backup policy. For manually created backups,
         it will be absent, signifying that there is no expiration time and the backup will
         last forever until manually deleted.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The expiration_time of this BootVolumeBackup.
@@ -365,10 +367,12 @@ class BootVolumeBackup(object):
         """
         Sets the expiration_time of this BootVolumeBackup.
         The date and time the volume backup will expire and be automatically deleted.
-        Format defined by RFC3339. This parameter will always be present for backups that
+        Format defined by `RFC3339`__. This parameter will always be present for backups that
         were created automatically by a scheduled-backup policy. For manually created backups,
         it will be absent, signifying that there is no expiration time and the backup will
         last forever until manually deleted.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param expiration_time: The expiration_time of this BootVolumeBackup.
@@ -607,7 +611,9 @@ class BootVolumeBackup(object):
         """
         **[Required]** Gets the time_created of this BootVolumeBackup.
         The date and time the boot volume backup was created. This is the time the actual point-in-time image
-        of the volume data was taken. Format defined by RFC3339.
+        of the volume data was taken. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this BootVolumeBackup.
@@ -620,7 +626,9 @@ class BootVolumeBackup(object):
         """
         Sets the time_created of this BootVolumeBackup.
         The date and time the boot volume backup was created. This is the time the actual point-in-time image
-        of the volume data was taken. Format defined by RFC3339.
+        of the volume data was taken. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this BootVolumeBackup.
@@ -632,7 +640,9 @@ class BootVolumeBackup(object):
     def time_request_received(self):
         """
         Gets the time_request_received of this BootVolumeBackup.
-        The date and time the request to create the boot volume backup was received. Format defined by RFC3339.
+        The date and time the request to create the boot volume backup was received. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_request_received of this BootVolumeBackup.
@@ -644,7 +654,9 @@ class BootVolumeBackup(object):
     def time_request_received(self, time_request_received):
         """
         Sets the time_request_received of this BootVolumeBackup.
-        The date and time the request to create the boot volume backup was received. Format defined by RFC3339.
+        The date and time the request to create the boot volume backup was received. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_request_received: The time_request_received of this BootVolumeBackup.

--- a/src/oci/core/models/change_vlan_compartment_details.py
+++ b/src/oci/core/models/change_vlan_compartment_details.py
@@ -1,0 +1,74 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeVlanCompartmentDetails(object):
+    """
+    The configuration details for the move operation.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeVlanCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeVlanCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeVlanCompartmentDetails.
+        The `OCID`__ of the compartment to move the VLAN to.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeVlanCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeVlanCompartmentDetails.
+        The `OCID`__ of the compartment to move the VLAN to.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeVlanCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/cluster_network.py
+++ b/src/oci/core/models/cluster_network.py
@@ -368,9 +368,11 @@ class ClusterNetwork(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this ClusterNetwork.
-        The date and time the resource was created, in the format defined by RFC3339.
+        The date and time the resource was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this ClusterNetwork.
@@ -382,9 +384,11 @@ class ClusterNetwork(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this ClusterNetwork.
-        The date and time the resource was created, in the format defined by RFC3339.
+        The date and time the resource was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this ClusterNetwork.
@@ -396,9 +400,11 @@ class ClusterNetwork(object):
     def time_updated(self):
         """
         **[Required]** Gets the time_updated of this ClusterNetwork.
-        The date and time the resource was updated, in the format defined by RFC3339.
+        The date and time the resource was updated, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_updated of this ClusterNetwork.
@@ -410,9 +416,11 @@ class ClusterNetwork(object):
     def time_updated(self, time_updated):
         """
         Sets the time_updated of this ClusterNetwork.
-        The date and time the resource was updated, in the format defined by RFC3339.
+        The date and time the resource was updated, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_updated: The time_updated of this ClusterNetwork.

--- a/src/oci/core/models/cluster_network_summary.py
+++ b/src/oci/core/models/cluster_network_summary.py
@@ -331,9 +331,11 @@ class ClusterNetworkSummary(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this ClusterNetworkSummary.
-        The date and time the resource was created, in the format defined by RFC3339.
+        The date and time the resource was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this ClusterNetworkSummary.
@@ -345,9 +347,11 @@ class ClusterNetworkSummary(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this ClusterNetworkSummary.
-        The date and time the resource was created, in the format defined by RFC3339.
+        The date and time the resource was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this ClusterNetworkSummary.
@@ -359,9 +363,11 @@ class ClusterNetworkSummary(object):
     def time_updated(self):
         """
         **[Required]** Gets the time_updated of this ClusterNetworkSummary.
-        The date and time the resource was updated, in the format defined by RFC3339.
+        The date and time the resource was updated, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_updated of this ClusterNetworkSummary.
@@ -373,9 +379,11 @@ class ClusterNetworkSummary(object):
     def time_updated(self, time_updated):
         """
         Sets the time_updated of this ClusterNetworkSummary.
-        The date and time the resource was updated, in the format defined by RFC3339.
+        The date and time the resource was updated, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_updated: The time_updated of this ClusterNetworkSummary.

--- a/src/oci/core/models/console_history.py
+++ b/src/oci/core/models/console_history.py
@@ -344,8 +344,10 @@ class ConsoleHistory(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this ConsoleHistory.
-        The date and time the history was created, in the format defined by RFC3339.
+        The date and time the history was created, in the format defined by `RFC3339`__.
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this ConsoleHistory.
@@ -357,8 +359,10 @@ class ConsoleHistory(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this ConsoleHistory.
-        The date and time the history was created, in the format defined by RFC3339.
+        The date and time the history was created, in the format defined by `RFC3339`__.
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this ConsoleHistory.

--- a/src/oci/core/models/cpe.py
+++ b/src/oci/core/models/cpe.py
@@ -320,9 +320,11 @@ class Cpe(object):
     def time_created(self):
         """
         Gets the time_created of this Cpe.
-        The date and time the CPE was created, in the format defined by RFC3339.
+        The date and time the CPE was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this Cpe.
@@ -334,9 +336,11 @@ class Cpe(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Cpe.
-        The date and time the CPE was created, in the format defined by RFC3339.
+        The date and time the CPE was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this Cpe.

--- a/src/oci/core/models/create_app_catalog_subscription_details.py
+++ b/src/oci/core/models/create_app_catalog_subscription_details.py
@@ -199,8 +199,10 @@ class CreateAppCatalogSubscriptionDetails(object):
     def time_retrieved(self):
         """
         **[Required]** Gets the time_retrieved of this CreateAppCatalogSubscriptionDetails.
-        Date and time the agreements were retrieved, in RFC3339 format.
+        Date and time the agreements were retrieved, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_retrieved of this CreateAppCatalogSubscriptionDetails.
@@ -212,8 +214,10 @@ class CreateAppCatalogSubscriptionDetails(object):
     def time_retrieved(self, time_retrieved):
         """
         Sets the time_retrieved of this CreateAppCatalogSubscriptionDetails.
-        Date and time the agreements were retrieved, in RFC3339 format.
+        Date and time the agreements were retrieved, in `RFC3339`__ format.
         Example: `2018-03-20T12:32:53.532Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_retrieved: The time_retrieved of this CreateAppCatalogSubscriptionDetails.

--- a/src/oci/core/models/create_cpe_details.py
+++ b/src/oci/core/models/create_cpe_details.py
@@ -190,7 +190,7 @@ class CreateCpeDetails(object):
         **[Required]** Gets the ip_address of this CreateCpeDetails.
         The public IP address of the on-premises router.
 
-        Example: `143.19.23.16`
+        Example: `203.0.113.2`
 
 
         :return: The ip_address of this CreateCpeDetails.
@@ -204,7 +204,7 @@ class CreateCpeDetails(object):
         Sets the ip_address of this CreateCpeDetails.
         The public IP address of the on-premises router.
 
-        Example: `143.19.23.16`
+        Example: `203.0.113.2`
 
 
         :param ip_address: The ip_address of this CreateCpeDetails.

--- a/src/oci/core/models/create_ip_sec_connection_tunnel_details.py
+++ b/src/oci/core/models/create_ip_sec_connection_tunnel_details.py
@@ -178,8 +178,6 @@ class CreateIPSecConnectionTunnelDetails(object):
         Oracle generates a value for you. You can specify your own shared secret later if
         you like with :func:`update_ip_sec_connection_tunnel_shared_secret`.
 
-        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
-
 
         :return: The shared_secret of this CreateIPSecConnectionTunnelDetails.
         :rtype: str
@@ -194,8 +192,6 @@ class CreateIPSecConnectionTunnelDetails(object):
         spaces are allowed. If you don't provide a value,
         Oracle generates a value for you. You can specify your own shared secret later if
         you like with :func:`update_ip_sec_connection_tunnel_shared_secret`.
-
-        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 
 
         :param shared_secret: The shared_secret of this CreateIPSecConnectionTunnelDetails.

--- a/src/oci/core/models/create_ipv6_details.py
+++ b/src/oci/core/models/create_ipv6_details.py
@@ -171,7 +171,7 @@ class CreateIpv6Details(object):
         assigns an IPv6 address from the subnet. The subnet is the one that
         contains the VNIC you specify in `vnicId`.
 
-        Example: `2001:0db8:0123:1111:abcd:ef01:2345:6789`
+        Example: `2001:DB8::`
 
 
         :return: The ip_address of this CreateIpv6Details.
@@ -188,7 +188,7 @@ class CreateIpv6Details(object):
         assigns an IPv6 address from the subnet. The subnet is the one that
         contains the VNIC you specify in `vnicId`.
 
-        Example: `2001:0db8:0123:1111:abcd:ef01:2345:6789`
+        Example: `2001:DB8::`
 
 
         :param ip_address: The ip_address of this CreateIpv6Details.

--- a/src/oci/core/models/create_private_ip_details.py
+++ b/src/oci/core/models/create_private_ip_details.py
@@ -42,6 +42,10 @@ class CreatePrivateIpDetails(object):
             The value to assign to the vnic_id property of this CreatePrivateIpDetails.
         :type vnic_id: str
 
+        :param vlan_id:
+            The value to assign to the vlan_id property of this CreatePrivateIpDetails.
+        :type vlan_id: str
+
         """
         self.swagger_types = {
             'defined_tags': 'dict(str, dict(str, object))',
@@ -49,7 +53,8 @@ class CreatePrivateIpDetails(object):
             'freeform_tags': 'dict(str, str)',
             'hostname_label': 'str',
             'ip_address': 'str',
-            'vnic_id': 'str'
+            'vnic_id': 'str',
+            'vlan_id': 'str'
         }
 
         self.attribute_map = {
@@ -58,7 +63,8 @@ class CreatePrivateIpDetails(object):
             'freeform_tags': 'freeformTags',
             'hostname_label': 'hostnameLabel',
             'ip_address': 'ipAddress',
-            'vnic_id': 'vnicId'
+            'vnic_id': 'vnicId',
+            'vlan_id': 'vlanId'
         }
 
         self._defined_tags = None
@@ -67,6 +73,7 @@ class CreatePrivateIpDetails(object):
         self._hostname_label = None
         self._ip_address = None
         self._vnic_id = None
+        self._vlan_id = None
 
     @property
     def defined_tags(self):
@@ -249,7 +256,7 @@ class CreatePrivateIpDetails(object):
     @property
     def vnic_id(self):
         """
-        **[Required]** Gets the vnic_id of this CreatePrivateIpDetails.
+        Gets the vnic_id of this CreatePrivateIpDetails.
         The OCID of the VNIC to assign the private IP to. The VNIC and private IP
         must be in the same subnet.
 
@@ -271,6 +278,36 @@ class CreatePrivateIpDetails(object):
         :type: str
         """
         self._vnic_id = vnic_id
+
+    @property
+    def vlan_id(self):
+        """
+        Gets the vlan_id of this CreatePrivateIpDetails.
+        Use this attribute only with the Oracle Cloud VMware Solution.
+
+        The OCID of the VLAN from which the private IP is to be drawn. The IP address,
+        *if supplied*, must be valid for the given VLAN. See :class:`Vlan`.
+
+
+        :return: The vlan_id of this CreatePrivateIpDetails.
+        :rtype: str
+        """
+        return self._vlan_id
+
+    @vlan_id.setter
+    def vlan_id(self, vlan_id):
+        """
+        Sets the vlan_id of this CreatePrivateIpDetails.
+        Use this attribute only with the Oracle Cloud VMware Solution.
+
+        The OCID of the VLAN from which the private IP is to be drawn. The IP address,
+        *if supplied*, must be valid for the given VLAN. See :class:`Vlan`.
+
+
+        :param vlan_id: The vlan_id of this CreatePrivateIpDetails.
+        :type: str
+        """
+        self._vlan_id = vlan_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/create_subnet_details.py
+++ b/src/oci/core/models/create_subnet_details.py
@@ -171,7 +171,7 @@ class CreateSubnetDetails(object):
         **[Required]** Gets the cidr_block of this CreateSubnetDetails.
         The CIDR IP address range of the subnet.
 
-        Example: `172.16.1.0/24`
+        Example: `10.0.1.0/24`
 
 
         :return: The cidr_block of this CreateSubnetDetails.
@@ -185,7 +185,7 @@ class CreateSubnetDetails(object):
         Sets the cidr_block of this CreateSubnetDetails.
         The CIDR IP address range of the subnet.
 
-        Example: `172.16.1.0/24`
+        Example: `10.0.1.0/24`
 
 
         :param cidr_block: The cidr_block of this CreateSubnetDetails.

--- a/src/oci/core/models/create_vcn_details.py
+++ b/src/oci/core/models/create_vcn_details.py
@@ -88,7 +88,7 @@ class CreateVcnDetails(object):
         **[Required]** Gets the cidr_block of this CreateVcnDetails.
         The CIDR IP address block of the VCN.
 
-        Example: `172.16.0.0/16`
+        Example: `10.0.0.0/16`
 
 
         :return: The cidr_block of this CreateVcnDetails.
@@ -102,7 +102,7 @@ class CreateVcnDetails(object):
         Sets the cidr_block of this CreateVcnDetails.
         The CIDR IP address block of the VCN.
 
-        Example: `172.16.0.0/16`
+        Example: `10.0.0.0/16`
 
 
         :param cidr_block: The cidr_block of this CreateVcnDetails.

--- a/src/oci/core/models/create_vlan_details.py
+++ b/src/oci/core/models/create_vlan_details.py
@@ -1,0 +1,389 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateVlanDetails(object):
+    """
+    CreateVlanDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateVlanDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this CreateVlanDetails.
+        :type availability_domain: str
+
+        :param cidr_block:
+            The value to assign to the cidr_block property of this CreateVlanDetails.
+        :type cidr_block: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateVlanDetails.
+        :type compartment_id: str
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateVlanDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateVlanDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateVlanDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this CreateVlanDetails.
+        :type nsg_ids: list[str]
+
+        :param route_table_id:
+            The value to assign to the route_table_id property of this CreateVlanDetails.
+        :type route_table_id: str
+
+        :param vcn_id:
+            The value to assign to the vcn_id property of this CreateVlanDetails.
+        :type vcn_id: str
+
+        :param vlan_tag:
+            The value to assign to the vlan_tag property of this CreateVlanDetails.
+        :type vlan_tag: int
+
+        """
+        self.swagger_types = {
+            'availability_domain': 'str',
+            'cidr_block': 'str',
+            'compartment_id': 'str',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'nsg_ids': 'list[str]',
+            'route_table_id': 'str',
+            'vcn_id': 'str',
+            'vlan_tag': 'int'
+        }
+
+        self.attribute_map = {
+            'availability_domain': 'availabilityDomain',
+            'cidr_block': 'cidrBlock',
+            'compartment_id': 'compartmentId',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'nsg_ids': 'nsgIds',
+            'route_table_id': 'routeTableId',
+            'vcn_id': 'vcnId',
+            'vlan_tag': 'vlanTag'
+        }
+
+        self._availability_domain = None
+        self._cidr_block = None
+        self._compartment_id = None
+        self._defined_tags = None
+        self._display_name = None
+        self._freeform_tags = None
+        self._nsg_ids = None
+        self._route_table_id = None
+        self._vcn_id = None
+        self._vlan_tag = None
+
+    @property
+    def availability_domain(self):
+        """
+        **[Required]** Gets the availability_domain of this CreateVlanDetails.
+        The availability domain of the VLAN.
+
+        Example: `Uocm:PHX-AD-1`
+
+
+        :return: The availability_domain of this CreateVlanDetails.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this CreateVlanDetails.
+        The availability domain of the VLAN.
+
+        Example: `Uocm:PHX-AD-1`
+
+
+        :param availability_domain: The availability_domain of this CreateVlanDetails.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def cidr_block(self):
+        """
+        **[Required]** Gets the cidr_block of this CreateVlanDetails.
+        The range of IPv4 addresses that will be used for layer 3 communication with
+        hosts outside the VLAN.
+
+        Example: `192.0.2.0/24`
+
+
+        :return: The cidr_block of this CreateVlanDetails.
+        :rtype: str
+        """
+        return self._cidr_block
+
+    @cidr_block.setter
+    def cidr_block(self, cidr_block):
+        """
+        Sets the cidr_block of this CreateVlanDetails.
+        The range of IPv4 addresses that will be used for layer 3 communication with
+        hosts outside the VLAN.
+
+        Example: `192.0.2.0/24`
+
+
+        :param cidr_block: The cidr_block of this CreateVlanDetails.
+        :type: str
+        """
+        self._cidr_block = cidr_block
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateVlanDetails.
+        The OCID of the compartment to contain the VLAN.
+
+
+        :return: The compartment_id of this CreateVlanDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateVlanDetails.
+        The OCID of the compartment to contain the VLAN.
+
+
+        :param compartment_id: The compartment_id of this CreateVlanDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateVlanDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateVlanDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateVlanDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateVlanDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateVlanDetails.
+        A descriptive name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+
+
+        :return: The display_name of this CreateVlanDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateVlanDetails.
+        A descriptive name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this CreateVlanDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateVlanDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateVlanDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateVlanDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateVlanDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this CreateVlanDetails.
+        A list of the OCIDs of the network security groups (NSGs) to add all VNICs in the VLAN to. For more
+        information about NSGs, see
+        :class:`NetworkSecurityGroup`.
+
+
+        :return: The nsg_ids of this CreateVlanDetails.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this CreateVlanDetails.
+        A list of the OCIDs of the network security groups (NSGs) to add all VNICs in the VLAN to. For more
+        information about NSGs, see
+        :class:`NetworkSecurityGroup`.
+
+
+        :param nsg_ids: The nsg_ids of this CreateVlanDetails.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
+
+    @property
+    def route_table_id(self):
+        """
+        Gets the route_table_id of this CreateVlanDetails.
+        The OCID of the route table the VLAN will use. If you don't provide a value,
+        the VLAN uses the VCN's default route table.
+
+
+        :return: The route_table_id of this CreateVlanDetails.
+        :rtype: str
+        """
+        return self._route_table_id
+
+    @route_table_id.setter
+    def route_table_id(self, route_table_id):
+        """
+        Sets the route_table_id of this CreateVlanDetails.
+        The OCID of the route table the VLAN will use. If you don't provide a value,
+        the VLAN uses the VCN's default route table.
+
+
+        :param route_table_id: The route_table_id of this CreateVlanDetails.
+        :type: str
+        """
+        self._route_table_id = route_table_id
+
+    @property
+    def vcn_id(self):
+        """
+        **[Required]** Gets the vcn_id of this CreateVlanDetails.
+        The OCID of the VCN to contain the VLAN.
+
+
+        :return: The vcn_id of this CreateVlanDetails.
+        :rtype: str
+        """
+        return self._vcn_id
+
+    @vcn_id.setter
+    def vcn_id(self, vcn_id):
+        """
+        Sets the vcn_id of this CreateVlanDetails.
+        The OCID of the VCN to contain the VLAN.
+
+
+        :param vcn_id: The vcn_id of this CreateVlanDetails.
+        :type: str
+        """
+        self._vcn_id = vcn_id
+
+    @property
+    def vlan_tag(self):
+        """
+        Gets the vlan_tag of this CreateVlanDetails.
+        The IEEE 802.1Q VLAN tag for this VLAN. The value must be unique across all
+        VLANs in the VCN. If you don't provide a value, Oracle assigns one.
+        You cannot change the value later. VLAN tag 0 is reserved for use by Oracle.
+
+
+        :return: The vlan_tag of this CreateVlanDetails.
+        :rtype: int
+        """
+        return self._vlan_tag
+
+    @vlan_tag.setter
+    def vlan_tag(self, vlan_tag):
+        """
+        Sets the vlan_tag of this CreateVlanDetails.
+        The IEEE 802.1Q VLAN tag for this VLAN. The value must be unique across all
+        VLANs in the VCN. If you don't provide a value, Oracle assigns one.
+        You cannot change the value later. VLAN tag 0 is reserved for use by Oracle.
+
+
+        :param vlan_tag: The vlan_tag of this CreateVlanDetails.
+        :type: int
+        """
+        self._vlan_tag = vlan_tag
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/create_vnic_details.py
+++ b/src/oci/core/models/create_vnic_details.py
@@ -59,6 +59,10 @@ class CreateVnicDetails(object):
             The value to assign to the subnet_id property of this CreateVnicDetails.
         :type subnet_id: str
 
+        :param vlan_id:
+            The value to assign to the vlan_id property of this CreateVnicDetails.
+        :type vlan_id: str
+
         """
         self.swagger_types = {
             'assign_public_ip': 'bool',
@@ -69,7 +73,8 @@ class CreateVnicDetails(object):
             'nsg_ids': 'list[str]',
             'private_ip': 'str',
             'skip_source_dest_check': 'bool',
-            'subnet_id': 'str'
+            'subnet_id': 'str',
+            'vlan_id': 'str'
         }
 
         self.attribute_map = {
@@ -81,7 +86,8 @@ class CreateVnicDetails(object):
             'nsg_ids': 'nsgIds',
             'private_ip': 'privateIp',
             'skip_source_dest_check': 'skipSourceDestCheck',
-            'subnet_id': 'subnetId'
+            'subnet_id': 'subnetId',
+            'vlan_id': 'vlanId'
         }
 
         self._assign_public_ip = None
@@ -93,6 +99,7 @@ class CreateVnicDetails(object):
         self._private_ip = None
         self._skip_source_dest_check = None
         self._subnet_id = None
+        self._vlan_id = None
 
     @property
     def assign_public_ip(self):
@@ -334,6 +341,11 @@ class CreateVnicDetails(object):
         information about NSGs, see
         :class:`NetworkSecurityGroup`.
 
+        If a `vlanId` is specified, the `nsgIds` is ignored. The `vlanId`
+        indicates that the VNIC will belong to a VLAN instead of a subnet. With VLANs,
+        all VNICs in the VLAN belong to the NSGs that are associated with the VLAN.
+        See :class:`Vlan`.
+
 
         :return: The nsg_ids of this CreateVnicDetails.
         :rtype: list[str]
@@ -347,6 +359,11 @@ class CreateVnicDetails(object):
         A list of the OCIDs of the network security groups (NSGs) to add the VNIC to. For more
         information about NSGs, see
         :class:`NetworkSecurityGroup`.
+
+        If a `vlanId` is specified, the `nsgIds` is ignored. The `vlanId`
+        indicates that the VNIC will belong to a VLAN instead of a subnet. With VLANs,
+        all VNICs in the VLAN belong to the NSGs that are associated with the VLAN.
+        See :class:`Vlan`.
 
 
         :param nsg_ids: The nsg_ids of this CreateVnicDetails.
@@ -366,6 +383,11 @@ class CreateVnicDetails(object):
         :class:`PrivateIp` object returned by
         :func:`list_private_ips` and
         :func:`get_private_ip`.
+
+
+        If you specify a `vlanId`, the `privateIp` is ignored.
+        See :class:`Vlan`.
+
         Example: `10.0.3.3`
 
 
@@ -386,6 +408,11 @@ class CreateVnicDetails(object):
         :class:`PrivateIp` object returned by
         :func:`list_private_ips` and
         :func:`get_private_ip`.
+
+
+        If you specify a `vlanId`, the `privateIp` is ignored.
+        See :class:`Vlan`.
+
         Example: `10.0.3.3`
 
 
@@ -402,6 +429,11 @@ class CreateVnicDetails(object):
         Defaults to `false`, which means the check is performed. For information
         about why you would skip the source/destination check, see
         `Using a Private IP as a Route Target`__.
+
+
+        If you specify a `vlanId`, the `skipSourceDestCheck` is ignored because the
+        source/destination check is always disabled for VNICs in a VLAN. See
+        :class:`Vlan`.
 
         Example: `true`
 
@@ -422,6 +454,11 @@ class CreateVnicDetails(object):
         about why you would skip the source/destination check, see
         `Using a Private IP as a Route Target`__.
 
+
+        If you specify a `vlanId`, the `skipSourceDestCheck` is ignored because the
+        source/destination check is always disabled for VNICs in a VLAN. See
+        :class:`Vlan`.
+
         Example: `true`
 
         __ https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip
@@ -435,11 +472,15 @@ class CreateVnicDetails(object):
     @property
     def subnet_id(self):
         """
-        **[Required]** Gets the subnet_id of this CreateVnicDetails.
+        Gets the subnet_id of this CreateVnicDetails.
         The OCID of the subnet to create the VNIC in. When launching an instance,
         use this `subnetId` instead of the deprecated `subnetId` in
         :func:`launch_instance_details`.
         At least one of them is required; if you provide both, the values must match.
+
+        If you are an Oracle Cloud VMware Solution customer and creating a secondary
+        VNIC in a VLAN instead of a subnet, provide a `vlanId` instead of a `subnetId`.
+        If you provide both a `vlanId` and `subnetId`, the request fails.
 
 
         :return: The subnet_id of this CreateVnicDetails.
@@ -456,11 +497,49 @@ class CreateVnicDetails(object):
         :func:`launch_instance_details`.
         At least one of them is required; if you provide both, the values must match.
 
+        If you are an Oracle Cloud VMware Solution customer and creating a secondary
+        VNIC in a VLAN instead of a subnet, provide a `vlanId` instead of a `subnetId`.
+        If you provide both a `vlanId` and `subnetId`, the request fails.
+
 
         :param subnet_id: The subnet_id of this CreateVnicDetails.
         :type: str
         """
         self._subnet_id = subnet_id
+
+    @property
+    def vlan_id(self):
+        """
+        Gets the vlan_id of this CreateVnicDetails.
+        Provide this attribute only if you are an Oracle Cloud VMware Solution
+        customer and creating a secondary VNIC in a VLAN. The value is the OCID of the VLAN.
+        See :class:`Vlan`.
+
+        Provide a `vlanId` instead of a `subnetId`. If you provide both a
+        `vlanId` and `subnetId`, the request fails.
+
+
+        :return: The vlan_id of this CreateVnicDetails.
+        :rtype: str
+        """
+        return self._vlan_id
+
+    @vlan_id.setter
+    def vlan_id(self, vlan_id):
+        """
+        Sets the vlan_id of this CreateVnicDetails.
+        Provide this attribute only if you are an Oracle Cloud VMware Solution
+        customer and creating a secondary VNIC in a VLAN. The value is the OCID of the VLAN.
+        See :class:`Vlan`.
+
+        Provide a `vlanId` instead of a `subnetId`. If you provide both a
+        `vlanId` and `subnetId`, the request fails.
+
+
+        :param vlan_id: The vlan_id of this CreateVnicDetails.
+        :type: str
+        """
+        self._vlan_id = vlan_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/create_volume_backup_policy_details.py
+++ b/src/oci/core/models/create_volume_backup_policy_details.py
@@ -128,7 +128,10 @@ class CreateVolumeBackupPolicyDetails(object):
     def destination_region(self):
         """
         Gets the destination_region of this CreateVolumeBackupPolicyDetails.
-        The paired destination region (pre-defined by oracle) for scheduled cross region backup calls. Example: `us-ashburn-1`
+        The paired destination region for copying scheduled backups to. Example: `us-ashburn-1`.
+        See `Region Pairs`__ for details about paired regions.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Block/Tasks/schedulingvolumebackups.htm#RegionPairs
 
 
         :return: The destination_region of this CreateVolumeBackupPolicyDetails.
@@ -140,7 +143,10 @@ class CreateVolumeBackupPolicyDetails(object):
     def destination_region(self, destination_region):
         """
         Sets the destination_region of this CreateVolumeBackupPolicyDetails.
-        The paired destination region (pre-defined by oracle) for scheduled cross region backup calls. Example: `us-ashburn-1`
+        The paired destination region for copying scheduled backups to. Example: `us-ashburn-1`.
+        See `Region Pairs`__ for details about paired regions.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Block/Tasks/schedulingvolumebackups.htm#RegionPairs
 
 
         :param destination_region: The destination_region of this CreateVolumeBackupPolicyDetails.

--- a/src/oci/core/models/cross_connect.py
+++ b/src/oci/core/models/cross_connect.py
@@ -459,9 +459,11 @@ class CrossConnect(object):
     def time_created(self):
         """
         Gets the time_created of this CrossConnect.
-        The date and time the cross-connect was created, in the format defined by RFC3339.
+        The date and time the cross-connect was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this CrossConnect.
@@ -473,9 +475,11 @@ class CrossConnect(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this CrossConnect.
-        The date and time the cross-connect was created, in the format defined by RFC3339.
+        The date and time the cross-connect was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this CrossConnect.

--- a/src/oci/core/models/cross_connect_group.py
+++ b/src/oci/core/models/cross_connect_group.py
@@ -324,9 +324,11 @@ class CrossConnectGroup(object):
     def time_created(self):
         """
         Gets the time_created of this CrossConnectGroup.
-        The date and time the cross-connect group was created, in the format defined by RFC3339.
+        The date and time the cross-connect group was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this CrossConnectGroup.
@@ -338,9 +340,11 @@ class CrossConnectGroup(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this CrossConnectGroup.
-        The date and time the cross-connect group was created, in the format defined by RFC3339.
+        The date and time the cross-connect group was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this CrossConnectGroup.

--- a/src/oci/core/models/dedicated_vm_host.py
+++ b/src/oci/core/models/dedicated_vm_host.py
@@ -417,9 +417,11 @@ class DedicatedVmHost(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this DedicatedVmHost.
-        The date and time the dedicated VM host was created, in the format defined by RFC3339.
+        The date and time the dedicated VM host was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this DedicatedVmHost.
@@ -431,9 +433,11 @@ class DedicatedVmHost(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this DedicatedVmHost.
-        The date and time the dedicated VM host was created, in the format defined by RFC3339.
+        The date and time the dedicated VM host was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this DedicatedVmHost.

--- a/src/oci/core/models/dedicated_vm_host_instance_summary.py
+++ b/src/oci/core/models/dedicated_vm_host_instance_summary.py
@@ -165,9 +165,11 @@ class DedicatedVmHostInstanceSummary(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this DedicatedVmHostInstanceSummary.
-        The date and time the virtual machine instance was created, in the format defined by RFC3339.
+        The date and time the virtual machine instance was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this DedicatedVmHostInstanceSummary.
@@ -179,9 +181,11 @@ class DedicatedVmHostInstanceSummary(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this DedicatedVmHostInstanceSummary.
-        The date and time the virtual machine instance was created, in the format defined by RFC3339.
+        The date and time the virtual machine instance was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this DedicatedVmHostInstanceSummary.

--- a/src/oci/core/models/dedicated_vm_host_summary.py
+++ b/src/oci/core/models/dedicated_vm_host_summary.py
@@ -326,9 +326,11 @@ class DedicatedVmHostSummary(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this DedicatedVmHostSummary.
-        The date and time the dedicated VM host was created, in the format defined by RFC3339.
+        The date and time the dedicated VM host was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this DedicatedVmHostSummary.
@@ -340,9 +342,11 @@ class DedicatedVmHostSummary(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this DedicatedVmHostSummary.
-        The date and time the dedicated VM host was created, in the format defined by RFC3339.
+        The date and time the dedicated VM host was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this DedicatedVmHostSummary.

--- a/src/oci/core/models/dhcp_options.py
+++ b/src/oci/core/models/dhcp_options.py
@@ -328,9 +328,11 @@ class DhcpOptions(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this DhcpOptions.
-        Date and time the set of DHCP options was created, in the format defined by RFC3339.
+        Date and time the set of DHCP options was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this DhcpOptions.
@@ -342,9 +344,11 @@ class DhcpOptions(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this DhcpOptions.
-        Date and time the set of DHCP options was created, in the format defined by RFC3339.
+        Date and time the set of DHCP options was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this DhcpOptions.

--- a/src/oci/core/models/drg.py
+++ b/src/oci/core/models/drg.py
@@ -283,9 +283,11 @@ class Drg(object):
     def time_created(self):
         """
         Gets the time_created of this Drg.
-        The date and time the DRG was created, in the format defined by RFC3339.
+        The date and time the DRG was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this Drg.
@@ -297,9 +299,11 @@ class Drg(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Drg.
-        The date and time the DRG was created, in the format defined by RFC3339.
+        The date and time the DRG was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this Drg.

--- a/src/oci/core/models/drg_attachment.py
+++ b/src/oci/core/models/drg_attachment.py
@@ -278,9 +278,11 @@ class DrgAttachment(object):
     def time_created(self):
         """
         Gets the time_created of this DrgAttachment.
-        The date and time the DRG attachment was created, in the format defined by RFC3339.
+        The date and time the DRG attachment was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this DrgAttachment.
@@ -292,9 +294,11 @@ class DrgAttachment(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this DrgAttachment.
-        The date and time the DRG attachment was created, in the format defined by RFC3339.
+        The date and time the DRG attachment was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this DrgAttachment.

--- a/src/oci/core/models/get_public_ip_by_ip_address_details.py
+++ b/src/oci/core/models/get_public_ip_by_ip_address_details.py
@@ -38,7 +38,7 @@ class GetPublicIpByIpAddressDetails(object):
         """
         **[Required]** Gets the ip_address of this GetPublicIpByIpAddressDetails.
         The public IP address.
-        Example: 129.146.2.1
+        Example: 203.0.113.2
 
 
         :return: The ip_address of this GetPublicIpByIpAddressDetails.
@@ -51,7 +51,7 @@ class GetPublicIpByIpAddressDetails(object):
         """
         Sets the ip_address of this GetPublicIpByIpAddressDetails.
         The public IP address.
-        Example: 129.146.2.1
+        Example: 203.0.113.2
 
 
         :param ip_address: The ip_address of this GetPublicIpByIpAddressDetails.

--- a/src/oci/core/models/i_scsi_volume_attachment.py
+++ b/src/oci/core/models/i_scsi_volume_attachment.py
@@ -162,8 +162,6 @@ class IScsiVolumeAttachment(VolumeAttachment):
         The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name.
         (Also called the \"CHAP password\".)
 
-        Example: `d6866c0d-298b-48ba-95af-309b4faux45e`
-
 
         :return: The chap_secret of this IScsiVolumeAttachment.
         :rtype: str
@@ -177,8 +175,6 @@ class IScsiVolumeAttachment(VolumeAttachment):
         The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name.
         (Also called the \"CHAP password\".)
 
-        Example: `d6866c0d-298b-48ba-95af-309b4faux45e`
-
 
         :param chap_secret: The chap_secret of this IScsiVolumeAttachment.
         :type: str
@@ -189,9 +185,11 @@ class IScsiVolumeAttachment(VolumeAttachment):
     def chap_username(self):
         """
         Gets the chap_username of this IScsiVolumeAttachment.
-        The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.
+        The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name. See `RFC 1994`__ for more on CHAP.
 
-        Example: `ocid1.volume.oc1.phx.abyhqljrgvttnlx73nmrwfaux7kcvzfs3s66izvxf2h4lgvyndsdsnoiwr5q`
+        Example: `ocid1.volume.oc1.phx.<unique_ID>`
+
+        __ https://tools.ietf.org/html/rfc1994
 
 
         :return: The chap_username of this IScsiVolumeAttachment.
@@ -203,9 +201,11 @@ class IScsiVolumeAttachment(VolumeAttachment):
     def chap_username(self, chap_username):
         """
         Sets the chap_username of this IScsiVolumeAttachment.
-        The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.
+        The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name. See `RFC 1994`__ for more on CHAP.
 
-        Example: `ocid1.volume.oc1.phx.abyhqljrgvttnlx73nmrwfaux7kcvzfs3s66izvxf2h4lgvyndsdsnoiwr5q`
+        Example: `ocid1.volume.oc1.phx.<unique_ID>`
+
+        __ https://tools.ietf.org/html/rfc1994
 
 
         :param chap_username: The chap_username of this IScsiVolumeAttachment.
@@ -245,9 +245,11 @@ class IScsiVolumeAttachment(VolumeAttachment):
     def iqn(self):
         """
         **[Required]** Gets the iqn of this IScsiVolumeAttachment.
-        The target volume's iSCSI Qualified Name in the format defined by RFC 3720.
+        The target volume's iSCSI Qualified Name in the format defined by `RFC 3720`__.
 
-        Example: `iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9`
+        Example: `iqn.2015-12.us.oracle.com:<CHAP_username>`
+
+        __ https://tools.ietf.org/html/rfc3720#page-32
 
 
         :return: The iqn of this IScsiVolumeAttachment.
@@ -259,9 +261,11 @@ class IScsiVolumeAttachment(VolumeAttachment):
     def iqn(self, iqn):
         """
         Sets the iqn of this IScsiVolumeAttachment.
-        The target volume's iSCSI Qualified Name in the format defined by RFC 3720.
+        The target volume's iSCSI Qualified Name in the format defined by `RFC 3720`__.
 
-        Example: `iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9`
+        Example: `iqn.2015-12.us.oracle.com:<CHAP_username>`
+
+        __ https://tools.ietf.org/html/rfc3720#page-32
 
 
         :param iqn: The iqn of this IScsiVolumeAttachment.
@@ -273,7 +277,7 @@ class IScsiVolumeAttachment(VolumeAttachment):
     def port(self):
         """
         **[Required]** Gets the port of this IScsiVolumeAttachment.
-        The volume's iSCSI port.
+        The volume's iSCSI port, usually port 860 or 3260.
 
         Example: `3260`
 
@@ -287,7 +291,7 @@ class IScsiVolumeAttachment(VolumeAttachment):
     def port(self, port):
         """
         Sets the port of this IScsiVolumeAttachment.
-        The volume's iSCSI port.
+        The volume's iSCSI port, usually port 860 or 3260.
 
         Example: `3260`
 

--- a/src/oci/core/models/image.py
+++ b/src/oci/core/models/image.py
@@ -584,9 +584,11 @@ class Image(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this Image.
-        The date and time the image was created, in the format defined by RFC3339.
+        The date and time the image was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this Image.
@@ -598,9 +600,11 @@ class Image(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Image.
-        The date and time the image was created, in the format defined by RFC3339.
+        The date and time the image was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this Image.

--- a/src/oci/core/models/image_shape_compatibility_summary.py
+++ b/src/oci/core/models/image_shape_compatibility_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ImageShapeCompatibilitySummary(object):
     """
-    Summary information for an image shape compatibility entry.
+    Summary information for a compatible image and shape.
     """
 
     def __init__(self, **kwargs):
@@ -51,7 +51,9 @@ class ImageShapeCompatibilitySummary(object):
     def image_id(self):
         """
         **[Required]** Gets the image_id of this ImageShapeCompatibilitySummary.
-        The image OCID.
+        The image `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The image_id of this ImageShapeCompatibilitySummary.
@@ -63,7 +65,9 @@ class ImageShapeCompatibilitySummary(object):
     def image_id(self, image_id):
         """
         Sets the image_id of this ImageShapeCompatibilitySummary.
-        The image OCID.
+        The image `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param image_id: The image_id of this ImageShapeCompatibilitySummary.

--- a/src/oci/core/models/instance.py
+++ b/src/oci/core/models/instance.py
@@ -870,9 +870,11 @@ class Instance(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this Instance.
-        The date and time the instance was created, in the format defined by RFC3339.
+        The date and time the instance was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this Instance.
@@ -884,9 +886,11 @@ class Instance(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Instance.
-        The date and time the instance was created, in the format defined by RFC3339.
+        The date and time the instance was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this Instance.
@@ -918,10 +922,12 @@ class Instance(object):
     def time_maintenance_reboot_due(self):
         """
         Gets the time_maintenance_reboot_due of this Instance.
-        The date and time the instance is expected to be stopped / started,  in the format defined by RFC3339.
+        The date and time the instance is expected to be stopped / started,  in the format defined by `RFC3339`__.
         After that time if instance hasn't been rebooted, Oracle will reboot the instance within 24 hours of the due time.
         Regardless of how the instance was stopped, the flag will be reset to empty as soon as instance reaches Stopped state.
         Example: `2018-05-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_maintenance_reboot_due of this Instance.
@@ -933,10 +939,12 @@ class Instance(object):
     def time_maintenance_reboot_due(self, time_maintenance_reboot_due):
         """
         Sets the time_maintenance_reboot_due of this Instance.
-        The date and time the instance is expected to be stopped / started,  in the format defined by RFC3339.
+        The date and time the instance is expected to be stopped / started,  in the format defined by `RFC3339`__.
         After that time if instance hasn't been rebooted, Oracle will reboot the instance within 24 hours of the due time.
         Regardless of how the instance was stopped, the flag will be reset to empty as soon as instance reaches Stopped state.
         Example: `2018-05-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_maintenance_reboot_due: The time_maintenance_reboot_due of this Instance.

--- a/src/oci/core/models/instance_configuration.py
+++ b/src/oci/core/models/instance_configuration.py
@@ -288,9 +288,11 @@ class InstanceConfiguration(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this InstanceConfiguration.
-        The date and time the instance configuration was created, in the format defined by RFC3339.
+        The date and time the instance configuration was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this InstanceConfiguration.
@@ -302,9 +304,11 @@ class InstanceConfiguration(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this InstanceConfiguration.
-        The date and time the instance configuration was created, in the format defined by RFC3339.
+        The date and time the instance configuration was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this InstanceConfiguration.

--- a/src/oci/core/models/instance_configuration_attach_volume_details.py
+++ b/src/oci/core/models/instance_configuration_attach_volume_details.py
@@ -31,6 +31,14 @@ class InstanceConfigurationAttachVolumeDetails(object):
             The value to assign to the is_read_only property of this InstanceConfigurationAttachVolumeDetails.
         :type is_read_only: bool
 
+        :param device:
+            The value to assign to the device property of this InstanceConfigurationAttachVolumeDetails.
+        :type device: str
+
+        :param is_shareable:
+            The value to assign to the is_shareable property of this InstanceConfigurationAttachVolumeDetails.
+        :type is_shareable: bool
+
         :param type:
             The value to assign to the type property of this InstanceConfigurationAttachVolumeDetails.
         :type type: str
@@ -39,17 +47,23 @@ class InstanceConfigurationAttachVolumeDetails(object):
         self.swagger_types = {
             'display_name': 'str',
             'is_read_only': 'bool',
+            'device': 'str',
+            'is_shareable': 'bool',
             'type': 'str'
         }
 
         self.attribute_map = {
             'display_name': 'displayName',
             'is_read_only': 'isReadOnly',
+            'device': 'device',
+            'is_shareable': 'isShareable',
             'type': 'type'
         }
 
         self._display_name = None
         self._is_read_only = None
+        self._device = None
+        self._is_shareable = None
         self._type = None
 
     @staticmethod
@@ -115,6 +129,60 @@ class InstanceConfigurationAttachVolumeDetails(object):
         :type: bool
         """
         self._is_read_only = is_read_only
+
+    @property
+    def device(self):
+        """
+        Gets the device of this InstanceConfigurationAttachVolumeDetails.
+        The device name.
+
+
+        :return: The device of this InstanceConfigurationAttachVolumeDetails.
+        :rtype: str
+        """
+        return self._device
+
+    @device.setter
+    def device(self, device):
+        """
+        Sets the device of this InstanceConfigurationAttachVolumeDetails.
+        The device name.
+
+
+        :param device: The device of this InstanceConfigurationAttachVolumeDetails.
+        :type: str
+        """
+        self._device = device
+
+    @property
+    def is_shareable(self):
+        """
+        Gets the is_shareable of this InstanceConfigurationAttachVolumeDetails.
+        Whether the attachment should be created in shareable mode. If an attachment
+        is created in shareable mode, then other instances can attach the same volume, provided
+        that they also create their attachments in shareable mode. Only certain volume types can
+        be attached in shareable mode. Defaults to false if not specified.
+
+
+        :return: The is_shareable of this InstanceConfigurationAttachVolumeDetails.
+        :rtype: bool
+        """
+        return self._is_shareable
+
+    @is_shareable.setter
+    def is_shareable(self, is_shareable):
+        """
+        Sets the is_shareable of this InstanceConfigurationAttachVolumeDetails.
+        Whether the attachment should be created in shareable mode. If an attachment
+        is created in shareable mode, then other instances can attach the same volume, provided
+        that they also create their attachments in shareable mode. Only certain volume types can
+        be attached in shareable mode. Defaults to false if not specified.
+
+
+        :param is_shareable: The is_shareable of this InstanceConfigurationAttachVolumeDetails.
+        :type: bool
+        """
+        self._is_shareable = is_shareable
 
     @property
     def type(self):

--- a/src/oci/core/models/instance_configuration_iscsi_attach_volume_details.py
+++ b/src/oci/core/models/instance_configuration_iscsi_attach_volume_details.py
@@ -27,6 +27,14 @@ class InstanceConfigurationIscsiAttachVolumeDetails(InstanceConfigurationAttachV
             The value to assign to the is_read_only property of this InstanceConfigurationIscsiAttachVolumeDetails.
         :type is_read_only: bool
 
+        :param device:
+            The value to assign to the device property of this InstanceConfigurationIscsiAttachVolumeDetails.
+        :type device: str
+
+        :param is_shareable:
+            The value to assign to the is_shareable property of this InstanceConfigurationIscsiAttachVolumeDetails.
+        :type is_shareable: bool
+
         :param type:
             The value to assign to the type property of this InstanceConfigurationIscsiAttachVolumeDetails.
         :type type: str
@@ -39,6 +47,8 @@ class InstanceConfigurationIscsiAttachVolumeDetails(InstanceConfigurationAttachV
         self.swagger_types = {
             'display_name': 'str',
             'is_read_only': 'bool',
+            'device': 'str',
+            'is_shareable': 'bool',
             'type': 'str',
             'use_chap': 'bool'
         }
@@ -46,12 +56,16 @@ class InstanceConfigurationIscsiAttachVolumeDetails(InstanceConfigurationAttachV
         self.attribute_map = {
             'display_name': 'displayName',
             'is_read_only': 'isReadOnly',
+            'device': 'device',
+            'is_shareable': 'isShareable',
             'type': 'type',
             'use_chap': 'useChap'
         }
 
         self._display_name = None
         self._is_read_only = None
+        self._device = None
+        self._is_shareable = None
         self._type = None
         self._use_chap = None
         self._type = 'iscsi'

--- a/src/oci/core/models/instance_configuration_launch_instance_details.py
+++ b/src/oci/core/models/instance_configuration_launch_instance_details.py
@@ -497,33 +497,21 @@ class InstanceConfigurationLaunchInstanceDetails(object):
          information about how to take advantage of user data, see the
          `Cloud-Init Documentation`__.
 
-         **Note:** Cloud-Init does not pull this data from the `http://169.254.169.254/opc/v1/instance/metadata/`
-         path. When the instance launches and either of these keys are provided, the key values are formatted as
-         OpenStack metadata and copied to the following locations, which are recognized by Cloud-Init:
-
-         `http://169.254.169.254/openstack/latest/meta_data.json` - This JSON blob
-         contains, among other things, the SSH keys that you provided for
-          **\"ssh_authorized_keys\"**.
-
-         `http://169.254.169.254/openstack/latest/user_data` - Contains the
-         base64-decoded data that you provided for **\"user_data\"**.
-
          **Metadata Example**
 
               \"metadata\" : {
                  \"quake_bot_level\" : \"Severe\",
-                 \"ssh_authorized_keys\" : \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCZ06fccNTQfq+xubFlJ5ZR3kt+uzspdH9tXL+lAejSM1NXM+CFZev7MIxfEjas06y80ZBZ7DUTQO0GxJPeD8NCOb1VorF8M4xuLwrmzRtkoZzU16umt4y1W0Q4ifdp3IiiU0U8/WxczSXcUVZOLqkz5dc6oMHdMVpkimietWzGZ4LBBsH/LjEVY7E0V+a0sNchlVDIZcm7ErReBLcdTGDq0uLBiuChyl6RUkX1PNhusquTGwK7zc8OBXkRuubn5UKXhI3Ul9Nyk4XESkVWIGNKmw8mSpoJSjR8P9ZjRmcZVo8S+x4KVPMZKQEor== ryan.smith@company.com
-                 ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAzJSAtwEPoB3Jmr58IXrDGzLuDYkWAYg8AsLYlo6JZvKpjY1xednIcfEVQJm4T2DhVmdWhRrwQ8DmayVZvBkLt+zs2LdoAJEVimKwXcJFD/7wtH8Lnk17HiglbbbNXsemjDY0hea4JUE5CfvkIdZBITuMrfqSmA4n3VNoorXYdvtTMoGG8fxMub46RPtuxtqi9bG9Zqenordkg5FJt2mVNfQRqf83CWojcOkklUWq4CjyxaeLf5i9gv1fRoBo4QhiA8I6NCSppO8GnoV/6Ox6TNoh9BiifqGKC9VGYuC89RvUajRBTZSK2TK4DPfaT+2R+slPsFrwiT/oPEhhEK1S5Q== rsa-key-20160227\",
-                 \"user_data\" : \"SWYgeW91IGNhbiBzZWUgdGhpcywgdGhlbiBpdCB3b3JrZWQgbWF5YmUuCg==\"
+                 \"ssh_authorized_keys\" : \"ssh-rsa <your_public_SSH_key>== rsa-key-20160227\",
+                 \"user_data\" : \"<your_public_SSH_key>==\"
               }
          **Getting Metadata on the Instance**
 
          To get information about your instance, connect to the instance using SSH and issue any of the
          following GET requests:
 
-             curl http://169.254.169.254/opc/v1/instance/
-             curl http://169.254.169.254/opc/v1/instance/metadata/
-             curl http://169.254.169.254/opc/v1/instance/metadata/<any-key-name>
+             curl -H \"Authorization: Bearer Oracle\" http://169.254.169.254/opc/v2/instance/
+             curl -H \"Authorization: Bearer Oracle\" http://169.254.169.254/opc/v2/instance/metadata/
+             curl -H \"Authorization: Bearer Oracle\" http://169.254.169.254/opc/v2/instance/metadata/<any-key-name>
 
          You'll get back a response that includes all the instance information; only the metadata information; or
          the metadata information for the specified key name, respectively.
@@ -569,33 +557,21 @@ class InstanceConfigurationLaunchInstanceDetails(object):
          information about how to take advantage of user data, see the
          `Cloud-Init Documentation`__.
 
-         **Note:** Cloud-Init does not pull this data from the `http://169.254.169.254/opc/v1/instance/metadata/`
-         path. When the instance launches and either of these keys are provided, the key values are formatted as
-         OpenStack metadata and copied to the following locations, which are recognized by Cloud-Init:
-
-         `http://169.254.169.254/openstack/latest/meta_data.json` - This JSON blob
-         contains, among other things, the SSH keys that you provided for
-          **\"ssh_authorized_keys\"**.
-
-         `http://169.254.169.254/openstack/latest/user_data` - Contains the
-         base64-decoded data that you provided for **\"user_data\"**.
-
          **Metadata Example**
 
               \"metadata\" : {
                  \"quake_bot_level\" : \"Severe\",
-                 \"ssh_authorized_keys\" : \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCZ06fccNTQfq+xubFlJ5ZR3kt+uzspdH9tXL+lAejSM1NXM+CFZev7MIxfEjas06y80ZBZ7DUTQO0GxJPeD8NCOb1VorF8M4xuLwrmzRtkoZzU16umt4y1W0Q4ifdp3IiiU0U8/WxczSXcUVZOLqkz5dc6oMHdMVpkimietWzGZ4LBBsH/LjEVY7E0V+a0sNchlVDIZcm7ErReBLcdTGDq0uLBiuChyl6RUkX1PNhusquTGwK7zc8OBXkRuubn5UKXhI3Ul9Nyk4XESkVWIGNKmw8mSpoJSjR8P9ZjRmcZVo8S+x4KVPMZKQEor== ryan.smith@company.com
-                 ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAzJSAtwEPoB3Jmr58IXrDGzLuDYkWAYg8AsLYlo6JZvKpjY1xednIcfEVQJm4T2DhVmdWhRrwQ8DmayVZvBkLt+zs2LdoAJEVimKwXcJFD/7wtH8Lnk17HiglbbbNXsemjDY0hea4JUE5CfvkIdZBITuMrfqSmA4n3VNoorXYdvtTMoGG8fxMub46RPtuxtqi9bG9Zqenordkg5FJt2mVNfQRqf83CWojcOkklUWq4CjyxaeLf5i9gv1fRoBo4QhiA8I6NCSppO8GnoV/6Ox6TNoh9BiifqGKC9VGYuC89RvUajRBTZSK2TK4DPfaT+2R+slPsFrwiT/oPEhhEK1S5Q== rsa-key-20160227\",
-                 \"user_data\" : \"SWYgeW91IGNhbiBzZWUgdGhpcywgdGhlbiBpdCB3b3JrZWQgbWF5YmUuCg==\"
+                 \"ssh_authorized_keys\" : \"ssh-rsa <your_public_SSH_key>== rsa-key-20160227\",
+                 \"user_data\" : \"<your_public_SSH_key>==\"
               }
          **Getting Metadata on the Instance**
 
          To get information about your instance, connect to the instance using SSH and issue any of the
          following GET requests:
 
-             curl http://169.254.169.254/opc/v1/instance/
-             curl http://169.254.169.254/opc/v1/instance/metadata/
-             curl http://169.254.169.254/opc/v1/instance/metadata/<any-key-name>
+             curl -H \"Authorization: Bearer Oracle\" http://169.254.169.254/opc/v2/instance/
+             curl -H \"Authorization: Bearer Oracle\" http://169.254.169.254/opc/v2/instance/metadata/
+             curl -H \"Authorization: Bearer Oracle\" http://169.254.169.254/opc/v2/instance/metadata/<any-key-name>
 
          You'll get back a response that includes all the instance information; only the metadata information; or
          the metadata information for the specified key name, respectively.
@@ -741,6 +717,9 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         Gets the dedicated_vm_host_id of this InstanceConfigurationLaunchInstanceDetails.
         The OCID of dedicated VM host.
 
+        Dedicated VM hosts can be used when launching individual instances from an instance configuration. They
+        cannot be used to launch instance pools.
+
 
         :return: The dedicated_vm_host_id of this InstanceConfigurationLaunchInstanceDetails.
         :rtype: str
@@ -752,6 +731,9 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         """
         Sets the dedicated_vm_host_id of this InstanceConfigurationLaunchInstanceDetails.
         The OCID of dedicated VM host.
+
+        Dedicated VM hosts can be used when launching individual instances from an instance configuration. They
+        cannot be used to launch instance pools.
 
 
         :param dedicated_vm_host_id: The dedicated_vm_host_id of this InstanceConfigurationLaunchInstanceDetails.

--- a/src/oci/core/models/instance_configuration_launch_instance_shape_config_details.py
+++ b/src/oci/core/models/instance_configuration_launch_instance_shape_config_details.py
@@ -10,13 +10,20 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class InstanceConfigurationLaunchInstanceShapeConfigDetails(object):
     """
-    The shape configuration requested for the instance. If provided, the instance will be created
-    with the resources specified. In the case where some properties are missing or
-    the entire parameter is not provided, the instance will be created with the default
-    configuration values for the provided `shape`.
+    The shape configuration requested for the instance.
 
-    Each shape only supports certain configurable values. If the values provided are invalid for the
-    provided `shape`, an error will be returned.
+    If the parameter is provided, the instance is created
+    with the resources that you specify. If some properties are missing or
+    the entire parameter is not provided, the instance is created with the default
+    configuration values for the `shape` that you specify.
+
+    Each shape only supports certain configurable values. If the values that you provid are not valid for the
+    specified `shape`, an error is returned.
+
+    For more information about customizing the resources that are allocated to a flexible shapes, see
+    `Flexible Shapes`__.
+
+    __ https://docs.cloud.oracle.com/Content/Compute/References/computeshapes.htm#flexible
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/core/models/instance_configuration_launch_options.py
+++ b/src/oci/core/models/instance_configuration_launch_options.py
@@ -141,13 +141,13 @@ class InstanceConfigurationLaunchOptions(object):
         """
         Gets the boot_volume_type of this InstanceConfigurationLaunchOptions.
         Emulation type for volume.
-        * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
         * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
         volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
+        Storage volumes on Oracle provided images.
 
         Allowed values for this property are: "ISCSI", "SCSI", "IDE", "VFIO", "PARAVIRTUALIZED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -163,13 +163,13 @@ class InstanceConfigurationLaunchOptions(object):
         """
         Sets the boot_volume_type of this InstanceConfigurationLaunchOptions.
         Emulation type for volume.
-        * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
         * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
         volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
+        Storage volumes on Oracle provided images.
 
 
         :param boot_volume_type: The boot_volume_type of this InstanceConfigurationLaunchOptions.
@@ -261,13 +261,13 @@ class InstanceConfigurationLaunchOptions(object):
         """
         Gets the remote_data_volume_type of this InstanceConfigurationLaunchOptions.
         Emulation type for volume.
-        * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
         * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
         volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
+        Storage volumes on Oracle provided images.
 
         Allowed values for this property are: "ISCSI", "SCSI", "IDE", "VFIO", "PARAVIRTUALIZED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -283,13 +283,13 @@ class InstanceConfigurationLaunchOptions(object):
         """
         Sets the remote_data_volume_type of this InstanceConfigurationLaunchOptions.
         Emulation type for volume.
-        * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
         * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
         volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
+        Storage volumes on Oracle provided images.
 
 
         :param remote_data_volume_type: The remote_data_volume_type of this InstanceConfigurationLaunchOptions.

--- a/src/oci/core/models/instance_configuration_paravirtualized_attach_volume_details.py
+++ b/src/oci/core/models/instance_configuration_paravirtualized_attach_volume_details.py
@@ -27,27 +27,72 @@ class InstanceConfigurationParavirtualizedAttachVolumeDetails(InstanceConfigurat
             The value to assign to the is_read_only property of this InstanceConfigurationParavirtualizedAttachVolumeDetails.
         :type is_read_only: bool
 
+        :param device:
+            The value to assign to the device property of this InstanceConfigurationParavirtualizedAttachVolumeDetails.
+        :type device: str
+
+        :param is_shareable:
+            The value to assign to the is_shareable property of this InstanceConfigurationParavirtualizedAttachVolumeDetails.
+        :type is_shareable: bool
+
         :param type:
             The value to assign to the type property of this InstanceConfigurationParavirtualizedAttachVolumeDetails.
         :type type: str
+
+        :param is_pv_encryption_in_transit_enabled:
+            The value to assign to the is_pv_encryption_in_transit_enabled property of this InstanceConfigurationParavirtualizedAttachVolumeDetails.
+        :type is_pv_encryption_in_transit_enabled: bool
 
         """
         self.swagger_types = {
             'display_name': 'str',
             'is_read_only': 'bool',
-            'type': 'str'
+            'device': 'str',
+            'is_shareable': 'bool',
+            'type': 'str',
+            'is_pv_encryption_in_transit_enabled': 'bool'
         }
 
         self.attribute_map = {
             'display_name': 'displayName',
             'is_read_only': 'isReadOnly',
-            'type': 'type'
+            'device': 'device',
+            'is_shareable': 'isShareable',
+            'type': 'type',
+            'is_pv_encryption_in_transit_enabled': 'isPvEncryptionInTransitEnabled'
         }
 
         self._display_name = None
         self._is_read_only = None
+        self._device = None
+        self._is_shareable = None
         self._type = None
+        self._is_pv_encryption_in_transit_enabled = None
         self._type = 'paravirtualized'
+
+    @property
+    def is_pv_encryption_in_transit_enabled(self):
+        """
+        Gets the is_pv_encryption_in_transit_enabled of this InstanceConfigurationParavirtualizedAttachVolumeDetails.
+        Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false.
+
+
+        :return: The is_pv_encryption_in_transit_enabled of this InstanceConfigurationParavirtualizedAttachVolumeDetails.
+        :rtype: bool
+        """
+        return self._is_pv_encryption_in_transit_enabled
+
+    @is_pv_encryption_in_transit_enabled.setter
+    def is_pv_encryption_in_transit_enabled(self, is_pv_encryption_in_transit_enabled):
+        """
+        Sets the is_pv_encryption_in_transit_enabled of this InstanceConfigurationParavirtualizedAttachVolumeDetails.
+        Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false.
+
+
+        :param is_pv_encryption_in_transit_enabled: The is_pv_encryption_in_transit_enabled of this InstanceConfigurationParavirtualizedAttachVolumeDetails.
+        :type: bool
+        """
+        self._is_pv_encryption_in_transit_enabled = is_pv_encryption_in_transit_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/instance_configuration_summary.py
+++ b/src/oci/core/models/instance_configuration_summary.py
@@ -144,8 +144,10 @@ class InstanceConfigurationSummary(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this InstanceConfigurationSummary.
-        The date and time the instance configuration was created, in the format defined by RFC3339.
+        The date and time the instance configuration was created, in the format defined by `RFC3339`__.
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this InstanceConfigurationSummary.
@@ -157,8 +159,10 @@ class InstanceConfigurationSummary(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this InstanceConfigurationSummary.
-        The date and time the instance configuration was created, in the format defined by RFC3339.
+        The date and time the instance configuration was created, in the format defined by `RFC3339`__.
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this InstanceConfigurationSummary.

--- a/src/oci/core/models/instance_pool.py
+++ b/src/oci/core/models/instance_pool.py
@@ -403,8 +403,10 @@ class InstancePool(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this InstancePool.
-        The date and time the instance pool was created, in the format defined by RFC3339.
+        The date and time the instance pool was created, in the format defined by `RFC3339`__.
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this InstancePool.
@@ -416,8 +418,10 @@ class InstancePool(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this InstancePool.
-        The date and time the instance pool was created, in the format defined by RFC3339.
+        The date and time the instance pool was created, in the format defined by `RFC3339`__.
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this InstancePool.

--- a/src/oci/core/models/instance_pool_summary.py
+++ b/src/oci/core/models/instance_pool_summary.py
@@ -308,8 +308,10 @@ class InstancePoolSummary(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this InstancePoolSummary.
-        The date and time the instance pool was created, in the format defined by RFC3339.
+        The date and time the instance pool was created, in the format defined by `RFC3339`__.
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this InstancePoolSummary.
@@ -321,8 +323,10 @@ class InstancePoolSummary(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this InstancePoolSummary.
-        The date and time the instance pool was created, in the format defined by RFC3339.
+        The date and time the instance pool was created, in the format defined by `RFC3339`__.
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this InstancePoolSummary.

--- a/src/oci/core/models/instance_shape_config.py
+++ b/src/oci/core/models/instance_shape_config.py
@@ -125,7 +125,7 @@ class InstanceShapeConfig(object):
     def memory_in_gbs(self):
         """
         Gets the memory_in_gbs of this InstanceShapeConfig.
-        The total amount of memory, in gigabytes, available to the instance.
+        The total amount of memory available to the instance, in gigabytes.
 
 
         :return: The memory_in_gbs of this InstanceShapeConfig.
@@ -137,7 +137,7 @@ class InstanceShapeConfig(object):
     def memory_in_gbs(self, memory_in_gbs):
         """
         Sets the memory_in_gbs of this InstanceShapeConfig.
-        The total amount of memory, in gigabytes, available to the instance.
+        The total amount of memory available to the instance, in gigabytes.
 
 
         :param memory_in_gbs: The memory_in_gbs of this InstanceShapeConfig.
@@ -149,7 +149,7 @@ class InstanceShapeConfig(object):
     def processor_description(self):
         """
         Gets the processor_description of this InstanceShapeConfig.
-        A short description of the processors available to the instance.
+        A short description of the instance's processor (CPU).
 
 
         :return: The processor_description of this InstanceShapeConfig.
@@ -161,7 +161,7 @@ class InstanceShapeConfig(object):
     def processor_description(self, processor_description):
         """
         Sets the processor_description of this InstanceShapeConfig.
-        A short description of the processors available to the instance.
+        A short description of the instance's processor (CPU).
 
 
         :param processor_description: The processor_description of this InstanceShapeConfig.
@@ -173,7 +173,7 @@ class InstanceShapeConfig(object):
     def networking_bandwidth_in_gbps(self):
         """
         Gets the networking_bandwidth_in_gbps of this InstanceShapeConfig.
-        The networking bandwidth, in gigabits per second, available to the instance.
+        The networking bandwidth available to the instance, in gigabits per second.
 
 
         :return: The networking_bandwidth_in_gbps of this InstanceShapeConfig.
@@ -185,7 +185,7 @@ class InstanceShapeConfig(object):
     def networking_bandwidth_in_gbps(self, networking_bandwidth_in_gbps):
         """
         Sets the networking_bandwidth_in_gbps of this InstanceShapeConfig.
-        The networking bandwidth, in gigabits per second, available to the instance.
+        The networking bandwidth available to the instance, in gigabits per second.
 
 
         :param networking_bandwidth_in_gbps: The networking_bandwidth_in_gbps of this InstanceShapeConfig.
@@ -221,7 +221,7 @@ class InstanceShapeConfig(object):
     def gpus(self):
         """
         Gets the gpus of this InstanceShapeConfig.
-        The number of GPUs available to this instance.
+        The number of GPUs available to the instance.
 
 
         :return: The gpus of this InstanceShapeConfig.
@@ -233,7 +233,7 @@ class InstanceShapeConfig(object):
     def gpus(self, gpus):
         """
         Sets the gpus of this InstanceShapeConfig.
-        The number of GPUs available to this instance.
+        The number of GPUs available to the instance.
 
 
         :param gpus: The gpus of this InstanceShapeConfig.
@@ -245,8 +245,9 @@ class InstanceShapeConfig(object):
     def gpu_description(self):
         """
         Gets the gpu_description of this InstanceShapeConfig.
-        A short description of the GPUs available to this instance.
-        This field is `null` if `gpus` is `0`.
+        A short description of the instance's graphics processing unit (GPU).
+
+        If the instance does not have any GPUs, this field is `null`.
 
 
         :return: The gpu_description of this InstanceShapeConfig.
@@ -258,8 +259,9 @@ class InstanceShapeConfig(object):
     def gpu_description(self, gpu_description):
         """
         Sets the gpu_description of this InstanceShapeConfig.
-        A short description of the GPUs available to this instance.
-        This field is `null` if `gpus` is `0`.
+        A short description of the instance's graphics processing unit (GPU).
+
+        If the instance does not have any GPUs, this field is `null`.
 
 
         :param gpu_description: The gpu_description of this InstanceShapeConfig.
@@ -295,8 +297,9 @@ class InstanceShapeConfig(object):
     def local_disks_total_size_in_gbs(self):
         """
         Gets the local_disks_total_size_in_gbs of this InstanceShapeConfig.
-        The size of the local disks, aggregated, in gigabytes.
-        This field is `null` if `localDisks` is equal to `0`.
+        The aggregate size of all local disks, in gigabytes.
+
+        If the instance does not have any local disks, this field is `null`.
 
 
         :return: The local_disks_total_size_in_gbs of this InstanceShapeConfig.
@@ -308,8 +311,9 @@ class InstanceShapeConfig(object):
     def local_disks_total_size_in_gbs(self, local_disks_total_size_in_gbs):
         """
         Sets the local_disks_total_size_in_gbs of this InstanceShapeConfig.
-        The size of the local disks, aggregated, in gigabytes.
-        This field is `null` if `localDisks` is equal to `0`.
+        The aggregate size of all local disks, in gigabytes.
+
+        If the instance does not have any local disks, this field is `null`.
 
 
         :param local_disks_total_size_in_gbs: The local_disks_total_size_in_gbs of this InstanceShapeConfig.
@@ -322,7 +326,8 @@ class InstanceShapeConfig(object):
         """
         Gets the local_disk_description of this InstanceShapeConfig.
         A short description of the local disks available to this instance.
-        This field is `null` if `localDisks` is equal to `0`.
+
+        If the instance does not have any local disks, this field is `null`.
 
 
         :return: The local_disk_description of this InstanceShapeConfig.
@@ -335,7 +340,8 @@ class InstanceShapeConfig(object):
         """
         Sets the local_disk_description of this InstanceShapeConfig.
         A short description of the local disks available to this instance.
-        This field is `null` if `localDisks` is equal to `0`.
+
+        If the instance does not have any local disks, this field is `null`.
 
 
         :param local_disk_description: The local_disk_description of this InstanceShapeConfig.

--- a/src/oci/core/models/instance_summary.py
+++ b/src/oci/core/models/instance_summary.py
@@ -329,8 +329,10 @@ class InstanceSummary(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this InstanceSummary.
-        The date and time the instance pool instance was created, in the format defined by RFC3339.
+        The date and time the instance pool instance was created, in the format defined by `RFC3339`__.
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this InstanceSummary.
@@ -342,8 +344,10 @@ class InstanceSummary(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this InstanceSummary.
-        The date and time the instance pool instance was created, in the format defined by RFC3339.
+        The date and time the instance pool instance was created, in the format defined by `RFC3339`__.
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this InstanceSummary.

--- a/src/oci/core/models/internet_gateway.py
+++ b/src/oci/core/models/internet_gateway.py
@@ -321,9 +321,11 @@ class InternetGateway(object):
     def time_created(self):
         """
         Gets the time_created of this InternetGateway.
-        The date and time the internet gateway was created, in the format defined by RFC3339.
+        The date and time the internet gateway was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this InternetGateway.
@@ -335,9 +337,11 @@ class InternetGateway(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this InternetGateway.
-        The date and time the internet gateway was created, in the format defined by RFC3339.
+        The date and time the internet gateway was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this InternetGateway.

--- a/src/oci/core/models/ip_sec_connection.py
+++ b/src/oci/core/models/ip_sec_connection.py
@@ -526,9 +526,11 @@ class IPSecConnection(object):
     def time_created(self):
         """
         Gets the time_created of this IPSecConnection.
-        The date and time the IPSec connection was created, in the format defined by RFC3339.
+        The date and time the IPSec connection was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this IPSecConnection.
@@ -540,9 +542,11 @@ class IPSecConnection(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this IPSecConnection.
-        The date and time the IPSec connection was created, in the format defined by RFC3339.
+        The date and time the IPSec connection was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this IPSecConnection.

--- a/src/oci/core/models/ip_sec_connection_device_status.py
+++ b/src/oci/core/models/ip_sec_connection_device_status.py
@@ -107,9 +107,11 @@ class IPSecConnectionDeviceStatus(object):
     def time_created(self):
         """
         Gets the time_created of this IPSecConnectionDeviceStatus.
-        The date and time the IPSec connection was created, in the format defined by RFC3339.
+        The date and time the IPSec connection was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this IPSecConnectionDeviceStatus.
@@ -121,9 +123,11 @@ class IPSecConnectionDeviceStatus(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this IPSecConnectionDeviceStatus.
-        The date and time the IPSec connection was created, in the format defined by RFC3339.
+        The date and time the IPSec connection was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this IPSecConnectionDeviceStatus.

--- a/src/oci/core/models/ip_sec_connection_tunnel.py
+++ b/src/oci/core/models/ip_sec_connection_tunnel.py
@@ -226,7 +226,7 @@ class IPSecConnectionTunnel(object):
         Gets the vpn_ip of this IPSecConnectionTunnel.
         The IP address of Oracle's VPN headend.
 
-        Example: `192.0.2.5`
+        Example: `203.0.113.21`
 
 
         :return: The vpn_ip of this IPSecConnectionTunnel.
@@ -240,7 +240,7 @@ class IPSecConnectionTunnel(object):
         Sets the vpn_ip of this IPSecConnectionTunnel.
         The IP address of Oracle's VPN headend.
 
-        Example: `192.0.2.5`
+        Example: `203.0.113.21`
 
 
         :param vpn_ip: The vpn_ip of this IPSecConnectionTunnel.
@@ -254,7 +254,7 @@ class IPSecConnectionTunnel(object):
         Gets the cpe_ip of this IPSecConnectionTunnel.
         The IP address of the CPE's VPN headend.
 
-        Example: `192.0.2.157`
+        Example: `203.0.113.22`
 
 
         :return: The cpe_ip of this IPSecConnectionTunnel.
@@ -268,7 +268,7 @@ class IPSecConnectionTunnel(object):
         Sets the cpe_ip of this IPSecConnectionTunnel.
         The IP address of the CPE's VPN headend.
 
-        Example: `192.0.2.157`
+        Example: `203.0.113.22`
 
 
         :param cpe_ip: The cpe_ip of this IPSecConnectionTunnel.
@@ -450,9 +450,11 @@ class IPSecConnectionTunnel(object):
     def time_created(self):
         """
         Gets the time_created of this IPSecConnectionTunnel.
-        The date and time the IPSec connection tunnel was created, in the format defined by RFC3339.
+        The date and time the IPSec connection tunnel was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this IPSecConnectionTunnel.
@@ -464,9 +466,11 @@ class IPSecConnectionTunnel(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this IPSecConnectionTunnel.
-        The date and time the IPSec connection tunnel was created, in the format defined by RFC3339.
+        The date and time the IPSec connection tunnel was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this IPSecConnectionTunnel.
@@ -478,9 +482,11 @@ class IPSecConnectionTunnel(object):
     def time_status_updated(self):
         """
         Gets the time_status_updated of this IPSecConnectionTunnel.
-        When the status of the tunnel last changed, in the format defined by RFC3339.
+        When the status of the tunnel last changed, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_status_updated of this IPSecConnectionTunnel.
@@ -492,9 +498,11 @@ class IPSecConnectionTunnel(object):
     def time_status_updated(self, time_status_updated):
         """
         Sets the time_status_updated of this IPSecConnectionTunnel.
-        When the status of the tunnel last changed, in the format defined by RFC3339.
+        When the status of the tunnel last changed, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_status_updated: The time_status_updated of this IPSecConnectionTunnel.

--- a/src/oci/core/models/ip_sec_connection_tunnel_shared_secret.py
+++ b/src/oci/core/models/ip_sec_connection_tunnel_shared_secret.py
@@ -39,8 +39,6 @@ class IPSecConnectionTunnelSharedSecret(object):
         **[Required]** Gets the shared_secret of this IPSecConnectionTunnelSharedSecret.
         The tunnel's shared secret (pre-shared key).
 
-        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
-
 
         :return: The shared_secret of this IPSecConnectionTunnelSharedSecret.
         :rtype: str
@@ -52,8 +50,6 @@ class IPSecConnectionTunnelSharedSecret(object):
         """
         Sets the shared_secret of this IPSecConnectionTunnelSharedSecret.
         The tunnel's shared secret (pre-shared key).
-
-        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 
 
         :param shared_secret: The shared_secret of this IPSecConnectionTunnelSharedSecret.

--- a/src/oci/core/models/ipv6.py
+++ b/src/oci/core/models/ipv6.py
@@ -469,9 +469,11 @@ class Ipv6(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this Ipv6.
-        The date and time the IPv6 was created, in the format defined by RFC3339.
+        The date and time the IPv6 was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this Ipv6.
@@ -483,9 +485,11 @@ class Ipv6(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Ipv6.
-        The date and time the IPv6 was created, in the format defined by RFC3339.
+        The date and time the IPv6 was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this Ipv6.

--- a/src/oci/core/models/launch_instance_details.py
+++ b/src/oci/core/models/launch_instance_details.py
@@ -625,33 +625,21 @@ class LaunchInstanceDetails(object):
          information about how to take advantage of user data, see the
          `Cloud-Init Documentation`__.
 
-         **Note:** Cloud-Init does not pull this data from the `http://169.254.169.254/opc/v1/instance/metadata/`
-         path. When the instance launches and either of these keys are provided, the key values are formatted as
-         OpenStack metadata and copied to the following locations, which are recognized by Cloud-Init:
-
-         `http://169.254.169.254/openstack/latest/meta_data.json` - This JSON blob
-         contains, among other things, the SSH keys that you provided for
-          **\"ssh_authorized_keys\"**.
-
-         `http://169.254.169.254/openstack/latest/user_data` - Contains the
-         base64-decoded data that you provided for **\"user_data\"**.
-
          **Metadata Example**
 
               \"metadata\" : {
                  \"quake_bot_level\" : \"Severe\",
-                 \"ssh_authorized_keys\" : \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCZ06fccNTQfq+xubFlJ5ZR3kt+uzspdH9tXL+lAejSM1NXM+CFZev7MIxfEjas06y80ZBZ7DUTQO0GxJPeD8NCOb1VorF8M4xuLwrmzRtkoZzU16umt4y1W0Q4ifdp3IiiU0U8/WxczSXcUVZOLqkz5dc6oMHdMVpkimietWzGZ4LBBsH/LjEVY7E0V+a0sNchlVDIZcm7ErReBLcdTGDq0uLBiuChyl6RUkX1PNhusquTGwK7zc8OBXkRuubn5UKXhI3Ul9Nyk4XESkVWIGNKmw8mSpoJSjR8P9ZjRmcZVo8S+x4KVPMZKQEor== ryan.smith@company.com
-                 ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAzJSAtwEPoB3Jmr58IXrDGzLuDYkWAYg8AsLYlo6JZvKpjY1xednIcfEVQJm4T2DhVmdWhRrwQ8DmayVZvBkLt+zs2LdoAJEVimKwXcJFD/7wtH8Lnk17HiglbbbNXsemjDY0hea4JUE5CfvkIdZBITuMrfqSmA4n3VNoorXYdvtTMoGG8fxMub46RPtuxtqi9bG9Zqenordkg5FJt2mVNfQRqf83CWojcOkklUWq4CjyxaeLf5i9gv1fRoBo4QhiA8I6NCSppO8GnoV/6Ox6TNoh9BiifqGKC9VGYuC89RvUajRBTZSK2TK4DPfaT+2R+slPsFrwiT/oPEhhEK1S5Q== rsa-key-20160227\",
-                 \"user_data\" : \"SWYgeW91IGNhbiBzZWUgdGhpcywgdGhlbiBpdCB3b3JrZWQgbWF5YmUuCg==\"
+                 \"ssh_authorized_keys\" : \"ssh-rsa <your_public_SSH_key>== rsa-key-20160227\",
+                 \"user_data\" : \"<your_public_SSH_key>==\"
               }
          **Getting Metadata on the Instance**
 
          To get information about your instance, connect to the instance using SSH and issue any of the
          following GET requests:
 
-             curl http://169.254.169.254/opc/v1/instance/
-             curl http://169.254.169.254/opc/v1/instance/metadata/
-             curl http://169.254.169.254/opc/v1/instance/metadata/<any-key-name>
+             curl -H \"Authorization: Bearer Oracle\" http://169.254.169.254/opc/v2/instance/
+             curl -H \"Authorization: Bearer Oracle\" http://169.254.169.254/opc/v2/instance/metadata/
+             curl -H \"Authorization: Bearer Oracle\" http://169.254.169.254/opc/v2/instance/metadata/<any-key-name>
 
          You'll get back a response that includes all the instance information; only the metadata information; or
          the metadata information for the specified key name, respectively.
@@ -697,33 +685,21 @@ class LaunchInstanceDetails(object):
          information about how to take advantage of user data, see the
          `Cloud-Init Documentation`__.
 
-         **Note:** Cloud-Init does not pull this data from the `http://169.254.169.254/opc/v1/instance/metadata/`
-         path. When the instance launches and either of these keys are provided, the key values are formatted as
-         OpenStack metadata and copied to the following locations, which are recognized by Cloud-Init:
-
-         `http://169.254.169.254/openstack/latest/meta_data.json` - This JSON blob
-         contains, among other things, the SSH keys that you provided for
-          **\"ssh_authorized_keys\"**.
-
-         `http://169.254.169.254/openstack/latest/user_data` - Contains the
-         base64-decoded data that you provided for **\"user_data\"**.
-
          **Metadata Example**
 
               \"metadata\" : {
                  \"quake_bot_level\" : \"Severe\",
-                 \"ssh_authorized_keys\" : \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCZ06fccNTQfq+xubFlJ5ZR3kt+uzspdH9tXL+lAejSM1NXM+CFZev7MIxfEjas06y80ZBZ7DUTQO0GxJPeD8NCOb1VorF8M4xuLwrmzRtkoZzU16umt4y1W0Q4ifdp3IiiU0U8/WxczSXcUVZOLqkz5dc6oMHdMVpkimietWzGZ4LBBsH/LjEVY7E0V+a0sNchlVDIZcm7ErReBLcdTGDq0uLBiuChyl6RUkX1PNhusquTGwK7zc8OBXkRuubn5UKXhI3Ul9Nyk4XESkVWIGNKmw8mSpoJSjR8P9ZjRmcZVo8S+x4KVPMZKQEor== ryan.smith@company.com
-                 ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAzJSAtwEPoB3Jmr58IXrDGzLuDYkWAYg8AsLYlo6JZvKpjY1xednIcfEVQJm4T2DhVmdWhRrwQ8DmayVZvBkLt+zs2LdoAJEVimKwXcJFD/7wtH8Lnk17HiglbbbNXsemjDY0hea4JUE5CfvkIdZBITuMrfqSmA4n3VNoorXYdvtTMoGG8fxMub46RPtuxtqi9bG9Zqenordkg5FJt2mVNfQRqf83CWojcOkklUWq4CjyxaeLf5i9gv1fRoBo4QhiA8I6NCSppO8GnoV/6Ox6TNoh9BiifqGKC9VGYuC89RvUajRBTZSK2TK4DPfaT+2R+slPsFrwiT/oPEhhEK1S5Q== rsa-key-20160227\",
-                 \"user_data\" : \"SWYgeW91IGNhbiBzZWUgdGhpcywgdGhlbiBpdCB3b3JrZWQgbWF5YmUuCg==\"
+                 \"ssh_authorized_keys\" : \"ssh-rsa <your_public_SSH_key>== rsa-key-20160227\",
+                 \"user_data\" : \"<your_public_SSH_key>==\"
               }
          **Getting Metadata on the Instance**
 
          To get information about your instance, connect to the instance using SSH and issue any of the
          following GET requests:
 
-             curl http://169.254.169.254/opc/v1/instance/
-             curl http://169.254.169.254/opc/v1/instance/metadata/
-             curl http://169.254.169.254/opc/v1/instance/metadata/<any-key-name>
+             curl -H \"Authorization: Bearer Oracle\" http://169.254.169.254/opc/v2/instance/
+             curl -H \"Authorization: Bearer Oracle\" http://169.254.169.254/opc/v2/instance/metadata/
+             curl -H \"Authorization: Bearer Oracle\" http://169.254.169.254/opc/v2/instance/metadata/<any-key-name>
 
          You'll get back a response that includes all the instance information; only the metadata information; or
          the metadata information for the specified key name, respectively.

--- a/src/oci/core/models/launch_instance_shape_config_details.py
+++ b/src/oci/core/models/launch_instance_shape_config_details.py
@@ -10,13 +10,19 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class LaunchInstanceShapeConfigDetails(object):
     """
-    The shape configuration requested for the instance. If provided, the instance will be created
-    with the resources specified. In the case where some properties are missing or
-    the entire parameter is not provided, the instance will be created with the default
-    configuration values for the provided `shape`.
+    The shape configuration requested for the instance.
 
-    Each shape only supports certain configurable values. If the values provided are invalid for the
-    provided `shape`, an error will be returned.
+    If the parameter is provided, the instance is created with the resources that you specify. If some
+    properties are missing or the entire parameter is not provided, the instance is created
+    with the default configuration values for the `shape` that you specify.
+
+    Each shape only supports certain configurable values. If the values that you provide are not valid for the
+    specified `shape`, an error is returned.
+
+    For more information about customizing the resources that are allocated to a flexible shapes,
+    see `Flexible Shapes`__.
+
+    __ https://docs.cloud.oracle.com/Content/Compute/References/computeshapes.htm#flexible
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/core/models/launch_options.py
+++ b/src/oci/core/models/launch_options.py
@@ -141,13 +141,13 @@ class LaunchOptions(object):
         """
         Gets the boot_volume_type of this LaunchOptions.
         Emulation type for volume.
-        * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
         * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
         volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
+        Storage volumes on Oracle provided images.
 
         Allowed values for this property are: "ISCSI", "SCSI", "IDE", "VFIO", "PARAVIRTUALIZED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -163,13 +163,13 @@ class LaunchOptions(object):
         """
         Sets the boot_volume_type of this LaunchOptions.
         Emulation type for volume.
-        * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
         * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
         volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
+        Storage volumes on Oracle provided images.
 
 
         :param boot_volume_type: The boot_volume_type of this LaunchOptions.
@@ -261,13 +261,13 @@ class LaunchOptions(object):
         """
         Gets the remote_data_volume_type of this LaunchOptions.
         Emulation type for volume.
-        * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
         * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
         volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk.
+        * `PARAVIRTUALIZED` - Paravirtualized disk.This is the default for Boot Volumes and Remote Block
+        Storage volumes on Oracle provided images.
 
         Allowed values for this property are: "ISCSI", "SCSI", "IDE", "VFIO", "PARAVIRTUALIZED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -283,13 +283,13 @@ class LaunchOptions(object):
         """
         Sets the remote_data_volume_type of this LaunchOptions.
         Emulation type for volume.
-        * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
         * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
         volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk.
+        * `PARAVIRTUALIZED` - Paravirtualized disk.This is the default for Boot Volumes and Remote Block
+        Storage volumes on Oracle provided images.
 
 
         :param remote_data_volume_type: The remote_data_volume_type of this LaunchOptions.

--- a/src/oci/core/models/letter_of_authority.py
+++ b/src/oci/core/models/letter_of_authority.py
@@ -216,7 +216,9 @@ class LetterOfAuthority(object):
     def time_expires(self):
         """
         Gets the time_expires of this LetterOfAuthority.
-        The date and time when the Letter of Authority expires, in the format defined by RFC3339.
+        The date and time when the Letter of Authority expires, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_expires of this LetterOfAuthority.
@@ -228,7 +230,9 @@ class LetterOfAuthority(object):
     def time_expires(self, time_expires):
         """
         Sets the time_expires of this LetterOfAuthority.
-        The date and time when the Letter of Authority expires, in the format defined by RFC3339.
+        The date and time when the Letter of Authority expires, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_expires: The time_expires of this LetterOfAuthority.
@@ -240,9 +244,11 @@ class LetterOfAuthority(object):
     def time_issued(self):
         """
         Gets the time_issued of this LetterOfAuthority.
-        The date and time the Letter of Authority was created, in the format defined by RFC3339.
+        The date and time the Letter of Authority was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_issued of this LetterOfAuthority.
@@ -254,9 +260,11 @@ class LetterOfAuthority(object):
     def time_issued(self, time_issued):
         """
         Sets the time_issued of this LetterOfAuthority.
-        The date and time the Letter of Authority was created, in the format defined by RFC3339.
+        The date and time the Letter of Authority was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_issued: The time_issued of this LetterOfAuthority.

--- a/src/oci/core/models/local_peering_gateway.py
+++ b/src/oci/core/models/local_peering_gateway.py
@@ -540,9 +540,11 @@ class LocalPeeringGateway(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this LocalPeeringGateway.
-        The date and time the LPG was created, in the format defined by RFC3339.
+        The date and time the LPG was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this LocalPeeringGateway.
@@ -554,9 +556,11 @@ class LocalPeeringGateway(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this LocalPeeringGateway.
-        The date and time the LPG was created, in the format defined by RFC3339.
+        The date and time the LPG was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this LocalPeeringGateway.

--- a/src/oci/core/models/nat_gateway.py
+++ b/src/oci/core/models/nat_gateway.py
@@ -367,9 +367,11 @@ class NatGateway(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this NatGateway.
-        The date and time the NAT gateway was created, in the format defined by RFC3339.
+        The date and time the NAT gateway was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this NatGateway.
@@ -381,9 +383,11 @@ class NatGateway(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this NatGateway.
-        The date and time the NAT gateway was created, in the format defined by RFC3339.
+        The date and time the NAT gateway was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this NatGateway.

--- a/src/oci/core/models/network_security_group.py
+++ b/src/oci/core/models/network_security_group.py
@@ -327,9 +327,11 @@ class NetworkSecurityGroup(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this NetworkSecurityGroup.
-        The date and time the network security group was created, in the format defined by RFC3339.
+        The date and time the network security group was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this NetworkSecurityGroup.
@@ -341,9 +343,11 @@ class NetworkSecurityGroup(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this NetworkSecurityGroup.
-        The date and time the network security group was created, in the format defined by RFC3339.
+        The date and time the network security group was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this NetworkSecurityGroup.

--- a/src/oci/core/models/network_security_group_vnic.py
+++ b/src/oci/core/models/network_security_group_vnic.py
@@ -82,9 +82,11 @@ class NetworkSecurityGroupVnic(object):
         """
         Gets the time_associated of this NetworkSecurityGroupVnic.
         The date and time the VNIC was added to the network security group, in the format
-        defined by RFC3339.
+        defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_associated of this NetworkSecurityGroupVnic.
@@ -97,9 +99,11 @@ class NetworkSecurityGroupVnic(object):
         """
         Sets the time_associated of this NetworkSecurityGroupVnic.
         The date and time the VNIC was added to the network security group, in the format
-        defined by RFC3339.
+        defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_associated: The time_associated of this NetworkSecurityGroupVnic.

--- a/src/oci/core/models/private_ip.py
+++ b/src/oci/core/models/private_ip.py
@@ -36,6 +36,11 @@ class PrivateIp(object):
     :func:`attach_vnic`. To update the hostname
     for a primary private IP, you use :func:`update_vnic`.
 
+    `PrivateIp` objects that are created for use with the Oracle Cloud VMware Solution are
+    assigned to a VLAN and not a VNIC in a subnet. See the
+    descriptions of the relevant attributes in the `PrivateIp` object. Also see
+    :class:`Vlan`.
+
     To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
@@ -88,6 +93,10 @@ class PrivateIp(object):
             The value to assign to the is_primary property of this PrivateIp.
         :type is_primary: bool
 
+        :param vlan_id:
+            The value to assign to the vlan_id property of this PrivateIp.
+        :type vlan_id: str
+
         :param subnet_id:
             The value to assign to the subnet_id property of this PrivateIp.
         :type subnet_id: str
@@ -111,6 +120,7 @@ class PrivateIp(object):
             'id': 'str',
             'ip_address': 'str',
             'is_primary': 'bool',
+            'vlan_id': 'str',
             'subnet_id': 'str',
             'time_created': 'datetime',
             'vnic_id': 'str'
@@ -126,6 +136,7 @@ class PrivateIp(object):
             'id': 'id',
             'ip_address': 'ipAddress',
             'is_primary': 'isPrimary',
+            'vlan_id': 'vlanId',
             'subnet_id': 'subnetId',
             'time_created': 'timeCreated',
             'vnic_id': 'vnicId'
@@ -140,6 +151,7 @@ class PrivateIp(object):
         self._id = None
         self._ip_address = None
         self._is_primary = None
+        self._vlan_id = None
         self._subnet_id = None
         self._time_created = None
         self._vnic_id = None
@@ -375,6 +387,10 @@ class PrivateIp(object):
         The private IP address of the `privateIp` object. The address is within the CIDR
         of the VNIC's subnet.
 
+        However, if the `PrivateIp` object is being used with a VLAN as part of
+        the Oracle Cloud VMware Solution, the address is from the range specified by the
+        `cidrBlock` attribute for the VLAN. See :class:`Vlan`.
+
         Example: `10.0.3.3`
 
 
@@ -389,6 +405,10 @@ class PrivateIp(object):
         Sets the ip_address of this PrivateIp.
         The private IP address of the `privateIp` object. The address is within the CIDR
         of the VNIC's subnet.
+
+        However, if the `PrivateIp` object is being used with a VLAN as part of
+        the Oracle Cloud VMware Solution, the address is from the range specified by the
+        `cidrBlock` attribute for the VLAN. See :class:`Vlan`.
 
         Example: `10.0.3.3`
 
@@ -429,10 +449,41 @@ class PrivateIp(object):
         self._is_primary = is_primary
 
     @property
+    def vlan_id(self):
+        """
+        Gets the vlan_id of this PrivateIp.
+        Applicable only if the `PrivateIp` object is being used with a VLAN as part of
+        the Oracle Cloud VMware Solution. The `vlanId` is the OCID of the VLAN. See
+        :class:`Vlan`.
+
+
+        :return: The vlan_id of this PrivateIp.
+        :rtype: str
+        """
+        return self._vlan_id
+
+    @vlan_id.setter
+    def vlan_id(self, vlan_id):
+        """
+        Sets the vlan_id of this PrivateIp.
+        Applicable only if the `PrivateIp` object is being used with a VLAN as part of
+        the Oracle Cloud VMware Solution. The `vlanId` is the OCID of the VLAN. See
+        :class:`Vlan`.
+
+
+        :param vlan_id: The vlan_id of this PrivateIp.
+        :type: str
+        """
+        self._vlan_id = vlan_id
+
+    @property
     def subnet_id(self):
         """
         Gets the subnet_id of this PrivateIp.
         The OCID of the subnet the VNIC is in.
+
+        However, if the `PrivateIp` object is being used with a VLAN as part of
+        the Oracle Cloud VMware Solution, the `subnetId` is null.
 
 
         :return: The subnet_id of this PrivateIp.
@@ -446,6 +497,9 @@ class PrivateIp(object):
         Sets the subnet_id of this PrivateIp.
         The OCID of the subnet the VNIC is in.
 
+        However, if the `PrivateIp` object is being used with a VLAN as part of
+        the Oracle Cloud VMware Solution, the `subnetId` is null.
+
 
         :param subnet_id: The subnet_id of this PrivateIp.
         :type: str
@@ -456,9 +510,11 @@ class PrivateIp(object):
     def time_created(self):
         """
         Gets the time_created of this PrivateIp.
-        The date and time the private IP was created, in the format defined by RFC3339.
+        The date and time the private IP was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this PrivateIp.
@@ -470,9 +526,11 @@ class PrivateIp(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this PrivateIp.
-        The date and time the private IP was created, in the format defined by RFC3339.
+        The date and time the private IP was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this PrivateIp.
@@ -487,6 +545,9 @@ class PrivateIp(object):
         The OCID of the VNIC the private IP is assigned to. The VNIC and private IP
         must be in the same subnet.
 
+        However, if the `PrivateIp` object is being used with a VLAN as part of
+        the Oracle Cloud VMware Solution, the `vnicId` is null.
+
 
         :return: The vnic_id of this PrivateIp.
         :rtype: str
@@ -499,6 +560,9 @@ class PrivateIp(object):
         Sets the vnic_id of this PrivateIp.
         The OCID of the VNIC the private IP is assigned to. The VNIC and private IP
         must be in the same subnet.
+
+        However, if the `PrivateIp` object is being used with a VLAN as part of
+        the Oracle Cloud VMware Solution, the `vnicId` is null.
 
 
         :param vnic_id: The vnic_id of this PrivateIp.

--- a/src/oci/core/models/public_ip.py
+++ b/src/oci/core/models/public_ip.py
@@ -445,7 +445,7 @@ class PublicIp(object):
         Gets the ip_address of this PublicIp.
         The public IP address of the `publicIp` object.
 
-        Example: `129.146.2.1`
+        Example: `203.0.113.2`
 
 
         :return: The ip_address of this PublicIp.
@@ -459,7 +459,7 @@ class PublicIp(object):
         Sets the ip_address of this PublicIp.
         The public IP address of the `publicIp` object.
 
-        Example: `129.146.2.1`
+        Example: `203.0.113.2`
 
 
         :param ip_address: The ip_address of this PublicIp.
@@ -645,9 +645,11 @@ class PublicIp(object):
     def time_created(self):
         """
         Gets the time_created of this PublicIp.
-        The date and time the public IP was created, in the format defined by RFC3339.
+        The date and time the public IP was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this PublicIp.
@@ -659,9 +661,11 @@ class PublicIp(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this PublicIp.
-        The date and time the public IP was created, in the format defined by RFC3339.
+        The date and time the public IP was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this PublicIp.

--- a/src/oci/core/models/remote_peering_connection.py
+++ b/src/oci/core/models/remote_peering_connection.py
@@ -509,9 +509,11 @@ class RemotePeeringConnection(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this RemotePeeringConnection.
-        The date and time the RPC was created, in the format defined by RFC3339.
+        The date and time the RPC was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this RemotePeeringConnection.
@@ -523,9 +525,11 @@ class RemotePeeringConnection(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this RemotePeeringConnection.
-        The date and time the RPC was created, in the format defined by RFC3339.
+        The date and time the RPC was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this RemotePeeringConnection.

--- a/src/oci/core/models/route_table.py
+++ b/src/oci/core/models/route_table.py
@@ -319,9 +319,11 @@ class RouteTable(object):
     def time_created(self):
         """
         Gets the time_created of this RouteTable.
-        The date and time the route table was created, in the format defined by RFC3339.
+        The date and time the route table was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this RouteTable.
@@ -333,9 +335,11 @@ class RouteTable(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this RouteTable.
-        The date and time the route table was created, in the format defined by RFC3339.
+        The date and time the route table was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this RouteTable.

--- a/src/oci/core/models/security_list.py
+++ b/src/oci/core/models/security_list.py
@@ -360,9 +360,11 @@ class SecurityList(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this SecurityList.
-        The date and time the security list was created, in the format defined by RFC3339.
+        The date and time the security list was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this SecurityList.
@@ -374,9 +376,11 @@ class SecurityList(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this SecurityList.
-        The date and time the security list was created, in the format defined by RFC3339.
+        The date and time the security list was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this SecurityList.

--- a/src/oci/core/models/security_rule.py
+++ b/src/oci/core/models/security_rule.py
@@ -636,7 +636,9 @@ class SecurityRule(object):
     def time_created(self):
         """
         Gets the time_created of this SecurityRule.
-        The date and time the security rule was created. Format defined by RFC3339.
+        The date and time the security rule was created. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this SecurityRule.
@@ -648,7 +650,9 @@ class SecurityRule(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this SecurityRule.
-        The date and time the security rule was created. Format defined by RFC3339.
+        The date and time the security rule was created. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this SecurityRule.

--- a/src/oci/core/models/service_gateway.py
+++ b/src/oci/core/models/service_gateway.py
@@ -415,9 +415,11 @@ class ServiceGateway(object):
     def time_created(self):
         """
         Gets the time_created of this ServiceGateway.
-        The date and time the service gateway was created, in the format defined by RFC3339.
+        The date and time the service gateway was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this ServiceGateway.
@@ -429,9 +431,11 @@ class ServiceGateway(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this ServiceGateway.
-        The date and time the service gateway was created, in the format defined by RFC3339.
+        The date and time the service gateway was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this ServiceGateway.

--- a/src/oci/core/models/shape.py
+++ b/src/oci/core/models/shape.py
@@ -11,9 +11,11 @@ from oci.decorators import init_model_state_from_kwargs
 class Shape(object):
     """
     A compute instance shape that can be used in :func:`launch_instance`.
-    For more information, see `Overview of the Compute Service`__.
+    For more information, see `Overview of the Compute Service`__ and
+    `Compute Shapes`__.
 
     __ https://docs.cloud.oracle.com/Content/Compute/Concepts/computeoverview.htm
+    __ https://docs.cloud.oracle.com/Content/Compute/References/computeshapes.htm
     """
 
     def __init__(self, **kwargs):
@@ -164,7 +166,7 @@ class Shape(object):
     def processor_description(self):
         """
         Gets the processor_description of this Shape.
-        A short description of the processors available to an instance of this shape.
+        A short description of the shape's processor (CPU).
 
 
         :return: The processor_description of this Shape.
@@ -176,7 +178,7 @@ class Shape(object):
     def processor_description(self, processor_description):
         """
         Sets the processor_description of this Shape.
-        A short description of the processors available to an instance of this shape.
+        A short description of the shape's processor (CPU).
 
 
         :param processor_description: The processor_description of this Shape.
@@ -188,7 +190,7 @@ class Shape(object):
     def ocpus(self):
         """
         Gets the ocpus of this Shape.
-        The default number of OCPUs available to an instance of this shape.
+        The default number of OCPUs available for this shape.
 
 
         :return: The ocpus of this Shape.
@@ -200,7 +202,7 @@ class Shape(object):
     def ocpus(self, ocpus):
         """
         Sets the ocpus of this Shape.
-        The default number of OCPUs available to an instance of this shape.
+        The default number of OCPUs available for this shape.
 
 
         :param ocpus: The ocpus of this Shape.
@@ -212,7 +214,7 @@ class Shape(object):
     def memory_in_gbs(self):
         """
         Gets the memory_in_gbs of this Shape.
-        The default amount of memory, in gigabytes, available to an instance of this shape.
+        The default amount of memory available for this shape, in gigabytes.
 
 
         :return: The memory_in_gbs of this Shape.
@@ -224,7 +226,7 @@ class Shape(object):
     def memory_in_gbs(self, memory_in_gbs):
         """
         Sets the memory_in_gbs of this Shape.
-        The default amount of memory, in gigabytes, available to an instance of this shape.
+        The default amount of memory available for this shape, in gigabytes.
 
 
         :param memory_in_gbs: The memory_in_gbs of this Shape.
@@ -236,7 +238,7 @@ class Shape(object):
     def networking_bandwidth_in_gbps(self):
         """
         Gets the networking_bandwidth_in_gbps of this Shape.
-        The networking bandwidth, in gigabits per second, available to an instance of this shape.
+        The networking bandwidth available for this shape, in gigabits per second.
 
 
         :return: The networking_bandwidth_in_gbps of this Shape.
@@ -248,7 +250,7 @@ class Shape(object):
     def networking_bandwidth_in_gbps(self, networking_bandwidth_in_gbps):
         """
         Sets the networking_bandwidth_in_gbps of this Shape.
-        The networking bandwidth, in gigabits per second, available to an instance of this shape.
+        The networking bandwidth available for this shape, in gigabits per second.
 
 
         :param networking_bandwidth_in_gbps: The networking_bandwidth_in_gbps of this Shape.
@@ -260,7 +262,7 @@ class Shape(object):
     def max_vnic_attachments(self):
         """
         Gets the max_vnic_attachments of this Shape.
-        The maximum number of VNIC attachments available to an instance of this shape.
+        The maximum number of VNIC attachments available for this shape.
 
 
         :return: The max_vnic_attachments of this Shape.
@@ -272,7 +274,7 @@ class Shape(object):
     def max_vnic_attachments(self, max_vnic_attachments):
         """
         Sets the max_vnic_attachments of this Shape.
-        The maximum number of VNIC attachments available to an instance of this shape.
+        The maximum number of VNIC attachments available for this shape.
 
 
         :param max_vnic_attachments: The max_vnic_attachments of this Shape.
@@ -284,7 +286,7 @@ class Shape(object):
     def gpus(self):
         """
         Gets the gpus of this Shape.
-        The number of GPUs available to an instance of this shape.
+        The number of GPUs available for this shape.
 
 
         :return: The gpus of this Shape.
@@ -296,7 +298,7 @@ class Shape(object):
     def gpus(self, gpus):
         """
         Sets the gpus of this Shape.
-        The number of GPUs available to an instance of this shape.
+        The number of GPUs available for this shape.
 
 
         :param gpus: The gpus of this Shape.
@@ -308,8 +310,9 @@ class Shape(object):
     def gpu_description(self):
         """
         Gets the gpu_description of this Shape.
-        A short description of the GPUs available to instances of this shape.
-        This field is `null` if `gpus` is `0`.
+        A short description of the graphics processing unit (GPU) available for this shape.
+
+        If the shape does not have any GPUs, this field is `null`.
 
 
         :return: The gpu_description of this Shape.
@@ -321,8 +324,9 @@ class Shape(object):
     def gpu_description(self, gpu_description):
         """
         Sets the gpu_description of this Shape.
-        A short description of the GPUs available to instances of this shape.
-        This field is `null` if `gpus` is `0`.
+        A short description of the graphics processing unit (GPU) available for this shape.
+
+        If the shape does not have any GPUs, this field is `null`.
 
 
         :param gpu_description: The gpu_description of this Shape.
@@ -334,7 +338,7 @@ class Shape(object):
     def local_disks(self):
         """
         Gets the local_disks of this Shape.
-        The number of local disks available to the instance.
+        The number of local disks available for this shape.
 
 
         :return: The local_disks of this Shape.
@@ -346,7 +350,7 @@ class Shape(object):
     def local_disks(self, local_disks):
         """
         Sets the local_disks of this Shape.
-        The number of local disks available to the instance.
+        The number of local disks available for this shape.
 
 
         :param local_disks: The local_disks of this Shape.
@@ -358,8 +362,9 @@ class Shape(object):
     def local_disks_total_size_in_gbs(self):
         """
         Gets the local_disks_total_size_in_gbs of this Shape.
-        The size of the local disks, aggregated, in gigabytes.
-        This field is `null` if `localDisks` is equal to `0`.
+        The aggregate size of the local disks available for this shape, in gigabytes.
+
+        If the shape does not have any local disks, this field is `null`.
 
 
         :return: The local_disks_total_size_in_gbs of this Shape.
@@ -371,8 +376,9 @@ class Shape(object):
     def local_disks_total_size_in_gbs(self, local_disks_total_size_in_gbs):
         """
         Sets the local_disks_total_size_in_gbs of this Shape.
-        The size of the local disks, aggregated, in gigabytes.
-        This field is `null` if `localDisks` is equal to `0`.
+        The aggregate size of the local disks available for this shape, in gigabytes.
+
+        If the shape does not have any local disks, this field is `null`.
 
 
         :param local_disks_total_size_in_gbs: The local_disks_total_size_in_gbs of this Shape.
@@ -384,8 +390,9 @@ class Shape(object):
     def local_disk_description(self):
         """
         Gets the local_disk_description of this Shape.
-        A short description of the local disks available to instances of this shape.
-        This field is `null` if `localDisks` is equal to `0`.
+        A short description of the local disks available for this shape.
+
+        If the shape does not have any local disks, this field is `null`.
 
 
         :return: The local_disk_description of this Shape.
@@ -397,8 +404,9 @@ class Shape(object):
     def local_disk_description(self, local_disk_description):
         """
         Sets the local_disk_description of this Shape.
-        A short description of the local disks available to instances of this shape.
-        This field is `null` if `localDisks` is equal to `0`.
+        A short description of the local disks available for this shape.
+
+        If the shape does not have any local disks, this field is `null`.
 
 
         :param local_disk_description: The local_disk_description of this Shape.

--- a/src/oci/core/models/shape_max_vnic_attachment_options.py
+++ b/src/oci/core/models/shape_max_vnic_attachment_options.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ShapeMaxVnicAttachmentOptions(object):
     """
-    The possible configurations for the number of VNIC attachments available to an instance of this shape. If this field is null, then all instances of this shape have a fixed maximum number of VNIC attachments equal to `maxVnicAttachments`.
+    For a flexible shape, the number of VNIC attachments that are available for instances that use this shape.
+
+    If this field is null, then this shape has a fixed maximum number of VNIC attachments equal to `maxVnicAttachments`.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/core/models/shape_memory_options.py
+++ b/src/oci/core/models/shape_memory_options.py
@@ -10,9 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ShapeMemoryOptions(object):
     """
-    The possible configurations for the amount of memory available to an instance of this shape.
-    If this field is null, then all instances of this shape have a fixed
-    amount of memory equivalent to `memoryInGBs`.
+    For a flexible shape, the amount of memory available for instances that use this shape.
+
+    If this field is null, then this shape has a fixed amount of memory equivalent to `memoryInGBs`.
     """
 
     def __init__(self, **kwargs):
@@ -101,8 +101,7 @@ class ShapeMemoryOptions(object):
     def default_per_ocpu_in_g_bs(self):
         """
         Gets the default_per_ocpu_in_g_bs of this ShapeMemoryOptions.
-        The default amount of memory, in gigabytes, per OCPU available to an instance
-        of this shape.
+        The default amount of memory per OCPU available for this shape, in gigabytes.
 
 
         :return: The default_per_ocpu_in_g_bs of this ShapeMemoryOptions.
@@ -114,8 +113,7 @@ class ShapeMemoryOptions(object):
     def default_per_ocpu_in_g_bs(self, default_per_ocpu_in_g_bs):
         """
         Sets the default_per_ocpu_in_g_bs of this ShapeMemoryOptions.
-        The default amount of memory, in gigabytes, per OCPU available to an instance
-        of this shape.
+        The default amount of memory per OCPU available for this shape, in gigabytes.
 
 
         :param default_per_ocpu_in_g_bs: The default_per_ocpu_in_g_bs of this ShapeMemoryOptions.

--- a/src/oci/core/models/shape_networking_bandwidth_options.py
+++ b/src/oci/core/models/shape_networking_bandwidth_options.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ShapeNetworkingBandwidthOptions(object):
     """
-    The possible configurations for the amount of networking bandwidth available to an instance of this shape. If this field is null, then all instances of this shape have a fixed amount of bandwidth equivalent to `networkingBandwidthInGbps`.
+    For a flexible shape, the amount of networking bandwidth available for instances that use this shape.
+
+    If this field is null, then this shape has a fixed amount of bandwidth equivalent to `networkingBandwidthInGbps`.
     """
 
     def __init__(self, **kwargs):
@@ -99,8 +101,7 @@ class ShapeNetworkingBandwidthOptions(object):
     def default_per_ocpu_in_gbps(self):
         """
         Gets the default_per_ocpu_in_gbps of this ShapeNetworkingBandwidthOptions.
-        The default amount of networking bandwidth, in gigabits per second,
-        per OCPU.
+        The default amount of networking bandwidth per OCPU, in gigabits per second.
 
 
         :return: The default_per_ocpu_in_gbps of this ShapeNetworkingBandwidthOptions.
@@ -112,8 +113,7 @@ class ShapeNetworkingBandwidthOptions(object):
     def default_per_ocpu_in_gbps(self, default_per_ocpu_in_gbps):
         """
         Sets the default_per_ocpu_in_gbps of this ShapeNetworkingBandwidthOptions.
-        The default amount of networking bandwidth, in gigabits per second,
-        per OCPU.
+        The default amount of networking bandwidth per OCPU, in gigabits per second.
 
 
         :param default_per_ocpu_in_gbps: The default_per_ocpu_in_gbps of this ShapeNetworkingBandwidthOptions.

--- a/src/oci/core/models/shape_ocpu_options.py
+++ b/src/oci/core/models/shape_ocpu_options.py
@@ -10,9 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ShapeOcpuOptions(object):
     """
-    The possible configurations for the number of OCPUs available to an instance of this shape.
-    If this field is null, then all instances of this shape have a fixed
-    number of OCPUs equal to `ocpus`.
+    For a flexible shape, the number of OCPUs available for instances that use this shape.
+
+    If this field is null, then this shape has a fixed number of OCPUs equal to `ocpus`.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/core/models/subnet.py
+++ b/src/oci/core/models/subnet.py
@@ -242,7 +242,7 @@ class Subnet(object):
         **[Required]** Gets the cidr_block of this Subnet.
         The subnet's CIDR block.
 
-        Example: `172.16.1.0/24`
+        Example: `10.0.1.0/24`
 
 
         :return: The cidr_block of this Subnet.
@@ -256,7 +256,7 @@ class Subnet(object):
         Sets the cidr_block of this Subnet.
         The subnet's CIDR block.
 
-        Example: `172.16.1.0/24`
+        Example: `10.0.1.0/24`
 
 
         :param cidr_block: The cidr_block of this Subnet.
@@ -750,9 +750,11 @@ class Subnet(object):
     def time_created(self):
         """
         Gets the time_created of this Subnet.
-        The date and time the subnet was created, in the format defined by RFC3339.
+        The date and time the subnet was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this Subnet.
@@ -764,9 +766,11 @@ class Subnet(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Subnet.
-        The date and time the subnet was created, in the format defined by RFC3339.
+        The date and time the subnet was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this Subnet.
@@ -832,7 +836,7 @@ class Subnet(object):
         **[Required]** Gets the virtual_router_mac of this Subnet.
         The MAC address of the virtual router.
 
-        Example: `00:00:17:B6:4D:DD`
+        Example: `00:00:00:00:00:01`
 
 
         :return: The virtual_router_mac of this Subnet.
@@ -846,7 +850,7 @@ class Subnet(object):
         Sets the virtual_router_mac of this Subnet.
         The MAC address of the virtual router.
 
-        Example: `00:00:17:B6:4D:DD`
+        Example: `00:00:00:00:00:01`
 
 
         :param virtual_router_mac: The virtual_router_mac of this Subnet.

--- a/src/oci/core/models/tunnel_config.py
+++ b/src/oci/core/models/tunnel_config.py
@@ -56,7 +56,7 @@ class TunnelConfig(object):
         **[Required]** Gets the ip_address of this TunnelConfig.
         The IP address of Oracle's VPN headend.
 
-        Example: `129.146.17.50`
+        Example: `203.0.113.50 `
 
 
         :return: The ip_address of this TunnelConfig.
@@ -70,7 +70,7 @@ class TunnelConfig(object):
         Sets the ip_address of this TunnelConfig.
         The IP address of Oracle's VPN headend.
 
-        Example: `129.146.17.50`
+        Example: `203.0.113.50 `
 
 
         :param ip_address: The ip_address of this TunnelConfig.
@@ -84,8 +84,6 @@ class TunnelConfig(object):
         **[Required]** Gets the shared_secret of this TunnelConfig.
         The shared secret of the IPSec tunnel.
 
-        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
-
 
         :return: The shared_secret of this TunnelConfig.
         :rtype: str
@@ -98,8 +96,6 @@ class TunnelConfig(object):
         Sets the shared_secret of this TunnelConfig.
         The shared secret of the IPSec tunnel.
 
-        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
-
 
         :param shared_secret: The shared_secret of this TunnelConfig.
         :type: str
@@ -110,9 +106,11 @@ class TunnelConfig(object):
     def time_created(self):
         """
         Gets the time_created of this TunnelConfig.
-        The date and time the IPSec connection was created, in the format defined by RFC3339.
+        The date and time the IPSec connection was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this TunnelConfig.
@@ -124,9 +122,11 @@ class TunnelConfig(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this TunnelConfig.
-        The date and time the IPSec connection was created, in the format defined by RFC3339.
+        The date and time the IPSec connection was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this TunnelConfig.

--- a/src/oci/core/models/tunnel_status.py
+++ b/src/oci/core/models/tunnel_status.py
@@ -74,7 +74,7 @@ class TunnelStatus(object):
         **[Required]** Gets the ip_address of this TunnelStatus.
         The IP address of Oracle's VPN headend.
 
-        Example: `129.146.17.50`
+        Example: `203.0.113.50`
 
 
         :return: The ip_address of this TunnelStatus.
@@ -88,7 +88,7 @@ class TunnelStatus(object):
         Sets the ip_address of this TunnelStatus.
         The IP address of Oracle's VPN headend.
 
-        Example: `129.146.17.50`
+        Example: `203.0.113.50`
 
 
         :param ip_address: The ip_address of this TunnelStatus.
@@ -130,9 +130,11 @@ class TunnelStatus(object):
     def time_created(self):
         """
         Gets the time_created of this TunnelStatus.
-        The date and time the IPSec connection was created, in the format defined by RFC3339.
+        The date and time the IPSec connection was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this TunnelStatus.
@@ -144,9 +146,11 @@ class TunnelStatus(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this TunnelStatus.
-        The date and time the IPSec connection was created, in the format defined by RFC3339.
+        The date and time the IPSec connection was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this TunnelStatus.
@@ -158,9 +162,11 @@ class TunnelStatus(object):
     def time_state_modified(self):
         """
         Gets the time_state_modified of this TunnelStatus.
-        When the state of the tunnel last changed, in the format defined by RFC3339.
+        When the state of the tunnel last changed, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_state_modified of this TunnelStatus.
@@ -172,9 +178,11 @@ class TunnelStatus(object):
     def time_state_modified(self, time_state_modified):
         """
         Sets the time_state_modified of this TunnelStatus.
-        When the state of the tunnel last changed, in the format defined by RFC3339.
+        When the state of the tunnel last changed, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_state_modified: The time_state_modified of this TunnelStatus.

--- a/src/oci/core/models/update_ip_sec_connection_tunnel_shared_secret_details.py
+++ b/src/oci/core/models/update_ip_sec_connection_tunnel_shared_secret_details.py
@@ -40,8 +40,6 @@ class UpdateIPSecConnectionTunnelSharedSecretDetails(object):
         The shared secret (pre-shared key) to use for the tunnel. Only numbers, letters, and spaces
         are allowed.
 
-        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
-
 
         :return: The shared_secret of this UpdateIPSecConnectionTunnelSharedSecretDetails.
         :rtype: str
@@ -54,8 +52,6 @@ class UpdateIPSecConnectionTunnelSharedSecretDetails(object):
         Sets the shared_secret of this UpdateIPSecConnectionTunnelSharedSecretDetails.
         The shared secret (pre-shared key) to use for the tunnel. Only numbers, letters, and spaces
         are allowed.
-
-        Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 
 
         :param shared_secret: The shared_secret of this UpdateIPSecConnectionTunnelSharedSecretDetails.

--- a/src/oci/core/models/update_vlan_details.py
+++ b/src/oci/core/models/update_vlan_details.py
@@ -1,0 +1,222 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateVlanDetails(object):
+    """
+    UpdateVlanDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateVlanDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateVlanDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateVlanDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateVlanDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this UpdateVlanDetails.
+        :type nsg_ids: list[str]
+
+        :param route_table_id:
+            The value to assign to the route_table_id property of this UpdateVlanDetails.
+        :type route_table_id: str
+
+        """
+        self.swagger_types = {
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'nsg_ids': 'list[str]',
+            'route_table_id': 'str'
+        }
+
+        self.attribute_map = {
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'nsg_ids': 'nsgIds',
+            'route_table_id': 'routeTableId'
+        }
+
+        self._defined_tags = None
+        self._display_name = None
+        self._freeform_tags = None
+        self._nsg_ids = None
+        self._route_table_id = None
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateVlanDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateVlanDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateVlanDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateVlanDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateVlanDetails.
+        A descriptive name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+
+        :return: The display_name of this UpdateVlanDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateVlanDetails.
+        A descriptive name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this UpdateVlanDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateVlanDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateVlanDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateVlanDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateVlanDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this UpdateVlanDetails.
+        A list of the OCIDs of the network security groups (NSGs) to use with
+        this VLAN. All VNICs in the VLAN will belong to these NSGs. For more
+        information about NSGs, see
+        :class:`NetworkSecurityGroup`.
+
+
+        :return: The nsg_ids of this UpdateVlanDetails.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this UpdateVlanDetails.
+        A list of the OCIDs of the network security groups (NSGs) to use with
+        this VLAN. All VNICs in the VLAN will belong to these NSGs. For more
+        information about NSGs, see
+        :class:`NetworkSecurityGroup`.
+
+
+        :param nsg_ids: The nsg_ids of this UpdateVlanDetails.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
+
+    @property
+    def route_table_id(self):
+        """
+        Gets the route_table_id of this UpdateVlanDetails.
+        The OCID of the route table the VLAN will use.
+
+
+        :return: The route_table_id of this UpdateVlanDetails.
+        :rtype: str
+        """
+        return self._route_table_id
+
+    @route_table_id.setter
+    def route_table_id(self, route_table_id):
+        """
+        Sets the route_table_id of this UpdateVlanDetails.
+        The OCID of the route table the VLAN will use.
+
+
+        :param route_table_id: The route_table_id of this UpdateVlanDetails.
+        :type: str
+        """
+        self._route_table_id = route_table_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/update_vnic_details.py
+++ b/src/oci/core/models/update_vnic_details.py
@@ -225,6 +225,10 @@ class UpdateVnicDetails(object):
         A list of the OCIDs of the network security groups (NSGs) to add the VNIC to. Setting this as
         an empty array removes the VNIC from all network security groups.
 
+        If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+        belonging to a subnet), the value of the `nsgIds` attribute is ignored. Instead, the
+        VNIC belongs to the NSGs that are associated with the VLAN itself. See :class:`Vlan`.
+
         For more information about NSGs, see
         :class:`NetworkSecurityGroup`.
 
@@ -241,6 +245,10 @@ class UpdateVnicDetails(object):
         A list of the OCIDs of the network security groups (NSGs) to add the VNIC to. Setting this as
         an empty array removes the VNIC from all network security groups.
 
+        If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+        belonging to a subnet), the value of the `nsgIds` attribute is ignored. Instead, the
+        VNIC belongs to the NSGs that are associated with the VLAN itself. See :class:`Vlan`.
+
         For more information about NSGs, see
         :class:`NetworkSecurityGroup`.
 
@@ -255,10 +263,13 @@ class UpdateVnicDetails(object):
         """
         Gets the skip_source_dest_check of this UpdateVnicDetails.
         Whether the source/destination check is disabled on the VNIC.
-        Defaults to `false`, which means the check is performed.
-
-        For information about why you would skip the source/destination check, see
+        Defaults to `false`, which means the check is performed. For information about why you would
+        skip the source/destination check, see
         `Using a Private IP as a Route Target`__.
+
+        If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+        belonging to a subnet), the value of the `skipSourceDestCheck` attribute is ignored.
+        This is because the source/destination check is always disabled for VNICs in a VLAN.
         Example: `true`
 
         __ https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip
@@ -274,10 +285,13 @@ class UpdateVnicDetails(object):
         """
         Sets the skip_source_dest_check of this UpdateVnicDetails.
         Whether the source/destination check is disabled on the VNIC.
-        Defaults to `false`, which means the check is performed.
-
-        For information about why you would skip the source/destination check, see
+        Defaults to `false`, which means the check is performed. For information about why you would
+        skip the source/destination check, see
         `Using a Private IP as a Route Target`__.
+
+        If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+        belonging to a subnet), the value of the `skipSourceDestCheck` attribute is ignored.
+        This is because the source/destination check is always disabled for VNICs in a VLAN.
         Example: `true`
 
         __ https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip

--- a/src/oci/core/models/update_volume_backup_policy_details.py
+++ b/src/oci/core/models/update_volume_backup_policy_details.py
@@ -97,7 +97,11 @@ class UpdateVolumeBackupPolicyDetails(object):
     def destination_region(self):
         """
         Gets the destination_region of this UpdateVolumeBackupPolicyDetails.
-        The paired destination region (pre-defined by oracle) for scheduled cross region backup calls. Example: `us-ashburn-1`
+        The paired destination region for copying scheduled backups to. Example: `us-ashburn-1`.
+        Specify `none` to reset the `destinationRegion` parameter.
+        See `Region Pairs`__ for details about paired regions.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Block/Tasks/schedulingvolumebackups.htm#RegionPairs
 
 
         :return: The destination_region of this UpdateVolumeBackupPolicyDetails.
@@ -109,7 +113,11 @@ class UpdateVolumeBackupPolicyDetails(object):
     def destination_region(self, destination_region):
         """
         Sets the destination_region of this UpdateVolumeBackupPolicyDetails.
-        The paired destination region (pre-defined by oracle) for scheduled cross region backup calls. Example: `us-ashburn-1`
+        The paired destination region for copying scheduled backups to. Example: `us-ashburn-1`.
+        Specify `none` to reset the `destinationRegion` parameter.
+        See `Region Pairs`__ for details about paired regions.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Block/Tasks/schedulingvolumebackups.htm#RegionPairs
 
 
         :param destination_region: The destination_region of this UpdateVolumeBackupPolicyDetails.

--- a/src/oci/core/models/vcn.py
+++ b/src/oci/core/models/vcn.py
@@ -566,9 +566,11 @@ class Vcn(object):
     def time_created(self):
         """
         Gets the time_created of this Vcn.
-        The date and time the VCN was created, in the format defined by RFC3339.
+        The date and time the VCN was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this Vcn.
@@ -580,9 +582,11 @@ class Vcn(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Vcn.
-        The date and time the VCN was created, in the format defined by RFC3339.
+        The date and time the VCN was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this Vcn.

--- a/src/oci/core/models/virtual_circuit.py
+++ b/src/oci/core/models/virtual_circuit.py
@@ -976,9 +976,11 @@ class VirtualCircuit(object):
         """
         Gets the time_created of this VirtualCircuit.
         The date and time the virtual circuit was created,
-        in the format defined by RFC3339.
+        in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this VirtualCircuit.
@@ -991,9 +993,11 @@ class VirtualCircuit(object):
         """
         Sets the time_created of this VirtualCircuit.
         The date and time the virtual circuit was created,
-        in the format defined by RFC3339.
+        in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this VirtualCircuit.

--- a/src/oci/core/models/vlan.py
+++ b/src/oci/core/models/vlan.py
@@ -1,0 +1,529 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Vlan(object):
+    """
+    A resource to be used only with the Oracle Cloud VMware Solution.
+
+    Conceptually, a virtual LAN (VLAN) is a broadcast domain that is created
+    by partitioning and isolating a network at the data link layer (a *layer 2 network*).
+    VLANs work by using IEEE 802.1Q VLAN tags. Layer 2 traffic is forwarded within the
+    VLAN based on MAC learning.
+
+    In the Networking service, a VLAN is an object within a VCN. You use VLANs to
+    partition the VCN at the data link layer (layer 2). A VLAN is analagous to a subnet,
+    which is an object for partitioning the VCN at the IP layer (layer 3).
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a Vlan.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a Vlan.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a Vlan.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a Vlan.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a Vlan.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Vlan object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this Vlan.
+        :type availability_domain: str
+
+        :param cidr_block:
+            The value to assign to the cidr_block property of this Vlan.
+        :type cidr_block: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this Vlan.
+        :type compartment_id: str
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this Vlan.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this Vlan.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this Vlan.
+        :type freeform_tags: dict(str, str)
+
+        :param id:
+            The value to assign to the id property of this Vlan.
+        :type id: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this Vlan.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this Vlan.
+        :type nsg_ids: list[str]
+
+        :param vlan_tag:
+            The value to assign to the vlan_tag property of this Vlan.
+        :type vlan_tag: int
+
+        :param route_table_id:
+            The value to assign to the route_table_id property of this Vlan.
+        :type route_table_id: str
+
+        :param time_created:
+            The value to assign to the time_created property of this Vlan.
+        :type time_created: datetime
+
+        :param vcn_id:
+            The value to assign to the vcn_id property of this Vlan.
+        :type vcn_id: str
+
+        """
+        self.swagger_types = {
+            'availability_domain': 'str',
+            'cidr_block': 'str',
+            'compartment_id': 'str',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'id': 'str',
+            'lifecycle_state': 'str',
+            'nsg_ids': 'list[str]',
+            'vlan_tag': 'int',
+            'route_table_id': 'str',
+            'time_created': 'datetime',
+            'vcn_id': 'str'
+        }
+
+        self.attribute_map = {
+            'availability_domain': 'availabilityDomain',
+            'cidr_block': 'cidrBlock',
+            'compartment_id': 'compartmentId',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'id': 'id',
+            'lifecycle_state': 'lifecycleState',
+            'nsg_ids': 'nsgIds',
+            'vlan_tag': 'vlanTag',
+            'route_table_id': 'routeTableId',
+            'time_created': 'timeCreated',
+            'vcn_id': 'vcnId'
+        }
+
+        self._availability_domain = None
+        self._cidr_block = None
+        self._compartment_id = None
+        self._defined_tags = None
+        self._display_name = None
+        self._freeform_tags = None
+        self._id = None
+        self._lifecycle_state = None
+        self._nsg_ids = None
+        self._vlan_tag = None
+        self._route_table_id = None
+        self._time_created = None
+        self._vcn_id = None
+
+    @property
+    def availability_domain(self):
+        """
+        Gets the availability_domain of this Vlan.
+        The availability domain of the VLAN.
+
+        Example: `Uocm:PHX-AD-1`
+
+
+        :return: The availability_domain of this Vlan.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this Vlan.
+        The availability domain of the VLAN.
+
+        Example: `Uocm:PHX-AD-1`
+
+
+        :param availability_domain: The availability_domain of this Vlan.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def cidr_block(self):
+        """
+        **[Required]** Gets the cidr_block of this Vlan.
+        The range of IPv4 addresses that will be used for layer 3 communication with
+        hosts outside the VLAN.
+
+        Example: `192.168.1.0/24`
+
+
+        :return: The cidr_block of this Vlan.
+        :rtype: str
+        """
+        return self._cidr_block
+
+    @cidr_block.setter
+    def cidr_block(self, cidr_block):
+        """
+        Sets the cidr_block of this Vlan.
+        The range of IPv4 addresses that will be used for layer 3 communication with
+        hosts outside the VLAN.
+
+        Example: `192.168.1.0/24`
+
+
+        :param cidr_block: The cidr_block of this Vlan.
+        :type: str
+        """
+        self._cidr_block = cidr_block
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this Vlan.
+        The OCID of the compartment containing the VLAN.
+
+
+        :return: The compartment_id of this Vlan.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this Vlan.
+        The OCID of the compartment containing the VLAN.
+
+
+        :param compartment_id: The compartment_id of this Vlan.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this Vlan.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this Vlan.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this Vlan.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this Vlan.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this Vlan.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+
+        :return: The display_name of this Vlan.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this Vlan.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this Vlan.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this Vlan.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this Vlan.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this Vlan.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this Vlan.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this Vlan.
+        The VLAN's Oracle ID (OCID).
+
+
+        :return: The id of this Vlan.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this Vlan.
+        The VLAN's Oracle ID (OCID).
+
+
+        :param id: The id of this Vlan.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this Vlan.
+        The VLAN's current state.
+
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this Vlan.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this Vlan.
+        The VLAN's current state.
+
+
+        :param lifecycle_state: The lifecycle_state of this Vlan.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED", "UPDATING"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this Vlan.
+        A list of the OCIDs of the network security groups (NSGs) to use with this VLAN.
+        All VNICs in the VLAN belong to these NSGs. For more
+        information about NSGs, see
+        :class:`NetworkSecurityGroup`.
+
+
+        :return: The nsg_ids of this Vlan.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this Vlan.
+        A list of the OCIDs of the network security groups (NSGs) to use with this VLAN.
+        All VNICs in the VLAN belong to these NSGs. For more
+        information about NSGs, see
+        :class:`NetworkSecurityGroup`.
+
+
+        :param nsg_ids: The nsg_ids of this Vlan.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
+
+    @property
+    def vlan_tag(self):
+        """
+        Gets the vlan_tag of this Vlan.
+        The IEEE 802.1Q VLAN tag of this VLAN.
+
+        Example: `100`
+
+
+        :return: The vlan_tag of this Vlan.
+        :rtype: int
+        """
+        return self._vlan_tag
+
+    @vlan_tag.setter
+    def vlan_tag(self, vlan_tag):
+        """
+        Sets the vlan_tag of this Vlan.
+        The IEEE 802.1Q VLAN tag of this VLAN.
+
+        Example: `100`
+
+
+        :param vlan_tag: The vlan_tag of this Vlan.
+        :type: int
+        """
+        self._vlan_tag = vlan_tag
+
+    @property
+    def route_table_id(self):
+        """
+        Gets the route_table_id of this Vlan.
+        The OCID of the route table that the VLAN uses.
+
+
+        :return: The route_table_id of this Vlan.
+        :rtype: str
+        """
+        return self._route_table_id
+
+    @route_table_id.setter
+    def route_table_id(self, route_table_id):
+        """
+        Sets the route_table_id of this Vlan.
+        The OCID of the route table that the VLAN uses.
+
+
+        :param route_table_id: The route_table_id of this Vlan.
+        :type: str
+        """
+        self._route_table_id = route_table_id
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this Vlan.
+        The date and time the VLAN was created, in the format defined by `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this Vlan.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this Vlan.
+        The date and time the VLAN was created, in the format defined by `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this Vlan.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def vcn_id(self):
+        """
+        **[Required]** Gets the vcn_id of this Vlan.
+        The OCID of the VCN the VLAN is in.
+
+
+        :return: The vcn_id of this Vlan.
+        :rtype: str
+        """
+        return self._vcn_id
+
+    @vcn_id.setter
+    def vcn_id(self, vcn_id):
+        """
+        Sets the vcn_id of this Vlan.
+        The OCID of the VCN the VLAN is in.
+
+
+        :param vcn_id: The vcn_id of this Vlan.
+        :type: str
+        """
+        self._vcn_id = vcn_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/vnic.py
+++ b/src/oci/core/models/vnic.py
@@ -22,6 +22,12 @@ class Vnic(object):
     information, see :func:`create_private_ip` and
     `IP Addresses`__.
 
+
+    If you are an Oracle Cloud VMware Solution customer, you will have secondary VNICs
+    that reside in a VLAN instead of a subnet. These VNICs have other differences, which
+    are called out in the descriptions of the relevant attributes in the `Vnic` object.
+    Also see :class:`Vlan`.
+
     To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
@@ -101,6 +107,10 @@ class Vnic(object):
             The value to assign to the nsg_ids property of this Vnic.
         :type nsg_ids: list[str]
 
+        :param vlan_id:
+            The value to assign to the vlan_id property of this Vnic.
+        :type vlan_id: str
+
         :param private_ip:
             The value to assign to the private_ip property of this Vnic.
         :type private_ip: str
@@ -134,6 +144,7 @@ class Vnic(object):
             'lifecycle_state': 'str',
             'mac_address': 'str',
             'nsg_ids': 'list[str]',
+            'vlan_id': 'str',
             'private_ip': 'str',
             'public_ip': 'str',
             'skip_source_dest_check': 'bool',
@@ -153,6 +164,7 @@ class Vnic(object):
             'lifecycle_state': 'lifecycleState',
             'mac_address': 'macAddress',
             'nsg_ids': 'nsgIds',
+            'vlan_id': 'vlanId',
             'private_ip': 'privateIp',
             'public_ip': 'publicIp',
             'skip_source_dest_check': 'skipSourceDestCheck',
@@ -171,6 +183,7 @@ class Vnic(object):
         self._lifecycle_state = None
         self._mac_address = None
         self._nsg_ids = None
+        self._vlan_id = None
         self._private_ip = None
         self._public_ip = None
         self._skip_source_dest_check = None
@@ -461,7 +474,11 @@ class Vnic(object):
         Gets the mac_address of this Vnic.
         The MAC address of the VNIC.
 
-        Example: `00:00:17:B6:4D:DD`
+        If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution,
+        the MAC address is learned. If the VNIC belongs to a subnet, the
+        MAC address is a static, Oracle-provided value.
+
+        Example: `00:00:00:00:00:01`
 
 
         :return: The mac_address of this Vnic.
@@ -475,7 +492,11 @@ class Vnic(object):
         Sets the mac_address of this Vnic.
         The MAC address of the VNIC.
 
-        Example: `00:00:17:B6:4D:DD`
+        If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution,
+        the MAC address is learned. If the VNIC belongs to a subnet, the
+        MAC address is a static, Oracle-provided value.
+
+        Example: `00:00:00:00:00:01`
 
 
         :param mac_address: The mac_address of this Vnic.
@@ -487,8 +508,13 @@ class Vnic(object):
     def nsg_ids(self):
         """
         Gets the nsg_ids of this Vnic.
-        A list of the OCIDs of the network security groups that the VNIC belongs to. For more
-        information about NSGs, see
+        A list of the OCIDs of the network security groups that the VNIC belongs to.
+
+        If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+        belonging to a subnet), the value of the `nsgIds` attribute is ignored. Instead, the
+        VNIC belongs to the NSGs that are associated with the VLAN itself. See :class:`Vlan`.
+
+        For more information about NSGs, see
         :class:`NetworkSecurityGroup`.
 
 
@@ -501,8 +527,13 @@ class Vnic(object):
     def nsg_ids(self, nsg_ids):
         """
         Sets the nsg_ids of this Vnic.
-        A list of the OCIDs of the network security groups that the VNIC belongs to. For more
-        information about NSGs, see
+        A list of the OCIDs of the network security groups that the VNIC belongs to.
+
+        If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+        belonging to a subnet), the value of the `nsgIds` attribute is ignored. Instead, the
+        VNIC belongs to the NSGs that are associated with the VLAN itself. See :class:`Vlan`.
+
+        For more information about NSGs, see
         :class:`NetworkSecurityGroup`.
 
 
@@ -510,6 +541,34 @@ class Vnic(object):
         :type: list[str]
         """
         self._nsg_ids = nsg_ids
+
+    @property
+    def vlan_id(self):
+        """
+        Gets the vlan_id of this Vnic.
+        If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+        belonging to a subnet), the `vlanId` is the OCID of the VLAN the VNIC is in. See
+        :class:`Vlan`. If the VNIC is instead in a subnet, `subnetId` has a value.
+
+
+        :return: The vlan_id of this Vnic.
+        :rtype: str
+        """
+        return self._vlan_id
+
+    @vlan_id.setter
+    def vlan_id(self, vlan_id):
+        """
+        Sets the vlan_id of this Vnic.
+        If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+        belonging to a subnet), the `vlanId` is the OCID of the VLAN the VNIC is in. See
+        :class:`Vlan`. If the VNIC is instead in a subnet, `subnetId` has a value.
+
+
+        :param vlan_id: The vlan_id of this Vnic.
+        :type: str
+        """
+        self._vlan_id = vlan_id
 
     @property
     def private_ip(self):
@@ -574,6 +633,11 @@ class Vnic(object):
         about why you would skip the source/destination check, see
         `Using a Private IP as a Route Target`__.
 
+
+        If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+        belonging to a subnet), the `skipSourceDestCheck` attribute is `true`.
+        This is because the source/destination check is always disabled for VNICs in a VLAN.
+
         Example: `true`
 
         __ https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip
@@ -593,6 +657,11 @@ class Vnic(object):
         about why you would skip the source/destination check, see
         `Using a Private IP as a Route Target`__.
 
+
+        If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+        belonging to a subnet), the `skipSourceDestCheck` attribute is `true`.
+        This is because the source/destination check is always disabled for VNICs in a VLAN.
+
         Example: `true`
 
         __ https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip
@@ -606,7 +675,7 @@ class Vnic(object):
     @property
     def subnet_id(self):
         """
-        **[Required]** Gets the subnet_id of this Vnic.
+        Gets the subnet_id of this Vnic.
         The OCID of the subnet the VNIC is in.
 
 
@@ -631,9 +700,11 @@ class Vnic(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this Vnic.
-        The date and time the VNIC was created, in the format defined by RFC3339.
+        The date and time the VNIC was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this Vnic.
@@ -645,9 +716,11 @@ class Vnic(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Vnic.
-        The date and time the VNIC was created, in the format defined by RFC3339.
+        The date and time the VNIC was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this Vnic.

--- a/src/oci/core/models/vnic_attachment.py
+++ b/src/oci/core/models/vnic_attachment.py
@@ -74,6 +74,10 @@ class VnicAttachment(object):
             The value to assign to the subnet_id property of this VnicAttachment.
         :type subnet_id: str
 
+        :param vlan_id:
+            The value to assign to the vlan_id property of this VnicAttachment.
+        :type vlan_id: str
+
         :param time_created:
             The value to assign to the time_created property of this VnicAttachment.
         :type time_created: datetime
@@ -96,6 +100,7 @@ class VnicAttachment(object):
             'lifecycle_state': 'str',
             'nic_index': 'int',
             'subnet_id': 'str',
+            'vlan_id': 'str',
             'time_created': 'datetime',
             'vlan_tag': 'int',
             'vnic_id': 'str'
@@ -110,6 +115,7 @@ class VnicAttachment(object):
             'lifecycle_state': 'lifecycleState',
             'nic_index': 'nicIndex',
             'subnet_id': 'subnetId',
+            'vlan_id': 'vlanId',
             'time_created': 'timeCreated',
             'vlan_tag': 'vlanTag',
             'vnic_id': 'vnicId'
@@ -123,6 +129,7 @@ class VnicAttachment(object):
         self._lifecycle_state = None
         self._nic_index = None
         self._subnet_id = None
+        self._vlan_id = None
         self._time_created = None
         self._vlan_tag = None
         self._vnic_id = None
@@ -324,7 +331,7 @@ class VnicAttachment(object):
     @property
     def subnet_id(self):
         """
-        **[Required]** Gets the subnet_id of this VnicAttachment.
+        Gets the subnet_id of this VnicAttachment.
         The OCID of the subnet to create the VNIC in.
 
 
@@ -346,12 +353,46 @@ class VnicAttachment(object):
         self._subnet_id = subnet_id
 
     @property
+    def vlan_id(self):
+        """
+        Gets the vlan_id of this VnicAttachment.
+        The OCID of the VLAN to create the VNIC in. Creating the VNIC in a VLAN (instead
+        of a subnet) is possible only if you are an Oracle Cloud VMware Solution customer.
+        See :class:`Vlan`.
+
+        An error is returned if the instance already has a VNIC attached to it from this VLAN.
+
+
+        :return: The vlan_id of this VnicAttachment.
+        :rtype: str
+        """
+        return self._vlan_id
+
+    @vlan_id.setter
+    def vlan_id(self, vlan_id):
+        """
+        Sets the vlan_id of this VnicAttachment.
+        The OCID of the VLAN to create the VNIC in. Creating the VNIC in a VLAN (instead
+        of a subnet) is possible only if you are an Oracle Cloud VMware Solution customer.
+        See :class:`Vlan`.
+
+        An error is returned if the instance already has a VNIC attached to it from this VLAN.
+
+
+        :param vlan_id: The vlan_id of this VnicAttachment.
+        :type: str
+        """
+        self._vlan_id = vlan_id
+
+    @property
     def time_created(self):
         """
         **[Required]** Gets the time_created of this VnicAttachment.
-        The date and time the VNIC attachment was created, in the format defined by RFC3339.
+        The date and time the VNIC attachment was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this VnicAttachment.
@@ -363,9 +404,11 @@ class VnicAttachment(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this VnicAttachment.
-        The date and time the VNIC attachment was created, in the format defined by RFC3339.
+        The date and time the VNIC attachment was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this VnicAttachment.
@@ -379,6 +422,10 @@ class VnicAttachment(object):
         Gets the vlan_tag of this VnicAttachment.
         The Oracle-assigned VLAN tag of the attached VNIC. Available after the
         attachment process is complete.
+
+        However, if the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution,
+        the `vlanTag` value is instead the value of the `vlanTag` attribute for the VLAN.
+        See :class:`Vlan`.
 
         Example: `0`
 
@@ -394,6 +441,10 @@ class VnicAttachment(object):
         Sets the vlan_tag of this VnicAttachment.
         The Oracle-assigned VLAN tag of the attached VNIC. Available after the
         attachment process is complete.
+
+        However, if the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution,
+        the `vlanTag` value is instead the value of the `vlanTag` attribute for the VLAN.
+        See :class:`Vlan`.
 
         Example: `0`
 

--- a/src/oci/core/models/volume.py
+++ b/src/oci/core/models/volume.py
@@ -576,7 +576,9 @@ class Volume(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this Volume.
-        The date and time the volume was created. Format defined by RFC3339.
+        The date and time the volume was created. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this Volume.
@@ -588,7 +590,9 @@ class Volume(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Volume.
-        The date and time the volume was created. Format defined by RFC3339.
+        The date and time the volume was created. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this Volume.

--- a/src/oci/core/models/volume_attachment.py
+++ b/src/oci/core/models/volume_attachment.py
@@ -430,9 +430,11 @@ class VolumeAttachment(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this VolumeAttachment.
-        The date and time the volume was created, in the format defined by RFC3339.
+        The date and time the volume was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this VolumeAttachment.
@@ -444,9 +446,11 @@ class VolumeAttachment(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this VolumeAttachment.
-        The date and time the volume was created, in the format defined by RFC3339.
+        The date and time the volume was created, in the format defined by `RFC3339`__.
 
         Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this VolumeAttachment.

--- a/src/oci/core/models/volume_backup.py
+++ b/src/oci/core/models/volume_backup.py
@@ -332,10 +332,12 @@ class VolumeBackup(object):
         """
         Gets the expiration_time of this VolumeBackup.
         The date and time the volume backup will expire and be automatically deleted.
-        Format defined by RFC3339. This parameter will always be present for backups that
+        Format defined by `RFC3339`__. This parameter will always be present for backups that
         were created automatically by a scheduled-backup policy. For manually created backups,
         it will be absent, signifying that there is no expiration time and the backup will
         last forever until manually deleted.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The expiration_time of this VolumeBackup.
@@ -348,10 +350,12 @@ class VolumeBackup(object):
         """
         Sets the expiration_time of this VolumeBackup.
         The date and time the volume backup will expire and be automatically deleted.
-        Format defined by RFC3339. This parameter will always be present for backups that
+        Format defined by `RFC3339`__. This parameter will always be present for backups that
         were created automatically by a scheduled-backup policy. For manually created backups,
         it will be absent, signifying that there is no expiration time and the backup will
         last forever until manually deleted.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param expiration_time: The expiration_time of this VolumeBackup.
@@ -592,7 +596,9 @@ class VolumeBackup(object):
         """
         **[Required]** Gets the time_created of this VolumeBackup.
         The date and time the volume backup was created. This is the time the actual point-in-time image
-        of the volume data was taken. Format defined by RFC3339.
+        of the volume data was taken. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this VolumeBackup.
@@ -605,7 +611,9 @@ class VolumeBackup(object):
         """
         Sets the time_created of this VolumeBackup.
         The date and time the volume backup was created. This is the time the actual point-in-time image
-        of the volume data was taken. Format defined by RFC3339.
+        of the volume data was taken. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this VolumeBackup.
@@ -617,7 +625,7 @@ class VolumeBackup(object):
     def time_request_received(self):
         """
         Gets the time_request_received of this VolumeBackup.
-        The date and time the request to create the volume backup was received. Format defined by RFC3339.
+        The date and time the request to create the volume backup was received. Format defined by [RFC3339]https://tools.ietf.org/html/rfc3339.
 
 
         :return: The time_request_received of this VolumeBackup.
@@ -629,7 +637,7 @@ class VolumeBackup(object):
     def time_request_received(self, time_request_received):
         """
         Sets the time_request_received of this VolumeBackup.
-        The date and time the request to create the volume backup was received. Format defined by RFC3339.
+        The date and time the request to create the volume backup was received. Format defined by [RFC3339]https://tools.ietf.org/html/rfc3339.
 
 
         :param time_request_received: The time_request_received of this VolumeBackup.

--- a/src/oci/core/models/volume_backup_policy.py
+++ b/src/oci/core/models/volume_backup_policy.py
@@ -165,7 +165,10 @@ class VolumeBackupPolicy(object):
     def destination_region(self):
         """
         Gets the destination_region of this VolumeBackupPolicy.
-        The paired destination region (pre-defined by oracle) for scheduled cross region backup calls. Example `us-ashburn-1`
+        The paired destination region for copying scheduled backups to. Example `us-ashburn-1`.
+        See `Region Pairs`__ for details about paired regions.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Block/Tasks/schedulingvolumebackups.htm#RegionPairs
 
 
         :return: The destination_region of this VolumeBackupPolicy.
@@ -177,7 +180,10 @@ class VolumeBackupPolicy(object):
     def destination_region(self, destination_region):
         """
         Sets the destination_region of this VolumeBackupPolicy.
-        The paired destination region (pre-defined by oracle) for scheduled cross region backup calls. Example `us-ashburn-1`
+        The paired destination region for copying scheduled backups to. Example `us-ashburn-1`.
+        See `Region Pairs`__ for details about paired regions.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Block/Tasks/schedulingvolumebackups.htm#RegionPairs
 
 
         :param destination_region: The destination_region of this VolumeBackupPolicy.
@@ -189,7 +195,9 @@ class VolumeBackupPolicy(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this VolumeBackupPolicy.
-        The date and time the volume backup policy was created. Format defined by RFC3339.
+        The date and time the volume backup policy was created. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this VolumeBackupPolicy.
@@ -201,7 +209,9 @@ class VolumeBackupPolicy(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this VolumeBackupPolicy.
-        The date and time the volume backup policy was created. Format defined by RFC3339.
+        The date and time the volume backup policy was created. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this VolumeBackupPolicy.

--- a/src/oci/core/models/volume_backup_policy_assignment.py
+++ b/src/oci/core/models/volume_backup_policy_assignment.py
@@ -135,7 +135,9 @@ class VolumeBackupPolicyAssignment(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this VolumeBackupPolicyAssignment.
-        The date and time the volume backup policy was assigned to the volume. The format is defined by RFC3339.
+        The date and time the volume backup policy was assigned to the volume. The format is defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this VolumeBackupPolicyAssignment.
@@ -147,7 +149,9 @@ class VolumeBackupPolicyAssignment(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this VolumeBackupPolicyAssignment.
-        The date and time the volume backup policy was assigned to the volume. The format is defined by RFC3339.
+        The date and time the volume backup policy was assigned to the volume. The format is defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this VolumeBackupPolicyAssignment.

--- a/src/oci/core/models/volume_group.py
+++ b/src/oci/core/models/volume_group.py
@@ -417,7 +417,9 @@ class VolumeGroup(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this VolumeGroup.
-        The date and time the volume group was created. Format defined by RFC3339.
+        The date and time the volume group was created. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this VolumeGroup.
@@ -429,7 +431,9 @@ class VolumeGroup(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this VolumeGroup.
-        The date and time the volume group was created. Format defined by RFC3339.
+        The date and time the volume group was created. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this VolumeGroup.

--- a/src/oci/core/models/volume_group_backup.py
+++ b/src/oci/core/models/volume_group_backup.py
@@ -405,7 +405,9 @@ class VolumeGroupBackup(object):
         """
         **[Required]** Gets the time_created of this VolumeGroupBackup.
         The date and time the volume group backup was created. This is the time the actual point-in-time image
-        of the volume group data was taken. Format defined by RFC3339.
+        of the volume group data was taken. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this VolumeGroupBackup.
@@ -418,7 +420,9 @@ class VolumeGroupBackup(object):
         """
         Sets the time_created of this VolumeGroupBackup.
         The date and time the volume group backup was created. This is the time the actual point-in-time image
-        of the volume group data was taken. Format defined by RFC3339.
+        of the volume group data was taken. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this VolumeGroupBackup.
@@ -430,7 +434,9 @@ class VolumeGroupBackup(object):
     def time_request_received(self):
         """
         Gets the time_request_received of this VolumeGroupBackup.
-        The date and time the request to create the volume group backup was received. Format defined by RFC3339.
+        The date and time the request to create the volume group backup was received. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_request_received of this VolumeGroupBackup.
@@ -442,7 +448,9 @@ class VolumeGroupBackup(object):
     def time_request_received(self, time_request_received):
         """
         Sets the time_request_received of this VolumeGroupBackup.
-        The date and time the request to create the volume group backup was received. Format defined by RFC3339.
+        The date and time the request to create the volume group backup was received. Format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_request_received: The time_request_received of this VolumeGroupBackup.

--- a/src/oci/core/virtual_network_client.py
+++ b/src/oci/core/virtual_network_client.py
@@ -2033,6 +2033,106 @@ class VirtualNetworkClient(object):
                 header_params=header_params,
                 body=change_virtual_circuit_compartment_details)
 
+    def change_vlan_compartment(self, vlan_id, change_vlan_compartment_details, **kwargs):
+        """
+        Moves a VLAN into a different compartment within the same tenancy.
+        For information about moving resources between compartments, see
+        `Moving Resources to a Different Compartment`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes
+
+
+        :param str vlan_id: (required)
+            The `OCID`__ of the VLAN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param ChangeVlanCompartmentDetails change_vlan_compartment_details: (required)
+            Request to change the compartment of a given VLAN.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vlans/{vlanId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_vlan_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "vlanId": vlan_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_vlan_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_vlan_compartment_details)
+
     def connect_local_peering_gateways(self, local_peering_gateway_id, connect_local_peering_gateways_details, **kwargs):
         """
         Connects this local peering gateway (LPG) to another one in the same region.
@@ -3949,6 +4049,80 @@ class VirtualNetworkClient(object):
                 body=create_virtual_circuit_details,
                 response_type="VirtualCircuit")
 
+    def create_vlan(self, create_vlan_details, **kwargs):
+        """
+        Creates a VLAN in the specified VCN and the specified compartment.
+
+
+        :param CreateVlanDetails create_vlan_details: (required)
+            Details for creating a VLAN
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.Vlan`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vlans"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_vlan got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_vlan_details,
+                response_type="Vlan")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_vlan_details,
+                response_type="Vlan")
+
     def delete_cpe(self, cpe_id, **kwargs):
         """
         Deletes the specified CPE object. The CPE must not be connected to a DRG. This is an asynchronous
@@ -5541,6 +5715,86 @@ class VirtualNetworkClient(object):
             "accept": "application/json",
             "content-type": "application/json",
             "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_vlan(self, vlan_id, **kwargs):
+        """
+        Deletes the specified VLAN, but only if there are no VNICs in the VLAN.
+
+
+        :param str vlan_id: (required)
+            The `OCID`__ of the VLAN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vlans/{vlanId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_vlan got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "vlanId": vlan_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
@@ -7382,7 +7636,7 @@ class VirtualNetworkClient(object):
         Gets the specified public IP. You must specify the object's OCID.
 
         Alternatively, you can get the object by using :func:`get_public_ip_by_ip_address`
-        with the public IP address (for example, 129.146.2.1).
+        with the public IP address (for example, 203.0.113.2).
 
         Or you can use :func:`get_public_ip_by_private_ip_id`
         with the OCID of the private IP that the public IP is assigned to.
@@ -7452,7 +7706,7 @@ class VirtualNetworkClient(object):
 
     def get_public_ip_by_ip_address(self, get_public_ip_by_ip_address_details, **kwargs):
         """
-        Gets the public IP based on the public IP address (for example, 129.146.2.1).
+        Gets the public IP based on the public IP address (for example, 203.0.113.2).
 
         **Note:** If you're fetching a reserved public IP that is in the process of being
         moved to a different private IP, the service returns the public IP object with
@@ -8258,6 +8512,81 @@ class VirtualNetworkClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 response_type="VirtualCircuit")
+
+    def get_vlan(self, vlan_id, **kwargs):
+        """
+        Gets the specified VLAN's information.
+
+
+        :param str vlan_id: (required)
+            The `OCID`__ of the VLAN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.Vlan`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vlans/{vlanId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_vlan got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "vlanId": vlan_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Vlan")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Vlan")
 
     def get_vnic(self, vnic_id, **kwargs):
         """
@@ -10614,6 +10943,9 @@ class VirtualNetworkClient(object):
         If you're listing all the private IPs associated with a given subnet
         or VNIC, the response includes both primary and secondary private IPs.
 
+        If you are an Oracle Cloud VMware Solution customer and have VLANs
+        in your VCN, you can filter the list by VLAN OCID. See :class:`Vlan`.
+
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -10641,6 +10973,11 @@ class VirtualNetworkClient(object):
         :param str vnic_id: (optional)
             The OCID of the VNIC.
 
+        :param str vlan_id: (optional)
+            The `OCID`__ of the VLAN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -10662,7 +10999,8 @@ class VirtualNetworkClient(object):
             "page",
             "ip_address",
             "subnet_id",
-            "vnic_id"
+            "vnic_id",
+            "vlan_id"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -10674,7 +11012,8 @@ class VirtualNetworkClient(object):
             "page": kwargs.get("page", missing),
             "ipAddress": kwargs.get("ip_address", missing),
             "subnetId": kwargs.get("subnet_id", missing),
-            "vnicId": kwargs.get("vnic_id", missing)
+            "vnicId": kwargs.get("vnic_id", missing),
+            "vlanId": kwargs.get("vlan_id", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -12035,6 +12374,157 @@ class VirtualNetworkClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="list[VirtualCircuit]")
+
+    def list_vlans(self, compartment_id, vcn_id, **kwargs):
+        """
+        Lists the VLANs in the specified VCN and the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str vcn_id: (required)
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            Example: `50`
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+            call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the given display name exactly.
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+            TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+            sort order is case sensitive.
+
+            **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+            optionally filter by availability domain if the scope of the resource type is within a
+            single availability domain. If you call one of these \"List\" operations without specifying
+            an availability domain, the resources are grouped by availability domain, then sorted.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+            is case sensitive.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param str lifecycle_state: (optional)
+            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+
+            Allowed values are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED", "UPDATING"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.core.models.Vlan`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vlans"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "display_name",
+            "sort_by",
+            "sort_order",
+            "opc_request_id",
+            "lifecycle_state"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_vlans got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED", "UPDATING"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "vcnId": vcn_id,
+            "displayName": kwargs.get("display_name", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[Vlan]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[Vlan]")
 
     def remove_network_security_group_security_rules(self, network_security_group_id, remove_network_security_group_security_rules_details, **kwargs):
         """
@@ -14258,6 +14748,95 @@ class VirtualNetworkClient(object):
                 header_params=header_params,
                 body=update_virtual_circuit_details,
                 response_type="VirtualCircuit")
+
+    def update_vlan(self, vlan_id, update_vlan_details, **kwargs):
+        """
+        Updates the specified VLAN. This could result in changes to all
+        the VNICs in the VLAN, which can take time. During that transition
+        period, the VLAN will be in the UPDATING state.
+
+
+        :param str vlan_id: (required)
+            The `OCID`__ of the VLAN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateVlanDetails update_vlan_details: (required)
+            Details object for updating a subnet.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.Vlan`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/vlans/{vlanId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_vlan got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "vlanId": vlan_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_vlan_details,
+                response_type="Vlan")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_vlan_details,
+                response_type="Vlan")
 
     def update_vnic(self, vnic_id, update_vnic_details, **kwargs):
         """

--- a/src/oci/core/virtual_network_client_composite_operations.py
+++ b/src/oci/core/virtual_network_client_composite_operations.py
@@ -186,6 +186,46 @@ class VirtualNetworkClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def change_vlan_compartment_and_wait_for_work_request(self, vlan_id, change_vlan_compartment_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.core.VirtualNetworkClient.change_vlan_compartment` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str vlan_id: (required)
+            The `OCID`__ of the VLAN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param ChangeVlanCompartmentDetails change_vlan_compartment_details: (required)
+            Request to change the compartment of a given VLAN.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.core.VirtualNetworkClient.change_vlan_compartment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.change_vlan_compartment(vlan_id, change_vlan_compartment_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_cross_connect_and_wait_for_state(self, create_cross_connect_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.core.VirtualNetworkClient.create_cross_connect` and waits for the :py:class:`~oci.core.models.CrossConnect` acted upon
@@ -899,6 +939,44 @@ class VirtualNetworkClientCompositeOperations(object):
             waiter_result = oci.wait_until(
                 self.client,
                 self.client.get_virtual_circuit(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_vlan_and_wait_for_state(self, create_vlan_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.core.VirtualNetworkClient.create_vlan` and waits for the :py:class:`~oci.core.models.Vlan` acted upon
+        to enter the given state(s).
+
+        :param CreateVlanDetails create_vlan_details: (required)
+            Details for creating a VLAN
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.core.models.Vlan.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.core.VirtualNetworkClient.create_vlan`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_vlan(create_vlan_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_vlan(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )
@@ -1811,6 +1889,55 @@ class VirtualNetworkClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def delete_vlan_and_wait_for_state(self, vlan_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.core.VirtualNetworkClient.delete_vlan` and waits for the :py:class:`~oci.core.models.Vlan` acted upon
+        to enter the given state(s).
+
+        :param str vlan_id: (required)
+            The `OCID`__ of the VLAN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.core.models.Vlan.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.core.VirtualNetworkClient.delete_vlan`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        initial_get_result = self.client.get_vlan(vlan_id)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_vlan(vlan_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                initial_get_result,
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                succeed_on_not_found=True,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def detach_service_id_and_wait_for_state(self, service_gateway_id, detach_service_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.core.VirtualNetworkClient.detach_service_id` and waits for the :py:class:`~oci.core.models.ServiceGateway` acted upon
@@ -2680,6 +2807,49 @@ class VirtualNetworkClientCompositeOperations(object):
             waiter_result = oci.wait_until(
                 self.client,
                 self.client.get_virtual_circuit(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_vlan_and_wait_for_state(self, vlan_id, update_vlan_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.core.VirtualNetworkClient.update_vlan` and waits for the :py:class:`~oci.core.models.Vlan` acted upon
+        to enter the given state(s).
+
+        :param str vlan_id: (required)
+            The `OCID`__ of the VLAN.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateVlanDetails update_vlan_details: (required)
+            Details object for updating a subnet.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.core.models.Vlan.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.core.VirtualNetworkClient.update_vlan`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_vlan(vlan_id, update_vlan_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_vlan(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )

--- a/src/oci/database/models/db_home.py
+++ b/src/oci/database/models/db_home.py
@@ -88,6 +88,10 @@ class DbHome(object):
             The value to assign to the time_created property of this DbHome.
         :type time_created: datetime
 
+        :param one_off_patches:
+            The value to assign to the one_off_patches property of this DbHome.
+        :type one_off_patches: list[str]
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this DbHome.
         :type freeform_tags: dict(str, str)
@@ -109,6 +113,7 @@ class DbHome(object):
             'db_home_location': 'str',
             'lifecycle_details': 'str',
             'time_created': 'datetime',
+            'one_off_patches': 'list[str]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -125,6 +130,7 @@ class DbHome(object):
             'db_home_location': 'dbHomeLocation',
             'lifecycle_details': 'lifecycleDetails',
             'time_created': 'timeCreated',
+            'one_off_patches': 'oneOffPatches',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -140,6 +146,7 @@ class DbHome(object):
         self._db_home_location = None
         self._lifecycle_details = None
         self._time_created = None
+        self._one_off_patches = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -432,6 +439,30 @@ class DbHome(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def one_off_patches(self):
+        """
+        Gets the one_off_patches of this DbHome.
+        List of one-off patches for Database Homes.
+
+
+        :return: The one_off_patches of this DbHome.
+        :rtype: list[str]
+        """
+        return self._one_off_patches
+
+    @one_off_patches.setter
+    def one_off_patches(self, one_off_patches):
+        """
+        Sets the one_off_patches of this DbHome.
+        List of one-off patches for Database Homes.
+
+
+        :param one_off_patches: The one_off_patches of this DbHome.
+        :type: list[str]
+        """
+        self._one_off_patches = one_off_patches
 
     @property
     def freeform_tags(self):

--- a/src/oci/database/models/db_home_summary.py
+++ b/src/oci/database/models/db_home_summary.py
@@ -100,6 +100,10 @@ class DbHomeSummary(object):
             The value to assign to the time_created property of this DbHomeSummary.
         :type time_created: datetime
 
+        :param one_off_patches:
+            The value to assign to the one_off_patches property of this DbHomeSummary.
+        :type one_off_patches: list[str]
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this DbHomeSummary.
         :type freeform_tags: dict(str, str)
@@ -121,6 +125,7 @@ class DbHomeSummary(object):
             'db_home_location': 'str',
             'lifecycle_details': 'str',
             'time_created': 'datetime',
+            'one_off_patches': 'list[str]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -137,6 +142,7 @@ class DbHomeSummary(object):
             'db_home_location': 'dbHomeLocation',
             'lifecycle_details': 'lifecycleDetails',
             'time_created': 'timeCreated',
+            'one_off_patches': 'oneOffPatches',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -152,6 +158,7 @@ class DbHomeSummary(object):
         self._db_home_location = None
         self._lifecycle_details = None
         self._time_created = None
+        self._one_off_patches = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -444,6 +451,30 @@ class DbHomeSummary(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def one_off_patches(self):
+        """
+        Gets the one_off_patches of this DbHomeSummary.
+        List of one-off patches for Database Homes.
+
+
+        :return: The one_off_patches of this DbHomeSummary.
+        :rtype: list[str]
+        """
+        return self._one_off_patches
+
+    @one_off_patches.setter
+    def one_off_patches(self, one_off_patches):
+        """
+        Sets the one_off_patches of this DbHomeSummary.
+        List of one-off patches for Database Homes.
+
+
+        :param one_off_patches: The one_off_patches of this DbHomeSummary.
+        :type: list[str]
+        """
+        self._one_off_patches = one_off_patches
 
     @property
     def freeform_tags(self):

--- a/src/oci/database/models/update_db_home_details.py
+++ b/src/oci/database/models/update_db_home_details.py
@@ -22,6 +22,10 @@ class UpdateDbHomeDetails(object):
             The value to assign to the db_version property of this UpdateDbHomeDetails.
         :type db_version: PatchDetails
 
+        :param one_off_patches:
+            The value to assign to the one_off_patches property of this UpdateDbHomeDetails.
+        :type one_off_patches: list[str]
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this UpdateDbHomeDetails.
         :type freeform_tags: dict(str, str)
@@ -33,17 +37,20 @@ class UpdateDbHomeDetails(object):
         """
         self.swagger_types = {
             'db_version': 'PatchDetails',
+            'one_off_patches': 'list[str]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
 
         self.attribute_map = {
             'db_version': 'dbVersion',
+            'one_off_patches': 'oneOffPatches',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
 
         self._db_version = None
+        self._one_off_patches = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -66,6 +73,30 @@ class UpdateDbHomeDetails(object):
         :type: PatchDetails
         """
         self._db_version = db_version
+
+    @property
+    def one_off_patches(self):
+        """
+        Gets the one_off_patches of this UpdateDbHomeDetails.
+        List of one-off patches for Database Homes.
+
+
+        :return: The one_off_patches of this UpdateDbHomeDetails.
+        :rtype: list[str]
+        """
+        return self._one_off_patches
+
+    @one_off_patches.setter
+    def one_off_patches(self, one_off_patches):
+        """
+        Sets the one_off_patches of this UpdateDbHomeDetails.
+        List of one-off patches for Database Homes.
+
+
+        :param one_off_patches: The one_off_patches of this UpdateDbHomeDetails.
+        :type: list[str]
+        """
+        self._one_off_patches = one_off_patches
 
     @property
     def freeform_tags(self):

--- a/src/oci/load_balancer/models/__init__.py
+++ b/src/oci/load_balancer/models/__init__.py
@@ -33,6 +33,7 @@ from .health_checker import HealthChecker
 from .health_checker_details import HealthCheckerDetails
 from .hostname import Hostname
 from .hostname_details import HostnameDetails
+from .http_header_rule import HttpHeaderRule
 from .ip_address import IpAddress
 from .lb_cookie_session_persistence_configuration_details import LBCookieSessionPersistenceConfigurationDetails
 from .listener import Listener
@@ -106,6 +107,7 @@ load_balancer_type_mapping = {
     "HealthCheckerDetails": HealthCheckerDetails,
     "Hostname": Hostname,
     "HostnameDetails": HostnameDetails,
+    "HttpHeaderRule": HttpHeaderRule,
     "IpAddress": IpAddress,
     "LBCookieSessionPersistenceConfigurationDetails": LBCookieSessionPersistenceConfigurationDetails,
     "Listener": Listener,

--- a/src/oci/load_balancer/models/add_http_request_header_rule.py
+++ b/src/oci/load_balancer/models/add_http_request_header_rule.py
@@ -31,7 +31,7 @@ class AddHttpRequestHeaderRule(Rule):
 
         :param action:
             The value to assign to the action property of this AddHttpRequestHeaderRule.
-            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT"
+            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", "HTTP_HEADER"
         :type action: str
 
         :param header:

--- a/src/oci/load_balancer/models/add_http_response_header_rule.py
+++ b/src/oci/load_balancer/models/add_http_response_header_rule.py
@@ -31,7 +31,7 @@ class AddHttpResponseHeaderRule(Rule):
 
         :param action:
             The value to assign to the action property of this AddHttpResponseHeaderRule.
-            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT"
+            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", "HTTP_HEADER"
         :type action: str
 
         :param header:

--- a/src/oci/load_balancer/models/allow_rule.py
+++ b/src/oci/load_balancer/models/allow_rule.py
@@ -31,7 +31,7 @@ class AllowRule(Rule):
 
         :param action:
             The value to assign to the action property of this AllowRule.
-            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT"
+            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", "HTTP_HEADER"
         :type action: str
 
         :param conditions:

--- a/src/oci/load_balancer/models/control_access_using_http_methods_rule.py
+++ b/src/oci/load_balancer/models/control_access_using_http_methods_rule.py
@@ -30,7 +30,7 @@ class ControlAccessUsingHttpMethodsRule(Rule):
 
         :param action:
             The value to assign to the action property of this ControlAccessUsingHttpMethodsRule.
-            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT"
+            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", "HTTP_HEADER"
         :type action: str
 
         :param allowed_methods:

--- a/src/oci/load_balancer/models/extend_http_request_header_value_rule.py
+++ b/src/oci/load_balancer/models/extend_http_request_header_value_rule.py
@@ -34,7 +34,7 @@ class ExtendHttpRequestHeaderValueRule(Rule):
 
         :param action:
             The value to assign to the action property of this ExtendHttpRequestHeaderValueRule.
-            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT"
+            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", "HTTP_HEADER"
         :type action: str
 
         :param header:

--- a/src/oci/load_balancer/models/extend_http_response_header_value_rule.py
+++ b/src/oci/load_balancer/models/extend_http_response_header_value_rule.py
@@ -34,7 +34,7 @@ class ExtendHttpResponseHeaderValueRule(Rule):
 
         :param action:
             The value to assign to the action property of this ExtendHttpResponseHeaderValueRule.
-            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT"
+            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", "HTTP_HEADER"
         :type action: str
 
         :param header:

--- a/src/oci/load_balancer/models/http_header_rule.py
+++ b/src/oci/load_balancer/models/http_header_rule.py
@@ -1,0 +1,125 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .rule import Rule
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class HttpHeaderRule(Rule):
+    """
+    An object that represents the advance http header options that allow the setting of http header size and allow/disallow
+    invalid characters in the http headers.
+    For example httpLargeHeaderSizeInKB=32, the http header could have 4 buffers of 32KBs each
+    This rule applies only to HTTP listeners. No more than one `HttpHeaderRule` object can be present in
+    a given listener.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new HttpHeaderRule object with values from keyword arguments. The default value of the :py:attr:`~oci.load_balancer.models.HttpHeaderRule.action` attribute
+        of this class is ``HTTP_HEADER`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param action:
+            The value to assign to the action property of this HttpHeaderRule.
+            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", "HTTP_HEADER"
+        :type action: str
+
+        :param are_invalid_characters_allowed:
+            The value to assign to the are_invalid_characters_allowed property of this HttpHeaderRule.
+        :type are_invalid_characters_allowed: bool
+
+        :param http_large_header_size_in_kb:
+            The value to assign to the http_large_header_size_in_kb property of this HttpHeaderRule.
+        :type http_large_header_size_in_kb: int
+
+        """
+        self.swagger_types = {
+            'action': 'str',
+            'are_invalid_characters_allowed': 'bool',
+            'http_large_header_size_in_kb': 'int'
+        }
+
+        self.attribute_map = {
+            'action': 'action',
+            'are_invalid_characters_allowed': 'areInvalidCharactersAllowed',
+            'http_large_header_size_in_kb': 'httpLargeHeaderSizeInKB'
+        }
+
+        self._action = None
+        self._are_invalid_characters_allowed = None
+        self._http_large_header_size_in_kb = None
+        self._action = 'HTTP_HEADER'
+
+    @property
+    def are_invalid_characters_allowed(self):
+        """
+        Gets the are_invalid_characters_allowed of this HttpHeaderRule.
+        Indicates whether or not invalid characters in client header fields will be allowed.
+        Valid names are composed of English letters, digits, hyphens and underscores.
+        If \"true\", invalid characters are allowed in the HTTP header.
+        If \"false\", invalid characters are not allowed in the HTTP header
+
+
+        :return: The are_invalid_characters_allowed of this HttpHeaderRule.
+        :rtype: bool
+        """
+        return self._are_invalid_characters_allowed
+
+    @are_invalid_characters_allowed.setter
+    def are_invalid_characters_allowed(self, are_invalid_characters_allowed):
+        """
+        Sets the are_invalid_characters_allowed of this HttpHeaderRule.
+        Indicates whether or not invalid characters in client header fields will be allowed.
+        Valid names are composed of English letters, digits, hyphens and underscores.
+        If \"true\", invalid characters are allowed in the HTTP header.
+        If \"false\", invalid characters are not allowed in the HTTP header
+
+
+        :param are_invalid_characters_allowed: The are_invalid_characters_allowed of this HttpHeaderRule.
+        :type: bool
+        """
+        self._are_invalid_characters_allowed = are_invalid_characters_allowed
+
+    @property
+    def http_large_header_size_in_kb(self):
+        """
+        Gets the http_large_header_size_in_kb of this HttpHeaderRule.
+        The maximum size of each buffer used for reading http client request header.
+        This value indicates the maximum size allowed for each buffer.
+        The allowed values for buffer size are 8, 16, 32 and 64.
+
+
+        :return: The http_large_header_size_in_kb of this HttpHeaderRule.
+        :rtype: int
+        """
+        return self._http_large_header_size_in_kb
+
+    @http_large_header_size_in_kb.setter
+    def http_large_header_size_in_kb(self, http_large_header_size_in_kb):
+        """
+        Sets the http_large_header_size_in_kb of this HttpHeaderRule.
+        The maximum size of each buffer used for reading http client request header.
+        This value indicates the maximum size allowed for each buffer.
+        The allowed values for buffer size are 8, 16, 32 and 64.
+
+
+        :param http_large_header_size_in_kb: The http_large_header_size_in_kb of this HttpHeaderRule.
+        :type: int
+        """
+        self._http_large_header_size_in_kb = http_large_header_size_in_kb
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/load_balancer/models/redirect_rule.py
+++ b/src/oci/load_balancer/models/redirect_rule.py
@@ -32,7 +32,7 @@ class RedirectRule(Rule):
 
         :param action:
             The value to assign to the action property of this RedirectRule.
-            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT"
+            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", "HTTP_HEADER"
         :type action: str
 
         :param response_code:

--- a/src/oci/load_balancer/models/remove_http_request_header_rule.py
+++ b/src/oci/load_balancer/models/remove_http_request_header_rule.py
@@ -27,7 +27,7 @@ class RemoveHttpRequestHeaderRule(Rule):
 
         :param action:
             The value to assign to the action property of this RemoveHttpRequestHeaderRule.
-            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT"
+            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", "HTTP_HEADER"
         :type action: str
 
         :param header:

--- a/src/oci/load_balancer/models/remove_http_response_header_rule.py
+++ b/src/oci/load_balancer/models/remove_http_response_header_rule.py
@@ -27,7 +27,7 @@ class RemoveHttpResponseHeaderRule(Rule):
 
         :param action:
             The value to assign to the action property of this RemoveHttpResponseHeaderRule.
-            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT"
+            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", "HTTP_HEADER"
         :type action: str
 
         :param header:

--- a/src/oci/load_balancer/models/rule.py
+++ b/src/oci/load_balancer/models/rule.py
@@ -49,6 +49,10 @@ class Rule(object):
     #: This constant has a value of "REDIRECT"
     ACTION_REDIRECT = "REDIRECT"
 
+    #: A constant which can be used with the action property of a Rule.
+    #: This constant has a value of "HTTP_HEADER"
+    ACTION_HTTP_HEADER = "HTTP_HEADER"
+
     def __init__(self, **kwargs):
         """
         Initializes a new Rule object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
@@ -61,6 +65,7 @@ class Rule(object):
         * :class:`~oci.load_balancer.models.RemoveHttpResponseHeaderRule`
         * :class:`~oci.load_balancer.models.ControlAccessUsingHttpMethodsRule`
         * :class:`~oci.load_balancer.models.AllowRule`
+        * :class:`~oci.load_balancer.models.HttpHeaderRule`
         * :class:`~oci.load_balancer.models.AddHttpResponseHeaderRule`
         * :class:`~oci.load_balancer.models.ExtendHttpResponseHeaderValueRule`
 
@@ -68,7 +73,7 @@ class Rule(object):
 
         :param action:
             The value to assign to the action property of this Rule.
-            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", "HTTP_HEADER", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type action: str
 
@@ -112,6 +117,9 @@ class Rule(object):
         if type == 'ALLOW':
             return 'AllowRule'
 
+        if type == 'HTTP_HEADER':
+            return 'HttpHeaderRule'
+
         if type == 'ADD_HTTP_RESPONSE_HEADER':
             return 'AddHttpResponseHeaderRule'
 
@@ -124,7 +132,7 @@ class Rule(object):
     def action(self):
         """
         **[Required]** Gets the action of this Rule.
-        Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", "HTTP_HEADER", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -141,7 +149,7 @@ class Rule(object):
         :param action: The action of this Rule.
         :type: str
         """
-        allowed_values = ["ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT"]
+        allowed_values = ["ADD_HTTP_REQUEST_HEADER", "EXTEND_HTTP_REQUEST_HEADER_VALUE", "REMOVE_HTTP_REQUEST_HEADER", "ADD_HTTP_RESPONSE_HEADER", "EXTEND_HTTP_RESPONSE_HEADER_VALUE", "REMOVE_HTTP_RESPONSE_HEADER", "ALLOW", "CONTROL_ACCESS_USING_HTTP_METHODS", "REDIRECT", "HTTP_HEADER"]
         if not value_allowed_none_or_none_sentinel(action, allowed_values):
             action = 'UNKNOWN_ENUM_VALUE'
         self._action = action

--- a/src/oci/load_balancer/models/work_request.py
+++ b/src/oci/load_balancer/models/work_request.py
@@ -51,6 +51,10 @@ class WorkRequest(object):
             The value to assign to the type property of this WorkRequest.
         :type type: str
 
+        :param compartment_id:
+            The value to assign to the compartment_id property of this WorkRequest.
+        :type compartment_id: str
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this WorkRequest.
             Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", 'UNKNOWN_ENUM_VALUE'.
@@ -78,6 +82,7 @@ class WorkRequest(object):
             'id': 'str',
             'load_balancer_id': 'str',
             'type': 'str',
+            'compartment_id': 'str',
             'lifecycle_state': 'str',
             'message': 'str',
             'time_accepted': 'datetime',
@@ -89,6 +94,7 @@ class WorkRequest(object):
             'id': 'id',
             'load_balancer_id': 'loadBalancerId',
             'type': 'type',
+            'compartment_id': 'compartmentId',
             'lifecycle_state': 'lifecycleState',
             'message': 'message',
             'time_accepted': 'timeAccepted',
@@ -99,6 +105,7 @@ class WorkRequest(object):
         self._id = None
         self._load_balancer_id = None
         self._type = None
+        self._compartment_id = None
         self._lifecycle_state = None
         self._message = None
         self._time_accepted = None
@@ -190,6 +197,34 @@ class WorkRequest(object):
         :type: str
         """
         self._type = type
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this WorkRequest.
+        The `OCID`__ of the compartment containing the load balancer.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this WorkRequest.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this WorkRequest.
+        The `OCID`__ of the compartment containing the load balancer.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this WorkRequest.
+        :type: str
+        """
+        self._compartment_id = compartment_id
 
     @property
     def lifecycle_state(self):

--- a/src/oci/ocvp/__init__.py
+++ b/src/oci/ocvp/__init__.py
@@ -1,0 +1,16 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from __future__ import absolute_import
+
+
+from .esxi_host_client import EsxiHostClient
+from .esxi_host_client_composite_operations import EsxiHostClientCompositeOperations
+from .sddc_client import SddcClient
+from .sddc_client_composite_operations import SddcClientCompositeOperations
+from .work_request_client import WorkRequestClient
+from .work_request_client_composite_operations import WorkRequestClientCompositeOperations
+from . import models
+
+__all__ = ["EsxiHostClient", "EsxiHostClientCompositeOperations", "SddcClient", "SddcClientCompositeOperations", "WorkRequestClient", "WorkRequestClientCompositeOperations", "models"]

--- a/src/oci/ocvp/esxi_host_client.py
+++ b/src/oci/ocvp/esxi_host_client.py
@@ -1,0 +1,577 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import ocvp_type_mapping
+missing = Sentinel("Missing")
+
+
+class EsxiHostClient(object):
+    """
+    Use this API to manage the Oracle Cloud VMware Solution.
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20200501',
+            'service_endpoint_template': 'https://ocvps.{region}.oci.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("esxi_host", config, signer, ocvp_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def create_esxi_host(self, create_esxi_host_details, **kwargs):
+        """
+        Adds another ESXi host to an existing SDDC. The attributes of the specified
+        `Sddc` determine the VMware software and other configuration settings used
+        by the ESXi host.
+
+        Use the :class:`WorkRequest` operations to track the
+        creation of the ESXi host.
+
+
+        :param CreateEsxiHostDetails create_esxi_host_details: (required)
+            Details for the ESXi host.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/esxiHosts"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_esxi_host got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_esxi_host_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_esxi_host_details)
+
+    def delete_esxi_host(self, esxi_host_id, **kwargs):
+        """
+        Deletes the specified ESXi host. Before deleting the host, back up or
+        migrate any VMware workloads running on it.
+
+        When you delete an ESXi host, Oracle does not remove the node
+        configuration within the VMware environment itself. That is
+        your responsibility.
+
+        **Note:** If you delete EXSi hosts from the SDDC to total less than 3,
+        you are still billed for the 3 minimum recommended EXSi hosts. Also,
+        you cannot add more VMware workloads to the SDDC until it again has at
+        least 3 ESXi hosts.
+
+        Use the :class:`WorkRequest` operations to track the
+        deletion of the ESXi host.
+
+
+        :param str esxi_host_id: (required)
+            The `OCID`__ of the ESXi host.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/esxiHosts/{esxiHostId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_esxi_host got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "esxiHostId": esxi_host_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def get_esxi_host(self, esxi_host_id, **kwargs):
+        """
+        Gets the specified ESXi host's information.
+
+
+        :param str esxi_host_id: (required)
+            The `OCID`__ of the ESXi host.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.ocvp.models.EsxiHost`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/esxiHosts/{esxiHostId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_esxi_host got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "esxiHostId": esxi_host_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="EsxiHost")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="EsxiHost")
+
+    def list_esxi_hosts(self, **kwargs):
+        """
+        Lists the ESXi hosts in the specified SDDC. The list can be filtered
+        by Compute instance OCID or ESXi display name.
+
+        Remember that in terms of implementation, an ESXi host is a Compute instance that
+        is configured with the chosen bundle of VMware software. Each `EsxiHost`
+        object has its own OCID (`id`), and a separate attribute for the OCID of
+        the Compute instance (`computeInstanceId`). When filtering the list of
+        ESXi hosts, you can specify the OCID of the Compute instance, not the
+        ESXi host OCID.
+
+
+        :param str sddc_id: (optional)
+            The `OCID`__ of the SDDC.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str compute_instance_id: (optional)
+            The `OCID`__ of the Compute instance.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the given display name exactly.
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+            call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+            is case sensitive.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+            TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+            sort order is case sensitive.
+
+            **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+            optionally filter by availability domain if the scope of the resource type is within a
+            single availability domain. If you call one of these \"List\" operations without specifying
+            an availability domain, the resources are grouped by availability domain, then sorted.
+
+            Allowed values are: "timeCreated", "displayName"
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param str lifecycle_state: (optional)
+            The lifecycle state of the resource.
+
+            Allowed values are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.ocvp.models.EsxiHostCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/esxiHosts"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "sddc_id",
+            "compute_instance_id",
+            "display_name",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id",
+            "lifecycle_state"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_esxi_hosts got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["timeCreated", "displayName"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "sddcId": kwargs.get("sddc_id", missing),
+            "computeInstanceId": kwargs.get("compute_instance_id", missing),
+            "displayName": kwargs.get("display_name", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="EsxiHostCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="EsxiHostCollection")
+
+    def update_esxi_host(self, esxi_host_id, update_esxi_host_details, **kwargs):
+        """
+        Updates the specified ESXi host.
+
+
+        :param str esxi_host_id: (required)
+            The `OCID`__ of the ESXi host.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateEsxiHostDetails update_esxi_host_details: (required)
+            The information to be updated.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.ocvp.models.EsxiHost`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/esxiHosts/{esxiHostId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_esxi_host got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "esxiHostId": esxi_host_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_esxi_host_details,
+                response_type="EsxiHost")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_esxi_host_details,
+                response_type="EsxiHost")

--- a/src/oci/ocvp/esxi_host_client_composite_operations.py
+++ b/src/oci/ocvp/esxi_host_client_composite_operations.py
@@ -1,0 +1,153 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class EsxiHostClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.ocvp.EsxiHostClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new EsxiHostClientCompositeOperations object
+
+        :param EsxiHostClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client
+
+    def create_esxi_host_and_wait_for_state(self, create_esxi_host_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.ocvp.EsxiHostClient.create_esxi_host` and waits for the :py:class:`~oci.ocvp.models.WorkRequest`
+        to enter the given state(s).
+
+        :param CreateEsxiHostDetails create_esxi_host_details: (required)
+            Details for the ESXi host.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.ocvp.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.ocvp.EsxiHostClient.create_esxi_host`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_esxi_host(create_esxi_host_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_esxi_host_and_wait_for_state(self, esxi_host_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.ocvp.EsxiHostClient.delete_esxi_host` and waits for the :py:class:`~oci.ocvp.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str esxi_host_id: (required)
+            The `OCID`__ of the ESXi host.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.ocvp.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.ocvp.EsxiHostClient.delete_esxi_host`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = None
+        try:
+            operation_result = self.client.delete_esxi_host(esxi_host_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_esxi_host_and_wait_for_state(self, esxi_host_id, update_esxi_host_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.ocvp.EsxiHostClient.update_esxi_host` and waits for the :py:class:`~oci.ocvp.models.EsxiHost` acted upon
+        to enter the given state(s).
+
+        :param str esxi_host_id: (required)
+            The `OCID`__ of the ESXi host.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateEsxiHostDetails update_esxi_host_details: (required)
+            The information to be updated.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.ocvp.models.EsxiHost.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.ocvp.EsxiHostClient.update_esxi_host`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_esxi_host(esxi_host_id, update_esxi_host_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_esxi_host(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)

--- a/src/oci/ocvp/models/__init__.py
+++ b/src/oci/ocvp/models/__init__.py
@@ -1,0 +1,50 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from __future__ import absolute_import
+
+from .change_sddc_compartment_details import ChangeSddcCompartmentDetails
+from .create_esxi_host_details import CreateEsxiHostDetails
+from .create_sddc_details import CreateSddcDetails
+from .esxi_host import EsxiHost
+from .esxi_host_collection import EsxiHostCollection
+from .esxi_host_summary import EsxiHostSummary
+from .sddc import Sddc
+from .sddc_collection import SddcCollection
+from .sddc_summary import SddcSummary
+from .supported_vmware_software_version_collection import SupportedVmwareSoftwareVersionCollection
+from .supported_vmware_software_version_summary import SupportedVmwareSoftwareVersionSummary
+from .update_esxi_host_details import UpdateEsxiHostDetails
+from .update_sddc_details import UpdateSddcDetails
+from .work_request import WorkRequest
+from .work_request_collection import WorkRequestCollection
+from .work_request_error import WorkRequestError
+from .work_request_error_collection import WorkRequestErrorCollection
+from .work_request_log_entry import WorkRequestLogEntry
+from .work_request_log_entry_collection import WorkRequestLogEntryCollection
+from .work_request_resource import WorkRequestResource
+
+# Maps type names to classes for ocvp services.
+ocvp_type_mapping = {
+    "ChangeSddcCompartmentDetails": ChangeSddcCompartmentDetails,
+    "CreateEsxiHostDetails": CreateEsxiHostDetails,
+    "CreateSddcDetails": CreateSddcDetails,
+    "EsxiHost": EsxiHost,
+    "EsxiHostCollection": EsxiHostCollection,
+    "EsxiHostSummary": EsxiHostSummary,
+    "Sddc": Sddc,
+    "SddcCollection": SddcCollection,
+    "SddcSummary": SddcSummary,
+    "SupportedVmwareSoftwareVersionCollection": SupportedVmwareSoftwareVersionCollection,
+    "SupportedVmwareSoftwareVersionSummary": SupportedVmwareSoftwareVersionSummary,
+    "UpdateEsxiHostDetails": UpdateEsxiHostDetails,
+    "UpdateSddcDetails": UpdateSddcDetails,
+    "WorkRequest": WorkRequest,
+    "WorkRequestCollection": WorkRequestCollection,
+    "WorkRequestError": WorkRequestError,
+    "WorkRequestErrorCollection": WorkRequestErrorCollection,
+    "WorkRequestLogEntry": WorkRequestLogEntry,
+    "WorkRequestLogEntryCollection": WorkRequestLogEntryCollection,
+    "WorkRequestResource": WorkRequestResource
+}

--- a/src/oci/ocvp/models/change_sddc_compartment_details.py
+++ b/src/oci/ocvp/models/change_sddc_compartment_details.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeSddcCompartmentDetails(object):
+    """
+    The configuration details for the move operation.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeSddcCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeSddcCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeSddcCompartmentDetails.
+        The `OCID`__ of the compartment to move
+        the SDDC to.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeSddcCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeSddcCompartmentDetails.
+        The `OCID`__ of the compartment to move
+        the SDDC to.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeSddcCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/create_esxi_host_details.py
+++ b/src/oci/ocvp/models/create_esxi_host_details.py
@@ -1,0 +1,201 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateEsxiHostDetails(object):
+    """
+    Details of the ESXi host to add to the SDDC.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateEsxiHostDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param sddc_id:
+            The value to assign to the sddc_id property of this CreateEsxiHostDetails.
+        :type sddc_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateEsxiHostDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateEsxiHostDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateEsxiHostDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'sddc_id': 'str',
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'sddc_id': 'sddcId',
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._sddc_id = None
+        self._display_name = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def sddc_id(self):
+        """
+        **[Required]** Gets the sddc_id of this CreateEsxiHostDetails.
+        The `OCID`__ of the SDDC to add the
+        ESXi host to.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The sddc_id of this CreateEsxiHostDetails.
+        :rtype: str
+        """
+        return self._sddc_id
+
+    @sddc_id.setter
+    def sddc_id(self, sddc_id):
+        """
+        Sets the sddc_id of this CreateEsxiHostDetails.
+        The `OCID`__ of the SDDC to add the
+        ESXi host to.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param sddc_id: The sddc_id of this CreateEsxiHostDetails.
+        :type: str
+        """
+        self._sddc_id = sddc_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateEsxiHostDetails.
+        A descriptive name for the ESXi host. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        If this attribute is not specified, the SDDC's `instanceDisplayNamePrefix` attribute is used
+        to name and incrementally number the ESXi host. For example, if you're creating the fourth
+        ESXi host in the SDDC, and `instanceDisplayNamePrefix` is `MySDDC`, the host's display
+        name is `MySDDC-4`.
+
+
+        :return: The display_name of this CreateEsxiHostDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateEsxiHostDetails.
+        A descriptive name for the ESXi host. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+        If this attribute is not specified, the SDDC's `instanceDisplayNamePrefix` attribute is used
+        to name and incrementally number the ESXi host. For example, if you're creating the fourth
+        ESXi host in the SDDC, and `instanceDisplayNamePrefix` is `MySDDC`, the host's display
+        name is `MySDDC-4`.
+
+
+        :param display_name: The display_name of this CreateEsxiHostDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateEsxiHostDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateEsxiHostDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateEsxiHostDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateEsxiHostDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateEsxiHostDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateEsxiHostDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateEsxiHostDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateEsxiHostDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/create_sddc_details.py
+++ b/src/oci/ocvp/models/create_sddc_details.py
@@ -1,0 +1,705 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateSddcDetails(object):
+    """
+    Details of the SDDC.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateSddcDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compute_availability_domain:
+            The value to assign to the compute_availability_domain property of this CreateSddcDetails.
+        :type compute_availability_domain: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateSddcDetails.
+        :type display_name: str
+
+        :param vmware_software_version:
+            The value to assign to the vmware_software_version property of this CreateSddcDetails.
+        :type vmware_software_version: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateSddcDetails.
+        :type compartment_id: str
+
+        :param instance_display_name_prefix:
+            The value to assign to the instance_display_name_prefix property of this CreateSddcDetails.
+        :type instance_display_name_prefix: str
+
+        :param esxi_hosts_count:
+            The value to assign to the esxi_hosts_count property of this CreateSddcDetails.
+        :type esxi_hosts_count: int
+
+        :param ssh_authorized_keys:
+            The value to assign to the ssh_authorized_keys property of this CreateSddcDetails.
+        :type ssh_authorized_keys: str
+
+        :param workload_network_cidr:
+            The value to assign to the workload_network_cidr property of this CreateSddcDetails.
+        :type workload_network_cidr: str
+
+        :param provisioning_subnet_id:
+            The value to assign to the provisioning_subnet_id property of this CreateSddcDetails.
+        :type provisioning_subnet_id: str
+
+        :param vsphere_vlan_id:
+            The value to assign to the vsphere_vlan_id property of this CreateSddcDetails.
+        :type vsphere_vlan_id: str
+
+        :param vmotion_vlan_id:
+            The value to assign to the vmotion_vlan_id property of this CreateSddcDetails.
+        :type vmotion_vlan_id: str
+
+        :param vsan_vlan_id:
+            The value to assign to the vsan_vlan_id property of this CreateSddcDetails.
+        :type vsan_vlan_id: str
+
+        :param nsx_v_tep_vlan_id:
+            The value to assign to the nsx_v_tep_vlan_id property of this CreateSddcDetails.
+        :type nsx_v_tep_vlan_id: str
+
+        :param nsx_edge_v_tep_vlan_id:
+            The value to assign to the nsx_edge_v_tep_vlan_id property of this CreateSddcDetails.
+        :type nsx_edge_v_tep_vlan_id: str
+
+        :param nsx_edge_uplink1_vlan_id:
+            The value to assign to the nsx_edge_uplink1_vlan_id property of this CreateSddcDetails.
+        :type nsx_edge_uplink1_vlan_id: str
+
+        :param nsx_edge_uplink2_vlan_id:
+            The value to assign to the nsx_edge_uplink2_vlan_id property of this CreateSddcDetails.
+        :type nsx_edge_uplink2_vlan_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateSddcDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateSddcDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compute_availability_domain': 'str',
+            'display_name': 'str',
+            'vmware_software_version': 'str',
+            'compartment_id': 'str',
+            'instance_display_name_prefix': 'str',
+            'esxi_hosts_count': 'int',
+            'ssh_authorized_keys': 'str',
+            'workload_network_cidr': 'str',
+            'provisioning_subnet_id': 'str',
+            'vsphere_vlan_id': 'str',
+            'vmotion_vlan_id': 'str',
+            'vsan_vlan_id': 'str',
+            'nsx_v_tep_vlan_id': 'str',
+            'nsx_edge_v_tep_vlan_id': 'str',
+            'nsx_edge_uplink1_vlan_id': 'str',
+            'nsx_edge_uplink2_vlan_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compute_availability_domain': 'computeAvailabilityDomain',
+            'display_name': 'displayName',
+            'vmware_software_version': 'vmwareSoftwareVersion',
+            'compartment_id': 'compartmentId',
+            'instance_display_name_prefix': 'instanceDisplayNamePrefix',
+            'esxi_hosts_count': 'esxiHostsCount',
+            'ssh_authorized_keys': 'sshAuthorizedKeys',
+            'workload_network_cidr': 'workloadNetworkCidr',
+            'provisioning_subnet_id': 'provisioningSubnetId',
+            'vsphere_vlan_id': 'vsphereVlanId',
+            'vmotion_vlan_id': 'vmotionVlanId',
+            'vsan_vlan_id': 'vsanVlanId',
+            'nsx_v_tep_vlan_id': 'nsxVTepVlanId',
+            'nsx_edge_v_tep_vlan_id': 'nsxEdgeVTepVlanId',
+            'nsx_edge_uplink1_vlan_id': 'nsxEdgeUplink1VlanId',
+            'nsx_edge_uplink2_vlan_id': 'nsxEdgeUplink2VlanId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compute_availability_domain = None
+        self._display_name = None
+        self._vmware_software_version = None
+        self._compartment_id = None
+        self._instance_display_name_prefix = None
+        self._esxi_hosts_count = None
+        self._ssh_authorized_keys = None
+        self._workload_network_cidr = None
+        self._provisioning_subnet_id = None
+        self._vsphere_vlan_id = None
+        self._vmotion_vlan_id = None
+        self._vsan_vlan_id = None
+        self._nsx_v_tep_vlan_id = None
+        self._nsx_edge_v_tep_vlan_id = None
+        self._nsx_edge_uplink1_vlan_id = None
+        self._nsx_edge_uplink2_vlan_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compute_availability_domain(self):
+        """
+        **[Required]** Gets the compute_availability_domain of this CreateSddcDetails.
+        The availability domain to create the SDDC's ESXi hosts in.
+
+
+        :return: The compute_availability_domain of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._compute_availability_domain
+
+    @compute_availability_domain.setter
+    def compute_availability_domain(self, compute_availability_domain):
+        """
+        Sets the compute_availability_domain of this CreateSddcDetails.
+        The availability domain to create the SDDC's ESXi hosts in.
+
+
+        :param compute_availability_domain: The compute_availability_domain of this CreateSddcDetails.
+        :type: str
+        """
+        self._compute_availability_domain = compute_availability_domain
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateSddcDetails.
+        A descriptive name for the SDDC. It must be unique, start with a letter, and contain only letters, digits,
+        whitespaces, dashes and underscores.
+        Avoid entering confidential information.
+
+
+        :return: The display_name of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateSddcDetails.
+        A descriptive name for the SDDC. It must be unique, start with a letter, and contain only letters, digits,
+        whitespaces, dashes and underscores.
+        Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this CreateSddcDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def vmware_software_version(self):
+        """
+        **[Required]** Gets the vmware_software_version of this CreateSddcDetails.
+        The VMware software bundle to install on the ESXi hosts in the SDDC. To get a
+        list of the available versions, use
+        :func:`
+        _list_supported_vmware_software_versions`.
+
+
+        :return: The vmware_software_version of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._vmware_software_version
+
+    @vmware_software_version.setter
+    def vmware_software_version(self, vmware_software_version):
+        """
+        Sets the vmware_software_version of this CreateSddcDetails.
+        The VMware software bundle to install on the ESXi hosts in the SDDC. To get a
+        list of the available versions, use
+        :func:`
+        _list_supported_vmware_software_versions`.
+
+
+        :param vmware_software_version: The vmware_software_version of this CreateSddcDetails.
+        :type: str
+        """
+        self._vmware_software_version = vmware_software_version
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateSddcDetails.
+        The `OCID`__ of the compartment to contain the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateSddcDetails.
+        The `OCID`__ of the compartment to contain the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateSddcDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def instance_display_name_prefix(self):
+        """
+        Gets the instance_display_name_prefix of this CreateSddcDetails.
+        A prefix used in the name of each ESXi host and Compute instance in the SDDC.
+        If this isn't set, the SDDC's `displayName` is used as the prefix.
+
+        For example, if the value is `mySDDC`, the ESXi hosts are named `mySDDC-1`,
+        `mySDDC-2`, and so on.
+
+
+        :return: The instance_display_name_prefix of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._instance_display_name_prefix
+
+    @instance_display_name_prefix.setter
+    def instance_display_name_prefix(self, instance_display_name_prefix):
+        """
+        Sets the instance_display_name_prefix of this CreateSddcDetails.
+        A prefix used in the name of each ESXi host and Compute instance in the SDDC.
+        If this isn't set, the SDDC's `displayName` is used as the prefix.
+
+        For example, if the value is `mySDDC`, the ESXi hosts are named `mySDDC-1`,
+        `mySDDC-2`, and so on.
+
+
+        :param instance_display_name_prefix: The instance_display_name_prefix of this CreateSddcDetails.
+        :type: str
+        """
+        self._instance_display_name_prefix = instance_display_name_prefix
+
+    @property
+    def esxi_hosts_count(self):
+        """
+        **[Required]** Gets the esxi_hosts_count of this CreateSddcDetails.
+        The number of ESXi hosts to create in the SDDC. You can add more hosts later
+        (see :func:`create_esxi_host`).
+
+        **Note:** If you later delete EXSi hosts from the SDDC to total less than 3,
+        you are still billed for the 3 minimum recommended EXSi hosts. Also,
+        you cannot add more VMware workloads to the SDDC until it again has at least
+        3 ESXi hosts.
+
+
+        :return: The esxi_hosts_count of this CreateSddcDetails.
+        :rtype: int
+        """
+        return self._esxi_hosts_count
+
+    @esxi_hosts_count.setter
+    def esxi_hosts_count(self, esxi_hosts_count):
+        """
+        Sets the esxi_hosts_count of this CreateSddcDetails.
+        The number of ESXi hosts to create in the SDDC. You can add more hosts later
+        (see :func:`create_esxi_host`).
+
+        **Note:** If you later delete EXSi hosts from the SDDC to total less than 3,
+        you are still billed for the 3 minimum recommended EXSi hosts. Also,
+        you cannot add more VMware workloads to the SDDC until it again has at least
+        3 ESXi hosts.
+
+
+        :param esxi_hosts_count: The esxi_hosts_count of this CreateSddcDetails.
+        :type: int
+        """
+        self._esxi_hosts_count = esxi_hosts_count
+
+    @property
+    def ssh_authorized_keys(self):
+        """
+        **[Required]** Gets the ssh_authorized_keys of this CreateSddcDetails.
+        One or more public SSH keys to be included in the `~/.ssh/authorized_keys` file for
+        the default user on each ESXi host. Use a newline character to separate multiple keys.
+        The SSH keys must be in the format required for the `authorized_keys` file
+
+
+        :return: The ssh_authorized_keys of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._ssh_authorized_keys
+
+    @ssh_authorized_keys.setter
+    def ssh_authorized_keys(self, ssh_authorized_keys):
+        """
+        Sets the ssh_authorized_keys of this CreateSddcDetails.
+        One or more public SSH keys to be included in the `~/.ssh/authorized_keys` file for
+        the default user on each ESXi host. Use a newline character to separate multiple keys.
+        The SSH keys must be in the format required for the `authorized_keys` file
+
+
+        :param ssh_authorized_keys: The ssh_authorized_keys of this CreateSddcDetails.
+        :type: str
+        """
+        self._ssh_authorized_keys = ssh_authorized_keys
+
+    @property
+    def workload_network_cidr(self):
+        """
+        Gets the workload_network_cidr of this CreateSddcDetails.
+        The CIDR block for the IP addresses that VMware VMs in the SDDC use to run application
+        workloads.
+
+
+        :return: The workload_network_cidr of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._workload_network_cidr
+
+    @workload_network_cidr.setter
+    def workload_network_cidr(self, workload_network_cidr):
+        """
+        Sets the workload_network_cidr of this CreateSddcDetails.
+        The CIDR block for the IP addresses that VMware VMs in the SDDC use to run application
+        workloads.
+
+
+        :param workload_network_cidr: The workload_network_cidr of this CreateSddcDetails.
+        :type: str
+        """
+        self._workload_network_cidr = workload_network_cidr
+
+    @property
+    def provisioning_subnet_id(self):
+        """
+        **[Required]** Gets the provisioning_subnet_id of this CreateSddcDetails.
+        The `OCID`__ of the management subnet to use
+        for provisioning the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The provisioning_subnet_id of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._provisioning_subnet_id
+
+    @provisioning_subnet_id.setter
+    def provisioning_subnet_id(self, provisioning_subnet_id):
+        """
+        Sets the provisioning_subnet_id of this CreateSddcDetails.
+        The `OCID`__ of the management subnet to use
+        for provisioning the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param provisioning_subnet_id: The provisioning_subnet_id of this CreateSddcDetails.
+        :type: str
+        """
+        self._provisioning_subnet_id = provisioning_subnet_id
+
+    @property
+    def vsphere_vlan_id(self):
+        """
+        **[Required]** Gets the vsphere_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the vSphere
+        component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vsphere_vlan_id of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._vsphere_vlan_id
+
+    @vsphere_vlan_id.setter
+    def vsphere_vlan_id(self, vsphere_vlan_id):
+        """
+        Sets the vsphere_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the vSphere
+        component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vsphere_vlan_id: The vsphere_vlan_id of this CreateSddcDetails.
+        :type: str
+        """
+        self._vsphere_vlan_id = vsphere_vlan_id
+
+    @property
+    def vmotion_vlan_id(self):
+        """
+        **[Required]** Gets the vmotion_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the vMotion
+        component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vmotion_vlan_id of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._vmotion_vlan_id
+
+    @vmotion_vlan_id.setter
+    def vmotion_vlan_id(self, vmotion_vlan_id):
+        """
+        Sets the vmotion_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the vMotion
+        component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vmotion_vlan_id: The vmotion_vlan_id of this CreateSddcDetails.
+        :type: str
+        """
+        self._vmotion_vlan_id = vmotion_vlan_id
+
+    @property
+    def vsan_vlan_id(self):
+        """
+        **[Required]** Gets the vsan_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the vSAN
+        component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vsan_vlan_id of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._vsan_vlan_id
+
+    @vsan_vlan_id.setter
+    def vsan_vlan_id(self, vsan_vlan_id):
+        """
+        Sets the vsan_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the vSAN
+        component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vsan_vlan_id: The vsan_vlan_id of this CreateSddcDetails.
+        :type: str
+        """
+        self._vsan_vlan_id = vsan_vlan_id
+
+    @property
+    def nsx_v_tep_vlan_id(self):
+        """
+        **[Required]** Gets the nsx_v_tep_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the NSX VTEP
+        component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_v_tep_vlan_id of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._nsx_v_tep_vlan_id
+
+    @nsx_v_tep_vlan_id.setter
+    def nsx_v_tep_vlan_id(self, nsx_v_tep_vlan_id):
+        """
+        Sets the nsx_v_tep_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the NSX VTEP
+        component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_v_tep_vlan_id: The nsx_v_tep_vlan_id of this CreateSddcDetails.
+        :type: str
+        """
+        self._nsx_v_tep_vlan_id = nsx_v_tep_vlan_id
+
+    @property
+    def nsx_edge_v_tep_vlan_id(self):
+        """
+        **[Required]** Gets the nsx_edge_v_tep_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the NSX Edge VTEP
+        component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_edge_v_tep_vlan_id of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._nsx_edge_v_tep_vlan_id
+
+    @nsx_edge_v_tep_vlan_id.setter
+    def nsx_edge_v_tep_vlan_id(self, nsx_edge_v_tep_vlan_id):
+        """
+        Sets the nsx_edge_v_tep_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the NSX Edge VTEP
+        component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_edge_v_tep_vlan_id: The nsx_edge_v_tep_vlan_id of this CreateSddcDetails.
+        :type: str
+        """
+        self._nsx_edge_v_tep_vlan_id = nsx_edge_v_tep_vlan_id
+
+    @property
+    def nsx_edge_uplink1_vlan_id(self):
+        """
+        **[Required]** Gets the nsx_edge_uplink1_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the NSX Edge
+        Uplink 1 component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_edge_uplink1_vlan_id of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._nsx_edge_uplink1_vlan_id
+
+    @nsx_edge_uplink1_vlan_id.setter
+    def nsx_edge_uplink1_vlan_id(self, nsx_edge_uplink1_vlan_id):
+        """
+        Sets the nsx_edge_uplink1_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the NSX Edge
+        Uplink 1 component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_edge_uplink1_vlan_id: The nsx_edge_uplink1_vlan_id of this CreateSddcDetails.
+        :type: str
+        """
+        self._nsx_edge_uplink1_vlan_id = nsx_edge_uplink1_vlan_id
+
+    @property
+    def nsx_edge_uplink2_vlan_id(self):
+        """
+        **[Required]** Gets the nsx_edge_uplink2_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the NSX Edge
+        Uplink 2 component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_edge_uplink2_vlan_id of this CreateSddcDetails.
+        :rtype: str
+        """
+        return self._nsx_edge_uplink2_vlan_id
+
+    @nsx_edge_uplink2_vlan_id.setter
+    def nsx_edge_uplink2_vlan_id(self, nsx_edge_uplink2_vlan_id):
+        """
+        Sets the nsx_edge_uplink2_vlan_id of this CreateSddcDetails.
+        The `OCID`__ of the VLAN to use for the NSX Edge
+        Uplink 2 component of the VMware environment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_edge_uplink2_vlan_id: The nsx_edge_uplink2_vlan_id of this CreateSddcDetails.
+        :type: str
+        """
+        self._nsx_edge_uplink2_vlan_id = nsx_edge_uplink2_vlan_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateSddcDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateSddcDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateSddcDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateSddcDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateSddcDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateSddcDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateSddcDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateSddcDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/esxi_host.py
+++ b/src/oci/ocvp/models/esxi_host.py
@@ -1,0 +1,450 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EsxiHost(object):
+    """
+    An ESXi host is a node in an SDDC. At a minimum, each SDDC has 3 ESXi hosts
+    that are used to implement a functioning VMware environment.
+
+    In terms of implementation, an ESXi host is a Compute instance that
+    is configured with the chosen bundle of VMware software.
+
+    Notice that an `EsxiHost` object has its own OCID (`id`), and a separate
+    attribute for the OCID of the Compute instance (`computeInstanceId`).
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a EsxiHost.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a EsxiHost.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a EsxiHost.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a EsxiHost.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a EsxiHost.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a EsxiHost.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EsxiHost object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this EsxiHost.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this EsxiHost.
+        :type display_name: str
+
+        :param sddc_id:
+            The value to assign to the sddc_id property of this EsxiHost.
+        :type sddc_id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this EsxiHost.
+        :type compartment_id: str
+
+        :param compute_instance_id:
+            The value to assign to the compute_instance_id property of this EsxiHost.
+        :type compute_instance_id: str
+
+        :param time_created:
+            The value to assign to the time_created property of this EsxiHost.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this EsxiHost.
+        :type time_updated: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this EsxiHost.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this EsxiHost.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this EsxiHost.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'sddc_id': 'str',
+            'compartment_id': 'str',
+            'compute_instance_id': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'lifecycle_state': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'sddc_id': 'sddcId',
+            'compartment_id': 'compartmentId',
+            'compute_instance_id': 'computeInstanceId',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'lifecycle_state': 'lifecycleState',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._sddc_id = None
+        self._compartment_id = None
+        self._compute_instance_id = None
+        self._time_created = None
+        self._time_updated = None
+        self._lifecycle_state = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this EsxiHost.
+        The `OCID`__ of the ESXi host.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this EsxiHost.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this EsxiHost.
+        The `OCID`__ of the ESXi host.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this EsxiHost.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this EsxiHost.
+        A descriptive name for the ESXi host. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+
+        :return: The display_name of this EsxiHost.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this EsxiHost.
+        A descriptive name for the ESXi host. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this EsxiHost.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def sddc_id(self):
+        """
+        **[Required]** Gets the sddc_id of this EsxiHost.
+        The `OCID`__ of the SDDC that the
+        ESXi host belongs to.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The sddc_id of this EsxiHost.
+        :rtype: str
+        """
+        return self._sddc_id
+
+    @sddc_id.setter
+    def sddc_id(self, sddc_id):
+        """
+        Sets the sddc_id of this EsxiHost.
+        The `OCID`__ of the SDDC that the
+        ESXi host belongs to.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param sddc_id: The sddc_id of this EsxiHost.
+        :type: str
+        """
+        self._sddc_id = sddc_id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this EsxiHost.
+        The `OCID`__ of the compartment that
+        contains the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this EsxiHost.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this EsxiHost.
+        The `OCID`__ of the compartment that
+        contains the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this EsxiHost.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def compute_instance_id(self):
+        """
+        Gets the compute_instance_id of this EsxiHost.
+        In terms of implementation, an ESXi host is a Compute instance that
+        is configured with the chosen bundle of VMware software. The `computeInstanceId`
+        is the `OCID`__ of that Compute instance.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compute_instance_id of this EsxiHost.
+        :rtype: str
+        """
+        return self._compute_instance_id
+
+    @compute_instance_id.setter
+    def compute_instance_id(self, compute_instance_id):
+        """
+        Sets the compute_instance_id of this EsxiHost.
+        In terms of implementation, an ESXi host is a Compute instance that
+        is configured with the chosen bundle of VMware software. The `computeInstanceId`
+        is the `OCID`__ of that Compute instance.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compute_instance_id: The compute_instance_id of this EsxiHost.
+        :type: str
+        """
+        self._compute_instance_id = compute_instance_id
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this EsxiHost.
+        The date and time the ESXi host was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this EsxiHost.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this EsxiHost.
+        The date and time the ESXi host was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this EsxiHost.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this EsxiHost.
+        The date and time the ESXi host was updated, in the format defined by
+        `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_updated of this EsxiHost.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this EsxiHost.
+        The date and time the ESXi host was updated, in the format defined by
+        `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_updated: The time_updated of this EsxiHost.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this EsxiHost.
+        The current state of the ESXi host.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this EsxiHost.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this EsxiHost.
+        The current state of the ESXi host.
+
+
+        :param lifecycle_state: The lifecycle_state of this EsxiHost.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def freeform_tags(self):
+        """
+        **[Required]** Gets the freeform_tags of this EsxiHost.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this EsxiHost.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this EsxiHost.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this EsxiHost.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        **[Required]** Gets the defined_tags of this EsxiHost.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this EsxiHost.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this EsxiHost.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this EsxiHost.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/esxi_host_collection.py
+++ b/src/oci/ocvp/models/esxi_host_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EsxiHostCollection(object):
+    """
+    A list of ESXi hosts.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EsxiHostCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this EsxiHostCollection.
+        :type items: list[EsxiHostSummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[EsxiHostSummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this EsxiHostCollection.
+        A list of ESXi hosts.
+
+
+        :return: The items of this EsxiHostCollection.
+        :rtype: list[EsxiHostSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this EsxiHostCollection.
+        A list of ESXi hosts.
+
+
+        :param items: The items of this EsxiHostCollection.
+        :type: list[EsxiHostSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/esxi_host_summary.py
+++ b/src/oci/ocvp/models/esxi_host_summary.py
@@ -1,0 +1,443 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EsxiHostSummary(object):
+    """
+    A summary of the ESXi host.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a EsxiHostSummary.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a EsxiHostSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a EsxiHostSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a EsxiHostSummary.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a EsxiHostSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a EsxiHostSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EsxiHostSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this EsxiHostSummary.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this EsxiHostSummary.
+        :type display_name: str
+
+        :param sddc_id:
+            The value to assign to the sddc_id property of this EsxiHostSummary.
+        :type sddc_id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this EsxiHostSummary.
+        :type compartment_id: str
+
+        :param compute_instance_id:
+            The value to assign to the compute_instance_id property of this EsxiHostSummary.
+        :type compute_instance_id: str
+
+        :param time_created:
+            The value to assign to the time_created property of this EsxiHostSummary.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this EsxiHostSummary.
+        :type time_updated: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this EsxiHostSummary.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this EsxiHostSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this EsxiHostSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'sddc_id': 'str',
+            'compartment_id': 'str',
+            'compute_instance_id': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'lifecycle_state': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'sddc_id': 'sddcId',
+            'compartment_id': 'compartmentId',
+            'compute_instance_id': 'computeInstanceId',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'lifecycle_state': 'lifecycleState',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._sddc_id = None
+        self._compartment_id = None
+        self._compute_instance_id = None
+        self._time_created = None
+        self._time_updated = None
+        self._lifecycle_state = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this EsxiHostSummary.
+        The `OCID`__ of the ESXi host.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this EsxiHostSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this EsxiHostSummary.
+        The `OCID`__ of the ESXi host.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this EsxiHostSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this EsxiHostSummary.
+        A descriptive name for the ESXi host. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+
+        :return: The display_name of this EsxiHostSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this EsxiHostSummary.
+        A descriptive name for the ESXi host. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this EsxiHostSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def sddc_id(self):
+        """
+        **[Required]** Gets the sddc_id of this EsxiHostSummary.
+        The `OCID`__ of the SDDC that the
+        ESXi host belongs to.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The sddc_id of this EsxiHostSummary.
+        :rtype: str
+        """
+        return self._sddc_id
+
+    @sddc_id.setter
+    def sddc_id(self, sddc_id):
+        """
+        Sets the sddc_id of this EsxiHostSummary.
+        The `OCID`__ of the SDDC that the
+        ESXi host belongs to.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param sddc_id: The sddc_id of this EsxiHostSummary.
+        :type: str
+        """
+        self._sddc_id = sddc_id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this EsxiHostSummary.
+        The `OCID`__ of the compartment that
+        contains the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this EsxiHostSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this EsxiHostSummary.
+        The `OCID`__ of the compartment that
+        contains the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this EsxiHostSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def compute_instance_id(self):
+        """
+        Gets the compute_instance_id of this EsxiHostSummary.
+        In terms of implementation, an ESXi host is a Compute instance that
+        is configured with the chosen bundle of VMware software. The `computeInstanceId`
+        is the `OCID`__ of that Compute instance.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compute_instance_id of this EsxiHostSummary.
+        :rtype: str
+        """
+        return self._compute_instance_id
+
+    @compute_instance_id.setter
+    def compute_instance_id(self, compute_instance_id):
+        """
+        Sets the compute_instance_id of this EsxiHostSummary.
+        In terms of implementation, an ESXi host is a Compute instance that
+        is configured with the chosen bundle of VMware software. The `computeInstanceId`
+        is the `OCID`__ of that Compute instance.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compute_instance_id: The compute_instance_id of this EsxiHostSummary.
+        :type: str
+        """
+        self._compute_instance_id = compute_instance_id
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this EsxiHostSummary.
+        The date and time the ESXi host was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this EsxiHostSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this EsxiHostSummary.
+        The date and time the ESXi host was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this EsxiHostSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this EsxiHostSummary.
+        The date and time the ESXi host was updated, in the format defined by
+        `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_updated of this EsxiHostSummary.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this EsxiHostSummary.
+        The date and time the ESXi host was updated, in the format defined by
+        `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_updated: The time_updated of this EsxiHostSummary.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this EsxiHostSummary.
+        The current state of the ESXi host.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this EsxiHostSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this EsxiHostSummary.
+        The current state of the ESXi host.
+
+
+        :param lifecycle_state: The lifecycle_state of this EsxiHostSummary.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def freeform_tags(self):
+        """
+        **[Required]** Gets the freeform_tags of this EsxiHostSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this EsxiHostSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this EsxiHostSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this EsxiHostSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        **[Required]** Gets the defined_tags of this EsxiHostSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this EsxiHostSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this EsxiHostSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this EsxiHostSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/sddc.py
+++ b/src/oci/ocvp/models/sddc.py
@@ -1,0 +1,1433 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Sddc(object):
+    """
+    A software-defined data center (SDDC) contains the resources required for a
+    functional VMware environment. Instances in an SDDC
+    (see :class:`EsxiHost`) run in a virtual cloud network (VCN)
+    and are preconfigured with VMware and storage. Use the vCenter utility to manage
+    and deploy VMware virtual machines (VMs) in the SDDC.
+
+    The SDDC uses a single management subnet for provisioning the SDDC. It also uses a
+    set of VLANs for various components of the VMware environment (vSphere, vMotion,
+    vSAN, and so on). See the Core Services API for information about VCN subnets and VLANs.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a Sddc.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a Sddc.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a Sddc.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a Sddc.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a Sddc.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a Sddc.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Sddc object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this Sddc.
+        :type id: str
+
+        :param compute_availability_domain:
+            The value to assign to the compute_availability_domain property of this Sddc.
+        :type compute_availability_domain: str
+
+        :param display_name:
+            The value to assign to the display_name property of this Sddc.
+        :type display_name: str
+
+        :param instance_display_name_prefix:
+            The value to assign to the instance_display_name_prefix property of this Sddc.
+        :type instance_display_name_prefix: str
+
+        :param vmware_software_version:
+            The value to assign to the vmware_software_version property of this Sddc.
+        :type vmware_software_version: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this Sddc.
+        :type compartment_id: str
+
+        :param esxi_hosts_count:
+            The value to assign to the esxi_hosts_count property of this Sddc.
+        :type esxi_hosts_count: int
+
+        :param vcenter_fqdn:
+            The value to assign to the vcenter_fqdn property of this Sddc.
+        :type vcenter_fqdn: str
+
+        :param nsx_manager_fqdn:
+            The value to assign to the nsx_manager_fqdn property of this Sddc.
+        :type nsx_manager_fqdn: str
+
+        :param vcenter_private_ip_id:
+            The value to assign to the vcenter_private_ip_id property of this Sddc.
+        :type vcenter_private_ip_id: str
+
+        :param nsx_manager_private_ip_id:
+            The value to assign to the nsx_manager_private_ip_id property of this Sddc.
+        :type nsx_manager_private_ip_id: str
+
+        :param vcenter_initial_password:
+            The value to assign to the vcenter_initial_password property of this Sddc.
+        :type vcenter_initial_password: str
+
+        :param nsx_manager_initial_password:
+            The value to assign to the nsx_manager_initial_password property of this Sddc.
+        :type nsx_manager_initial_password: str
+
+        :param vcenter_username:
+            The value to assign to the vcenter_username property of this Sddc.
+        :type vcenter_username: str
+
+        :param nsx_manager_username:
+            The value to assign to the nsx_manager_username property of this Sddc.
+        :type nsx_manager_username: str
+
+        :param ssh_authorized_keys:
+            The value to assign to the ssh_authorized_keys property of this Sddc.
+        :type ssh_authorized_keys: str
+
+        :param workload_network_cidr:
+            The value to assign to the workload_network_cidr property of this Sddc.
+        :type workload_network_cidr: str
+
+        :param nsx_overlay_segment_name:
+            The value to assign to the nsx_overlay_segment_name property of this Sddc.
+        :type nsx_overlay_segment_name: str
+
+        :param nsx_edge_uplink_ip_id:
+            The value to assign to the nsx_edge_uplink_ip_id property of this Sddc.
+        :type nsx_edge_uplink_ip_id: str
+
+        :param provisioning_subnet_id:
+            The value to assign to the provisioning_subnet_id property of this Sddc.
+        :type provisioning_subnet_id: str
+
+        :param vsphere_vlan_id:
+            The value to assign to the vsphere_vlan_id property of this Sddc.
+        :type vsphere_vlan_id: str
+
+        :param vmotion_vlan_id:
+            The value to assign to the vmotion_vlan_id property of this Sddc.
+        :type vmotion_vlan_id: str
+
+        :param vsan_vlan_id:
+            The value to assign to the vsan_vlan_id property of this Sddc.
+        :type vsan_vlan_id: str
+
+        :param nsx_v_tep_vlan_id:
+            The value to assign to the nsx_v_tep_vlan_id property of this Sddc.
+        :type nsx_v_tep_vlan_id: str
+
+        :param nsx_edge_v_tep_vlan_id:
+            The value to assign to the nsx_edge_v_tep_vlan_id property of this Sddc.
+        :type nsx_edge_v_tep_vlan_id: str
+
+        :param nsx_edge_uplink1_vlan_id:
+            The value to assign to the nsx_edge_uplink1_vlan_id property of this Sddc.
+        :type nsx_edge_uplink1_vlan_id: str
+
+        :param nsx_edge_uplink2_vlan_id:
+            The value to assign to the nsx_edge_uplink2_vlan_id property of this Sddc.
+        :type nsx_edge_uplink2_vlan_id: str
+
+        :param time_created:
+            The value to assign to the time_created property of this Sddc.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this Sddc.
+        :type time_updated: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this Sddc.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this Sddc.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this Sddc.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compute_availability_domain': 'str',
+            'display_name': 'str',
+            'instance_display_name_prefix': 'str',
+            'vmware_software_version': 'str',
+            'compartment_id': 'str',
+            'esxi_hosts_count': 'int',
+            'vcenter_fqdn': 'str',
+            'nsx_manager_fqdn': 'str',
+            'vcenter_private_ip_id': 'str',
+            'nsx_manager_private_ip_id': 'str',
+            'vcenter_initial_password': 'str',
+            'nsx_manager_initial_password': 'str',
+            'vcenter_username': 'str',
+            'nsx_manager_username': 'str',
+            'ssh_authorized_keys': 'str',
+            'workload_network_cidr': 'str',
+            'nsx_overlay_segment_name': 'str',
+            'nsx_edge_uplink_ip_id': 'str',
+            'provisioning_subnet_id': 'str',
+            'vsphere_vlan_id': 'str',
+            'vmotion_vlan_id': 'str',
+            'vsan_vlan_id': 'str',
+            'nsx_v_tep_vlan_id': 'str',
+            'nsx_edge_v_tep_vlan_id': 'str',
+            'nsx_edge_uplink1_vlan_id': 'str',
+            'nsx_edge_uplink2_vlan_id': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'lifecycle_state': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compute_availability_domain': 'computeAvailabilityDomain',
+            'display_name': 'displayName',
+            'instance_display_name_prefix': 'instanceDisplayNamePrefix',
+            'vmware_software_version': 'vmwareSoftwareVersion',
+            'compartment_id': 'compartmentId',
+            'esxi_hosts_count': 'esxiHostsCount',
+            'vcenter_fqdn': 'vcenterFqdn',
+            'nsx_manager_fqdn': 'nsxManagerFqdn',
+            'vcenter_private_ip_id': 'vcenterPrivateIpId',
+            'nsx_manager_private_ip_id': 'nsxManagerPrivateIpId',
+            'vcenter_initial_password': 'vcenterInitialPassword',
+            'nsx_manager_initial_password': 'nsxManagerInitialPassword',
+            'vcenter_username': 'vcenterUsername',
+            'nsx_manager_username': 'nsxManagerUsername',
+            'ssh_authorized_keys': 'sshAuthorizedKeys',
+            'workload_network_cidr': 'workloadNetworkCidr',
+            'nsx_overlay_segment_name': 'nsxOverlaySegmentName',
+            'nsx_edge_uplink_ip_id': 'nsxEdgeUplinkIpId',
+            'provisioning_subnet_id': 'provisioningSubnetId',
+            'vsphere_vlan_id': 'vsphereVlanId',
+            'vmotion_vlan_id': 'vmotionVlanId',
+            'vsan_vlan_id': 'vsanVlanId',
+            'nsx_v_tep_vlan_id': 'nsxVTepVlanId',
+            'nsx_edge_v_tep_vlan_id': 'nsxEdgeVTepVlanId',
+            'nsx_edge_uplink1_vlan_id': 'nsxEdgeUplink1VlanId',
+            'nsx_edge_uplink2_vlan_id': 'nsxEdgeUplink2VlanId',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'lifecycle_state': 'lifecycleState',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compute_availability_domain = None
+        self._display_name = None
+        self._instance_display_name_prefix = None
+        self._vmware_software_version = None
+        self._compartment_id = None
+        self._esxi_hosts_count = None
+        self._vcenter_fqdn = None
+        self._nsx_manager_fqdn = None
+        self._vcenter_private_ip_id = None
+        self._nsx_manager_private_ip_id = None
+        self._vcenter_initial_password = None
+        self._nsx_manager_initial_password = None
+        self._vcenter_username = None
+        self._nsx_manager_username = None
+        self._ssh_authorized_keys = None
+        self._workload_network_cidr = None
+        self._nsx_overlay_segment_name = None
+        self._nsx_edge_uplink_ip_id = None
+        self._provisioning_subnet_id = None
+        self._vsphere_vlan_id = None
+        self._vmotion_vlan_id = None
+        self._vsan_vlan_id = None
+        self._nsx_v_tep_vlan_id = None
+        self._nsx_edge_v_tep_vlan_id = None
+        self._nsx_edge_uplink1_vlan_id = None
+        self._nsx_edge_uplink2_vlan_id = None
+        self._time_created = None
+        self._time_updated = None
+        self._lifecycle_state = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this Sddc.
+        The `OCID`__ of the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this Sddc.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this Sddc.
+        The `OCID`__ of the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this Sddc.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compute_availability_domain(self):
+        """
+        **[Required]** Gets the compute_availability_domain of this Sddc.
+        The availability domain the ESXi hosts are running in.
+
+        Example: `Uocm:PHX-AD-1`
+
+
+        :return: The compute_availability_domain of this Sddc.
+        :rtype: str
+        """
+        return self._compute_availability_domain
+
+    @compute_availability_domain.setter
+    def compute_availability_domain(self, compute_availability_domain):
+        """
+        Sets the compute_availability_domain of this Sddc.
+        The availability domain the ESXi hosts are running in.
+
+        Example: `Uocm:PHX-AD-1`
+
+
+        :param compute_availability_domain: The compute_availability_domain of this Sddc.
+        :type: str
+        """
+        self._compute_availability_domain = compute_availability_domain
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this Sddc.
+        A descriptive name for the SDDC. It must be unique, start with a letter, and contain only letters, digits,
+        whitespaces, dashes and underscores.
+        Avoid entering confidential information.
+
+
+        :return: The display_name of this Sddc.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this Sddc.
+        A descriptive name for the SDDC. It must be unique, start with a letter, and contain only letters, digits,
+        whitespaces, dashes and underscores.
+        Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this Sddc.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def instance_display_name_prefix(self):
+        """
+        Gets the instance_display_name_prefix of this Sddc.
+        A prefix used in the name of each ESXi host and Compute instance in the SDDC.
+        If this isn't set, the SDDC's `displayName` is used as the prefix.
+
+        For example, if the value is `MySDDC`, the ESXi hosts are named `MySDDC-1`,
+        `MySDDC-2`, and so on.
+
+
+        :return: The instance_display_name_prefix of this Sddc.
+        :rtype: str
+        """
+        return self._instance_display_name_prefix
+
+    @instance_display_name_prefix.setter
+    def instance_display_name_prefix(self, instance_display_name_prefix):
+        """
+        Sets the instance_display_name_prefix of this Sddc.
+        A prefix used in the name of each ESXi host and Compute instance in the SDDC.
+        If this isn't set, the SDDC's `displayName` is used as the prefix.
+
+        For example, if the value is `MySDDC`, the ESXi hosts are named `MySDDC-1`,
+        `MySDDC-2`, and so on.
+
+
+        :param instance_display_name_prefix: The instance_display_name_prefix of this Sddc.
+        :type: str
+        """
+        self._instance_display_name_prefix = instance_display_name_prefix
+
+    @property
+    def vmware_software_version(self):
+        """
+        **[Required]** Gets the vmware_software_version of this Sddc.
+        In general, this is a specific version of bundled VMware software supported by
+        Oracle Cloud VMware Solution (see
+        :func:`
+        _list_supported_vmware_software_versions`).
+
+        This attribute is not guaranteed to reflect the version of
+        software currently installed on the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the version of software that the Oracle
+        Cloud VMware Solution will install on any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you upgrade the existing ESXi hosts in the SDDC to use a newer
+        version of bundled VMware software supported by the Oracle Cloud VMware Solution, you
+        should use :func:`update_sddc` to update the SDDC's
+        `vmwareSoftwareVersion` with that new version.
+
+
+        :return: The vmware_software_version of this Sddc.
+        :rtype: str
+        """
+        return self._vmware_software_version
+
+    @vmware_software_version.setter
+    def vmware_software_version(self, vmware_software_version):
+        """
+        Sets the vmware_software_version of this Sddc.
+        In general, this is a specific version of bundled VMware software supported by
+        Oracle Cloud VMware Solution (see
+        :func:`
+        _list_supported_vmware_software_versions`).
+
+        This attribute is not guaranteed to reflect the version of
+        software currently installed on the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the version of software that the Oracle
+        Cloud VMware Solution will install on any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you upgrade the existing ESXi hosts in the SDDC to use a newer
+        version of bundled VMware software supported by the Oracle Cloud VMware Solution, you
+        should use :func:`update_sddc` to update the SDDC's
+        `vmwareSoftwareVersion` with that new version.
+
+
+        :param vmware_software_version: The vmware_software_version of this Sddc.
+        :type: str
+        """
+        self._vmware_software_version = vmware_software_version
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this Sddc.
+        The `OCID`__ of the compartment that
+        contains the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this Sddc.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this Sddc.
+        The `OCID`__ of the compartment that
+        contains the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this Sddc.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def esxi_hosts_count(self):
+        """
+        **[Required]** Gets the esxi_hosts_count of this Sddc.
+        The number of ESXi hosts in the SDDC.
+
+
+        :return: The esxi_hosts_count of this Sddc.
+        :rtype: int
+        """
+        return self._esxi_hosts_count
+
+    @esxi_hosts_count.setter
+    def esxi_hosts_count(self, esxi_hosts_count):
+        """
+        Sets the esxi_hosts_count of this Sddc.
+        The number of ESXi hosts in the SDDC.
+
+
+        :param esxi_hosts_count: The esxi_hosts_count of this Sddc.
+        :type: int
+        """
+        self._esxi_hosts_count = esxi_hosts_count
+
+    @property
+    def vcenter_fqdn(self):
+        """
+        **[Required]** Gets the vcenter_fqdn of this Sddc.
+        FQDN for vCenter
+
+        Example: `vcenter-my-sddc.sddc.us-phoenix-1.oraclecloud.com`
+
+
+        :return: The vcenter_fqdn of this Sddc.
+        :rtype: str
+        """
+        return self._vcenter_fqdn
+
+    @vcenter_fqdn.setter
+    def vcenter_fqdn(self, vcenter_fqdn):
+        """
+        Sets the vcenter_fqdn of this Sddc.
+        FQDN for vCenter
+
+        Example: `vcenter-my-sddc.sddc.us-phoenix-1.oraclecloud.com`
+
+
+        :param vcenter_fqdn: The vcenter_fqdn of this Sddc.
+        :type: str
+        """
+        self._vcenter_fqdn = vcenter_fqdn
+
+    @property
+    def nsx_manager_fqdn(self):
+        """
+        **[Required]** Gets the nsx_manager_fqdn of this Sddc.
+        FQDN for NSX Manager
+
+        Example: `nsx-my-sddc.sddc.us-phoenix-1.oraclecloud.com`
+
+
+        :return: The nsx_manager_fqdn of this Sddc.
+        :rtype: str
+        """
+        return self._nsx_manager_fqdn
+
+    @nsx_manager_fqdn.setter
+    def nsx_manager_fqdn(self, nsx_manager_fqdn):
+        """
+        Sets the nsx_manager_fqdn of this Sddc.
+        FQDN for NSX Manager
+
+        Example: `nsx-my-sddc.sddc.us-phoenix-1.oraclecloud.com`
+
+
+        :param nsx_manager_fqdn: The nsx_manager_fqdn of this Sddc.
+        :type: str
+        """
+        self._nsx_manager_fqdn = nsx_manager_fqdn
+
+    @property
+    def vcenter_private_ip_id(self):
+        """
+        **[Required]** Gets the vcenter_private_ip_id of this Sddc.
+        The `OCID`__ of the `PrivateIp` object that is
+        the virtual IP (VIP) for vCenter. For information about `PrivateIp` objects, see the
+        Core Services API.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vcenter_private_ip_id of this Sddc.
+        :rtype: str
+        """
+        return self._vcenter_private_ip_id
+
+    @vcenter_private_ip_id.setter
+    def vcenter_private_ip_id(self, vcenter_private_ip_id):
+        """
+        Sets the vcenter_private_ip_id of this Sddc.
+        The `OCID`__ of the `PrivateIp` object that is
+        the virtual IP (VIP) for vCenter. For information about `PrivateIp` objects, see the
+        Core Services API.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vcenter_private_ip_id: The vcenter_private_ip_id of this Sddc.
+        :type: str
+        """
+        self._vcenter_private_ip_id = vcenter_private_ip_id
+
+    @property
+    def nsx_manager_private_ip_id(self):
+        """
+        **[Required]** Gets the nsx_manager_private_ip_id of this Sddc.
+        The `OCID`__ of the `PrivateIp` object that is
+        the virtual IP (VIP) for NSX Manager. For information about `PrivateIp` objects, see the
+        Core Services API.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_manager_private_ip_id of this Sddc.
+        :rtype: str
+        """
+        return self._nsx_manager_private_ip_id
+
+    @nsx_manager_private_ip_id.setter
+    def nsx_manager_private_ip_id(self, nsx_manager_private_ip_id):
+        """
+        Sets the nsx_manager_private_ip_id of this Sddc.
+        The `OCID`__ of the `PrivateIp` object that is
+        the virtual IP (VIP) for NSX Manager. For information about `PrivateIp` objects, see the
+        Core Services API.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_manager_private_ip_id: The nsx_manager_private_ip_id of this Sddc.
+        :type: str
+        """
+        self._nsx_manager_private_ip_id = nsx_manager_private_ip_id
+
+    @property
+    def vcenter_initial_password(self):
+        """
+        Gets the vcenter_initial_password of this Sddc.
+        The SDDC includes an administrator username and initial password for vCenter. Make sure
+        to change this initial vCenter password to a different value.
+
+
+        :return: The vcenter_initial_password of this Sddc.
+        :rtype: str
+        """
+        return self._vcenter_initial_password
+
+    @vcenter_initial_password.setter
+    def vcenter_initial_password(self, vcenter_initial_password):
+        """
+        Sets the vcenter_initial_password of this Sddc.
+        The SDDC includes an administrator username and initial password for vCenter. Make sure
+        to change this initial vCenter password to a different value.
+
+
+        :param vcenter_initial_password: The vcenter_initial_password of this Sddc.
+        :type: str
+        """
+        self._vcenter_initial_password = vcenter_initial_password
+
+    @property
+    def nsx_manager_initial_password(self):
+        """
+        Gets the nsx_manager_initial_password of this Sddc.
+        The SDDC includes an administrator username and initial password for NSX Manager. Make sure
+        to change this initial NSX Manager password to a different value.
+
+
+        :return: The nsx_manager_initial_password of this Sddc.
+        :rtype: str
+        """
+        return self._nsx_manager_initial_password
+
+    @nsx_manager_initial_password.setter
+    def nsx_manager_initial_password(self, nsx_manager_initial_password):
+        """
+        Sets the nsx_manager_initial_password of this Sddc.
+        The SDDC includes an administrator username and initial password for NSX Manager. Make sure
+        to change this initial NSX Manager password to a different value.
+
+
+        :param nsx_manager_initial_password: The nsx_manager_initial_password of this Sddc.
+        :type: str
+        """
+        self._nsx_manager_initial_password = nsx_manager_initial_password
+
+    @property
+    def vcenter_username(self):
+        """
+        Gets the vcenter_username of this Sddc.
+        The SDDC includes an administrator username and initial password for vCenter. You can
+        change this initial username to a different value in vCenter.
+
+
+        :return: The vcenter_username of this Sddc.
+        :rtype: str
+        """
+        return self._vcenter_username
+
+    @vcenter_username.setter
+    def vcenter_username(self, vcenter_username):
+        """
+        Sets the vcenter_username of this Sddc.
+        The SDDC includes an administrator username and initial password for vCenter. You can
+        change this initial username to a different value in vCenter.
+
+
+        :param vcenter_username: The vcenter_username of this Sddc.
+        :type: str
+        """
+        self._vcenter_username = vcenter_username
+
+    @property
+    def nsx_manager_username(self):
+        """
+        Gets the nsx_manager_username of this Sddc.
+        The SDDC includes an administrator username and initial password for NSX Manager. You
+        can change this initial username to a different value in NSX Manager.
+
+
+        :return: The nsx_manager_username of this Sddc.
+        :rtype: str
+        """
+        return self._nsx_manager_username
+
+    @nsx_manager_username.setter
+    def nsx_manager_username(self, nsx_manager_username):
+        """
+        Sets the nsx_manager_username of this Sddc.
+        The SDDC includes an administrator username and initial password for NSX Manager. You
+        can change this initial username to a different value in NSX Manager.
+
+
+        :param nsx_manager_username: The nsx_manager_username of this Sddc.
+        :type: str
+        """
+        self._nsx_manager_username = nsx_manager_username
+
+    @property
+    def ssh_authorized_keys(self):
+        """
+        **[Required]** Gets the ssh_authorized_keys of this Sddc.
+        One or more public SSH keys to be included in the `~/.ssh/authorized_keys` file for
+        the default user on each ESXi host. Use a newline character to separate multiple keys.
+        The SSH keys must be in the format required for the `authorized_keys` file.
+
+        This attribute is not guaranteed to reflect the public SSH keys
+        currently installed on the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the public SSH keys that Oracle
+        Cloud VMware Solution will install on any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you upgrade the existing ESXi hosts in the SDDC to use different
+        SSH keys, you should use :func:`update_sddc` to update
+        the SDDC's `sshAuthorizedKeys` with the new public keys.
+
+
+        :return: The ssh_authorized_keys of this Sddc.
+        :rtype: str
+        """
+        return self._ssh_authorized_keys
+
+    @ssh_authorized_keys.setter
+    def ssh_authorized_keys(self, ssh_authorized_keys):
+        """
+        Sets the ssh_authorized_keys of this Sddc.
+        One or more public SSH keys to be included in the `~/.ssh/authorized_keys` file for
+        the default user on each ESXi host. Use a newline character to separate multiple keys.
+        The SSH keys must be in the format required for the `authorized_keys` file.
+
+        This attribute is not guaranteed to reflect the public SSH keys
+        currently installed on the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the public SSH keys that Oracle
+        Cloud VMware Solution will install on any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you upgrade the existing ESXi hosts in the SDDC to use different
+        SSH keys, you should use :func:`update_sddc` to update
+        the SDDC's `sshAuthorizedKeys` with the new public keys.
+
+
+        :param ssh_authorized_keys: The ssh_authorized_keys of this Sddc.
+        :type: str
+        """
+        self._ssh_authorized_keys = ssh_authorized_keys
+
+    @property
+    def workload_network_cidr(self):
+        """
+        Gets the workload_network_cidr of this Sddc.
+        The CIDR block for the IP addresses that VMware VMs in the SDDC use to run application
+        workloads.
+
+
+        :return: The workload_network_cidr of this Sddc.
+        :rtype: str
+        """
+        return self._workload_network_cidr
+
+    @workload_network_cidr.setter
+    def workload_network_cidr(self, workload_network_cidr):
+        """
+        Sets the workload_network_cidr of this Sddc.
+        The CIDR block for the IP addresses that VMware VMs in the SDDC use to run application
+        workloads.
+
+
+        :param workload_network_cidr: The workload_network_cidr of this Sddc.
+        :type: str
+        """
+        self._workload_network_cidr = workload_network_cidr
+
+    @property
+    def nsx_overlay_segment_name(self):
+        """
+        Gets the nsx_overlay_segment_name of this Sddc.
+        The VMware NSX overlay workload segment to host your application. Connect to workload
+        portgroup in vCenter to access this overlay segment.
+
+
+        :return: The nsx_overlay_segment_name of this Sddc.
+        :rtype: str
+        """
+        return self._nsx_overlay_segment_name
+
+    @nsx_overlay_segment_name.setter
+    def nsx_overlay_segment_name(self, nsx_overlay_segment_name):
+        """
+        Sets the nsx_overlay_segment_name of this Sddc.
+        The VMware NSX overlay workload segment to host your application. Connect to workload
+        portgroup in vCenter to access this overlay segment.
+
+
+        :param nsx_overlay_segment_name: The nsx_overlay_segment_name of this Sddc.
+        :type: str
+        """
+        self._nsx_overlay_segment_name = nsx_overlay_segment_name
+
+    @property
+    def nsx_edge_uplink_ip_id(self):
+        """
+        Gets the nsx_edge_uplink_ip_id of this Sddc.
+        The `OCID`__ of the `PrivateIp` object that is
+        the virtual IP (VIP) for the NSX Edge Uplink. Use this OCID as the route target for
+        route table rules when setting up connectivity between the SDDC and other networks.
+        For information about `PrivateIp` objects, see the Core Services API.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_edge_uplink_ip_id of this Sddc.
+        :rtype: str
+        """
+        return self._nsx_edge_uplink_ip_id
+
+    @nsx_edge_uplink_ip_id.setter
+    def nsx_edge_uplink_ip_id(self, nsx_edge_uplink_ip_id):
+        """
+        Sets the nsx_edge_uplink_ip_id of this Sddc.
+        The `OCID`__ of the `PrivateIp` object that is
+        the virtual IP (VIP) for the NSX Edge Uplink. Use this OCID as the route target for
+        route table rules when setting up connectivity between the SDDC and other networks.
+        For information about `PrivateIp` objects, see the Core Services API.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_edge_uplink_ip_id: The nsx_edge_uplink_ip_id of this Sddc.
+        :type: str
+        """
+        self._nsx_edge_uplink_ip_id = nsx_edge_uplink_ip_id
+
+    @property
+    def provisioning_subnet_id(self):
+        """
+        **[Required]** Gets the provisioning_subnet_id of this Sddc.
+        The `OCID`__ of the management subnet used
+        to provision the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The provisioning_subnet_id of this Sddc.
+        :rtype: str
+        """
+        return self._provisioning_subnet_id
+
+    @provisioning_subnet_id.setter
+    def provisioning_subnet_id(self, provisioning_subnet_id):
+        """
+        Sets the provisioning_subnet_id of this Sddc.
+        The `OCID`__ of the management subnet used
+        to provision the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param provisioning_subnet_id: The provisioning_subnet_id of this Sddc.
+        :type: str
+        """
+        self._provisioning_subnet_id = provisioning_subnet_id
+
+    @property
+    def vsphere_vlan_id(self):
+        """
+        **[Required]** Gets the vsphere_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the vSphere component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the vSphere VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the vSphere VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the vSphere component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `vsphereVlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vsphere_vlan_id of this Sddc.
+        :rtype: str
+        """
+        return self._vsphere_vlan_id
+
+    @vsphere_vlan_id.setter
+    def vsphere_vlan_id(self, vsphere_vlan_id):
+        """
+        Sets the vsphere_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the vSphere component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the vSphere VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the vSphere VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the vSphere component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `vsphereVlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vsphere_vlan_id: The vsphere_vlan_id of this Sddc.
+        :type: str
+        """
+        self._vsphere_vlan_id = vsphere_vlan_id
+
+    @property
+    def vmotion_vlan_id(self):
+        """
+        **[Required]** Gets the vmotion_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the vMotion component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the vMotion VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the vMotion VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the vMotion component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `vmotionVlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vmotion_vlan_id of this Sddc.
+        :rtype: str
+        """
+        return self._vmotion_vlan_id
+
+    @vmotion_vlan_id.setter
+    def vmotion_vlan_id(self, vmotion_vlan_id):
+        """
+        Sets the vmotion_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the vMotion component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the vMotion VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the vMotion VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the vMotion component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `vmotionVlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vmotion_vlan_id: The vmotion_vlan_id of this Sddc.
+        :type: str
+        """
+        self._vmotion_vlan_id = vmotion_vlan_id
+
+    @property
+    def vsan_vlan_id(self):
+        """
+        **[Required]** Gets the vsan_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the vSAN component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the vSAN VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the vSAN VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the vSAN component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `vsanVlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vsan_vlan_id of this Sddc.
+        :rtype: str
+        """
+        return self._vsan_vlan_id
+
+    @vsan_vlan_id.setter
+    def vsan_vlan_id(self, vsan_vlan_id):
+        """
+        Sets the vsan_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the vSAN component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the vSAN VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the vSAN VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the vSAN component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `vsanVlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vsan_vlan_id: The vsan_vlan_id of this Sddc.
+        :type: str
+        """
+        self._vsan_vlan_id = vsan_vlan_id
+
+    @property
+    def nsx_v_tep_vlan_id(self):
+        """
+        **[Required]** Gets the nsx_v_tep_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the NSX VTEP component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the NSX VTEP VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the NSX VTEP VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the NSX VTEP component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `nsxVTepVlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_v_tep_vlan_id of this Sddc.
+        :rtype: str
+        """
+        return self._nsx_v_tep_vlan_id
+
+    @nsx_v_tep_vlan_id.setter
+    def nsx_v_tep_vlan_id(self, nsx_v_tep_vlan_id):
+        """
+        Sets the nsx_v_tep_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the NSX VTEP component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the NSX VTEP VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the NSX VTEP VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the NSX VTEP component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `nsxVTepVlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_v_tep_vlan_id: The nsx_v_tep_vlan_id of this Sddc.
+        :type: str
+        """
+        self._nsx_v_tep_vlan_id = nsx_v_tep_vlan_id
+
+    @property
+    def nsx_edge_v_tep_vlan_id(self):
+        """
+        **[Required]** Gets the nsx_edge_v_tep_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the NSX Edge VTEP component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the NSX Edge VTEP VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the NSX Edge VTEP VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the NSX Edge VTEP component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `nsxEdgeVTepVlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_edge_v_tep_vlan_id of this Sddc.
+        :rtype: str
+        """
+        return self._nsx_edge_v_tep_vlan_id
+
+    @nsx_edge_v_tep_vlan_id.setter
+    def nsx_edge_v_tep_vlan_id(self, nsx_edge_v_tep_vlan_id):
+        """
+        Sets the nsx_edge_v_tep_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the NSX Edge VTEP component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the NSX Edge VTEP VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the NSX Edge VTEP VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the NSX Edge VTEP component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `nsxEdgeVTepVlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_edge_v_tep_vlan_id: The nsx_edge_v_tep_vlan_id of this Sddc.
+        :type: str
+        """
+        self._nsx_edge_v_tep_vlan_id = nsx_edge_v_tep_vlan_id
+
+    @property
+    def nsx_edge_uplink1_vlan_id(self):
+        """
+        **[Required]** Gets the nsx_edge_uplink1_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the NSX Edge Uplink 1 component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the NSX Edge Uplink 1 VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the NSX Edge Uplink 1 VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the NSX Edge Uplink 1 component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `nsxEdgeUplink1VlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_edge_uplink1_vlan_id of this Sddc.
+        :rtype: str
+        """
+        return self._nsx_edge_uplink1_vlan_id
+
+    @nsx_edge_uplink1_vlan_id.setter
+    def nsx_edge_uplink1_vlan_id(self, nsx_edge_uplink1_vlan_id):
+        """
+        Sets the nsx_edge_uplink1_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the NSX Edge Uplink 1 component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the NSX Edge Uplink 1 VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the NSX Edge Uplink 1 VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the NSX Edge Uplink 1 component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `nsxEdgeUplink1VlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_edge_uplink1_vlan_id: The nsx_edge_uplink1_vlan_id of this Sddc.
+        :type: str
+        """
+        self._nsx_edge_uplink1_vlan_id = nsx_edge_uplink1_vlan_id
+
+    @property
+    def nsx_edge_uplink2_vlan_id(self):
+        """
+        **[Required]** Gets the nsx_edge_uplink2_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the NSX Edge Uplink 2 component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the NSX Edge Uplink 2 VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the NSX Edge Uplink 2 VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the NSX Edge Uplink 2 component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `nsxEdgeUplink2VlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_edge_uplink2_vlan_id of this Sddc.
+        :rtype: str
+        """
+        return self._nsx_edge_uplink2_vlan_id
+
+    @nsx_edge_uplink2_vlan_id.setter
+    def nsx_edge_uplink2_vlan_id(self, nsx_edge_uplink2_vlan_id):
+        """
+        Sets the nsx_edge_uplink2_vlan_id of this Sddc.
+        The `OCID`__ of the VLAN used by the SDDC
+        for the NSX Edge Uplink 2 component of the VMware environment.
+
+        This attribute is not guaranteed to reflect the NSX Edge Uplink 2 VLAN
+        currently used by the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the NSX Edge Uplink 2 VLAN that the Oracle
+        Cloud VMware Solution will use for any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you change the existing ESXi hosts in the SDDC to use a different VLAN
+        for the NSX Edge Uplink 2 component of the VMware environment, you
+        should use :func:`update_sddc` to update the SDDC's
+        `nsxEdgeUplink2VlanId` with that new VLAN's OCID.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_edge_uplink2_vlan_id: The nsx_edge_uplink2_vlan_id of this Sddc.
+        :type: str
+        """
+        self._nsx_edge_uplink2_vlan_id = nsx_edge_uplink2_vlan_id
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this Sddc.
+        The date and time the SDDC was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this Sddc.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this Sddc.
+        The date and time the SDDC was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this Sddc.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this Sddc.
+        The date and time the SDDC was updated, in the format defined by
+        `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_updated of this Sddc.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this Sddc.
+        The date and time the SDDC was updated, in the format defined by
+        `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_updated: The time_updated of this Sddc.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this Sddc.
+        The current state of the SDDC.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this Sddc.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this Sddc.
+        The current state of the SDDC.
+
+
+        :param lifecycle_state: The lifecycle_state of this Sddc.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def freeform_tags(self):
+        """
+        **[Required]** Gets the freeform_tags of this Sddc.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this Sddc.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this Sddc.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this Sddc.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        **[Required]** Gets the defined_tags of this Sddc.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this Sddc.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this Sddc.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this Sddc.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/sddc_collection.py
+++ b/src/oci/ocvp/models/sddc_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SddcCollection(object):
+    """
+    A list of SDDCs.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SddcCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this SddcCollection.
+        :type items: list[SddcSummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[SddcSummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this SddcCollection.
+        A list of SDDCs.
+
+
+        :return: The items of this SddcCollection.
+        :rtype: list[SddcSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this SddcCollection.
+        A list of SDDCs.
+
+
+        :param items: The items of this SddcCollection.
+        :type: list[SddcSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/sddc_summary.py
+++ b/src/oci/ocvp/models/sddc_summary.py
@@ -1,0 +1,562 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SddcSummary(object):
+    """
+    A summary of the SDDC.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a SddcSummary.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a SddcSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a SddcSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a SddcSummary.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a SddcSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a SddcSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SddcSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this SddcSummary.
+        :type id: str
+
+        :param compute_availability_domain:
+            The value to assign to the compute_availability_domain property of this SddcSummary.
+        :type compute_availability_domain: str
+
+        :param display_name:
+            The value to assign to the display_name property of this SddcSummary.
+        :type display_name: str
+
+        :param vmware_software_version:
+            The value to assign to the vmware_software_version property of this SddcSummary.
+        :type vmware_software_version: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this SddcSummary.
+        :type compartment_id: str
+
+        :param esxi_hosts_count:
+            The value to assign to the esxi_hosts_count property of this SddcSummary.
+        :type esxi_hosts_count: int
+
+        :param vcenter_fqdn:
+            The value to assign to the vcenter_fqdn property of this SddcSummary.
+        :type vcenter_fqdn: str
+
+        :param nsx_manager_fqdn:
+            The value to assign to the nsx_manager_fqdn property of this SddcSummary.
+        :type nsx_manager_fqdn: str
+
+        :param time_created:
+            The value to assign to the time_created property of this SddcSummary.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this SddcSummary.
+        :type time_updated: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this SddcSummary.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this SddcSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this SddcSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compute_availability_domain': 'str',
+            'display_name': 'str',
+            'vmware_software_version': 'str',
+            'compartment_id': 'str',
+            'esxi_hosts_count': 'int',
+            'vcenter_fqdn': 'str',
+            'nsx_manager_fqdn': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'lifecycle_state': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compute_availability_domain': 'computeAvailabilityDomain',
+            'display_name': 'displayName',
+            'vmware_software_version': 'vmwareSoftwareVersion',
+            'compartment_id': 'compartmentId',
+            'esxi_hosts_count': 'esxiHostsCount',
+            'vcenter_fqdn': 'vcenterFqdn',
+            'nsx_manager_fqdn': 'nsxManagerFqdn',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'lifecycle_state': 'lifecycleState',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compute_availability_domain = None
+        self._display_name = None
+        self._vmware_software_version = None
+        self._compartment_id = None
+        self._esxi_hosts_count = None
+        self._vcenter_fqdn = None
+        self._nsx_manager_fqdn = None
+        self._time_created = None
+        self._time_updated = None
+        self._lifecycle_state = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this SddcSummary.
+        The `OCID`__ of the compartment that
+        contains the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this SddcSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this SddcSummary.
+        The `OCID`__ of the compartment that
+        contains the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this SddcSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compute_availability_domain(self):
+        """
+        **[Required]** Gets the compute_availability_domain of this SddcSummary.
+        The availability domain that the SDDC's ESXi hosts are running in.
+
+
+        :return: The compute_availability_domain of this SddcSummary.
+        :rtype: str
+        """
+        return self._compute_availability_domain
+
+    @compute_availability_domain.setter
+    def compute_availability_domain(self, compute_availability_domain):
+        """
+        Sets the compute_availability_domain of this SddcSummary.
+        The availability domain that the SDDC's ESXi hosts are running in.
+
+
+        :param compute_availability_domain: The compute_availability_domain of this SddcSummary.
+        :type: str
+        """
+        self._compute_availability_domain = compute_availability_domain
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this SddcSummary.
+        A descriptive name for the SDDC. It must be unique, start with a letter, and contain only letters, digits,
+        whitespaces, dashes and underscores.
+        Avoid entering confidential information.
+
+
+        :return: The display_name of this SddcSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this SddcSummary.
+        A descriptive name for the SDDC. It must be unique, start with a letter, and contain only letters, digits,
+        whitespaces, dashes and underscores.
+        Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this SddcSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def vmware_software_version(self):
+        """
+        **[Required]** Gets the vmware_software_version of this SddcSummary.
+        In general, this is a specific version of bundled VMware software supported by
+        Oracle Cloud VMware Solution (see
+        :func:`
+        _list_supported_vmware_software_versions`).
+
+        This attribute is not guaranteed to reflect the version of
+        software currently installed on the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the version of software that the Oracle
+        Cloud VMware Solution will install on any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you upgrade the existing ESXi hosts in the SDDC to use a newer
+        version of bundled VMware software supported by the Oracle Cloud VMware Solution, you
+        should use :func:`update_sddc` to update the SDDC's
+        `vmwareSoftwareVersion` with that new version.
+
+
+        :return: The vmware_software_version of this SddcSummary.
+        :rtype: str
+        """
+        return self._vmware_software_version
+
+    @vmware_software_version.setter
+    def vmware_software_version(self, vmware_software_version):
+        """
+        Sets the vmware_software_version of this SddcSummary.
+        In general, this is a specific version of bundled VMware software supported by
+        Oracle Cloud VMware Solution (see
+        :func:`
+        _list_supported_vmware_software_versions`).
+
+        This attribute is not guaranteed to reflect the version of
+        software currently installed on the ESXi hosts in the SDDC. The purpose
+        of this attribute is to show the version of software that the Oracle
+        Cloud VMware Solution will install on any new ESXi hosts that you *add to this
+        SDDC in the future* with :func:`create_esxi_host`.
+
+        Therefore, if you upgrade the existing ESXi hosts in the SDDC to use a newer
+        version of bundled VMware software supported by the Oracle Cloud VMware Solution, you
+        should use :func:`update_sddc` to update the SDDC's
+        `vmwareSoftwareVersion` with that new version.
+
+
+        :param vmware_software_version: The vmware_software_version of this SddcSummary.
+        :type: str
+        """
+        self._vmware_software_version = vmware_software_version
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this SddcSummary.
+        The `OCID`__ of the compartment that
+        contains the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this SddcSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this SddcSummary.
+        The `OCID`__ of the compartment that
+        contains the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this SddcSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def esxi_hosts_count(self):
+        """
+        **[Required]** Gets the esxi_hosts_count of this SddcSummary.
+        The number of ESXi hosts in the SDDC.
+
+
+        :return: The esxi_hosts_count of this SddcSummary.
+        :rtype: int
+        """
+        return self._esxi_hosts_count
+
+    @esxi_hosts_count.setter
+    def esxi_hosts_count(self, esxi_hosts_count):
+        """
+        Sets the esxi_hosts_count of this SddcSummary.
+        The number of ESXi hosts in the SDDC.
+
+
+        :param esxi_hosts_count: The esxi_hosts_count of this SddcSummary.
+        :type: int
+        """
+        self._esxi_hosts_count = esxi_hosts_count
+
+    @property
+    def vcenter_fqdn(self):
+        """
+        Gets the vcenter_fqdn of this SddcSummary.
+        FQDN for vCenter
+
+        Example: `vcenter-my-sddc.sddc.us-phoenix-1.oraclecloud.com`
+
+
+        :return: The vcenter_fqdn of this SddcSummary.
+        :rtype: str
+        """
+        return self._vcenter_fqdn
+
+    @vcenter_fqdn.setter
+    def vcenter_fqdn(self, vcenter_fqdn):
+        """
+        Sets the vcenter_fqdn of this SddcSummary.
+        FQDN for vCenter
+
+        Example: `vcenter-my-sddc.sddc.us-phoenix-1.oraclecloud.com`
+
+
+        :param vcenter_fqdn: The vcenter_fqdn of this SddcSummary.
+        :type: str
+        """
+        self._vcenter_fqdn = vcenter_fqdn
+
+    @property
+    def nsx_manager_fqdn(self):
+        """
+        Gets the nsx_manager_fqdn of this SddcSummary.
+        FQDN for NSX Manager
+
+        Example: `nsx-my-sddc.sddc.us-phoenix-1.oraclecloud.com`
+
+
+        :return: The nsx_manager_fqdn of this SddcSummary.
+        :rtype: str
+        """
+        return self._nsx_manager_fqdn
+
+    @nsx_manager_fqdn.setter
+    def nsx_manager_fqdn(self, nsx_manager_fqdn):
+        """
+        Sets the nsx_manager_fqdn of this SddcSummary.
+        FQDN for NSX Manager
+
+        Example: `nsx-my-sddc.sddc.us-phoenix-1.oraclecloud.com`
+
+
+        :param nsx_manager_fqdn: The nsx_manager_fqdn of this SddcSummary.
+        :type: str
+        """
+        self._nsx_manager_fqdn = nsx_manager_fqdn
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this SddcSummary.
+        The date and time the SDDC was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this SddcSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this SddcSummary.
+        The date and time the SDDC was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this SddcSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this SddcSummary.
+        The date and time the SDDC was updated, in the format defined by
+        `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_updated of this SddcSummary.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this SddcSummary.
+        The date and time the SDDC was updated, in the format defined by
+        `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_updated: The time_updated of this SddcSummary.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this SddcSummary.
+        The current state of the SDDC.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this SddcSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this SddcSummary.
+        The current state of the SDDC.
+
+
+        :param lifecycle_state: The lifecycle_state of this SddcSummary.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def freeform_tags(self):
+        """
+        **[Required]** Gets the freeform_tags of this SddcSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this SddcSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this SddcSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this SddcSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        **[Required]** Gets the defined_tags of this SddcSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this SddcSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this SddcSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this SddcSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/supported_vmware_software_version_collection.py
+++ b/src/oci/ocvp/models/supported_vmware_software_version_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SupportedVmwareSoftwareVersionCollection(object):
+    """
+    A list of the supported versions of bundled VMware software.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SupportedVmwareSoftwareVersionCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this SupportedVmwareSoftwareVersionCollection.
+        :type items: list[SupportedVmwareSoftwareVersionSummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[SupportedVmwareSoftwareVersionSummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this SupportedVmwareSoftwareVersionCollection.
+        A list of the supported versions of bundled VMware software.
+
+
+        :return: The items of this SupportedVmwareSoftwareVersionCollection.
+        :rtype: list[SupportedVmwareSoftwareVersionSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this SupportedVmwareSoftwareVersionCollection.
+        A list of the supported versions of bundled VMware software.
+
+
+        :param items: The items of this SupportedVmwareSoftwareVersionCollection.
+        :type: list[SupportedVmwareSoftwareVersionSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/supported_vmware_software_version_summary.py
+++ b/src/oci/ocvp/models/supported_vmware_software_version_summary.py
@@ -1,0 +1,102 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SupportedVmwareSoftwareVersionSummary(object):
+    """
+    A specific version of bundled VMware software supported by the Oracle Cloud
+    VMware Solution.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SupportedVmwareSoftwareVersionSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param version:
+            The value to assign to the version property of this SupportedVmwareSoftwareVersionSummary.
+        :type version: str
+
+        :param description:
+            The value to assign to the description property of this SupportedVmwareSoftwareVersionSummary.
+        :type description: str
+
+        """
+        self.swagger_types = {
+            'version': 'str',
+            'description': 'str'
+        }
+
+        self.attribute_map = {
+            'version': 'version',
+            'description': 'description'
+        }
+
+        self._version = None
+        self._description = None
+
+    @property
+    def version(self):
+        """
+        **[Required]** Gets the version of this SupportedVmwareSoftwareVersionSummary.
+        A short, unique string that identifies the version of bundled software.
+
+
+        :return: The version of this SupportedVmwareSoftwareVersionSummary.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this SupportedVmwareSoftwareVersionSummary.
+        A short, unique string that identifies the version of bundled software.
+
+
+        :param version: The version of this SupportedVmwareSoftwareVersionSummary.
+        :type: str
+        """
+        self._version = version
+
+    @property
+    def description(self):
+        """
+        **[Required]** Gets the description of this SupportedVmwareSoftwareVersionSummary.
+        A description of the software in the bundle.
+
+
+        :return: The description of this SupportedVmwareSoftwareVersionSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this SupportedVmwareSoftwareVersionSummary.
+        A description of the software in the bundle.
+
+
+        :param description: The description of this SupportedVmwareSoftwareVersionSummary.
+        :type: str
+        """
+        self._description = description
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/update_esxi_host_details.py
+++ b/src/oci/ocvp/models/update_esxi_host_details.py
@@ -1,0 +1,154 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateEsxiHostDetails(object):
+    """
+    The ESXi host information to be updated.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateEsxiHostDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateEsxiHostDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateEsxiHostDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateEsxiHostDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateEsxiHostDetails.
+        A descriptive name for the ESXi host. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+
+        :return: The display_name of this UpdateEsxiHostDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateEsxiHostDetails.
+        A descriptive name for the ESXi host. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this UpdateEsxiHostDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateEsxiHostDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateEsxiHostDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateEsxiHostDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateEsxiHostDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateEsxiHostDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateEsxiHostDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateEsxiHostDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateEsxiHostDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/update_sddc_details.py
+++ b/src/oci/ocvp/models/update_sddc_details.py
@@ -1,0 +1,499 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateSddcDetails(object):
+    """
+    The SDDC information to be updated.
+
+    **Important:** Only the `displayName`, `freeFormTags`, and `definedTags` attributes
+    affect the existing SDDC. Changing the other attributes affects the `Sddc` object, but not
+    the VMware environment currently running on that SDDC. Those other attributes are used
+    by the Oracle Cloud VMware Solution *only* for new ESXi hosts that you add to this
+    SDDC in the future with :func:`create_esxi_host`.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateSddcDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateSddcDetails.
+        :type display_name: str
+
+        :param vmware_software_version:
+            The value to assign to the vmware_software_version property of this UpdateSddcDetails.
+        :type vmware_software_version: str
+
+        :param ssh_authorized_keys:
+            The value to assign to the ssh_authorized_keys property of this UpdateSddcDetails.
+        :type ssh_authorized_keys: str
+
+        :param vsphere_vlan_id:
+            The value to assign to the vsphere_vlan_id property of this UpdateSddcDetails.
+        :type vsphere_vlan_id: str
+
+        :param vmotion_vlan_id:
+            The value to assign to the vmotion_vlan_id property of this UpdateSddcDetails.
+        :type vmotion_vlan_id: str
+
+        :param vsan_vlan_id:
+            The value to assign to the vsan_vlan_id property of this UpdateSddcDetails.
+        :type vsan_vlan_id: str
+
+        :param nsx_v_tep_vlan_id:
+            The value to assign to the nsx_v_tep_vlan_id property of this UpdateSddcDetails.
+        :type nsx_v_tep_vlan_id: str
+
+        :param nsx_edge_v_tep_vlan_id:
+            The value to assign to the nsx_edge_v_tep_vlan_id property of this UpdateSddcDetails.
+        :type nsx_edge_v_tep_vlan_id: str
+
+        :param nsx_edge_uplink1_vlan_id:
+            The value to assign to the nsx_edge_uplink1_vlan_id property of this UpdateSddcDetails.
+        :type nsx_edge_uplink1_vlan_id: str
+
+        :param nsx_edge_uplink2_vlan_id:
+            The value to assign to the nsx_edge_uplink2_vlan_id property of this UpdateSddcDetails.
+        :type nsx_edge_uplink2_vlan_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateSddcDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateSddcDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'vmware_software_version': 'str',
+            'ssh_authorized_keys': 'str',
+            'vsphere_vlan_id': 'str',
+            'vmotion_vlan_id': 'str',
+            'vsan_vlan_id': 'str',
+            'nsx_v_tep_vlan_id': 'str',
+            'nsx_edge_v_tep_vlan_id': 'str',
+            'nsx_edge_uplink1_vlan_id': 'str',
+            'nsx_edge_uplink2_vlan_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'vmware_software_version': 'vmwareSoftwareVersion',
+            'ssh_authorized_keys': 'sshAuthorizedKeys',
+            'vsphere_vlan_id': 'vsphereVlanId',
+            'vmotion_vlan_id': 'vmotionVlanId',
+            'vsan_vlan_id': 'vsanVlanId',
+            'nsx_v_tep_vlan_id': 'nsxVTepVlanId',
+            'nsx_edge_v_tep_vlan_id': 'nsxEdgeVTepVlanId',
+            'nsx_edge_uplink1_vlan_id': 'nsxEdgeUplink1VlanId',
+            'nsx_edge_uplink2_vlan_id': 'nsxEdgeUplink2VlanId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._vmware_software_version = None
+        self._ssh_authorized_keys = None
+        self._vsphere_vlan_id = None
+        self._vmotion_vlan_id = None
+        self._vsan_vlan_id = None
+        self._nsx_v_tep_vlan_id = None
+        self._nsx_edge_v_tep_vlan_id = None
+        self._nsx_edge_uplink1_vlan_id = None
+        self._nsx_edge_uplink2_vlan_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateSddcDetails.
+        The `OCID`__ of the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The display_name of this UpdateSddcDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateSddcDetails.
+        The `OCID`__ of the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param display_name: The display_name of this UpdateSddcDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def vmware_software_version(self):
+        """
+        Gets the vmware_software_version of this UpdateSddcDetails.
+        The version of bundled VMware software that the Oracle Cloud VMware Solution will
+        install on any new ESXi hosts that you add to this SDDC in the future.
+
+        For the list of versions supported by the Oracle Cloud VMware Solution, see
+        :func:`
+        _list_supported_vmware_software_versions`).
+
+
+        :return: The vmware_software_version of this UpdateSddcDetails.
+        :rtype: str
+        """
+        return self._vmware_software_version
+
+    @vmware_software_version.setter
+    def vmware_software_version(self, vmware_software_version):
+        """
+        Sets the vmware_software_version of this UpdateSddcDetails.
+        The version of bundled VMware software that the Oracle Cloud VMware Solution will
+        install on any new ESXi hosts that you add to this SDDC in the future.
+
+        For the list of versions supported by the Oracle Cloud VMware Solution, see
+        :func:`
+        _list_supported_vmware_software_versions`).
+
+
+        :param vmware_software_version: The vmware_software_version of this UpdateSddcDetails.
+        :type: str
+        """
+        self._vmware_software_version = vmware_software_version
+
+    @property
+    def ssh_authorized_keys(self):
+        """
+        Gets the ssh_authorized_keys of this UpdateSddcDetails.
+        One or more public SSH keys to be included in the `~/.ssh/authorized_keys` file for
+        the default user on each ESXi host, only when adding new ESXi hosts to this SDDC.
+        Use a newline character to separate multiple keys.
+        The SSH keys must be in the format required for the `authorized_keys` file.
+
+
+        :return: The ssh_authorized_keys of this UpdateSddcDetails.
+        :rtype: str
+        """
+        return self._ssh_authorized_keys
+
+    @ssh_authorized_keys.setter
+    def ssh_authorized_keys(self, ssh_authorized_keys):
+        """
+        Sets the ssh_authorized_keys of this UpdateSddcDetails.
+        One or more public SSH keys to be included in the `~/.ssh/authorized_keys` file for
+        the default user on each ESXi host, only when adding new ESXi hosts to this SDDC.
+        Use a newline character to separate multiple keys.
+        The SSH keys must be in the format required for the `authorized_keys` file.
+
+
+        :param ssh_authorized_keys: The ssh_authorized_keys of this UpdateSddcDetails.
+        :type: str
+        """
+        self._ssh_authorized_keys = ssh_authorized_keys
+
+    @property
+    def vsphere_vlan_id(self):
+        """
+        Gets the vsphere_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the vSphere component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vsphere_vlan_id of this UpdateSddcDetails.
+        :rtype: str
+        """
+        return self._vsphere_vlan_id
+
+    @vsphere_vlan_id.setter
+    def vsphere_vlan_id(self, vsphere_vlan_id):
+        """
+        Sets the vsphere_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the vSphere component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vsphere_vlan_id: The vsphere_vlan_id of this UpdateSddcDetails.
+        :type: str
+        """
+        self._vsphere_vlan_id = vsphere_vlan_id
+
+    @property
+    def vmotion_vlan_id(self):
+        """
+        Gets the vmotion_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the vMotion component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vmotion_vlan_id of this UpdateSddcDetails.
+        :rtype: str
+        """
+        return self._vmotion_vlan_id
+
+    @vmotion_vlan_id.setter
+    def vmotion_vlan_id(self, vmotion_vlan_id):
+        """
+        Sets the vmotion_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the vMotion component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vmotion_vlan_id: The vmotion_vlan_id of this UpdateSddcDetails.
+        :type: str
+        """
+        self._vmotion_vlan_id = vmotion_vlan_id
+
+    @property
+    def vsan_vlan_id(self):
+        """
+        Gets the vsan_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the vSAN component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vsan_vlan_id of this UpdateSddcDetails.
+        :rtype: str
+        """
+        return self._vsan_vlan_id
+
+    @vsan_vlan_id.setter
+    def vsan_vlan_id(self, vsan_vlan_id):
+        """
+        Sets the vsan_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the vSAN component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vsan_vlan_id: The vsan_vlan_id of this UpdateSddcDetails.
+        :type: str
+        """
+        self._vsan_vlan_id = vsan_vlan_id
+
+    @property
+    def nsx_v_tep_vlan_id(self):
+        """
+        Gets the nsx_v_tep_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the NSX VTEP component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_v_tep_vlan_id of this UpdateSddcDetails.
+        :rtype: str
+        """
+        return self._nsx_v_tep_vlan_id
+
+    @nsx_v_tep_vlan_id.setter
+    def nsx_v_tep_vlan_id(self, nsx_v_tep_vlan_id):
+        """
+        Sets the nsx_v_tep_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the NSX VTEP component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_v_tep_vlan_id: The nsx_v_tep_vlan_id of this UpdateSddcDetails.
+        :type: str
+        """
+        self._nsx_v_tep_vlan_id = nsx_v_tep_vlan_id
+
+    @property
+    def nsx_edge_v_tep_vlan_id(self):
+        """
+        Gets the nsx_edge_v_tep_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the NSX Edge VTEP component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_edge_v_tep_vlan_id of this UpdateSddcDetails.
+        :rtype: str
+        """
+        return self._nsx_edge_v_tep_vlan_id
+
+    @nsx_edge_v_tep_vlan_id.setter
+    def nsx_edge_v_tep_vlan_id(self, nsx_edge_v_tep_vlan_id):
+        """
+        Sets the nsx_edge_v_tep_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the NSX Edge VTEP component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_edge_v_tep_vlan_id: The nsx_edge_v_tep_vlan_id of this UpdateSddcDetails.
+        :type: str
+        """
+        self._nsx_edge_v_tep_vlan_id = nsx_edge_v_tep_vlan_id
+
+    @property
+    def nsx_edge_uplink1_vlan_id(self):
+        """
+        Gets the nsx_edge_uplink1_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the NSX Edge Uplink 1 component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_edge_uplink1_vlan_id of this UpdateSddcDetails.
+        :rtype: str
+        """
+        return self._nsx_edge_uplink1_vlan_id
+
+    @nsx_edge_uplink1_vlan_id.setter
+    def nsx_edge_uplink1_vlan_id(self, nsx_edge_uplink1_vlan_id):
+        """
+        Sets the nsx_edge_uplink1_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the NSX Edge Uplink 1 component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_edge_uplink1_vlan_id: The nsx_edge_uplink1_vlan_id of this UpdateSddcDetails.
+        :type: str
+        """
+        self._nsx_edge_uplink1_vlan_id = nsx_edge_uplink1_vlan_id
+
+    @property
+    def nsx_edge_uplink2_vlan_id(self):
+        """
+        Gets the nsx_edge_uplink2_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the NSX Edge Uplink 2 component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The nsx_edge_uplink2_vlan_id of this UpdateSddcDetails.
+        :rtype: str
+        """
+        return self._nsx_edge_uplink2_vlan_id
+
+    @nsx_edge_uplink2_vlan_id.setter
+    def nsx_edge_uplink2_vlan_id(self, nsx_edge_uplink2_vlan_id):
+        """
+        Sets the nsx_edge_uplink2_vlan_id of this UpdateSddcDetails.
+        The `OCID`__ of the VLAN to use for
+        the NSX Edge Uplink 2 component of the VMware environment when adding new ESXi hosts to the SDDC.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param nsx_edge_uplink2_vlan_id: The nsx_edge_uplink2_vlan_id of this UpdateSddcDetails.
+        :type: str
+        """
+        self._nsx_edge_uplink2_vlan_id = nsx_edge_uplink2_vlan_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateSddcDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateSddcDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateSddcDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateSddcDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateSddcDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateSddcDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateSddcDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateSddcDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/work_request.py
+++ b/src/oci/ocvp/models/work_request.py
@@ -1,0 +1,406 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequest(object):
+    """
+    An asynchronous work request.
+    """
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "CREATE_SDDC"
+    OPERATION_TYPE_CREATE_SDDC = "CREATE_SDDC"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "DELETE_SDDC"
+    OPERATION_TYPE_DELETE_SDDC = "DELETE_SDDC"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "CREATE_ESXI_HOST"
+    OPERATION_TYPE_CREATE_ESXI_HOST = "CREATE_ESXI_HOST"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "DELETE_ESXI_HOST"
+    OPERATION_TYPE_DELETE_ESXI_HOST = "DELETE_ESXI_HOST"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "ACCEPTED"
+    STATUS_ACCEPTED = "ACCEPTED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "IN_PROGRESS"
+    STATUS_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "FAILED"
+    STATUS_FAILED = "FAILED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "SUCCEEDED"
+    STATUS_SUCCEEDED = "SUCCEEDED"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "CANCELING"
+    STATUS_CANCELING = "CANCELING"
+
+    #: A constant which can be used with the status property of a WorkRequest.
+    #: This constant has a value of "CANCELED"
+    STATUS_CANCELED = "CANCELED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequest object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operation_type:
+            The value to assign to the operation_type property of this WorkRequest.
+            Allowed values for this property are: "CREATE_SDDC", "DELETE_SDDC", "CREATE_ESXI_HOST", "DELETE_ESXI_HOST", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type operation_type: str
+
+        :param status:
+            The value to assign to the status property of this WorkRequest.
+            Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param id:
+            The value to assign to the id property of this WorkRequest.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this WorkRequest.
+        :type compartment_id: str
+
+        :param resources:
+            The value to assign to the resources property of this WorkRequest.
+        :type resources: list[WorkRequestResource]
+
+        :param percent_complete:
+            The value to assign to the percent_complete property of this WorkRequest.
+        :type percent_complete: float
+
+        :param time_accepted:
+            The value to assign to the time_accepted property of this WorkRequest.
+        :type time_accepted: datetime
+
+        :param time_started:
+            The value to assign to the time_started property of this WorkRequest.
+        :type time_started: datetime
+
+        :param time_finished:
+            The value to assign to the time_finished property of this WorkRequest.
+        :type time_finished: datetime
+
+        """
+        self.swagger_types = {
+            'operation_type': 'str',
+            'status': 'str',
+            'id': 'str',
+            'compartment_id': 'str',
+            'resources': 'list[WorkRequestResource]',
+            'percent_complete': 'float',
+            'time_accepted': 'datetime',
+            'time_started': 'datetime',
+            'time_finished': 'datetime'
+        }
+
+        self.attribute_map = {
+            'operation_type': 'operationType',
+            'status': 'status',
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'resources': 'resources',
+            'percent_complete': 'percentComplete',
+            'time_accepted': 'timeAccepted',
+            'time_started': 'timeStarted',
+            'time_finished': 'timeFinished'
+        }
+
+        self._operation_type = None
+        self._status = None
+        self._id = None
+        self._compartment_id = None
+        self._resources = None
+        self._percent_complete = None
+        self._time_accepted = None
+        self._time_started = None
+        self._time_finished = None
+
+    @property
+    def operation_type(self):
+        """
+        **[Required]** Gets the operation_type of this WorkRequest.
+        The asynchronous operation tracked by this work request.
+
+        Allowed values for this property are: "CREATE_SDDC", "DELETE_SDDC", "CREATE_ESXI_HOST", "DELETE_ESXI_HOST", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The operation_type of this WorkRequest.
+        :rtype: str
+        """
+        return self._operation_type
+
+    @operation_type.setter
+    def operation_type(self, operation_type):
+        """
+        Sets the operation_type of this WorkRequest.
+        The asynchronous operation tracked by this work request.
+
+
+        :param operation_type: The operation_type of this WorkRequest.
+        :type: str
+        """
+        allowed_values = ["CREATE_SDDC", "DELETE_SDDC", "CREATE_ESXI_HOST", "DELETE_ESXI_HOST"]
+        if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
+            operation_type = 'UNKNOWN_ENUM_VALUE'
+        self._operation_type = operation_type
+
+    @property
+    def status(self):
+        """
+        **[Required]** Gets the status of this WorkRequest.
+        The status of the work request.
+
+        Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this WorkRequest.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this WorkRequest.
+        The status of the work request.
+
+
+        :param status: The status of this WorkRequest.
+        :type: str
+        """
+        allowed_values = ["ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this WorkRequest.
+        The `OCID`__ of the work request.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this WorkRequest.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this WorkRequest.
+        The `OCID`__ of the work request.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this WorkRequest.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this WorkRequest.
+        The `OCID`__ of the compartment that
+        contains the work request.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this WorkRequest.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this WorkRequest.
+        The `OCID`__ of the compartment that
+        contains the work request.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this WorkRequest.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def resources(self):
+        """
+        **[Required]** Gets the resources of this WorkRequest.
+        The resources that are affected by this work request.
+
+
+        :return: The resources of this WorkRequest.
+        :rtype: list[WorkRequestResource]
+        """
+        return self._resources
+
+    @resources.setter
+    def resources(self, resources):
+        """
+        Sets the resources of this WorkRequest.
+        The resources that are affected by this work request.
+
+
+        :param resources: The resources of this WorkRequest.
+        :type: list[WorkRequestResource]
+        """
+        self._resources = resources
+
+    @property
+    def percent_complete(self):
+        """
+        **[Required]** Gets the percent_complete of this WorkRequest.
+        The percentage complete of the operation tracked by this work request.
+
+
+        :return: The percent_complete of this WorkRequest.
+        :rtype: float
+        """
+        return self._percent_complete
+
+    @percent_complete.setter
+    def percent_complete(self, percent_complete):
+        """
+        Sets the percent_complete of this WorkRequest.
+        The percentage complete of the operation tracked by this work request.
+
+
+        :param percent_complete: The percent_complete of this WorkRequest.
+        :type: float
+        """
+        self._percent_complete = percent_complete
+
+    @property
+    def time_accepted(self):
+        """
+        **[Required]** Gets the time_accepted of this WorkRequest.
+        The date and time the work request was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_accepted of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_accepted
+
+    @time_accepted.setter
+    def time_accepted(self, time_accepted):
+        """
+        Sets the time_accepted of this WorkRequest.
+        The date and time the work request was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_accepted: The time_accepted of this WorkRequest.
+        :type: datetime
+        """
+        self._time_accepted = time_accepted
+
+    @property
+    def time_started(self):
+        """
+        Gets the time_started of this WorkRequest.
+        The date and time the work request transitioned from `ACCEPTED` to `IN_PROGRESS`,
+        in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_started of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_started
+
+    @time_started.setter
+    def time_started(self, time_started):
+        """
+        Sets the time_started of this WorkRequest.
+        The date and time the work request transitioned from `ACCEPTED` to `IN_PROGRESS`,
+        in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_started: The time_started of this WorkRequest.
+        :type: datetime
+        """
+        self._time_started = time_started
+
+    @property
+    def time_finished(self):
+        """
+        Gets the time_finished of this WorkRequest.
+        The date and time the work request reached a terminal state, either `FAILED` OR
+        `SUCCEEDED`. Format is defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_finished of this WorkRequest.
+        :rtype: datetime
+        """
+        return self._time_finished
+
+    @time_finished.setter
+    def time_finished(self, time_finished):
+        """
+        Sets the time_finished of this WorkRequest.
+        The date and time the work request reached a terminal state, either `FAILED` OR
+        `SUCCEEDED`. Format is defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_finished: The time_finished of this WorkRequest.
+        :type: datetime
+        """
+        self._time_finished = time_finished
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/work_request_collection.py
+++ b/src/oci/ocvp/models/work_request_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestCollection(object):
+    """
+    A list of work requests.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this WorkRequestCollection.
+        :type items: list[WorkRequest]
+
+        """
+        self.swagger_types = {
+            'items': 'list[WorkRequest]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this WorkRequestCollection.
+        A list of work requests.
+
+
+        :return: The items of this WorkRequestCollection.
+        :rtype: list[WorkRequest]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this WorkRequestCollection.
+        A list of work requests.
+
+
+        :param items: The items of this WorkRequestCollection.
+        :type: list[WorkRequest]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/work_request_error.py
+++ b/src/oci/ocvp/models/work_request_error.py
@@ -1,0 +1,138 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestError(object):
+    """
+    An error encountered while executing an operation that is tracked by a work request.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestError object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param code:
+            The value to assign to the code property of this WorkRequestError.
+        :type code: str
+
+        :param message:
+            The value to assign to the message property of this WorkRequestError.
+        :type message: str
+
+        :param timestamp:
+            The value to assign to the timestamp property of this WorkRequestError.
+        :type timestamp: datetime
+
+        """
+        self.swagger_types = {
+            'code': 'str',
+            'message': 'str',
+            'timestamp': 'datetime'
+        }
+
+        self.attribute_map = {
+            'code': 'code',
+            'message': 'message',
+            'timestamp': 'timestamp'
+        }
+
+        self._code = None
+        self._message = None
+        self._timestamp = None
+
+    @property
+    def code(self):
+        """
+        **[Required]** Gets the code of this WorkRequestError.
+        A machine-usable code for the error that occurred.
+
+
+        :return: The code of this WorkRequestError.
+        :rtype: str
+        """
+        return self._code
+
+    @code.setter
+    def code(self, code):
+        """
+        Sets the code of this WorkRequestError.
+        A machine-usable code for the error that occurred.
+
+
+        :param code: The code of this WorkRequestError.
+        :type: str
+        """
+        self._code = code
+
+    @property
+    def message(self):
+        """
+        **[Required]** Gets the message of this WorkRequestError.
+        A human-readable error string.
+
+
+        :return: The message of this WorkRequestError.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this WorkRequestError.
+        A human-readable error string.
+
+
+        :param message: The message of this WorkRequestError.
+        :type: str
+        """
+        self._message = message
+
+    @property
+    def timestamp(self):
+        """
+        **[Required]** Gets the timestamp of this WorkRequestError.
+        The date and time the error occurred, in the format defined
+        by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The timestamp of this WorkRequestError.
+        :rtype: datetime
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp):
+        """
+        Sets the timestamp of this WorkRequestError.
+        The date and time the error occurred, in the format defined
+        by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param timestamp: The timestamp of this WorkRequestError.
+        :type: datetime
+        """
+        self._timestamp = timestamp
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/work_request_error_collection.py
+++ b/src/oci/ocvp/models/work_request_error_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestErrorCollection(object):
+    """
+    A list of work request errors.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestErrorCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this WorkRequestErrorCollection.
+        :type items: list[WorkRequestError]
+
+        """
+        self.swagger_types = {
+            'items': 'list[WorkRequestError]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this WorkRequestErrorCollection.
+        A list of work request errors.
+
+
+        :return: The items of this WorkRequestErrorCollection.
+        :rtype: list[WorkRequestError]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this WorkRequestErrorCollection.
+        A list of work request errors.
+
+
+        :param items: The items of this WorkRequestErrorCollection.
+        :type: list[WorkRequestError]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/work_request_log_entry.py
+++ b/src/oci/ocvp/models/work_request_log_entry.py
@@ -1,0 +1,107 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestLogEntry(object):
+    """
+    A log message from executing an operation that is tracked by a work request.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestLogEntry object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param message:
+            The value to assign to the message property of this WorkRequestLogEntry.
+        :type message: str
+
+        :param timestamp:
+            The value to assign to the timestamp property of this WorkRequestLogEntry.
+        :type timestamp: datetime
+
+        """
+        self.swagger_types = {
+            'message': 'str',
+            'timestamp': 'datetime'
+        }
+
+        self.attribute_map = {
+            'message': 'message',
+            'timestamp': 'timestamp'
+        }
+
+        self._message = None
+        self._timestamp = None
+
+    @property
+    def message(self):
+        """
+        **[Required]** Gets the message of this WorkRequestLogEntry.
+        A human-readable log message.
+
+
+        :return: The message of this WorkRequestLogEntry.
+        :rtype: str
+        """
+        return self._message
+
+    @message.setter
+    def message(self, message):
+        """
+        Sets the message of this WorkRequestLogEntry.
+        A human-readable log message.
+
+
+        :param message: The message of this WorkRequestLogEntry.
+        :type: str
+        """
+        self._message = message
+
+    @property
+    def timestamp(self):
+        """
+        **[Required]** Gets the timestamp of this WorkRequestLogEntry.
+        The date and time the log message was written, in the format defined
+        by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The timestamp of this WorkRequestLogEntry.
+        :rtype: datetime
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp):
+        """
+        Sets the timestamp of this WorkRequestLogEntry.
+        The date and time the log message was written, in the format defined
+        by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param timestamp: The timestamp of this WorkRequestLogEntry.
+        :type: datetime
+        """
+        self._timestamp = timestamp
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/work_request_log_entry_collection.py
+++ b/src/oci/ocvp/models/work_request_log_entry_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestLogEntryCollection(object):
+    """
+    A list of work request logs.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestLogEntryCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this WorkRequestLogEntryCollection.
+        :type items: list[WorkRequestLogEntry]
+
+        """
+        self.swagger_types = {
+            'items': 'list[WorkRequestLogEntry]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this WorkRequestLogEntryCollection.
+        A list of work request logs.
+
+
+        :return: The items of this WorkRequestLogEntryCollection.
+        :rtype: list[WorkRequestLogEntry]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this WorkRequestLogEntryCollection.
+        A list of work request logs.
+
+
+        :param items: The items of this WorkRequestLogEntryCollection.
+        :type: list[WorkRequestLogEntry]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/models/work_request_resource.py
+++ b/src/oci/ocvp/models/work_request_resource.py
@@ -1,0 +1,200 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestResource(object):
+    """
+    A resource that is created or operated on by an asynchronous operation that is
+    tracked by a work request.
+    """
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "CREATED"
+    ACTION_TYPE_CREATED = "CREATED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "UPDATED"
+    ACTION_TYPE_UPDATED = "UPDATED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "DELETED"
+    ACTION_TYPE_DELETED = "DELETED"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "IN_PROGRESS"
+    ACTION_TYPE_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "RELATED"
+    ACTION_TYPE_RELATED = "RELATED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestResource object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param entity_type:
+            The value to assign to the entity_type property of this WorkRequestResource.
+        :type entity_type: str
+
+        :param action_type:
+            The value to assign to the action_type property of this WorkRequestResource.
+            Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "IN_PROGRESS", "RELATED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type action_type: str
+
+        :param identifier:
+            The value to assign to the identifier property of this WorkRequestResource.
+        :type identifier: str
+
+        :param entity_uri:
+            The value to assign to the entity_uri property of this WorkRequestResource.
+        :type entity_uri: str
+
+        """
+        self.swagger_types = {
+            'entity_type': 'str',
+            'action_type': 'str',
+            'identifier': 'str',
+            'entity_uri': 'str'
+        }
+
+        self.attribute_map = {
+            'entity_type': 'entityType',
+            'action_type': 'actionType',
+            'identifier': 'identifier',
+            'entity_uri': 'entityUri'
+        }
+
+        self._entity_type = None
+        self._action_type = None
+        self._identifier = None
+        self._entity_uri = None
+
+    @property
+    def entity_type(self):
+        """
+        **[Required]** Gets the entity_type of this WorkRequestResource.
+        The resource type the work request affects.
+
+
+        :return: The entity_type of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._entity_type
+
+    @entity_type.setter
+    def entity_type(self, entity_type):
+        """
+        Sets the entity_type of this WorkRequestResource.
+        The resource type the work request affects.
+
+
+        :param entity_type: The entity_type of this WorkRequestResource.
+        :type: str
+        """
+        self._entity_type = entity_type
+
+    @property
+    def action_type(self):
+        """
+        **[Required]** Gets the action_type of this WorkRequestResource.
+        The way in which this resource was affected by the operation that spawned the
+        work request.
+
+        Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "IN_PROGRESS", "RELATED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The action_type of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._action_type
+
+    @action_type.setter
+    def action_type(self, action_type):
+        """
+        Sets the action_type of this WorkRequestResource.
+        The way in which this resource was affected by the operation that spawned the
+        work request.
+
+
+        :param action_type: The action_type of this WorkRequestResource.
+        :type: str
+        """
+        allowed_values = ["CREATED", "UPDATED", "DELETED", "IN_PROGRESS", "RELATED"]
+        if not value_allowed_none_or_none_sentinel(action_type, allowed_values):
+            action_type = 'UNKNOWN_ENUM_VALUE'
+        self._action_type = action_type
+
+    @property
+    def identifier(self):
+        """
+        **[Required]** Gets the identifier of this WorkRequestResource.
+        An `OCID`__ or other unique identifier
+        for the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The identifier of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this WorkRequestResource.
+        An `OCID`__ or other unique identifier
+        for the resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param identifier: The identifier of this WorkRequestResource.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def entity_uri(self):
+        """
+        Gets the entity_uri of this WorkRequestResource.
+        The URI path that you can use for a GET request to access the resource metadata.
+
+
+        :return: The entity_uri of this WorkRequestResource.
+        :rtype: str
+        """
+        return self._entity_uri
+
+    @entity_uri.setter
+    def entity_uri(self, entity_uri):
+        """
+        Sets the entity_uri of this WorkRequestResource.
+        The URI path that you can use for a GET request to access the resource metadata.
+
+
+        :param entity_uri: The entity_uri of this WorkRequestResource.
+        :type: str
+        """
+        self._entity_uri = entity_uri
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/ocvp/sddc_client.py
+++ b/src/oci/ocvp/sddc_client.py
@@ -1,0 +1,755 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import ocvp_type_mapping
+missing = Sentinel("Missing")
+
+
+class SddcClient(object):
+    """
+    Use this API to manage the Oracle Cloud VMware Solution.
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20200501',
+            'service_endpoint_template': 'https://ocvps.{region}.oci.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("sddc", config, signer, ocvp_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def change_sddc_compartment(self, sddc_id, change_sddc_compartment_details, **kwargs):
+        """
+        Moves an SDDC into a different compartment within the same tenancy. For information
+        about moving resources between compartments, see
+        `Moving Resources to a Different Compartment`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes
+
+
+        :param str sddc_id: (required)
+            The `OCID`__ of the SDDC.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param ChangeSddcCompartmentDetails change_sddc_compartment_details: (required)
+            Request to change the compartment of the specified SDDC
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/sddcs/{sddcId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_sddc_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "sddcId": sddc_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_sddc_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_sddc_compartment_details)
+
+    def create_sddc(self, create_sddc_details, **kwargs):
+        """
+        Creates a software-defined data center (SDDC).
+
+        Use the :class:`WorkRequest` operations to track the
+        creation of the SDDC.
+
+
+        :param CreateSddcDetails create_sddc_details: (required)
+            Details for the SDDC.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/sddcs"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_sddc got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_sddc_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_sddc_details)
+
+    def delete_sddc(self, sddc_id, **kwargs):
+        """
+        Deletes the specified SDDC, along with the other resources that were
+        created with the SDDC. For example: the Compute instances, DNS records,
+        and so on.
+
+        Use the :class:`WorkRequest` operations to track the
+        deletion of the SDDC.
+
+
+        :param str sddc_id: (required)
+            The `OCID`__ of the SDDC.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/sddcs/{sddcId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_sddc got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "sddcId": sddc_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def get_sddc(self, sddc_id, **kwargs):
+        """
+        Gets the specified SDDC's information.
+
+
+        :param str sddc_id: (required)
+            The `OCID`__ of the SDDC.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.ocvp.models.Sddc`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/sddcs/{sddcId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_sddc got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "sddcId": sddc_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Sddc")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Sddc")
+
+    def list_sddcs(self, compartment_id, **kwargs):
+        """
+        Lists the SDDCs in the specified compartment. The list can be
+        filtered by display name or availability domain.
+
+
+        :param str compartment_id: (required)
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str compute_availability_domain: (optional)
+            The name of the availability domain that the Compute instances are running in.
+
+            Example: `Uocm:PHX-AD-1`
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the given display name exactly.
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+            call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+            is case sensitive.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+            TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+            sort order is case sensitive.
+
+            **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+            optionally filter by availability domain if the scope of the resource type is within a
+            single availability domain. If you call one of these \"List\" operations without specifying
+            an availability domain, the resources are grouped by availability domain, then sorted.
+
+            Allowed values are: "timeCreated", "displayName"
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param str lifecycle_state: (optional)
+            The lifecycle state of the resource.
+
+            Allowed values are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.ocvp.models.SddcCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/sddcs"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "compute_availability_domain",
+            "display_name",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id",
+            "lifecycle_state"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_sddcs got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["timeCreated", "displayName"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "computeAvailabilityDomain": kwargs.get("compute_availability_domain", missing),
+            "displayName": kwargs.get("display_name", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="SddcCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="SddcCollection")
+
+    def list_supported_vmware_software_versions(self, compartment_id, **kwargs):
+        """
+        Lists the versions of bundled VMware software supported by the Oracle Cloud
+        VMware Solution.
+
+
+        :param str compartment_id: (required)
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+            call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.ocvp.models.SupportedVmwareSoftwareVersionCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/supportedVmwareSoftwareVersions"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_supported_vmware_software_versions got unknown kwargs: {!r}".format(extra_kwargs))
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="SupportedVmwareSoftwareVersionCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="SupportedVmwareSoftwareVersionCollection")
+
+    def update_sddc(self, sddc_id, update_sddc_details, **kwargs):
+        """
+        Updates the specified SDDC.
+
+        **Important:** Updating an SDDC affects only certain attributes in the `Sddc`
+        object and does not affect the VMware environment currently running in
+        the SDDC. For more information, see
+        :func:`update_sddc_details`.
+
+
+        :param str sddc_id: (required)
+            The `OCID`__ of the SDDC.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateSddcDetails update_sddc_details: (required)
+            The information to be updated.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.ocvp.models.Sddc`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/sddcs/{sddcId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_sddc got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "sddcId": sddc_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_sddc_details,
+                response_type="Sddc")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_sddc_details,
+                response_type="Sddc")

--- a/src/oci/ocvp/sddc_client_composite_operations.py
+++ b/src/oci/ocvp/sddc_client_composite_operations.py
@@ -1,0 +1,153 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class SddcClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.ocvp.SddcClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new SddcClientCompositeOperations object
+
+        :param SddcClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client
+
+    def create_sddc_and_wait_for_state(self, create_sddc_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.ocvp.SddcClient.create_sddc` and waits for the :py:class:`~oci.ocvp.models.WorkRequest`
+        to enter the given state(s).
+
+        :param CreateSddcDetails create_sddc_details: (required)
+            Details for the SDDC.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.ocvp.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.ocvp.SddcClient.create_sddc`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_sddc(create_sddc_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_sddc_and_wait_for_state(self, sddc_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.ocvp.SddcClient.delete_sddc` and waits for the :py:class:`~oci.ocvp.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str sddc_id: (required)
+            The `OCID`__ of the SDDC.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.ocvp.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.ocvp.SddcClient.delete_sddc`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = None
+        try:
+            operation_result = self.client.delete_sddc(sddc_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_sddc_and_wait_for_state(self, sddc_id, update_sddc_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.ocvp.SddcClient.update_sddc` and waits for the :py:class:`~oci.ocvp.models.Sddc` acted upon
+        to enter the given state(s).
+
+        :param str sddc_id: (required)
+            The `OCID`__ of the SDDC.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateSddcDetails update_sddc_details: (required)
+            The information to be updated.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.ocvp.models.Sddc.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.ocvp.SddcClient.update_sddc`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_sddc(sddc_id, update_sddc_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_sddc(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)

--- a/src/oci/ocvp/work_request_client.py
+++ b/src/oci/ocvp/work_request_client.py
@@ -1,0 +1,450 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import ocvp_type_mapping
+missing = Sentinel("Missing")
+
+
+class WorkRequestClient(object):
+    """
+    Use this API to manage the Oracle Cloud VMware Solution.
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20200501',
+            'service_endpoint_template': 'https://ocvps.{region}.oci.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("work_request", config, signer, ocvp_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def get_work_request(self, work_request_id, **kwargs):
+        """
+        Gets the specified work request's information.
+
+
+        :param str work_request_id: (required)
+            The `OCID`__ of the work request.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.ocvp.models.WorkRequest`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_work_request got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="WorkRequest")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="WorkRequest")
+
+    def list_work_request_errors(self, work_request_id, **kwargs):
+        """
+        Lists the errors for the specified work request.
+
+
+        :param str work_request_id: (required)
+            The `OCID`__ of the work request.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+            call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.ocvp.models.WorkRequestErrorCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}/errors"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "page",
+            "limit"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_request_errors got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="WorkRequestErrorCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="WorkRequestErrorCollection")
+
+    def list_work_request_logs(self, work_request_id, **kwargs):
+        """
+        Lists the logs for the specified work request.
+
+
+        :param str work_request_id: (required)
+            The `OCID`__ of the work request.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+            call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.ocvp.models.WorkRequestLogEntryCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests/{workRequestId}/logs"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "page",
+            "limit"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_request_logs got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workRequestId": work_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="WorkRequestLogEntryCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="WorkRequestLogEntryCollection")
+
+    def list_work_requests(self, compartment_id, **kwargs):
+        """
+        Lists the work requests in the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str resource_id: (optional)
+            The `OCID`__ of the resource.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request. If you need to contact Oracle about a particular
+            request, please provide the request ID.
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+            call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.ocvp.models.WorkRequestCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workRequests"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "resource_id",
+            "opc_request_id",
+            "page",
+            "limit"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_work_requests got unknown kwargs: {!r}".format(extra_kwargs))
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "resourceId": kwargs.get("resource_id", missing),
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="WorkRequestCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="WorkRequestCollection")

--- a/src/oci/ocvp/work_request_client_composite_operations.py
+++ b/src/oci/ocvp/work_request_client_composite_operations.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class WorkRequestClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.ocvp.WorkRequestClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new WorkRequestClientCompositeOperations object
+
+        :param WorkRequestClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client

--- a/src/oci/usage_api/__init__.py
+++ b/src/oci/usage_api/__init__.py
@@ -1,0 +1,12 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from __future__ import absolute_import
+
+
+from .usageapi_client import UsageapiClient
+from .usageapi_client_composite_operations import UsageapiClientCompositeOperations
+from . import models
+
+__all__ = ["UsageapiClient", "UsageapiClientCompositeOperations", "models"]

--- a/src/oci/usage_api/models/__init__.py
+++ b/src/oci/usage_api/models/__init__.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from __future__ import absolute_import
+
+from .configuration import Configuration
+from .configuration_aggregation import ConfigurationAggregation
+from .dimension import Dimension
+from .filter import Filter
+from .request_summarized_usages_details import RequestSummarizedUsagesDetails
+from .tag import Tag
+from .usage_aggregation import UsageAggregation
+from .usage_summary import UsageSummary
+
+# Maps type names to classes for usage_api services.
+usage_api_type_mapping = {
+    "Configuration": Configuration,
+    "ConfigurationAggregation": ConfigurationAggregation,
+    "Dimension": Dimension,
+    "Filter": Filter,
+    "RequestSummarizedUsagesDetails": RequestSummarizedUsagesDetails,
+    "Tag": Tag,
+    "UsageAggregation": UsageAggregation,
+    "UsageSummary": UsageSummary
+}

--- a/src/oci/usage_api/models/configuration.py
+++ b/src/oci/usage_api/models/configuration.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Configuration(object):
+    """
+    A configuration
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Configuration object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this Configuration.
+        :type key: str
+
+        :param values:
+            The value to assign to the values property of this Configuration.
+        :type values: list[str]
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'values': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'values': 'values'
+        }
+
+        self._key = None
+        self._values = None
+
+    @property
+    def key(self):
+        """
+        **[Required]** Gets the key of this Configuration.
+        The key of the config
+
+
+        :return: The key of this Configuration.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this Configuration.
+        The key of the config
+
+
+        :param key: The key of this Configuration.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def values(self):
+        """
+        Gets the values of this Configuration.
+        The value of the config
+
+
+        :return: The values of this Configuration.
+        :rtype: list[str]
+        """
+        return self._values
+
+    @values.setter
+    def values(self, values):
+        """
+        Sets the values of this Configuration.
+        The value of the config
+
+
+        :param values: The values of this Configuration.
+        :type: list[str]
+        """
+        self._values = values
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/usage_api/models/configuration_aggregation.py
+++ b/src/oci/usage_api/models/configuration_aggregation.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ConfigurationAggregation(object):
+    """
+    The available configurations
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ConfigurationAggregation object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this ConfigurationAggregation.
+        :type items: list[Configuration]
+
+        """
+        self.swagger_types = {
+            'items': 'list[Configuration]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this ConfigurationAggregation.
+        The list of available configurations
+
+
+        :return: The items of this ConfigurationAggregation.
+        :rtype: list[Configuration]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this ConfigurationAggregation.
+        The list of available configurations
+
+
+        :param items: The items of this ConfigurationAggregation.
+        :type: list[Configuration]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/usage_api/models/dimension.py
+++ b/src/oci/usage_api/models/dimension.py
@@ -1,0 +1,103 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Dimension(object):
+    """
+    The dimension use for filtering.
+    example:
+    `[{value: \"COMPUTE\", key: \"service\"}]`
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Dimension object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this Dimension.
+        :type key: str
+
+        :param value:
+            The value to assign to the value property of this Dimension.
+        :type value: str
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'value': 'str'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'value': 'value'
+        }
+
+        self._key = None
+        self._value = None
+
+    @property
+    def key(self):
+        """
+        **[Required]** Gets the key of this Dimension.
+        The key of the dimension.
+
+
+        :return: The key of this Dimension.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this Dimension.
+        The key of the dimension.
+
+
+        :param key: The key of this Dimension.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def value(self):
+        """
+        **[Required]** Gets the value of this Dimension.
+        The value of the dimension.
+
+
+        :return: The value of this Dimension.
+        :rtype: str
+        """
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        """
+        Sets the value of this Dimension.
+        The value of the dimension.
+
+
+        :param value: The value of this Dimension.
+        :type: str
+        """
+        self._value = value
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/usage_api/models/filter.py
+++ b/src/oci/usage_api/models/filter.py
@@ -1,0 +1,184 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Filter(object):
+    """
+    The filter object for query usage.
+    """
+
+    #: A constant which can be used with the operator property of a Filter.
+    #: This constant has a value of "AND"
+    OPERATOR_AND = "AND"
+
+    #: A constant which can be used with the operator property of a Filter.
+    #: This constant has a value of "NOT"
+    OPERATOR_NOT = "NOT"
+
+    #: A constant which can be used with the operator property of a Filter.
+    #: This constant has a value of "OR"
+    OPERATOR_OR = "OR"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Filter object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operator:
+            The value to assign to the operator property of this Filter.
+            Allowed values for this property are: "AND", "NOT", "OR"
+        :type operator: str
+
+        :param dimensions:
+            The value to assign to the dimensions property of this Filter.
+        :type dimensions: list[Dimension]
+
+        :param tags:
+            The value to assign to the tags property of this Filter.
+        :type tags: list[Tag]
+
+        :param filters:
+            The value to assign to the filters property of this Filter.
+        :type filters: list[Filter]
+
+        """
+        self.swagger_types = {
+            'operator': 'str',
+            'dimensions': 'list[Dimension]',
+            'tags': 'list[Tag]',
+            'filters': 'list[Filter]'
+        }
+
+        self.attribute_map = {
+            'operator': 'operator',
+            'dimensions': 'dimensions',
+            'tags': 'tags',
+            'filters': 'filters'
+        }
+
+        self._operator = None
+        self._dimensions = None
+        self._tags = None
+        self._filters = None
+
+    @property
+    def operator(self):
+        """
+        Gets the operator of this Filter.
+        The operator of the filter. Example: 'AND', 'OR', 'NOT'.
+
+        Allowed values for this property are: "AND", "NOT", "OR"
+
+
+        :return: The operator of this Filter.
+        :rtype: str
+        """
+        return self._operator
+
+    @operator.setter
+    def operator(self, operator):
+        """
+        Sets the operator of this Filter.
+        The operator of the filter. Example: 'AND', 'OR', 'NOT'.
+
+
+        :param operator: The operator of this Filter.
+        :type: str
+        """
+        allowed_values = ["AND", "NOT", "OR"]
+        if not value_allowed_none_or_none_sentinel(operator, allowed_values):
+            raise ValueError(
+                "Invalid value for `operator`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._operator = operator
+
+    @property
+    def dimensions(self):
+        """
+        Gets the dimensions of this Filter.
+        The dimensions to filter on.
+
+
+        :return: The dimensions of this Filter.
+        :rtype: list[Dimension]
+        """
+        return self._dimensions
+
+    @dimensions.setter
+    def dimensions(self, dimensions):
+        """
+        Sets the dimensions of this Filter.
+        The dimensions to filter on.
+
+
+        :param dimensions: The dimensions of this Filter.
+        :type: list[Dimension]
+        """
+        self._dimensions = dimensions
+
+    @property
+    def tags(self):
+        """
+        Gets the tags of this Filter.
+        The tags to filter on.
+
+
+        :return: The tags of this Filter.
+        :rtype: list[Tag]
+        """
+        return self._tags
+
+    @tags.setter
+    def tags(self, tags):
+        """
+        Sets the tags of this Filter.
+        The tags to filter on.
+
+
+        :param tags: The tags of this Filter.
+        :type: list[Tag]
+        """
+        self._tags = tags
+
+    @property
+    def filters(self):
+        """
+        Gets the filters of this Filter.
+        The nested filter object.
+
+
+        :return: The filters of this Filter.
+        :rtype: list[Filter]
+        """
+        return self._filters
+
+    @filters.setter
+    def filters(self, filters):
+        """
+        Sets the filters of this Filter.
+        The nested filter object.
+
+
+        :param filters: The filters of this Filter.
+        :type: list[Filter]
+        """
+        self._filters = filters
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/usage_api/models/request_summarized_usages_details.py
+++ b/src/oci/usage_api/models/request_summarized_usages_details.py
@@ -1,0 +1,341 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class RequestSummarizedUsagesDetails(object):
+    """
+    details for the '/usage' query
+    """
+
+    #: A constant which can be used with the granularity property of a RequestSummarizedUsagesDetails.
+    #: This constant has a value of "HOURLY"
+    GRANULARITY_HOURLY = "HOURLY"
+
+    #: A constant which can be used with the granularity property of a RequestSummarizedUsagesDetails.
+    #: This constant has a value of "DAILY"
+    GRANULARITY_DAILY = "DAILY"
+
+    #: A constant which can be used with the granularity property of a RequestSummarizedUsagesDetails.
+    #: This constant has a value of "MONTHLY"
+    GRANULARITY_MONTHLY = "MONTHLY"
+
+    #: A constant which can be used with the granularity property of a RequestSummarizedUsagesDetails.
+    #: This constant has a value of "TOTAL"
+    GRANULARITY_TOTAL = "TOTAL"
+
+    #: A constant which can be used with the query_type property of a RequestSummarizedUsagesDetails.
+    #: This constant has a value of "USAGE"
+    QUERY_TYPE_USAGE = "USAGE"
+
+    #: A constant which can be used with the query_type property of a RequestSummarizedUsagesDetails.
+    #: This constant has a value of "COST"
+    QUERY_TYPE_COST = "COST"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new RequestSummarizedUsagesDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param tenant_id:
+            The value to assign to the tenant_id property of this RequestSummarizedUsagesDetails.
+        :type tenant_id: str
+
+        :param time_usage_started:
+            The value to assign to the time_usage_started property of this RequestSummarizedUsagesDetails.
+        :type time_usage_started: datetime
+
+        :param time_usage_ended:
+            The value to assign to the time_usage_ended property of this RequestSummarizedUsagesDetails.
+        :type time_usage_ended: datetime
+
+        :param granularity:
+            The value to assign to the granularity property of this RequestSummarizedUsagesDetails.
+            Allowed values for this property are: "HOURLY", "DAILY", "MONTHLY", "TOTAL"
+        :type granularity: str
+
+        :param query_type:
+            The value to assign to the query_type property of this RequestSummarizedUsagesDetails.
+            Allowed values for this property are: "USAGE", "COST"
+        :type query_type: str
+
+        :param group_by:
+            The value to assign to the group_by property of this RequestSummarizedUsagesDetails.
+        :type group_by: list[str]
+
+        :param compartment_depth:
+            The value to assign to the compartment_depth property of this RequestSummarizedUsagesDetails.
+        :type compartment_depth: float
+
+        :param filter:
+            The value to assign to the filter property of this RequestSummarizedUsagesDetails.
+        :type filter: Filter
+
+        """
+        self.swagger_types = {
+            'tenant_id': 'str',
+            'time_usage_started': 'datetime',
+            'time_usage_ended': 'datetime',
+            'granularity': 'str',
+            'query_type': 'str',
+            'group_by': 'list[str]',
+            'compartment_depth': 'float',
+            'filter': 'Filter'
+        }
+
+        self.attribute_map = {
+            'tenant_id': 'tenantId',
+            'time_usage_started': 'timeUsageStarted',
+            'time_usage_ended': 'timeUsageEnded',
+            'granularity': 'granularity',
+            'query_type': 'queryType',
+            'group_by': 'groupBy',
+            'compartment_depth': 'compartmentDepth',
+            'filter': 'filter'
+        }
+
+        self._tenant_id = None
+        self._time_usage_started = None
+        self._time_usage_ended = None
+        self._granularity = None
+        self._query_type = None
+        self._group_by = None
+        self._compartment_depth = None
+        self._filter = None
+
+    @property
+    def tenant_id(self):
+        """
+        **[Required]** Gets the tenant_id of this RequestSummarizedUsagesDetails.
+        tenant id
+
+
+        :return: The tenant_id of this RequestSummarizedUsagesDetails.
+        :rtype: str
+        """
+        return self._tenant_id
+
+    @tenant_id.setter
+    def tenant_id(self, tenant_id):
+        """
+        Sets the tenant_id of this RequestSummarizedUsagesDetails.
+        tenant id
+
+
+        :param tenant_id: The tenant_id of this RequestSummarizedUsagesDetails.
+        :type: str
+        """
+        self._tenant_id = tenant_id
+
+    @property
+    def time_usage_started(self):
+        """
+        **[Required]** Gets the time_usage_started of this RequestSummarizedUsagesDetails.
+        The start time of the usage.
+
+
+        :return: The time_usage_started of this RequestSummarizedUsagesDetails.
+        :rtype: datetime
+        """
+        return self._time_usage_started
+
+    @time_usage_started.setter
+    def time_usage_started(self, time_usage_started):
+        """
+        Sets the time_usage_started of this RequestSummarizedUsagesDetails.
+        The start time of the usage.
+
+
+        :param time_usage_started: The time_usage_started of this RequestSummarizedUsagesDetails.
+        :type: datetime
+        """
+        self._time_usage_started = time_usage_started
+
+    @property
+    def time_usage_ended(self):
+        """
+        **[Required]** Gets the time_usage_ended of this RequestSummarizedUsagesDetails.
+        The end time of the usage.
+
+
+        :return: The time_usage_ended of this RequestSummarizedUsagesDetails.
+        :rtype: datetime
+        """
+        return self._time_usage_ended
+
+    @time_usage_ended.setter
+    def time_usage_ended(self, time_usage_ended):
+        """
+        Sets the time_usage_ended of this RequestSummarizedUsagesDetails.
+        The end time of the usage.
+
+
+        :param time_usage_ended: The time_usage_ended of this RequestSummarizedUsagesDetails.
+        :type: datetime
+        """
+        self._time_usage_ended = time_usage_ended
+
+    @property
+    def granularity(self):
+        """
+        **[Required]** Gets the granularity of this RequestSummarizedUsagesDetails.
+        The granularity of the usage.
+        HOURLY - Hourly aggregation of data
+        DAILY - Daily aggregation of data
+        MONTHLY - Monthly aggregation of data
+        TOTAL - Not Supported Yet
+
+        Allowed values for this property are: "HOURLY", "DAILY", "MONTHLY", "TOTAL"
+
+
+        :return: The granularity of this RequestSummarizedUsagesDetails.
+        :rtype: str
+        """
+        return self._granularity
+
+    @granularity.setter
+    def granularity(self, granularity):
+        """
+        Sets the granularity of this RequestSummarizedUsagesDetails.
+        The granularity of the usage.
+        HOURLY - Hourly aggregation of data
+        DAILY - Daily aggregation of data
+        MONTHLY - Monthly aggregation of data
+        TOTAL - Not Supported Yet
+
+
+        :param granularity: The granularity of this RequestSummarizedUsagesDetails.
+        :type: str
+        """
+        allowed_values = ["HOURLY", "DAILY", "MONTHLY", "TOTAL"]
+        if not value_allowed_none_or_none_sentinel(granularity, allowed_values):
+            raise ValueError(
+                "Invalid value for `granularity`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._granularity = granularity
+
+    @property
+    def query_type(self):
+        """
+        Gets the query_type of this RequestSummarizedUsagesDetails.
+        The type of query of the usage.
+        Usage - Query the usage data.
+        Cost - Query the cost / billing data.
+
+        Allowed values for this property are: "USAGE", "COST"
+
+
+        :return: The query_type of this RequestSummarizedUsagesDetails.
+        :rtype: str
+        """
+        return self._query_type
+
+    @query_type.setter
+    def query_type(self, query_type):
+        """
+        Sets the query_type of this RequestSummarizedUsagesDetails.
+        The type of query of the usage.
+        Usage - Query the usage data.
+        Cost - Query the cost / billing data.
+
+
+        :param query_type: The query_type of this RequestSummarizedUsagesDetails.
+        :type: str
+        """
+        allowed_values = ["USAGE", "COST"]
+        if not value_allowed_none_or_none_sentinel(query_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `query_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._query_type = query_type
+
+    @property
+    def group_by(self):
+        """
+        Gets the group_by of this RequestSummarizedUsagesDetails.
+        Aggregate the result by.
+        example:
+          `[\"service\"]`
+
+
+        :return: The group_by of this RequestSummarizedUsagesDetails.
+        :rtype: list[str]
+        """
+        return self._group_by
+
+    @group_by.setter
+    def group_by(self, group_by):
+        """
+        Sets the group_by of this RequestSummarizedUsagesDetails.
+        Aggregate the result by.
+        example:
+          `[\"service\"]`
+
+
+        :param group_by: The group_by of this RequestSummarizedUsagesDetails.
+        :type: list[str]
+        """
+        self._group_by = group_by
+
+    @property
+    def compartment_depth(self):
+        """
+        Gets the compartment_depth of this RequestSummarizedUsagesDetails.
+        The depth level of the compartment.
+
+
+        :return: The compartment_depth of this RequestSummarizedUsagesDetails.
+        :rtype: float
+        """
+        return self._compartment_depth
+
+    @compartment_depth.setter
+    def compartment_depth(self, compartment_depth):
+        """
+        Sets the compartment_depth of this RequestSummarizedUsagesDetails.
+        The depth level of the compartment.
+
+
+        :param compartment_depth: The compartment_depth of this RequestSummarizedUsagesDetails.
+        :type: float
+        """
+        self._compartment_depth = compartment_depth
+
+    @property
+    def filter(self):
+        """
+        Gets the filter of this RequestSummarizedUsagesDetails.
+
+        :return: The filter of this RequestSummarizedUsagesDetails.
+        :rtype: Filter
+        """
+        return self._filter
+
+    @filter.setter
+    def filter(self, filter):
+        """
+        Sets the filter of this RequestSummarizedUsagesDetails.
+
+        :param filter: The filter of this RequestSummarizedUsagesDetails.
+        :type: Filter
+        """
+        self._filter = filter
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/usage_api/models/tag.py
+++ b/src/oci/usage_api/models/tag.py
@@ -1,0 +1,132 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Tag(object):
+    """
+    The tag use for filtering.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Tag object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param namespace:
+            The value to assign to the namespace property of this Tag.
+        :type namespace: str
+
+        :param key:
+            The value to assign to the key property of this Tag.
+        :type key: str
+
+        :param value:
+            The value to assign to the value property of this Tag.
+        :type value: str
+
+        """
+        self.swagger_types = {
+            'namespace': 'str',
+            'key': 'str',
+            'value': 'str'
+        }
+
+        self.attribute_map = {
+            'namespace': 'namespace',
+            'key': 'key',
+            'value': 'value'
+        }
+
+        self._namespace = None
+        self._key = None
+        self._value = None
+
+    @property
+    def namespace(self):
+        """
+        Gets the namespace of this Tag.
+        The tag namespace.
+
+
+        :return: The namespace of this Tag.
+        :rtype: str
+        """
+        return self._namespace
+
+    @namespace.setter
+    def namespace(self, namespace):
+        """
+        Sets the namespace of this Tag.
+        The tag namespace.
+
+
+        :param namespace: The namespace of this Tag.
+        :type: str
+        """
+        self._namespace = namespace
+
+    @property
+    def key(self):
+        """
+        Gets the key of this Tag.
+        The key of the tag.
+
+
+        :return: The key of this Tag.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this Tag.
+        The key of the tag.
+
+
+        :param key: The key of this Tag.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def value(self):
+        """
+        Gets the value of this Tag.
+        The value of the tag.
+
+
+        :return: The value of this Tag.
+        :rtype: str
+        """
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        """
+        Sets the value of this Tag.
+        The value of the tag.
+
+
+        :param value: The value of this Tag.
+        :type: str
+        """
+        self._value = value
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/usage_api/models/usage_aggregation.py
+++ b/src/oci/usage_api/models/usage_aggregation.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UsageAggregation(object):
+    """
+    The usage of the account (tenant)
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UsageAggregation object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param group_by:
+            The value to assign to the group_by property of this UsageAggregation.
+        :type group_by: list[str]
+
+        :param items:
+            The value to assign to the items property of this UsageAggregation.
+        :type items: list[UsageSummary]
+
+        """
+        self.swagger_types = {
+            'group_by': 'list[str]',
+            'items': 'list[UsageSummary]'
+        }
+
+        self.attribute_map = {
+            'group_by': 'groupBy',
+            'items': 'items'
+        }
+
+        self._group_by = None
+        self._items = None
+
+    @property
+    def group_by(self):
+        """
+        Gets the group_by of this UsageAggregation.
+        Aggregate the result by.
+
+
+        :return: The group_by of this UsageAggregation.
+        :rtype: list[str]
+        """
+        return self._group_by
+
+    @group_by.setter
+    def group_by(self, group_by):
+        """
+        Sets the group_by of this UsageAggregation.
+        Aggregate the result by.
+
+
+        :param group_by: The group_by of this UsageAggregation.
+        :type: list[str]
+        """
+        self._group_by = group_by
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this UsageAggregation.
+        A list of usage items.
+
+
+        :return: The items of this UsageAggregation.
+        :rtype: list[UsageSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this UsageAggregation.
+        A list of usage items.
+
+
+        :param items: The items of this UsageAggregation.
+        :type: list[UsageSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/usage_api/models/usage_summary.py
+++ b/src/oci/usage_api/models/usage_summary.py
@@ -1,0 +1,845 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UsageSummary(object):
+    """
+    The result from usage store.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UsageSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this UsageSummary.
+        :type compartment_id: str
+
+        :param compartment_path:
+            The value to assign to the compartment_path property of this UsageSummary.
+        :type compartment_path: str
+
+        :param compartment_name:
+            The value to assign to the compartment_name property of this UsageSummary.
+        :type compartment_name: str
+
+        :param service:
+            The value to assign to the service property of this UsageSummary.
+        :type service: str
+
+        :param resource_name:
+            The value to assign to the resource_name property of this UsageSummary.
+        :type resource_name: str
+
+        :param resource_id:
+            The value to assign to the resource_id property of this UsageSummary.
+        :type resource_id: str
+
+        :param region:
+            The value to assign to the region property of this UsageSummary.
+        :type region: str
+
+        :param ad:
+            The value to assign to the ad property of this UsageSummary.
+        :type ad: str
+
+        :param weight:
+            The value to assign to the weight property of this UsageSummary.
+        :type weight: float
+
+        :param shape:
+            The value to assign to the shape property of this UsageSummary.
+        :type shape: str
+
+        :param sku_part_number:
+            The value to assign to the sku_part_number property of this UsageSummary.
+        :type sku_part_number: str
+
+        :param sku_name:
+            The value to assign to the sku_name property of this UsageSummary.
+        :type sku_name: str
+
+        :param unit:
+            The value to assign to the unit property of this UsageSummary.
+        :type unit: str
+
+        :param discount:
+            The value to assign to the discount property of this UsageSummary.
+        :type discount: float
+
+        :param list_rate:
+            The value to assign to the list_rate property of this UsageSummary.
+        :type list_rate: float
+
+        :param platform:
+            The value to assign to the platform property of this UsageSummary.
+        :type platform: str
+
+        :param time_usage_started:
+            The value to assign to the time_usage_started property of this UsageSummary.
+        :type time_usage_started: datetime
+
+        :param time_usage_ended:
+            The value to assign to the time_usage_ended property of this UsageSummary.
+        :type time_usage_ended: datetime
+
+        :param computed_amount:
+            The value to assign to the computed_amount property of this UsageSummary.
+        :type computed_amount: float
+
+        :param computed_quantity:
+            The value to assign to the computed_quantity property of this UsageSummary.
+        :type computed_quantity: float
+
+        :param overages_flag:
+            The value to assign to the overages_flag property of this UsageSummary.
+        :type overages_flag: str
+
+        :param unit_price:
+            The value to assign to the unit_price property of this UsageSummary.
+        :type unit_price: float
+
+        :param currency:
+            The value to assign to the currency property of this UsageSummary.
+        :type currency: str
+
+        :param subscription_id:
+            The value to assign to the subscription_id property of this UsageSummary.
+        :type subscription_id: str
+
+        :param overage:
+            The value to assign to the overage property of this UsageSummary.
+        :type overage: str
+
+        :param tags:
+            The value to assign to the tags property of this UsageSummary.
+        :type tags: list[Tag]
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'compartment_path': 'str',
+            'compartment_name': 'str',
+            'service': 'str',
+            'resource_name': 'str',
+            'resource_id': 'str',
+            'region': 'str',
+            'ad': 'str',
+            'weight': 'float',
+            'shape': 'str',
+            'sku_part_number': 'str',
+            'sku_name': 'str',
+            'unit': 'str',
+            'discount': 'float',
+            'list_rate': 'float',
+            'platform': 'str',
+            'time_usage_started': 'datetime',
+            'time_usage_ended': 'datetime',
+            'computed_amount': 'float',
+            'computed_quantity': 'float',
+            'overages_flag': 'str',
+            'unit_price': 'float',
+            'currency': 'str',
+            'subscription_id': 'str',
+            'overage': 'str',
+            'tags': 'list[Tag]'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'compartment_path': 'compartmentPath',
+            'compartment_name': 'compartmentName',
+            'service': 'service',
+            'resource_name': 'resourceName',
+            'resource_id': 'resourceId',
+            'region': 'region',
+            'ad': 'ad',
+            'weight': 'weight',
+            'shape': 'shape',
+            'sku_part_number': 'skuPartNumber',
+            'sku_name': 'skuName',
+            'unit': 'unit',
+            'discount': 'discount',
+            'list_rate': 'listRate',
+            'platform': 'platform',
+            'time_usage_started': 'timeUsageStarted',
+            'time_usage_ended': 'timeUsageEnded',
+            'computed_amount': 'computedAmount',
+            'computed_quantity': 'computedQuantity',
+            'overages_flag': 'overagesFlag',
+            'unit_price': 'unitPrice',
+            'currency': 'currency',
+            'subscription_id': 'subscriptionId',
+            'overage': 'overage',
+            'tags': 'tags'
+        }
+
+        self._compartment_id = None
+        self._compartment_path = None
+        self._compartment_name = None
+        self._service = None
+        self._resource_name = None
+        self._resource_id = None
+        self._region = None
+        self._ad = None
+        self._weight = None
+        self._shape = None
+        self._sku_part_number = None
+        self._sku_name = None
+        self._unit = None
+        self._discount = None
+        self._list_rate = None
+        self._platform = None
+        self._time_usage_started = None
+        self._time_usage_ended = None
+        self._computed_amount = None
+        self._computed_quantity = None
+        self._overages_flag = None
+        self._unit_price = None
+        self._currency = None
+        self._subscription_id = None
+        self._overage = None
+        self._tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this UsageSummary.
+        The OCID of the compartment.
+
+
+        :return: The compartment_id of this UsageSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this UsageSummary.
+        The OCID of the compartment.
+
+
+        :param compartment_id: The compartment_id of this UsageSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def compartment_path(self):
+        """
+        Gets the compartment_path of this UsageSummary.
+        The path of the compartment, starting from root.
+
+
+        :return: The compartment_path of this UsageSummary.
+        :rtype: str
+        """
+        return self._compartment_path
+
+    @compartment_path.setter
+    def compartment_path(self, compartment_path):
+        """
+        Sets the compartment_path of this UsageSummary.
+        The path of the compartment, starting from root.
+
+
+        :param compartment_path: The compartment_path of this UsageSummary.
+        :type: str
+        """
+        self._compartment_path = compartment_path
+
+    @property
+    def compartment_name(self):
+        """
+        Gets the compartment_name of this UsageSummary.
+        The name of the compartment.
+
+
+        :return: The compartment_name of this UsageSummary.
+        :rtype: str
+        """
+        return self._compartment_name
+
+    @compartment_name.setter
+    def compartment_name(self, compartment_name):
+        """
+        Sets the compartment_name of this UsageSummary.
+        The name of the compartment.
+
+
+        :param compartment_name: The compartment_name of this UsageSummary.
+        :type: str
+        """
+        self._compartment_name = compartment_name
+
+    @property
+    def service(self):
+        """
+        Gets the service of this UsageSummary.
+        The name of the service that is incurring the cost.
+
+
+        :return: The service of this UsageSummary.
+        :rtype: str
+        """
+        return self._service
+
+    @service.setter
+    def service(self, service):
+        """
+        Sets the service of this UsageSummary.
+        The name of the service that is incurring the cost.
+
+
+        :param service: The service of this UsageSummary.
+        :type: str
+        """
+        self._service = service
+
+    @property
+    def resource_name(self):
+        """
+        Gets the resource_name of this UsageSummary.
+        The name of the resource that is incurring the cost.
+
+
+        :return: The resource_name of this UsageSummary.
+        :rtype: str
+        """
+        return self._resource_name
+
+    @resource_name.setter
+    def resource_name(self, resource_name):
+        """
+        Sets the resource_name of this UsageSummary.
+        The name of the resource that is incurring the cost.
+
+
+        :param resource_name: The resource_name of this UsageSummary.
+        :type: str
+        """
+        self._resource_name = resource_name
+
+    @property
+    def resource_id(self):
+        """
+        Gets the resource_id of this UsageSummary.
+        The Ocid of the resource that is incurring the cost.
+
+
+        :return: The resource_id of this UsageSummary.
+        :rtype: str
+        """
+        return self._resource_id
+
+    @resource_id.setter
+    def resource_id(self, resource_id):
+        """
+        Sets the resource_id of this UsageSummary.
+        The Ocid of the resource that is incurring the cost.
+
+
+        :param resource_id: The resource_id of this UsageSummary.
+        :type: str
+        """
+        self._resource_id = resource_id
+
+    @property
+    def region(self):
+        """
+        Gets the region of this UsageSummary.
+        The region of the usage.
+
+
+        :return: The region of this UsageSummary.
+        :rtype: str
+        """
+        return self._region
+
+    @region.setter
+    def region(self, region):
+        """
+        Sets the region of this UsageSummary.
+        The region of the usage.
+
+
+        :param region: The region of this UsageSummary.
+        :type: str
+        """
+        self._region = region
+
+    @property
+    def ad(self):
+        """
+        Gets the ad of this UsageSummary.
+        The availability domain of the usage.
+
+
+        :return: The ad of this UsageSummary.
+        :rtype: str
+        """
+        return self._ad
+
+    @ad.setter
+    def ad(self, ad):
+        """
+        Sets the ad of this UsageSummary.
+        The availability domain of the usage.
+
+
+        :param ad: The ad of this UsageSummary.
+        :type: str
+        """
+        self._ad = ad
+
+    @property
+    def weight(self):
+        """
+        Gets the weight of this UsageSummary.
+        The size of resource being metered.
+
+
+        :return: The weight of this UsageSummary.
+        :rtype: float
+        """
+        return self._weight
+
+    @weight.setter
+    def weight(self, weight):
+        """
+        Sets the weight of this UsageSummary.
+        The size of resource being metered.
+
+
+        :param weight: The weight of this UsageSummary.
+        :type: float
+        """
+        self._weight = weight
+
+    @property
+    def shape(self):
+        """
+        Gets the shape of this UsageSummary.
+        The shape of the resource.
+
+
+        :return: The shape of this UsageSummary.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this UsageSummary.
+        The shape of the resource.
+
+
+        :param shape: The shape of this UsageSummary.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def sku_part_number(self):
+        """
+        Gets the sku_part_number of this UsageSummary.
+        The part number of the SKU.
+
+
+        :return: The sku_part_number of this UsageSummary.
+        :rtype: str
+        """
+        return self._sku_part_number
+
+    @sku_part_number.setter
+    def sku_part_number(self, sku_part_number):
+        """
+        Sets the sku_part_number of this UsageSummary.
+        The part number of the SKU.
+
+
+        :param sku_part_number: The sku_part_number of this UsageSummary.
+        :type: str
+        """
+        self._sku_part_number = sku_part_number
+
+    @property
+    def sku_name(self):
+        """
+        Gets the sku_name of this UsageSummary.
+        The friendly name for the SKU.
+
+
+        :return: The sku_name of this UsageSummary.
+        :rtype: str
+        """
+        return self._sku_name
+
+    @sku_name.setter
+    def sku_name(self, sku_name):
+        """
+        Sets the sku_name of this UsageSummary.
+        The friendly name for the SKU.
+
+
+        :param sku_name: The sku_name of this UsageSummary.
+        :type: str
+        """
+        self._sku_name = sku_name
+
+    @property
+    def unit(self):
+        """
+        Gets the unit of this UsageSummary.
+        The unit of the usage.
+
+
+        :return: The unit of this UsageSummary.
+        :rtype: str
+        """
+        return self._unit
+
+    @unit.setter
+    def unit(self, unit):
+        """
+        Sets the unit of this UsageSummary.
+        The unit of the usage.
+
+
+        :param unit: The unit of this UsageSummary.
+        :type: str
+        """
+        self._unit = unit
+
+    @property
+    def discount(self):
+        """
+        Gets the discount of this UsageSummary.
+        The discretionary discount applied to the SKU.
+
+
+        :return: The discount of this UsageSummary.
+        :rtype: float
+        """
+        return self._discount
+
+    @discount.setter
+    def discount(self, discount):
+        """
+        Sets the discount of this UsageSummary.
+        The discretionary discount applied to the SKU.
+
+
+        :param discount: The discount of this UsageSummary.
+        :type: float
+        """
+        self._discount = discount
+
+    @property
+    def list_rate(self):
+        """
+        Gets the list_rate of this UsageSummary.
+        The list rate for the SKU (not discount).
+
+
+        :return: The list_rate of this UsageSummary.
+        :rtype: float
+        """
+        return self._list_rate
+
+    @list_rate.setter
+    def list_rate(self, list_rate):
+        """
+        Sets the list_rate of this UsageSummary.
+        The list rate for the SKU (not discount).
+
+
+        :param list_rate: The list_rate of this UsageSummary.
+        :type: float
+        """
+        self._list_rate = list_rate
+
+    @property
+    def platform(self):
+        """
+        Gets the platform of this UsageSummary.
+        Platform for the cost.
+
+
+        :return: The platform of this UsageSummary.
+        :rtype: str
+        """
+        return self._platform
+
+    @platform.setter
+    def platform(self, platform):
+        """
+        Sets the platform of this UsageSummary.
+        Platform for the cost.
+
+
+        :param platform: The platform of this UsageSummary.
+        :type: str
+        """
+        self._platform = platform
+
+    @property
+    def time_usage_started(self):
+        """
+        **[Required]** Gets the time_usage_started of this UsageSummary.
+        The start time of the usage.
+
+
+        :return: The time_usage_started of this UsageSummary.
+        :rtype: datetime
+        """
+        return self._time_usage_started
+
+    @time_usage_started.setter
+    def time_usage_started(self, time_usage_started):
+        """
+        Sets the time_usage_started of this UsageSummary.
+        The start time of the usage.
+
+
+        :param time_usage_started: The time_usage_started of this UsageSummary.
+        :type: datetime
+        """
+        self._time_usage_started = time_usage_started
+
+    @property
+    def time_usage_ended(self):
+        """
+        **[Required]** Gets the time_usage_ended of this UsageSummary.
+        The end time of the usage.
+
+
+        :return: The time_usage_ended of this UsageSummary.
+        :rtype: datetime
+        """
+        return self._time_usage_ended
+
+    @time_usage_ended.setter
+    def time_usage_ended(self, time_usage_ended):
+        """
+        Sets the time_usage_ended of this UsageSummary.
+        The end time of the usage.
+
+
+        :param time_usage_ended: The time_usage_ended of this UsageSummary.
+        :type: datetime
+        """
+        self._time_usage_ended = time_usage_ended
+
+    @property
+    def computed_amount(self):
+        """
+        Gets the computed_amount of this UsageSummary.
+        The computed cost.
+
+
+        :return: The computed_amount of this UsageSummary.
+        :rtype: float
+        """
+        return self._computed_amount
+
+    @computed_amount.setter
+    def computed_amount(self, computed_amount):
+        """
+        Sets the computed_amount of this UsageSummary.
+        The computed cost.
+
+
+        :param computed_amount: The computed_amount of this UsageSummary.
+        :type: float
+        """
+        self._computed_amount = computed_amount
+
+    @property
+    def computed_quantity(self):
+        """
+        Gets the computed_quantity of this UsageSummary.
+        The usage number.
+
+
+        :return: The computed_quantity of this UsageSummary.
+        :rtype: float
+        """
+        return self._computed_quantity
+
+    @computed_quantity.setter
+    def computed_quantity(self, computed_quantity):
+        """
+        Sets the computed_quantity of this UsageSummary.
+        The usage number.
+
+
+        :param computed_quantity: The computed_quantity of this UsageSummary.
+        :type: float
+        """
+        self._computed_quantity = computed_quantity
+
+    @property
+    def overages_flag(self):
+        """
+        Gets the overages_flag of this UsageSummary.
+        The SPM OverageFlag.
+
+
+        :return: The overages_flag of this UsageSummary.
+        :rtype: str
+        """
+        return self._overages_flag
+
+    @overages_flag.setter
+    def overages_flag(self, overages_flag):
+        """
+        Sets the overages_flag of this UsageSummary.
+        The SPM OverageFlag.
+
+
+        :param overages_flag: The overages_flag of this UsageSummary.
+        :type: str
+        """
+        self._overages_flag = overages_flag
+
+    @property
+    def unit_price(self):
+        """
+        Gets the unit_price of this UsageSummary.
+        The price per unit.
+
+
+        :return: The unit_price of this UsageSummary.
+        :rtype: float
+        """
+        return self._unit_price
+
+    @unit_price.setter
+    def unit_price(self, unit_price):
+        """
+        Sets the unit_price of this UsageSummary.
+        The price per unit.
+
+
+        :param unit_price: The unit_price of this UsageSummary.
+        :type: float
+        """
+        self._unit_price = unit_price
+
+    @property
+    def currency(self):
+        """
+        Gets the currency of this UsageSummary.
+        The currency for the price.
+
+
+        :return: The currency of this UsageSummary.
+        :rtype: str
+        """
+        return self._currency
+
+    @currency.setter
+    def currency(self, currency):
+        """
+        Sets the currency of this UsageSummary.
+        The currency for the price.
+
+
+        :param currency: The currency of this UsageSummary.
+        :type: str
+        """
+        self._currency = currency
+
+    @property
+    def subscription_id(self):
+        """
+        Gets the subscription_id of this UsageSummary.
+        The subscription Id.
+
+
+        :return: The subscription_id of this UsageSummary.
+        :rtype: str
+        """
+        return self._subscription_id
+
+    @subscription_id.setter
+    def subscription_id(self, subscription_id):
+        """
+        Sets the subscription_id of this UsageSummary.
+        The subscription Id.
+
+
+        :param subscription_id: The subscription_id of this UsageSummary.
+        :type: str
+        """
+        self._subscription_id = subscription_id
+
+    @property
+    def overage(self):
+        """
+        Gets the overage of this UsageSummary.
+        The overage usage.
+
+
+        :return: The overage of this UsageSummary.
+        :rtype: str
+        """
+        return self._overage
+
+    @overage.setter
+    def overage(self, overage):
+        """
+        Sets the overage of this UsageSummary.
+        The overage usage.
+
+
+        :param overage: The overage of this UsageSummary.
+        :type: str
+        """
+        self._overage = overage
+
+    @property
+    def tags(self):
+        """
+        Gets the tags of this UsageSummary.
+        For grouping, a tag definition. For filtering, a definition and key
+
+
+        :return: The tags of this UsageSummary.
+        :rtype: list[Tag]
+        """
+        return self._tags
+
+    @tags.setter
+    def tags(self, tags):
+        """
+        Sets the tags of this UsageSummary.
+        For grouping, a tag definition. For filtering, a definition and key
+
+
+        :param tags: The tags of this UsageSummary.
+        :type: list[Tag]
+        """
+        self._tags = tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/usage_api/usageapi_client.py
+++ b/src/oci/usage_api/usageapi_client.py
@@ -1,0 +1,230 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import usage_api_type_mapping
+missing = Sentinel("Missing")
+
+
+class UsageapiClient(object):
+    """
+    A description of the UsageApi API.
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20200107',
+            'service_endpoint_template': 'https://usageapi.{region}.oci.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("usageapi", config, signer, usage_api_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def request_summarized_configurations(self, tenant_id, **kwargs):
+        """
+        Returns the list of config for UI dropdown list
+
+
+        :param str tenant_id: (required)
+            tenant id
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.usage_api.models.ConfigurationAggregation`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/configuration"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "request_summarized_configurations got unknown kwargs: {!r}".format(extra_kwargs))
+
+        query_params = {
+            "tenantId": tenant_id
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ConfigurationAggregation")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ConfigurationAggregation")
+
+    def request_summarized_usages(self, request_summarized_usages_details, **kwargs):
+        """
+        Returns the usage for the given account
+
+
+        :param RequestSummarizedUsagesDetails request_summarized_usages_details: (required)
+            getUsageRequest contain query inforamtion
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results.
+            This is usually retrieved from a previous list call.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.usage_api.models.UsageAggregation`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/usage"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "page",
+            "limit"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "request_summarized_usages got unknown kwargs: {!r}".format(extra_kwargs))
+
+        query_params = {
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                body=request_summarized_usages_details,
+                response_type="UsageAggregation")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                body=request_summarized_usages_details,
+                response_type="UsageAggregation")

--- a/src/oci/usage_api/usageapi_client_composite_operations.py
+++ b/src/oci/usage_api/usageapi_client_composite_operations.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class UsageapiClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.usage_api.UsageapiClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new UsageapiClientCompositeOperations object
+
+        :param UsageapiClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.17.0"
+__version__ = "2.17.1"


### PR DESCRIPTION
## Added

* Support for the Usage service

* Support for the VMware Provisioning service

* Support for applying one-off patches to databases in the Database service

* Support for layer-2 virtualization features on vlans in the Networking service

* Support for all AttachVolumeDetails and ParavirtualizedAttachVolumeDetails properties on instance configurations in the Compute Management service

* Support for setting HTTP header size and allowing invalid characters in HTTP request headers in the Load Balancing service

* Support for enabling/disabling HTTP logging. Please see https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/logging.html
