### PR TITLE
Releasing version 2.19.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.19.0 - 2020-07-28
+====================
+
+Added
+-----
+* Support for calling Oracle Cloud Infrastructure services in the us-sanjose-1 region
+* Support for updating the fault domain and launch options of VM instances in the Compute service
+* Support for image capability schemas and schema versions in the Compute service
+* Support for 'Patch Now' maintenance runs for autonomous Exadata infrastructure and autonomous container database resources in the Database service
+* Support for automatic performance and cost tuning on volumes in the Block Storage service
+
+Breaking
+--------
+* Removed the accessToken field from the GitlabAccessTokenConfigurationSourceProvider model in the Resource Manager service
+
+====================
 2.18.1 - 2020-07-21
 ====================
 

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -44,6 +44,7 @@ Core Services
     oci.core.models.AttachVnicDetails
     oci.core.models.AttachVolumeDetails
     oci.core.models.BgpSessionInfo
+    oci.core.models.BooleanImageCapabilitySchemaDescriptor
     oci.core.models.BootVolume
     oci.core.models.BootVolumeAttachment
     oci.core.models.BootVolumeBackup
@@ -57,6 +58,7 @@ Core Services
     oci.core.models.ChangeBootVolumeBackupCompartmentDetails
     oci.core.models.ChangeBootVolumeCompartmentDetails
     oci.core.models.ChangeClusterNetworkCompartmentDetails
+    oci.core.models.ChangeComputeImageCapabilitySchemaCompartmentDetails
     oci.core.models.ChangeCpeCompartmentDetails
     oci.core.models.ChangeCrossConnectCompartmentDetails
     oci.core.models.ChangeCrossConnectGroupCompartmentDetails
@@ -88,6 +90,12 @@ Core Services
     oci.core.models.ClusterNetwork
     oci.core.models.ClusterNetworkPlacementConfigurationDetails
     oci.core.models.ClusterNetworkSummary
+    oci.core.models.ComputeGlobalImageCapabilitySchema
+    oci.core.models.ComputeGlobalImageCapabilitySchemaSummary
+    oci.core.models.ComputeGlobalImageCapabilitySchemaVersion
+    oci.core.models.ComputeGlobalImageCapabilitySchemaVersionSummary
+    oci.core.models.ComputeImageCapabilitySchema
+    oci.core.models.ComputeImageCapabilitySchemaSummary
     oci.core.models.ComputeInstanceDetails
     oci.core.models.ConnectLocalPeeringGatewaysDetails
     oci.core.models.ConnectRemotePeeringConnectionsDetails
@@ -105,6 +113,7 @@ Core Services
     oci.core.models.CreateBootVolumeDetails
     oci.core.models.CreateClusterNetworkDetails
     oci.core.models.CreateClusterNetworkInstancePoolDetails
+    oci.core.models.CreateComputeImageCapabilitySchemaDetails
     oci.core.models.CreateCpeDetails
     oci.core.models.CreateCrossConnectDetails
     oci.core.models.CreateCrossConnectGroupDetails
@@ -168,6 +177,8 @@ Core Services
     oci.core.models.DrgRedundancyStatus
     oci.core.models.EgressSecurityRule
     oci.core.models.EmulatedVolumeAttachment
+    oci.core.models.EnumIntegerImageCapabilityDescriptor
+    oci.core.models.EnumStringImageCapabilitySchemaDescriptor
     oci.core.models.ExportImageDetails
     oci.core.models.ExportImageViaObjectStorageTupleDetails
     oci.core.models.ExportImageViaObjectStorageUriDetails
@@ -183,6 +194,7 @@ Core Services
     oci.core.models.IScsiVolumeAttachment
     oci.core.models.IcmpOptions
     oci.core.models.Image
+    oci.core.models.ImageCapabilitySchemaDescriptor
     oci.core.models.ImageOcpuConstraints
     oci.core.models.ImageShapeCompatibilityEntry
     oci.core.models.ImageShapeCompatibilitySummary
@@ -267,6 +279,7 @@ Core Services
     oci.core.models.UpdateBootVolumeDetails
     oci.core.models.UpdateBootVolumeKmsKeyDetails
     oci.core.models.UpdateClusterNetworkDetails
+    oci.core.models.UpdateComputeImageCapabilitySchemaDetails
     oci.core.models.UpdateConsoleHistoryDetails
     oci.core.models.UpdateCpeDetails
     oci.core.models.UpdateCrossConnectDetails
@@ -288,6 +301,7 @@ Core Services
     oci.core.models.UpdateInstanceShapeConfigDetails
     oci.core.models.UpdateInternetGatewayDetails
     oci.core.models.UpdateIpv6Details
+    oci.core.models.UpdateLaunchOptions
     oci.core.models.UpdateLocalPeeringGatewayDetails
     oci.core.models.UpdateNatGatewayDetails
     oci.core.models.UpdateNetworkSecurityGroupDetails

--- a/docs/api/core/models/oci.core.models.BooleanImageCapabilitySchemaDescriptor.rst
+++ b/docs/api/core/models/oci.core.models.BooleanImageCapabilitySchemaDescriptor.rst
@@ -1,0 +1,11 @@
+BooleanImageCapabilitySchemaDescriptor
+======================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: BooleanImageCapabilitySchemaDescriptor
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.ChangeComputeImageCapabilitySchemaCompartmentDetails.rst
+++ b/docs/api/core/models/oci.core.models.ChangeComputeImageCapabilitySchemaCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeComputeImageCapabilitySchemaCompartmentDetails
+====================================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: ChangeComputeImageCapabilitySchemaCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.ComputeGlobalImageCapabilitySchema.rst
+++ b/docs/api/core/models/oci.core.models.ComputeGlobalImageCapabilitySchema.rst
@@ -1,0 +1,11 @@
+ComputeGlobalImageCapabilitySchema
+==================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: ComputeGlobalImageCapabilitySchema
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.ComputeGlobalImageCapabilitySchemaSummary.rst
+++ b/docs/api/core/models/oci.core.models.ComputeGlobalImageCapabilitySchemaSummary.rst
@@ -1,0 +1,11 @@
+ComputeGlobalImageCapabilitySchemaSummary
+=========================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: ComputeGlobalImageCapabilitySchemaSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.ComputeGlobalImageCapabilitySchemaVersion.rst
+++ b/docs/api/core/models/oci.core.models.ComputeGlobalImageCapabilitySchemaVersion.rst
@@ -1,0 +1,11 @@
+ComputeGlobalImageCapabilitySchemaVersion
+=========================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: ComputeGlobalImageCapabilitySchemaVersion
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.ComputeGlobalImageCapabilitySchemaVersionSummary.rst
+++ b/docs/api/core/models/oci.core.models.ComputeGlobalImageCapabilitySchemaVersionSummary.rst
@@ -1,0 +1,11 @@
+ComputeGlobalImageCapabilitySchemaVersionSummary
+================================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: ComputeGlobalImageCapabilitySchemaVersionSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.ComputeImageCapabilitySchema.rst
+++ b/docs/api/core/models/oci.core.models.ComputeImageCapabilitySchema.rst
@@ -1,0 +1,11 @@
+ComputeImageCapabilitySchema
+============================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: ComputeImageCapabilitySchema
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.ComputeImageCapabilitySchemaSummary.rst
+++ b/docs/api/core/models/oci.core.models.ComputeImageCapabilitySchemaSummary.rst
@@ -1,0 +1,11 @@
+ComputeImageCapabilitySchemaSummary
+===================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: ComputeImageCapabilitySchemaSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.CreateComputeImageCapabilitySchemaDetails.rst
+++ b/docs/api/core/models/oci.core.models.CreateComputeImageCapabilitySchemaDetails.rst
@@ -1,0 +1,11 @@
+CreateComputeImageCapabilitySchemaDetails
+=========================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: CreateComputeImageCapabilitySchemaDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.EnumIntegerImageCapabilityDescriptor.rst
+++ b/docs/api/core/models/oci.core.models.EnumIntegerImageCapabilityDescriptor.rst
@@ -1,0 +1,11 @@
+EnumIntegerImageCapabilityDescriptor
+====================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: EnumIntegerImageCapabilityDescriptor
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.EnumStringImageCapabilitySchemaDescriptor.rst
+++ b/docs/api/core/models/oci.core.models.EnumStringImageCapabilitySchemaDescriptor.rst
@@ -1,0 +1,11 @@
+EnumStringImageCapabilitySchemaDescriptor
+=========================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: EnumStringImageCapabilitySchemaDescriptor
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.ImageCapabilitySchemaDescriptor.rst
+++ b/docs/api/core/models/oci.core.models.ImageCapabilitySchemaDescriptor.rst
@@ -1,0 +1,11 @@
+ImageCapabilitySchemaDescriptor
+===============================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: ImageCapabilitySchemaDescriptor
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.UpdateComputeImageCapabilitySchemaDetails.rst
+++ b/docs/api/core/models/oci.core.models.UpdateComputeImageCapabilitySchemaDetails.rst
@@ -1,0 +1,11 @@
+UpdateComputeImageCapabilitySchemaDetails
+=========================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: UpdateComputeImageCapabilitySchemaDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.UpdateLaunchOptions.rst
+++ b/docs/api/core/models/oci.core.models.UpdateLaunchOptions.rst
@@ -1,0 +1,11 @@
+UpdateLaunchOptions
+===================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: UpdateLaunchOptions
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/showoci/CHANGELOG.rst
+++ b/examples/showoci/CHANGELOG.rst
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 =====================
+20.07.28 - 2020-07-28
+=====================
+* Added Autonomous database properties for standby database
+
+=====================
 20.07.21 - 2020-07-21
 =====================
 * Remove vcn_id from several network list options to boost the performance - list_dhcp_options, list_local_peering_gateways, list_route_tables, list_security_lists, list_subnets and list_internet_gateways

--- a/examples/showoci/showoci.py
+++ b/examples/showoci/showoci.py
@@ -86,7 +86,7 @@ import sys
 import argparse
 import datetime
 
-version = "20.07.21"
+version = "20.07.28"
 
 ##########################################################################
 # check OCI version

--- a/examples/showoci/showoci_data.py
+++ b/examples/showoci/showoci_data.py
@@ -1940,7 +1940,9 @@ class ShowOCIData(object):
             list_autos = self.service.search_multi_items(self.service.C_DATABASE, self.service.C_DATABASE_AUTONOMOUS, 'region_name', region_name, 'compartment_id', compartment['id'])
 
             for dbs in list_autos:
-                value = {'id': str(dbs['id']), 'name': str(dbs['db_name']) + " (" + (str(dbs['display_name']) + ") - " + str(dbs['license_model']) + " - " + str(dbs['lifecycle_state']) + " (" + str(dbs['sum_count']) + " OCPUs" + (" AutoScale" if dbs['is_auto_scaling_enabled'] else "") + ") - " + dbs['db_workload'] + " - " + dbs['db_type']),
+                freemsg = ",  FreeTier" if dbs['is_free_tier'] else ""
+                value = {'id': str(dbs['id']),
+                         'name': str(dbs['db_name']) + " (" + (str(dbs['display_name']) + ") - " + str(dbs['license_model']) + " - " + str(dbs['lifecycle_state']) + " (" + str(dbs['sum_count']) + " OCPUs" + (" AutoScale" if dbs['is_auto_scaling_enabled'] else "") + ") - " + dbs['db_workload'] + " - " + dbs['db_type'] + freemsg),
                          'display_name': dbs['display_name'],
                          'license_model': dbs['license_model'],
                          'lifecycle_state': dbs['lifecycle_state'],
@@ -1972,7 +1974,23 @@ class ShowOCIData(object):
                          'nsg_names': [],
                          'private_endpoint': dbs['private_endpoint'],
                          'private_endpoint_label': dbs['private_endpoint_label'],
-                         'defined_tags': dbs['defined_tags'], 'freeform_tags': dbs['freeform_tags']}
+                         'defined_tags': dbs['defined_tags'],
+                         'freeform_tags': dbs['freeform_tags'],
+                         'is_free_tier': dbs['is_free_tier'],
+                         'is_preview': dbs['is_preview'],
+                         'infrastructure_type': dbs['infrastructure_type'],
+                         'time_deletion_of_free_autonomous_database': dbs['time_deletion_of_free_autonomous_database'],
+                         'time_reclamation_of_free_autonomous_database': dbs['time_reclamation_of_free_autonomous_database'],
+                         'system_tags': dbs['system_tags'],
+                         'time_of_last_switchover': dbs['time_of_last_switchover'],
+                         'time_of_last_failover': dbs['time_of_last_failover'],
+                         'failed_data_recovery_in_seconds': dbs['failed_data_recovery_in_seconds'],
+                         'available_upgrade_versions': dbs['available_upgrade_versions'],
+                         'standby_lag_time_in_seconds': dbs['standby_lag_time_in_seconds'],
+                         'standby_lifecycle_state': dbs['standby_lifecycle_state'],
+                         'autonomous_container_database_id': dbs['autonomous_container_database_id'],
+                         'is_data_guard_enabled': dbs['is_data_guard_enabled']
+                         }
 
                 # subnet
                 if dbs['subnet_id'] != 'None':

--- a/examples/showoci/showoci_output.py
+++ b/examples/showoci/showoci_output.py
@@ -970,6 +970,8 @@ class ShowOCIOutput(object):
                     print(self.tabs + "DataSafe   : " + db['data_safe_status'])
                 if 'time_maintenance_begin' in db:
                     print(self.tabs + "Maintenance: " + db['time_maintenance_begin'][0:16] + " - " + db['time_maintenance_end'][0:16])
+                if db['is_data_guard_enabled']:
+                    print(self.tabs + "Data Guard : Lag In Second: " + db['standby_lag_time_in_seconds'] + ", lifecycle: " + db['standby_lifecycle_state'] + ",  Last Switch: " + db['time_of_last_switchover'][0:16] + ",  Last Failover: " + db['time_of_last_switchover'][0:16])
 
                 # print backups
                 if db['backups']:

--- a/examples/showoci/showoci_service.py
+++ b/examples/showoci/showoci_service.py
@@ -6223,8 +6223,27 @@ class ShowOCIService(object):
                              'nsg_ids': dbs.nsg_ids,
                              'private_endpoint': str(dbs.private_endpoint),
                              'private_endpoint_label': str(dbs.private_endpoint_label),
-                             'backups': []
+                             'backups': [],
+                             'autonomous_container_database_id': str(dbs.autonomous_container_database_id),
+                             'is_data_guard_enabled': dbs.is_data_guard_enabled,
+                             'is_free_tier': dbs.is_free_tier,
+                             'is_preview': dbs.is_preview,
+                             'infrastructure_type': str(dbs.infrastructure_type),
+                             'time_deletion_of_free_autonomous_database': str(dbs.time_deletion_of_free_autonomous_database),
+                             'time_reclamation_of_free_autonomous_database': str(dbs.time_reclamation_of_free_autonomous_database),
+                             'system_tags': dbs.system_tags,
+                             'time_of_last_switchover': str(dbs.time_of_last_switchover),
+                             'time_of_last_failover': str(dbs.time_of_last_failover),
+                             'failed_data_recovery_in_seconds': str(dbs.failed_data_recovery_in_seconds),
+                             'available_upgrade_versions': dbs.available_upgrade_versions,
+                             'standby_lag_time_in_seconds': "",
+                             'standby_lifecycle_state': ""
                              }
+
+                    # if standby object exist
+                    if dbs.standby_db:
+                        value['standby_lag_time_in_seconds'] = str(dbs.standby_db.lag_time_in_seconds)
+                        value['standby_lifecycle_state'] = str(dbs.standby_db.lifecycle_state)
 
                     # load bakcups
                     if not self.flags.skip_backups:

--- a/examples/usage_reports_to_adw/CHANGELOG.rst
+++ b/examples/usage_reports_to_adw/CHANGELOG.rst
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 =====================
+20.07.28 - 2020-07-28
+=====================
+* Added sleep 0.5 to the public API call to avoid too many requests error
+* Change Public Rate API to use one value only after OCI change costs
+
+=====================
 20.07.21 - 2020-07-21
 =====================
 * Added Full + Parallel scan when retrieving max cost and usage file

--- a/examples/usage_reports_to_adw/usage2adw.py
+++ b/examples/usage_reports_to_adw/usage2adw.py
@@ -67,9 +67,10 @@ import os
 import csv
 import cx_Oracle
 import requests
+import time
 
 
-version = "20.07.21"
+version = "20.07.28"
 usage_report_namespace = "bling"
 work_report_dir = os.curdir + "/work_report_dir"
 
@@ -568,13 +569,22 @@ def update_public_rates(connection, tenant_name):
             for row in rows:
 
                 rate_description = ""
-                rate_paygo_price = None
-                rate_monthly_flex_price = None
+                rate_price = None
+                resp = None
 
-                # Call API to fetch the data
-                cost_produdt_sku = str(row[0])
-                country_code = str(row[1])
-                resp = requests.get(api_url + cost_produdt_sku, headers={'X-Oracle-Accept-CurrencyCode': country_code})
+                #######################################
+                # Call API to fetch the SKU Data
+                #######################################
+                try:
+                    cost_product_sku = str(row[0])
+                    country_code = str(row[1])
+                    resp = requests.get(api_url + cost_product_sku, headers={'X-Oracle-Accept-CurrencyCode': country_code})
+                    time.sleep(0.5)
+
+                except Exception as e:
+                    print("\nWarning  Calling REST API for Public Rate at update_public_rates() - " + str(e))
+                    time.sleep(2)
+                    continue
 
                 if not resp:
                     continue
@@ -583,24 +593,22 @@ def update_public_rates(connection, tenant_name):
                     rate_description = item["displayName"]
                     for price in item['prices']:
                         if price['model'] == 'PAY_AS_YOU_GO':
-                            rate_paygo_price = price['value']
-                        elif price['model'] == 'MONTHLY_COMMIT':
-                            rate_monthly_flex_price = price['value']
+                            rate_price = price['value']
 
                 # update database
                 sql = "update OCI_PRICE_LIST set "
                 sql += "RATE_DESCRIPTION=:rate_description, "
-                sql += "RATE_PAYGO_PRICE=:rate_paygo, "
-                sql += "RATE_MONTHLY_FLEX_PRICE=:rate_monthly, "
+                sql += "RATE_PAYGO_PRICE=:rate_price, "
+                sql += "RATE_MONTHLY_FLEX_PRICE=:rate_price, "
                 sql += "RATE_UPDATE_DATE=sysdate "
-                sql += "where TENANT_NAME=:tenant_name and COST_PRODUCT_SKU=:cost_produdt_sku "
+                sql += "where TENANT_NAME=:tenant_name and COST_PRODUCT_SKU=:cost_product_sku "
 
+                # only apply paygo cost after 7/13 oracle change rate
                 sql_variables = {
                     "rate_description": rate_description,
-                    "rate_paygo": rate_paygo_price,
-                    "rate_monthly": rate_monthly_flex_price,
+                    "rate_price": rate_price,
                     "tenant_name": tenant_name,
-                    "cost_produdt_sku": cost_produdt_sku
+                    "cost_product_sku": cost_product_sku
                 }
 
                 cursor.execute(sql, sql_variables)

--- a/src/oci/core/compute_client.py
+++ b/src/oci/core/compute_client.py
@@ -457,6 +457,104 @@ class ComputeClient(object):
                 body=capture_console_history_details,
                 response_type="ConsoleHistory")
 
+    def change_compute_image_capability_schema_compartment(self, compute_image_capability_schema_id, change_compute_image_capability_schema_compartment_details, **kwargs):
+        """
+        Moves a compute image capability schema into a different compartment within the same tenancy.
+        For information about moving resources between compartments, see
+                `Moving Resources to a Different Compartment`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes
+
+
+        :param str compute_image_capability_schema_id: (required)
+            The id of the compute image capability schema or the image ocid
+
+        :param ChangeComputeImageCapabilitySchemaCompartmentDetails change_compute_image_capability_schema_compartment_details: (required)
+            Compute Image Capability Schema change compartment details
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/computeImageCapabilitySchemas/{computeImageCapabilitySchemaId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_compute_image_capability_schema_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "computeImageCapabilitySchemaId": compute_image_capability_schema_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_compute_image_capability_schema_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_compute_image_capability_schema_compartment_details)
+
     def change_dedicated_vm_host_compartment(self, dedicated_vm_host_id, change_dedicated_vm_host_compartment_details, **kwargs):
         """
         Moves a dedicated virtual machine host from one compartment to another.
@@ -820,6 +918,74 @@ class ComputeClient(object):
                 body=create_app_catalog_subscription_details,
                 response_type="AppCatalogSubscription")
 
+    def create_compute_image_capability_schema(self, create_compute_image_capability_schema_details, **kwargs):
+        """
+        Creates compute image capability schema.
+
+
+        :param CreateComputeImageCapabilitySchemaDetails create_compute_image_capability_schema_details: (required)
+            Compute Image Capability Schema creation details
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.ComputeImageCapabilitySchema`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/computeImageCapabilitySchemas"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_compute_image_capability_schema got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_compute_image_capability_schema_details,
+                response_type="ComputeImageCapabilitySchema")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_compute_image_capability_schema_details,
+                response_type="ComputeImageCapabilitySchema")
+
     def create_dedicated_vm_host(self, create_dedicated_vm_host_details, **kwargs):
         """
         Creates a new dedicated virtual machine host in the specified compartment and the specified availability domain.
@@ -1132,6 +1298,78 @@ class ComputeClient(object):
                 resource_path=resource_path,
                 method=method,
                 query_params=query_params,
+                header_params=header_params)
+
+    def delete_compute_image_capability_schema(self, compute_image_capability_schema_id, **kwargs):
+        """
+        Deletes the specified Compute Image Capability Schema
+
+
+        :param str compute_image_capability_schema_id: (required)
+            The id of the compute image capability schema or the image ocid
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/computeImageCapabilitySchemas/{computeImageCapabilitySchemaId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_compute_image_capability_schema got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "computeImageCapabilitySchemaId": compute_image_capability_schema_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
                 header_params=header_params)
 
     def delete_console_history(self, instance_console_history_id, **kwargs):
@@ -2024,6 +2262,217 @@ class ComputeClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 response_type="BootVolumeAttachment")
+
+    def get_compute_global_image_capability_schema(self, compute_global_image_capability_schema_id, **kwargs):
+        """
+        Gets the specified Compute Global Image Capability Schema
+
+
+        :param str compute_global_image_capability_schema_id: (required)
+            The `OCID`__ of the compute global image capability schema
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.ComputeGlobalImageCapabilitySchema`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/computeGlobalImageCapabilitySchemas/{computeGlobalImageCapabilitySchemaId}"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_compute_global_image_capability_schema got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "computeGlobalImageCapabilitySchemaId": compute_global_image_capability_schema_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ComputeGlobalImageCapabilitySchema")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ComputeGlobalImageCapabilitySchema")
+
+    def get_compute_global_image_capability_schema_version(self, compute_global_image_capability_schema_id, compute_global_image_capability_schema_version_name, **kwargs):
+        """
+        Gets the specified Compute Global Image Capability Schema Version
+
+
+        :param str compute_global_image_capability_schema_id: (required)
+            The `OCID`__ of the compute global image capability schema
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str compute_global_image_capability_schema_version_name: (required)
+            The name of the compute global image capability schema version
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.ComputeGlobalImageCapabilitySchemaVersion`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/computeGlobalImageCapabilitySchemas/{computeGlobalImageCapabilitySchemaId}/versions/{computeGlobalImageCapabilitySchemaVersionName}"
+        method = "GET"
+
+        expected_kwargs = ["retry_strategy"]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_compute_global_image_capability_schema_version got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "computeGlobalImageCapabilitySchemaId": compute_global_image_capability_schema_id,
+            "computeGlobalImageCapabilitySchemaVersionName": compute_global_image_capability_schema_version_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ComputeGlobalImageCapabilitySchemaVersion")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ComputeGlobalImageCapabilitySchemaVersion")
+
+    def get_compute_image_capability_schema(self, compute_image_capability_schema_id, **kwargs):
+        """
+        Gets the specified Compute Image Capability Schema
+
+
+        :param str compute_image_capability_schema_id: (required)
+            The id of the compute image capability schema or the image ocid
+
+        :param bool is_merge_enabled: (optional)
+            Merge the image capability schema with the global image capability schema
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.ComputeImageCapabilitySchema`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/computeImageCapabilitySchemas/{computeImageCapabilitySchemaId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "is_merge_enabled"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_compute_image_capability_schema got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "computeImageCapabilitySchemaId": compute_image_capability_schema_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "isMergeEnabled": kwargs.get("is_merge_enabled", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ComputeImageCapabilitySchema")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ComputeImageCapabilitySchema")
 
     def get_console_history(self, instance_console_history_id, **kwargs):
         """
@@ -3370,6 +3819,394 @@ class ComputeClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="list[BootVolumeAttachment]")
+
+    def list_compute_global_image_capability_schema_versions(self, compute_global_image_capability_schema_id, **kwargs):
+        """
+        Lists Compute Global Image Capability Schema versions in the specified compartment.
+
+
+        :param str compute_global_image_capability_schema_id: (required)
+            The `OCID`__ of the compute global image capability schema
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the given display name exactly.
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            Example: `50`
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+            call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+            TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+            sort order is case sensitive.
+
+            **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+            optionally filter by availability domain if the scope of the resource type is within a
+            single availability domain. If you call one of these \"List\" operations without specifying
+            an availability domain, the resources are grouped by availability domain, then sorted.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+            is case sensitive.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.core.models.ComputeGlobalImageCapabilitySchemaVersionSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/computeGlobalImageCapabilitySchemas/{computeGlobalImageCapabilitySchemaId}/versions"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_compute_global_image_capability_schema_versions got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "computeGlobalImageCapabilitySchemaId": compute_global_image_capability_schema_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        query_params = {
+            "displayName": kwargs.get("display_name", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ComputeGlobalImageCapabilitySchemaVersionSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ComputeGlobalImageCapabilitySchemaVersionSummary]")
+
+    def list_compute_global_image_capability_schemas(self, **kwargs):
+        """
+        Lists Compute Global Image Capability Schema in the specified compartment.
+
+
+        :param str compartment_id: (optional)
+            A filter to return only resources that match the given compartment OCID exactly.
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the given display name exactly.
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            Example: `50`
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+            call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+            TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+            sort order is case sensitive.
+
+            **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+            optionally filter by availability domain if the scope of the resource type is within a
+            single availability domain. If you call one of these \"List\" operations without specifying
+            an availability domain, the resources are grouped by availability domain, then sorted.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+            is case sensitive.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.core.models.ComputeGlobalImageCapabilitySchemaSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/computeGlobalImageCapabilitySchemas"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "compartment_id",
+            "display_name",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_compute_global_image_capability_schemas got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": kwargs.get("compartment_id", missing),
+            "displayName": kwargs.get("display_name", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ComputeGlobalImageCapabilitySchemaSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ComputeGlobalImageCapabilitySchemaSummary]")
+
+    def list_compute_image_capability_schemas(self, **kwargs):
+        """
+        Lists Compute Image Capability Schema in the specified compartment. You can also query by a specific imageId.
+
+
+        :param str compartment_id: (optional)
+            A filter to return only resources that match the given compartment OCID exactly.
+
+        :param str image_id: (optional)
+            The `OCID`__ of an image.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the given display name exactly.
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            Example: `50`
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+            call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+            TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+            sort order is case sensitive.
+
+            **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+            optionally filter by availability domain if the scope of the resource type is within a
+            single availability domain. If you call one of these \"List\" operations without specifying
+            an availability domain, the resources are grouped by availability domain, then sorted.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+            is case sensitive.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.core.models.ComputeImageCapabilitySchemaSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/computeImageCapabilitySchemas"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "compartment_id",
+            "image_id",
+            "display_name",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_compute_image_capability_schemas got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": kwargs.get("compartment_id", missing),
+            "imageId": kwargs.get("image_id", missing),
+            "displayName": kwargs.get("display_name", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json"
+        }
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ComputeImageCapabilitySchemaSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ComputeImageCapabilitySchemaSummary]")
 
     def list_console_histories(self, compartment_id, **kwargs):
         """
@@ -5141,6 +5978,85 @@ class ComputeClient(object):
                 path_params=path_params,
                 query_params=query_params,
                 header_params=header_params)
+
+    def update_compute_image_capability_schema(self, compute_image_capability_schema_id, update_compute_image_capability_schema_details, **kwargs):
+        """
+        Updates the specified Compute Image Capability Schema
+
+
+        :param str compute_image_capability_schema_id: (required)
+            The id of the compute image capability schema or the image ocid
+
+        :param UpdateComputeImageCapabilitySchemaDetails update_compute_image_capability_schema_details: (required)
+            Updates the freeFormTags, definedTags, and display name of the image capability schema
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.ComputeImageCapabilitySchema`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/computeImageCapabilitySchemas/{computeImageCapabilitySchemaId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_compute_image_capability_schema got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "computeImageCapabilitySchemaId": compute_image_capability_schema_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_compute_image_capability_schema_details,
+                response_type="ComputeImageCapabilitySchema")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_compute_image_capability_schema_details,
+                response_type="ComputeImageCapabilitySchema")
 
     def update_console_history(self, instance_console_history_id, update_console_history_details, **kwargs):
         """

--- a/src/oci/core/models/__init__.py
+++ b/src/oci/core/models/__init__.py
@@ -24,6 +24,7 @@ from .attach_service_determined_volume_details import AttachServiceDeterminedVol
 from .attach_vnic_details import AttachVnicDetails
 from .attach_volume_details import AttachVolumeDetails
 from .bgp_session_info import BgpSessionInfo
+from .boolean_image_capability_schema_descriptor import BooleanImageCapabilitySchemaDescriptor
 from .boot_volume import BootVolume
 from .boot_volume_attachment import BootVolumeAttachment
 from .boot_volume_backup import BootVolumeBackup
@@ -37,6 +38,7 @@ from .capture_console_history_details import CaptureConsoleHistoryDetails
 from .change_boot_volume_backup_compartment_details import ChangeBootVolumeBackupCompartmentDetails
 from .change_boot_volume_compartment_details import ChangeBootVolumeCompartmentDetails
 from .change_cluster_network_compartment_details import ChangeClusterNetworkCompartmentDetails
+from .change_compute_image_capability_schema_compartment_details import ChangeComputeImageCapabilitySchemaCompartmentDetails
 from .change_cpe_compartment_details import ChangeCpeCompartmentDetails
 from .change_cross_connect_compartment_details import ChangeCrossConnectCompartmentDetails
 from .change_cross_connect_group_compartment_details import ChangeCrossConnectGroupCompartmentDetails
@@ -68,6 +70,12 @@ from .change_volume_group_compartment_details import ChangeVolumeGroupCompartmen
 from .cluster_network import ClusterNetwork
 from .cluster_network_placement_configuration_details import ClusterNetworkPlacementConfigurationDetails
 from .cluster_network_summary import ClusterNetworkSummary
+from .compute_global_image_capability_schema import ComputeGlobalImageCapabilitySchema
+from .compute_global_image_capability_schema_summary import ComputeGlobalImageCapabilitySchemaSummary
+from .compute_global_image_capability_schema_version import ComputeGlobalImageCapabilitySchemaVersion
+from .compute_global_image_capability_schema_version_summary import ComputeGlobalImageCapabilitySchemaVersionSummary
+from .compute_image_capability_schema import ComputeImageCapabilitySchema
+from .compute_image_capability_schema_summary import ComputeImageCapabilitySchemaSummary
 from .compute_instance_details import ComputeInstanceDetails
 from .connect_local_peering_gateways_details import ConnectLocalPeeringGatewaysDetails
 from .connect_remote_peering_connections_details import ConnectRemotePeeringConnectionsDetails
@@ -85,6 +93,7 @@ from .create_boot_volume_backup_details import CreateBootVolumeBackupDetails
 from .create_boot_volume_details import CreateBootVolumeDetails
 from .create_cluster_network_details import CreateClusterNetworkDetails
 from .create_cluster_network_instance_pool_details import CreateClusterNetworkInstancePoolDetails
+from .create_compute_image_capability_schema_details import CreateComputeImageCapabilitySchemaDetails
 from .create_cpe_details import CreateCpeDetails
 from .create_cross_connect_details import CreateCrossConnectDetails
 from .create_cross_connect_group_details import CreateCrossConnectGroupDetails
@@ -148,6 +157,8 @@ from .drg_attachment import DrgAttachment
 from .drg_redundancy_status import DrgRedundancyStatus
 from .egress_security_rule import EgressSecurityRule
 from .emulated_volume_attachment import EmulatedVolumeAttachment
+from .enum_integer_image_capability_descriptor import EnumIntegerImageCapabilityDescriptor
+from .enum_string_image_capability_schema_descriptor import EnumStringImageCapabilitySchemaDescriptor
 from .export_image_details import ExportImageDetails
 from .export_image_via_object_storage_tuple_details import ExportImageViaObjectStorageTupleDetails
 from .export_image_via_object_storage_uri_details import ExportImageViaObjectStorageUriDetails
@@ -163,6 +174,7 @@ from .ip_sec_connection_tunnel_shared_secret import IPSecConnectionTunnelSharedS
 from .i_scsi_volume_attachment import IScsiVolumeAttachment
 from .icmp_options import IcmpOptions
 from .image import Image
+from .image_capability_schema_descriptor import ImageCapabilitySchemaDescriptor
 from .image_ocpu_constraints import ImageOcpuConstraints
 from .image_shape_compatibility_entry import ImageShapeCompatibilityEntry
 from .image_shape_compatibility_summary import ImageShapeCompatibilitySummary
@@ -247,6 +259,7 @@ from .update_boot_volume_backup_details import UpdateBootVolumeBackupDetails
 from .update_boot_volume_details import UpdateBootVolumeDetails
 from .update_boot_volume_kms_key_details import UpdateBootVolumeKmsKeyDetails
 from .update_cluster_network_details import UpdateClusterNetworkDetails
+from .update_compute_image_capability_schema_details import UpdateComputeImageCapabilitySchemaDetails
 from .update_console_history_details import UpdateConsoleHistoryDetails
 from .update_cpe_details import UpdateCpeDetails
 from .update_cross_connect_details import UpdateCrossConnectDetails
@@ -268,6 +281,7 @@ from .update_instance_pool_placement_configuration_details import UpdateInstance
 from .update_instance_shape_config_details import UpdateInstanceShapeConfigDetails
 from .update_internet_gateway_details import UpdateInternetGatewayDetails
 from .update_ipv6_details import UpdateIpv6Details
+from .update_launch_options import UpdateLaunchOptions
 from .update_local_peering_gateway_details import UpdateLocalPeeringGatewayDetails
 from .update_nat_gateway_details import UpdateNatGatewayDetails
 from .update_network_security_group_details import UpdateNetworkSecurityGroupDetails
@@ -338,6 +352,7 @@ core_type_mapping = {
     "AttachVnicDetails": AttachVnicDetails,
     "AttachVolumeDetails": AttachVolumeDetails,
     "BgpSessionInfo": BgpSessionInfo,
+    "BooleanImageCapabilitySchemaDescriptor": BooleanImageCapabilitySchemaDescriptor,
     "BootVolume": BootVolume,
     "BootVolumeAttachment": BootVolumeAttachment,
     "BootVolumeBackup": BootVolumeBackup,
@@ -351,6 +366,7 @@ core_type_mapping = {
     "ChangeBootVolumeBackupCompartmentDetails": ChangeBootVolumeBackupCompartmentDetails,
     "ChangeBootVolumeCompartmentDetails": ChangeBootVolumeCompartmentDetails,
     "ChangeClusterNetworkCompartmentDetails": ChangeClusterNetworkCompartmentDetails,
+    "ChangeComputeImageCapabilitySchemaCompartmentDetails": ChangeComputeImageCapabilitySchemaCompartmentDetails,
     "ChangeCpeCompartmentDetails": ChangeCpeCompartmentDetails,
     "ChangeCrossConnectCompartmentDetails": ChangeCrossConnectCompartmentDetails,
     "ChangeCrossConnectGroupCompartmentDetails": ChangeCrossConnectGroupCompartmentDetails,
@@ -382,6 +398,12 @@ core_type_mapping = {
     "ClusterNetwork": ClusterNetwork,
     "ClusterNetworkPlacementConfigurationDetails": ClusterNetworkPlacementConfigurationDetails,
     "ClusterNetworkSummary": ClusterNetworkSummary,
+    "ComputeGlobalImageCapabilitySchema": ComputeGlobalImageCapabilitySchema,
+    "ComputeGlobalImageCapabilitySchemaSummary": ComputeGlobalImageCapabilitySchemaSummary,
+    "ComputeGlobalImageCapabilitySchemaVersion": ComputeGlobalImageCapabilitySchemaVersion,
+    "ComputeGlobalImageCapabilitySchemaVersionSummary": ComputeGlobalImageCapabilitySchemaVersionSummary,
+    "ComputeImageCapabilitySchema": ComputeImageCapabilitySchema,
+    "ComputeImageCapabilitySchemaSummary": ComputeImageCapabilitySchemaSummary,
     "ComputeInstanceDetails": ComputeInstanceDetails,
     "ConnectLocalPeeringGatewaysDetails": ConnectLocalPeeringGatewaysDetails,
     "ConnectRemotePeeringConnectionsDetails": ConnectRemotePeeringConnectionsDetails,
@@ -399,6 +421,7 @@ core_type_mapping = {
     "CreateBootVolumeDetails": CreateBootVolumeDetails,
     "CreateClusterNetworkDetails": CreateClusterNetworkDetails,
     "CreateClusterNetworkInstancePoolDetails": CreateClusterNetworkInstancePoolDetails,
+    "CreateComputeImageCapabilitySchemaDetails": CreateComputeImageCapabilitySchemaDetails,
     "CreateCpeDetails": CreateCpeDetails,
     "CreateCrossConnectDetails": CreateCrossConnectDetails,
     "CreateCrossConnectGroupDetails": CreateCrossConnectGroupDetails,
@@ -462,6 +485,8 @@ core_type_mapping = {
     "DrgRedundancyStatus": DrgRedundancyStatus,
     "EgressSecurityRule": EgressSecurityRule,
     "EmulatedVolumeAttachment": EmulatedVolumeAttachment,
+    "EnumIntegerImageCapabilityDescriptor": EnumIntegerImageCapabilityDescriptor,
+    "EnumStringImageCapabilitySchemaDescriptor": EnumStringImageCapabilitySchemaDescriptor,
     "ExportImageDetails": ExportImageDetails,
     "ExportImageViaObjectStorageTupleDetails": ExportImageViaObjectStorageTupleDetails,
     "ExportImageViaObjectStorageUriDetails": ExportImageViaObjectStorageUriDetails,
@@ -477,6 +502,7 @@ core_type_mapping = {
     "IScsiVolumeAttachment": IScsiVolumeAttachment,
     "IcmpOptions": IcmpOptions,
     "Image": Image,
+    "ImageCapabilitySchemaDescriptor": ImageCapabilitySchemaDescriptor,
     "ImageOcpuConstraints": ImageOcpuConstraints,
     "ImageShapeCompatibilityEntry": ImageShapeCompatibilityEntry,
     "ImageShapeCompatibilitySummary": ImageShapeCompatibilitySummary,
@@ -561,6 +587,7 @@ core_type_mapping = {
     "UpdateBootVolumeDetails": UpdateBootVolumeDetails,
     "UpdateBootVolumeKmsKeyDetails": UpdateBootVolumeKmsKeyDetails,
     "UpdateClusterNetworkDetails": UpdateClusterNetworkDetails,
+    "UpdateComputeImageCapabilitySchemaDetails": UpdateComputeImageCapabilitySchemaDetails,
     "UpdateConsoleHistoryDetails": UpdateConsoleHistoryDetails,
     "UpdateCpeDetails": UpdateCpeDetails,
     "UpdateCrossConnectDetails": UpdateCrossConnectDetails,
@@ -582,6 +609,7 @@ core_type_mapping = {
     "UpdateInstanceShapeConfigDetails": UpdateInstanceShapeConfigDetails,
     "UpdateInternetGatewayDetails": UpdateInternetGatewayDetails,
     "UpdateIpv6Details": UpdateIpv6Details,
+    "UpdateLaunchOptions": UpdateLaunchOptions,
     "UpdateLocalPeeringGatewayDetails": UpdateLocalPeeringGatewayDetails,
     "UpdateNatGatewayDetails": UpdateNatGatewayDetails,
     "UpdateNetworkSecurityGroupDetails": UpdateNetworkSecurityGroupDetails,

--- a/src/oci/core/models/boolean_image_capability_schema_descriptor.py
+++ b/src/oci/core/models/boolean_image_capability_schema_descriptor.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .image_capability_schema_descriptor import ImageCapabilitySchemaDescriptor
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class BooleanImageCapabilitySchemaDescriptor(ImageCapabilitySchemaDescriptor):
+    """
+    Boolean type ImageCapabilitySchemaDescriptor
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new BooleanImageCapabilitySchemaDescriptor object with values from keyword arguments. The default value of the :py:attr:`~oci.core.models.BooleanImageCapabilitySchemaDescriptor.descriptor_type` attribute
+        of this class is ``boolean`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param descriptor_type:
+            The value to assign to the descriptor_type property of this BooleanImageCapabilitySchemaDescriptor.
+        :type descriptor_type: str
+
+        :param source:
+            The value to assign to the source property of this BooleanImageCapabilitySchemaDescriptor.
+            Allowed values for this property are: "GLOBAL", "IMAGE"
+        :type source: str
+
+        :param default_value:
+            The value to assign to the default_value property of this BooleanImageCapabilitySchemaDescriptor.
+        :type default_value: bool
+
+        """
+        self.swagger_types = {
+            'descriptor_type': 'str',
+            'source': 'str',
+            'default_value': 'bool'
+        }
+
+        self.attribute_map = {
+            'descriptor_type': 'descriptorType',
+            'source': 'source',
+            'default_value': 'defaultValue'
+        }
+
+        self._descriptor_type = None
+        self._source = None
+        self._default_value = None
+        self._descriptor_type = 'boolean'
+
+    @property
+    def default_value(self):
+        """
+        Gets the default_value of this BooleanImageCapabilitySchemaDescriptor.
+        the default value
+
+
+        :return: The default_value of this BooleanImageCapabilitySchemaDescriptor.
+        :rtype: bool
+        """
+        return self._default_value
+
+    @default_value.setter
+    def default_value(self, default_value):
+        """
+        Sets the default_value of this BooleanImageCapabilitySchemaDescriptor.
+        the default value
+
+
+        :param default_value: The default_value of this BooleanImageCapabilitySchemaDescriptor.
+        :type: bool
+        """
+        self._default_value = default_value
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/boot_volume.py
+++ b/src/oci/core/models/boot_volume.py
@@ -123,6 +123,14 @@ class BootVolume(object):
             The value to assign to the kms_key_id property of this BootVolume.
         :type kms_key_id: str
 
+        :param is_auto_tune_enabled:
+            The value to assign to the is_auto_tune_enabled property of this BootVolume.
+        :type is_auto_tune_enabled: bool
+
+        :param auto_tuned_vpus_per_gb:
+            The value to assign to the auto_tuned_vpus_per_gb property of this BootVolume.
+        :type auto_tuned_vpus_per_gb: int
+
         """
         self.swagger_types = {
             'availability_domain': 'str',
@@ -141,7 +149,9 @@ class BootVolume(object):
             'source_details': 'BootVolumeSourceDetails',
             'time_created': 'datetime',
             'volume_group_id': 'str',
-            'kms_key_id': 'str'
+            'kms_key_id': 'str',
+            'is_auto_tune_enabled': 'bool',
+            'auto_tuned_vpus_per_gb': 'int'
         }
 
         self.attribute_map = {
@@ -161,7 +171,9 @@ class BootVolume(object):
             'source_details': 'sourceDetails',
             'time_created': 'timeCreated',
             'volume_group_id': 'volumeGroupId',
-            'kms_key_id': 'kmsKeyId'
+            'kms_key_id': 'kmsKeyId',
+            'is_auto_tune_enabled': 'isAutoTuneEnabled',
+            'auto_tuned_vpus_per_gb': 'autoTunedVpusPerGB'
         }
 
         self._availability_domain = None
@@ -181,6 +193,8 @@ class BootVolume(object):
         self._time_created = None
         self._volume_group_id = None
         self._kms_key_id = None
+        self._is_auto_tune_enabled = None
+        self._auto_tuned_vpus_per_gb = None
 
     @property
     def availability_domain(self):
@@ -653,6 +667,54 @@ class BootVolume(object):
         :type: str
         """
         self._kms_key_id = kms_key_id
+
+    @property
+    def is_auto_tune_enabled(self):
+        """
+        Gets the is_auto_tune_enabled of this BootVolume.
+        Specifies whether the auto-tune performance is enabled for this boot volume.
+
+
+        :return: The is_auto_tune_enabled of this BootVolume.
+        :rtype: bool
+        """
+        return self._is_auto_tune_enabled
+
+    @is_auto_tune_enabled.setter
+    def is_auto_tune_enabled(self, is_auto_tune_enabled):
+        """
+        Sets the is_auto_tune_enabled of this BootVolume.
+        Specifies whether the auto-tune performance is enabled for this boot volume.
+
+
+        :param is_auto_tune_enabled: The is_auto_tune_enabled of this BootVolume.
+        :type: bool
+        """
+        self._is_auto_tune_enabled = is_auto_tune_enabled
+
+    @property
+    def auto_tuned_vpus_per_gb(self):
+        """
+        Gets the auto_tuned_vpus_per_gb of this BootVolume.
+        The number of Volume Performance Units per GB that this boot volume is effectively tuned to when it's idle.
+
+
+        :return: The auto_tuned_vpus_per_gb of this BootVolume.
+        :rtype: int
+        """
+        return self._auto_tuned_vpus_per_gb
+
+    @auto_tuned_vpus_per_gb.setter
+    def auto_tuned_vpus_per_gb(self, auto_tuned_vpus_per_gb):
+        """
+        Sets the auto_tuned_vpus_per_gb of this BootVolume.
+        The number of Volume Performance Units per GB that this boot volume is effectively tuned to when it's idle.
+
+
+        :param auto_tuned_vpus_per_gb: The auto_tuned_vpus_per_gb of this BootVolume.
+        :type: int
+        """
+        self._auto_tuned_vpus_per_gb = auto_tuned_vpus_per_gb
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/change_compute_image_capability_schema_compartment_details.py
+++ b/src/oci/core/models/change_compute_image_capability_schema_compartment_details.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeComputeImageCapabilitySchemaCompartmentDetails(object):
+    """
+    The configuration details for the move operation.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeComputeImageCapabilitySchemaCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeComputeImageCapabilitySchemaCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeComputeImageCapabilitySchemaCompartmentDetails.
+        The `OCID`__ of the compartment to
+        move the instance configuration to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeComputeImageCapabilitySchemaCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeComputeImageCapabilitySchemaCompartmentDetails.
+        The `OCID`__ of the compartment to
+        move the instance configuration to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeComputeImageCapabilitySchemaCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/compute_global_image_capability_schema.py
+++ b/src/oci/core/models/compute_global_image_capability_schema.py
@@ -1,0 +1,290 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ComputeGlobalImageCapabilitySchema(object):
+    """
+    Compute Global Image Capability Schema is a container for a set of compute global image capability schema versions
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ComputeGlobalImageCapabilitySchema object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this ComputeGlobalImageCapabilitySchema.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ComputeGlobalImageCapabilitySchema.
+        :type compartment_id: str
+
+        :param current_version_name:
+            The value to assign to the current_version_name property of this ComputeGlobalImageCapabilitySchema.
+        :type current_version_name: str
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ComputeGlobalImageCapabilitySchema.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this ComputeGlobalImageCapabilitySchema.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ComputeGlobalImageCapabilitySchema.
+        :type freeform_tags: dict(str, str)
+
+        :param time_created:
+            The value to assign to the time_created property of this ComputeGlobalImageCapabilitySchema.
+        :type time_created: datetime
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'current_version_name': 'str',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'time_created': 'datetime'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'current_version_name': 'currentVersionName',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'time_created': 'timeCreated'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._current_version_name = None
+        self._defined_tags = None
+        self._display_name = None
+        self._freeform_tags = None
+        self._time_created = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ComputeGlobalImageCapabilitySchema.
+        The `OCID`__ of the compute global image capability schema
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ComputeGlobalImageCapabilitySchema.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ComputeGlobalImageCapabilitySchema.
+        The `OCID`__ of the compute global image capability schema
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ComputeGlobalImageCapabilitySchema.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this ComputeGlobalImageCapabilitySchema.
+        The OCID of the compartment that contains the resource.
+
+
+        :return: The compartment_id of this ComputeGlobalImageCapabilitySchema.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ComputeGlobalImageCapabilitySchema.
+        The OCID of the compartment that contains the resource.
+
+
+        :param compartment_id: The compartment_id of this ComputeGlobalImageCapabilitySchema.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def current_version_name(self):
+        """
+        Gets the current_version_name of this ComputeGlobalImageCapabilitySchema.
+        The name of the global capabilities version resource that is considered the current version.
+
+
+        :return: The current_version_name of this ComputeGlobalImageCapabilitySchema.
+        :rtype: str
+        """
+        return self._current_version_name
+
+    @current_version_name.setter
+    def current_version_name(self, current_version_name):
+        """
+        Sets the current_version_name of this ComputeGlobalImageCapabilitySchema.
+        The name of the global capabilities version resource that is considered the current version.
+
+
+        :param current_version_name: The current_version_name of this ComputeGlobalImageCapabilitySchema.
+        :type: str
+        """
+        self._current_version_name = current_version_name
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ComputeGlobalImageCapabilitySchema.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ComputeGlobalImageCapabilitySchema.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ComputeGlobalImageCapabilitySchema.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ComputeGlobalImageCapabilitySchema.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ComputeGlobalImageCapabilitySchema.
+        A user-friendly name for the compute global image capability schema
+
+
+        :return: The display_name of this ComputeGlobalImageCapabilitySchema.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ComputeGlobalImageCapabilitySchema.
+        A user-friendly name for the compute global image capability schema
+
+
+        :param display_name: The display_name of this ComputeGlobalImageCapabilitySchema.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ComputeGlobalImageCapabilitySchema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ComputeGlobalImageCapabilitySchema.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ComputeGlobalImageCapabilitySchema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ComputeGlobalImageCapabilitySchema.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ComputeGlobalImageCapabilitySchema.
+        The date and time the compute global image capability schema was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this ComputeGlobalImageCapabilitySchema.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ComputeGlobalImageCapabilitySchema.
+        The date and time the compute global image capability schema was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this ComputeGlobalImageCapabilitySchema.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/compute_global_image_capability_schema_summary.py
+++ b/src/oci/core/models/compute_global_image_capability_schema_summary.py
@@ -1,0 +1,290 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ComputeGlobalImageCapabilitySchemaSummary(object):
+    """
+    Summary information for a compute global image capability schema
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ComputeGlobalImageCapabilitySchemaSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type compartment_id: str
+
+        :param current_version_name:
+            The value to assign to the current_version_name property of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type current_version_name: str
+
+        :param display_name:
+            The value to assign to the display_name property of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type display_name: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type time_created: datetime
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type freeform_tags: dict(str, str)
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'current_version_name': 'str',
+            'display_name': 'str',
+            'time_created': 'datetime',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'freeform_tags': 'dict(str, str)'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'current_version_name': 'currentVersionName',
+            'display_name': 'displayName',
+            'time_created': 'timeCreated',
+            'defined_tags': 'definedTags',
+            'freeform_tags': 'freeformTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._current_version_name = None
+        self._display_name = None
+        self._time_created = None
+        self._defined_tags = None
+        self._freeform_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ComputeGlobalImageCapabilitySchemaSummary.
+        The compute global image capability schema `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ComputeGlobalImageCapabilitySchemaSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ComputeGlobalImageCapabilitySchemaSummary.
+        The compute global image capability schema `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this ComputeGlobalImageCapabilitySchemaSummary.
+        The OCID of the compartment containing the compute global image capability schema
+
+
+        :return: The compartment_id of this ComputeGlobalImageCapabilitySchemaSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ComputeGlobalImageCapabilitySchemaSummary.
+        The OCID of the compartment containing the compute global image capability schema
+
+
+        :param compartment_id: The compartment_id of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def current_version_name(self):
+        """
+        Gets the current_version_name of this ComputeGlobalImageCapabilitySchemaSummary.
+        The name of the global capabilities version resource that is considered the current version.
+
+
+        :return: The current_version_name of this ComputeGlobalImageCapabilitySchemaSummary.
+        :rtype: str
+        """
+        return self._current_version_name
+
+    @current_version_name.setter
+    def current_version_name(self, current_version_name):
+        """
+        Sets the current_version_name of this ComputeGlobalImageCapabilitySchemaSummary.
+        The name of the global capabilities version resource that is considered the current version.
+
+
+        :param current_version_name: The current_version_name of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type: str
+        """
+        self._current_version_name = current_version_name
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ComputeGlobalImageCapabilitySchemaSummary.
+        A user-friendly name for the compute global image capability schema.
+
+
+        :return: The display_name of this ComputeGlobalImageCapabilitySchemaSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ComputeGlobalImageCapabilitySchemaSummary.
+        A user-friendly name for the compute global image capability schema.
+
+
+        :param display_name: The display_name of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ComputeGlobalImageCapabilitySchemaSummary.
+        The date and time the compute global image capability schema was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this ComputeGlobalImageCapabilitySchemaSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ComputeGlobalImageCapabilitySchemaSummary.
+        The date and time the compute global image capability schema was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ComputeGlobalImageCapabilitySchemaSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ComputeGlobalImageCapabilitySchemaSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ComputeGlobalImageCapabilitySchemaSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ComputeGlobalImageCapabilitySchemaSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ComputeGlobalImageCapabilitySchemaSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ComputeGlobalImageCapabilitySchemaSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ComputeGlobalImageCapabilitySchemaSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/compute_global_image_capability_schema_version.py
+++ b/src/oci/core/models/compute_global_image_capability_schema_version.py
@@ -1,0 +1,204 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ComputeGlobalImageCapabilitySchemaVersion(object):
+    """
+    Compute Global Image Capability Schema Version is a set of all possible capabilities for a collection of images.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ComputeGlobalImageCapabilitySchemaVersion object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this ComputeGlobalImageCapabilitySchemaVersion.
+        :type name: str
+
+        :param compute_global_image_capability_schema_id:
+            The value to assign to the compute_global_image_capability_schema_id property of this ComputeGlobalImageCapabilitySchemaVersion.
+        :type compute_global_image_capability_schema_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this ComputeGlobalImageCapabilitySchemaVersion.
+        :type display_name: str
+
+        :param schema_data:
+            The value to assign to the schema_data property of this ComputeGlobalImageCapabilitySchemaVersion.
+        :type schema_data: dict(str, ImageCapabilitySchemaDescriptor)
+
+        :param time_created:
+            The value to assign to the time_created property of this ComputeGlobalImageCapabilitySchemaVersion.
+        :type time_created: datetime
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'compute_global_image_capability_schema_id': 'str',
+            'display_name': 'str',
+            'schema_data': 'dict(str, ImageCapabilitySchemaDescriptor)',
+            'time_created': 'datetime'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'compute_global_image_capability_schema_id': 'computeGlobalImageCapabilitySchemaId',
+            'display_name': 'displayName',
+            'schema_data': 'schemaData',
+            'time_created': 'timeCreated'
+        }
+
+        self._name = None
+        self._compute_global_image_capability_schema_id = None
+        self._display_name = None
+        self._schema_data = None
+        self._time_created = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this ComputeGlobalImageCapabilitySchemaVersion.
+        The name of the compute global image capability schema version
+
+
+        :return: The name of this ComputeGlobalImageCapabilitySchemaVersion.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this ComputeGlobalImageCapabilitySchemaVersion.
+        The name of the compute global image capability schema version
+
+
+        :param name: The name of this ComputeGlobalImageCapabilitySchemaVersion.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def compute_global_image_capability_schema_id(self):
+        """
+        **[Required]** Gets the compute_global_image_capability_schema_id of this ComputeGlobalImageCapabilitySchemaVersion.
+        The ocid of the compute global image capability schema
+
+
+        :return: The compute_global_image_capability_schema_id of this ComputeGlobalImageCapabilitySchemaVersion.
+        :rtype: str
+        """
+        return self._compute_global_image_capability_schema_id
+
+    @compute_global_image_capability_schema_id.setter
+    def compute_global_image_capability_schema_id(self, compute_global_image_capability_schema_id):
+        """
+        Sets the compute_global_image_capability_schema_id of this ComputeGlobalImageCapabilitySchemaVersion.
+        The ocid of the compute global image capability schema
+
+
+        :param compute_global_image_capability_schema_id: The compute_global_image_capability_schema_id of this ComputeGlobalImageCapabilitySchemaVersion.
+        :type: str
+        """
+        self._compute_global_image_capability_schema_id = compute_global_image_capability_schema_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ComputeGlobalImageCapabilitySchemaVersion.
+        A user-friendly name for the compute global image capability schema
+
+
+        :return: The display_name of this ComputeGlobalImageCapabilitySchemaVersion.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ComputeGlobalImageCapabilitySchemaVersion.
+        A user-friendly name for the compute global image capability schema
+
+
+        :param display_name: The display_name of this ComputeGlobalImageCapabilitySchemaVersion.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def schema_data(self):
+        """
+        **[Required]** Gets the schema_data of this ComputeGlobalImageCapabilitySchemaVersion.
+        The map of each capability name to its ImageCapabilityDescriptor.
+
+
+        :return: The schema_data of this ComputeGlobalImageCapabilitySchemaVersion.
+        :rtype: dict(str, ImageCapabilitySchemaDescriptor)
+        """
+        return self._schema_data
+
+    @schema_data.setter
+    def schema_data(self, schema_data):
+        """
+        Sets the schema_data of this ComputeGlobalImageCapabilitySchemaVersion.
+        The map of each capability name to its ImageCapabilityDescriptor.
+
+
+        :param schema_data: The schema_data of this ComputeGlobalImageCapabilitySchemaVersion.
+        :type: dict(str, ImageCapabilitySchemaDescriptor)
+        """
+        self._schema_data = schema_data
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ComputeGlobalImageCapabilitySchemaVersion.
+        The date and time the compute global image capability schema version was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this ComputeGlobalImageCapabilitySchemaVersion.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ComputeGlobalImageCapabilitySchemaVersion.
+        The date and time the compute global image capability schema version was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this ComputeGlobalImageCapabilitySchemaVersion.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/compute_global_image_capability_schema_version_summary.py
+++ b/src/oci/core/models/compute_global_image_capability_schema_version_summary.py
@@ -1,0 +1,171 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ComputeGlobalImageCapabilitySchemaVersionSummary(object):
+    """
+    Summary information for a compute global image capability schema
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ComputeGlobalImageCapabilitySchemaVersionSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        :type name: str
+
+        :param compute_global_image_capability_schema_id:
+            The value to assign to the compute_global_image_capability_schema_id property of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        :type compute_global_image_capability_schema_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        :type display_name: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        :type time_created: datetime
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'compute_global_image_capability_schema_id': 'str',
+            'display_name': 'str',
+            'time_created': 'datetime'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'compute_global_image_capability_schema_id': 'computeGlobalImageCapabilitySchemaId',
+            'display_name': 'displayName',
+            'time_created': 'timeCreated'
+        }
+
+        self._name = None
+        self._compute_global_image_capability_schema_id = None
+        self._display_name = None
+        self._time_created = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        The compute global image capability schema version name
+
+
+        :return: The name of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        The compute global image capability schema version name
+
+
+        :param name: The name of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def compute_global_image_capability_schema_id(self):
+        """
+        **[Required]** Gets the compute_global_image_capability_schema_id of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        The OCID of the compute global image capability schema
+
+
+        :return: The compute_global_image_capability_schema_id of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        :rtype: str
+        """
+        return self._compute_global_image_capability_schema_id
+
+    @compute_global_image_capability_schema_id.setter
+    def compute_global_image_capability_schema_id(self, compute_global_image_capability_schema_id):
+        """
+        Sets the compute_global_image_capability_schema_id of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        The OCID of the compute global image capability schema
+
+
+        :param compute_global_image_capability_schema_id: The compute_global_image_capability_schema_id of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        :type: str
+        """
+        self._compute_global_image_capability_schema_id = compute_global_image_capability_schema_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        The display name of the version
+
+
+        :return: The display_name of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        The display name of the version
+
+
+        :param display_name: The display_name of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        The date and time the compute global image capability schema version was created, in the format defined by `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        The date and time the compute global image capability schema version was created, in the format defined by `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this ComputeGlobalImageCapabilitySchemaVersionSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/compute_image_capability_schema.py
+++ b/src/oci/core/models/compute_image_capability_schema.py
@@ -1,0 +1,380 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ComputeImageCapabilitySchema(object):
+    """
+    Compute Image Capability Schema is a set of capabilities that filter the compute global capability schema
+    version for an image.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ComputeImageCapabilitySchema object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this ComputeImageCapabilitySchema.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ComputeImageCapabilitySchema.
+        :type compartment_id: str
+
+        :param compute_global_image_capability_schema_id:
+            The value to assign to the compute_global_image_capability_schema_id property of this ComputeImageCapabilitySchema.
+        :type compute_global_image_capability_schema_id: str
+
+        :param compute_global_image_capability_schema_version_name:
+            The value to assign to the compute_global_image_capability_schema_version_name property of this ComputeImageCapabilitySchema.
+        :type compute_global_image_capability_schema_version_name: str
+
+        :param image_id:
+            The value to assign to the image_id property of this ComputeImageCapabilitySchema.
+        :type image_id: str
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ComputeImageCapabilitySchema.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this ComputeImageCapabilitySchema.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ComputeImageCapabilitySchema.
+        :type freeform_tags: dict(str, str)
+
+        :param schema_data:
+            The value to assign to the schema_data property of this ComputeImageCapabilitySchema.
+        :type schema_data: dict(str, ImageCapabilitySchemaDescriptor)
+
+        :param time_created:
+            The value to assign to the time_created property of this ComputeImageCapabilitySchema.
+        :type time_created: datetime
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'compute_global_image_capability_schema_id': 'str',
+            'compute_global_image_capability_schema_version_name': 'str',
+            'image_id': 'str',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'schema_data': 'dict(str, ImageCapabilitySchemaDescriptor)',
+            'time_created': 'datetime'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'compute_global_image_capability_schema_id': 'computeGlobalImageCapabilitySchemaId',
+            'compute_global_image_capability_schema_version_name': 'computeGlobalImageCapabilitySchemaVersionName',
+            'image_id': 'imageId',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'schema_data': 'schemaData',
+            'time_created': 'timeCreated'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._compute_global_image_capability_schema_id = None
+        self._compute_global_image_capability_schema_version_name = None
+        self._image_id = None
+        self._defined_tags = None
+        self._display_name = None
+        self._freeform_tags = None
+        self._schema_data = None
+        self._time_created = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ComputeImageCapabilitySchema.
+        The id of the compute global image capability schema version
+
+
+        :return: The id of this ComputeImageCapabilitySchema.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ComputeImageCapabilitySchema.
+        The id of the compute global image capability schema version
+
+
+        :param id: The id of this ComputeImageCapabilitySchema.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this ComputeImageCapabilitySchema.
+        The OCID of the compartment that contains the resource.
+
+
+        :return: The compartment_id of this ComputeImageCapabilitySchema.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ComputeImageCapabilitySchema.
+        The OCID of the compartment that contains the resource.
+
+
+        :param compartment_id: The compartment_id of this ComputeImageCapabilitySchema.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def compute_global_image_capability_schema_id(self):
+        """
+        **[Required]** Gets the compute_global_image_capability_schema_id of this ComputeImageCapabilitySchema.
+        The ocid of the compute global image capability schema
+
+
+        :return: The compute_global_image_capability_schema_id of this ComputeImageCapabilitySchema.
+        :rtype: str
+        """
+        return self._compute_global_image_capability_schema_id
+
+    @compute_global_image_capability_schema_id.setter
+    def compute_global_image_capability_schema_id(self, compute_global_image_capability_schema_id):
+        """
+        Sets the compute_global_image_capability_schema_id of this ComputeImageCapabilitySchema.
+        The ocid of the compute global image capability schema
+
+
+        :param compute_global_image_capability_schema_id: The compute_global_image_capability_schema_id of this ComputeImageCapabilitySchema.
+        :type: str
+        """
+        self._compute_global_image_capability_schema_id = compute_global_image_capability_schema_id
+
+    @property
+    def compute_global_image_capability_schema_version_name(self):
+        """
+        **[Required]** Gets the compute_global_image_capability_schema_version_name of this ComputeImageCapabilitySchema.
+        The name of the compute global image capability schema version
+
+
+        :return: The compute_global_image_capability_schema_version_name of this ComputeImageCapabilitySchema.
+        :rtype: str
+        """
+        return self._compute_global_image_capability_schema_version_name
+
+    @compute_global_image_capability_schema_version_name.setter
+    def compute_global_image_capability_schema_version_name(self, compute_global_image_capability_schema_version_name):
+        """
+        Sets the compute_global_image_capability_schema_version_name of this ComputeImageCapabilitySchema.
+        The name of the compute global image capability schema version
+
+
+        :param compute_global_image_capability_schema_version_name: The compute_global_image_capability_schema_version_name of this ComputeImageCapabilitySchema.
+        :type: str
+        """
+        self._compute_global_image_capability_schema_version_name = compute_global_image_capability_schema_version_name
+
+    @property
+    def image_id(self):
+        """
+        **[Required]** Gets the image_id of this ComputeImageCapabilitySchema.
+        The OCID of the image associated with this compute image capability schema
+
+
+        :return: The image_id of this ComputeImageCapabilitySchema.
+        :rtype: str
+        """
+        return self._image_id
+
+    @image_id.setter
+    def image_id(self, image_id):
+        """
+        Sets the image_id of this ComputeImageCapabilitySchema.
+        The OCID of the image associated with this compute image capability schema
+
+
+        :param image_id: The image_id of this ComputeImageCapabilitySchema.
+        :type: str
+        """
+        self._image_id = image_id
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ComputeImageCapabilitySchema.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ComputeImageCapabilitySchema.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ComputeImageCapabilitySchema.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ComputeImageCapabilitySchema.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ComputeImageCapabilitySchema.
+        A user-friendly name for the compute global image capability schema
+
+
+        :return: The display_name of this ComputeImageCapabilitySchema.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ComputeImageCapabilitySchema.
+        A user-friendly name for the compute global image capability schema
+
+
+        :param display_name: The display_name of this ComputeImageCapabilitySchema.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ComputeImageCapabilitySchema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ComputeImageCapabilitySchema.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ComputeImageCapabilitySchema.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ComputeImageCapabilitySchema.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def schema_data(self):
+        """
+        **[Required]** Gets the schema_data of this ComputeImageCapabilitySchema.
+        The map of each capability name to its ImageCapabilityDescriptor.
+
+
+        :return: The schema_data of this ComputeImageCapabilitySchema.
+        :rtype: dict(str, ImageCapabilitySchemaDescriptor)
+        """
+        return self._schema_data
+
+    @schema_data.setter
+    def schema_data(self, schema_data):
+        """
+        Sets the schema_data of this ComputeImageCapabilitySchema.
+        The map of each capability name to its ImageCapabilityDescriptor.
+
+
+        :param schema_data: The schema_data of this ComputeImageCapabilitySchema.
+        :type: dict(str, ImageCapabilitySchemaDescriptor)
+        """
+        self._schema_data = schema_data
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ComputeImageCapabilitySchema.
+        The date and time the compute image capability schema was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this ComputeImageCapabilitySchema.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ComputeImageCapabilitySchema.
+        The date and time the compute image capability schema was created, in the format defined by
+        `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this ComputeImageCapabilitySchema.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/compute_image_capability_schema_summary.py
+++ b/src/oci/core/models/compute_image_capability_schema_summary.py
@@ -1,0 +1,319 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ComputeImageCapabilitySchemaSummary(object):
+    """
+    Summary information for a compute image capability schema
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ComputeImageCapabilitySchemaSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this ComputeImageCapabilitySchemaSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ComputeImageCapabilitySchemaSummary.
+        :type compartment_id: str
+
+        :param compute_global_image_capability_schema_version_name:
+            The value to assign to the compute_global_image_capability_schema_version_name property of this ComputeImageCapabilitySchemaSummary.
+        :type compute_global_image_capability_schema_version_name: str
+
+        :param image_id:
+            The value to assign to the image_id property of this ComputeImageCapabilitySchemaSummary.
+        :type image_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this ComputeImageCapabilitySchemaSummary.
+        :type display_name: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ComputeImageCapabilitySchemaSummary.
+        :type time_created: datetime
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ComputeImageCapabilitySchemaSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ComputeImageCapabilitySchemaSummary.
+        :type freeform_tags: dict(str, str)
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'compute_global_image_capability_schema_version_name': 'str',
+            'image_id': 'str',
+            'display_name': 'str',
+            'time_created': 'datetime',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'freeform_tags': 'dict(str, str)'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'compute_global_image_capability_schema_version_name': 'computeGlobalImageCapabilitySchemaVersionName',
+            'image_id': 'imageId',
+            'display_name': 'displayName',
+            'time_created': 'timeCreated',
+            'defined_tags': 'definedTags',
+            'freeform_tags': 'freeformTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._compute_global_image_capability_schema_version_name = None
+        self._image_id = None
+        self._display_name = None
+        self._time_created = None
+        self._defined_tags = None
+        self._freeform_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ComputeImageCapabilitySchemaSummary.
+        The compute image capability schema `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ComputeImageCapabilitySchemaSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ComputeImageCapabilitySchemaSummary.
+        The compute image capability schema `OCID`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ComputeImageCapabilitySchemaSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this ComputeImageCapabilitySchemaSummary.
+        The OCID of the compartment containing the compute global image capability schema
+
+
+        :return: The compartment_id of this ComputeImageCapabilitySchemaSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ComputeImageCapabilitySchemaSummary.
+        The OCID of the compartment containing the compute global image capability schema
+
+
+        :param compartment_id: The compartment_id of this ComputeImageCapabilitySchemaSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def compute_global_image_capability_schema_version_name(self):
+        """
+        **[Required]** Gets the compute_global_image_capability_schema_version_name of this ComputeImageCapabilitySchemaSummary.
+        The name of the compute global image capability schema version
+
+
+        :return: The compute_global_image_capability_schema_version_name of this ComputeImageCapabilitySchemaSummary.
+        :rtype: str
+        """
+        return self._compute_global_image_capability_schema_version_name
+
+    @compute_global_image_capability_schema_version_name.setter
+    def compute_global_image_capability_schema_version_name(self, compute_global_image_capability_schema_version_name):
+        """
+        Sets the compute_global_image_capability_schema_version_name of this ComputeImageCapabilitySchemaSummary.
+        The name of the compute global image capability schema version
+
+
+        :param compute_global_image_capability_schema_version_name: The compute_global_image_capability_schema_version_name of this ComputeImageCapabilitySchemaSummary.
+        :type: str
+        """
+        self._compute_global_image_capability_schema_version_name = compute_global_image_capability_schema_version_name
+
+    @property
+    def image_id(self):
+        """
+        **[Required]** Gets the image_id of this ComputeImageCapabilitySchemaSummary.
+        The OCID of the image associated with this compute image capability schema
+
+
+        :return: The image_id of this ComputeImageCapabilitySchemaSummary.
+        :rtype: str
+        """
+        return self._image_id
+
+    @image_id.setter
+    def image_id(self, image_id):
+        """
+        Sets the image_id of this ComputeImageCapabilitySchemaSummary.
+        The OCID of the image associated with this compute image capability schema
+
+
+        :param image_id: The image_id of this ComputeImageCapabilitySchemaSummary.
+        :type: str
+        """
+        self._image_id = image_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ComputeImageCapabilitySchemaSummary.
+        A user-friendly name for the compute image capability schema.
+
+
+        :return: The display_name of this ComputeImageCapabilitySchemaSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ComputeImageCapabilitySchemaSummary.
+        A user-friendly name for the compute image capability schema.
+
+
+        :param display_name: The display_name of this ComputeImageCapabilitySchemaSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ComputeImageCapabilitySchemaSummary.
+        The date and time the compute image capability schema was created, in the format defined by `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this ComputeImageCapabilitySchemaSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ComputeImageCapabilitySchemaSummary.
+        The date and time the compute image capability schema was created, in the format defined by `RFC3339`__.
+
+        Example: `2016-08-25T21:10:29.600Z`
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this ComputeImageCapabilitySchemaSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ComputeImageCapabilitySchemaSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ComputeImageCapabilitySchemaSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ComputeImageCapabilitySchemaSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ComputeImageCapabilitySchemaSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ComputeImageCapabilitySchemaSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ComputeImageCapabilitySchemaSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ComputeImageCapabilitySchemaSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ComputeImageCapabilitySchemaSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/create_boot_volume_details.py
+++ b/src/oci/core/models/create_boot_volume_details.py
@@ -58,6 +58,10 @@ class CreateBootVolumeDetails(object):
             The value to assign to the source_details property of this CreateBootVolumeDetails.
         :type source_details: BootVolumeSourceDetails
 
+        :param is_auto_tune_enabled:
+            The value to assign to the is_auto_tune_enabled property of this CreateBootVolumeDetails.
+        :type is_auto_tune_enabled: bool
+
         """
         self.swagger_types = {
             'availability_domain': 'str',
@@ -69,7 +73,8 @@ class CreateBootVolumeDetails(object):
             'kms_key_id': 'str',
             'size_in_gbs': 'int',
             'vpus_per_gb': 'int',
-            'source_details': 'BootVolumeSourceDetails'
+            'source_details': 'BootVolumeSourceDetails',
+            'is_auto_tune_enabled': 'bool'
         }
 
         self.attribute_map = {
@@ -82,7 +87,8 @@ class CreateBootVolumeDetails(object):
             'kms_key_id': 'kmsKeyId',
             'size_in_gbs': 'sizeInGBs',
             'vpus_per_gb': 'vpusPerGB',
-            'source_details': 'sourceDetails'
+            'source_details': 'sourceDetails',
+            'is_auto_tune_enabled': 'isAutoTuneEnabled'
         }
 
         self._availability_domain = None
@@ -95,6 +101,7 @@ class CreateBootVolumeDetails(object):
         self._size_in_gbs = None
         self._vpus_per_gb = None
         self._source_details = None
+        self._is_auto_tune_enabled = None
 
     @property
     def availability_domain(self):
@@ -387,6 +394,30 @@ class CreateBootVolumeDetails(object):
         :type: BootVolumeSourceDetails
         """
         self._source_details = source_details
+
+    @property
+    def is_auto_tune_enabled(self):
+        """
+        Gets the is_auto_tune_enabled of this CreateBootVolumeDetails.
+        Specifies whether the auto-tune performance is enabled for this boot volume.
+
+
+        :return: The is_auto_tune_enabled of this CreateBootVolumeDetails.
+        :rtype: bool
+        """
+        return self._is_auto_tune_enabled
+
+    @is_auto_tune_enabled.setter
+    def is_auto_tune_enabled(self, is_auto_tune_enabled):
+        """
+        Sets the is_auto_tune_enabled of this CreateBootVolumeDetails.
+        Specifies whether the auto-tune performance is enabled for this boot volume.
+
+
+        :param is_auto_tune_enabled: The is_auto_tune_enabled of this CreateBootVolumeDetails.
+        :type: bool
+        """
+        self._is_auto_tune_enabled = is_auto_tune_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/create_compute_image_capability_schema_details.py
+++ b/src/oci/core/models/create_compute_image_capability_schema_details.py
@@ -1,0 +1,276 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateComputeImageCapabilitySchemaDetails(object):
+    """
+    Create Image Capability Schema for an image.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateComputeImageCapabilitySchemaDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateComputeImageCapabilitySchemaDetails.
+        :type compartment_id: str
+
+        :param compute_global_image_capability_schema_version_name:
+            The value to assign to the compute_global_image_capability_schema_version_name property of this CreateComputeImageCapabilitySchemaDetails.
+        :type compute_global_image_capability_schema_version_name: str
+
+        :param image_id:
+            The value to assign to the image_id property of this CreateComputeImageCapabilitySchemaDetails.
+        :type image_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateComputeImageCapabilitySchemaDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateComputeImageCapabilitySchemaDetails.
+        :type display_name: str
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateComputeImageCapabilitySchemaDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param schema_data:
+            The value to assign to the schema_data property of this CreateComputeImageCapabilitySchemaDetails.
+        :type schema_data: dict(str, ImageCapabilitySchemaDescriptor)
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'compute_global_image_capability_schema_version_name': 'str',
+            'image_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'display_name': 'str',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'schema_data': 'dict(str, ImageCapabilitySchemaDescriptor)'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'compute_global_image_capability_schema_version_name': 'computeGlobalImageCapabilitySchemaVersionName',
+            'image_id': 'imageId',
+            'freeform_tags': 'freeformTags',
+            'display_name': 'displayName',
+            'defined_tags': 'definedTags',
+            'schema_data': 'schemaData'
+        }
+
+        self._compartment_id = None
+        self._compute_global_image_capability_schema_version_name = None
+        self._image_id = None
+        self._freeform_tags = None
+        self._display_name = None
+        self._defined_tags = None
+        self._schema_data = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateComputeImageCapabilitySchemaDetails.
+        The OCID of the compartment that contains the resource.
+
+
+        :return: The compartment_id of this CreateComputeImageCapabilitySchemaDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateComputeImageCapabilitySchemaDetails.
+        The OCID of the compartment that contains the resource.
+
+
+        :param compartment_id: The compartment_id of this CreateComputeImageCapabilitySchemaDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def compute_global_image_capability_schema_version_name(self):
+        """
+        **[Required]** Gets the compute_global_image_capability_schema_version_name of this CreateComputeImageCapabilitySchemaDetails.
+        The name of the compute global image capability schema version
+
+
+        :return: The compute_global_image_capability_schema_version_name of this CreateComputeImageCapabilitySchemaDetails.
+        :rtype: str
+        """
+        return self._compute_global_image_capability_schema_version_name
+
+    @compute_global_image_capability_schema_version_name.setter
+    def compute_global_image_capability_schema_version_name(self, compute_global_image_capability_schema_version_name):
+        """
+        Sets the compute_global_image_capability_schema_version_name of this CreateComputeImageCapabilitySchemaDetails.
+        The name of the compute global image capability schema version
+
+
+        :param compute_global_image_capability_schema_version_name: The compute_global_image_capability_schema_version_name of this CreateComputeImageCapabilitySchemaDetails.
+        :type: str
+        """
+        self._compute_global_image_capability_schema_version_name = compute_global_image_capability_schema_version_name
+
+    @property
+    def image_id(self):
+        """
+        **[Required]** Gets the image_id of this CreateComputeImageCapabilitySchemaDetails.
+        The ocid of the image
+
+
+        :return: The image_id of this CreateComputeImageCapabilitySchemaDetails.
+        :rtype: str
+        """
+        return self._image_id
+
+    @image_id.setter
+    def image_id(self, image_id):
+        """
+        Sets the image_id of this CreateComputeImageCapabilitySchemaDetails.
+        The ocid of the image
+
+
+        :param image_id: The image_id of this CreateComputeImageCapabilitySchemaDetails.
+        :type: str
+        """
+        self._image_id = image_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateComputeImageCapabilitySchemaDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateComputeImageCapabilitySchemaDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateComputeImageCapabilitySchemaDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateComputeImageCapabilitySchemaDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateComputeImageCapabilitySchemaDetails.
+        A user-friendly name for the compute image capability schema
+
+
+        :return: The display_name of this CreateComputeImageCapabilitySchemaDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateComputeImageCapabilitySchemaDetails.
+        A user-friendly name for the compute image capability schema
+
+
+        :param display_name: The display_name of this CreateComputeImageCapabilitySchemaDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateComputeImageCapabilitySchemaDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateComputeImageCapabilitySchemaDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateComputeImageCapabilitySchemaDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateComputeImageCapabilitySchemaDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def schema_data(self):
+        """
+        **[Required]** Gets the schema_data of this CreateComputeImageCapabilitySchemaDetails.
+        The map of each capability name to its ImageCapabilitySchemaDescriptor.
+
+
+        :return: The schema_data of this CreateComputeImageCapabilitySchemaDetails.
+        :rtype: dict(str, ImageCapabilitySchemaDescriptor)
+        """
+        return self._schema_data
+
+    @schema_data.setter
+    def schema_data(self, schema_data):
+        """
+        Sets the schema_data of this CreateComputeImageCapabilitySchemaDetails.
+        The map of each capability name to its ImageCapabilitySchemaDescriptor.
+
+
+        :param schema_data: The schema_data of this CreateComputeImageCapabilitySchemaDetails.
+        :type: dict(str, ImageCapabilitySchemaDescriptor)
+        """
+        self._schema_data = schema_data
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/create_image_details.py
+++ b/src/oci/core/models/create_image_details.py
@@ -273,7 +273,7 @@ class CreateImageDetails(object):
         Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
         * `NATIVE` - VM instances launch with paravirtualized boot and VFIO devices. The default value for Oracle-provided images.
         * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
         * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 
         Allowed values for this property are: "NATIVE", "EMULATED", "PARAVIRTUALIZED", "CUSTOM"
@@ -291,7 +291,7 @@ class CreateImageDetails(object):
         Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
         * `NATIVE` - VM instances launch with paravirtualized boot and VFIO devices. The default value for Oracle-provided images.
         * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
         * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 
 

--- a/src/oci/core/models/create_volume_details.py
+++ b/src/oci/core/models/create_volume_details.py
@@ -66,6 +66,10 @@ class CreateVolumeDetails(object):
             The value to assign to the volume_backup_id property of this CreateVolumeDetails.
         :type volume_backup_id: str
 
+        :param is_auto_tune_enabled:
+            The value to assign to the is_auto_tune_enabled property of this CreateVolumeDetails.
+        :type is_auto_tune_enabled: bool
+
         """
         self.swagger_types = {
             'availability_domain': 'str',
@@ -79,7 +83,8 @@ class CreateVolumeDetails(object):
             'size_in_gbs': 'int',
             'size_in_mbs': 'int',
             'source_details': 'VolumeSourceDetails',
-            'volume_backup_id': 'str'
+            'volume_backup_id': 'str',
+            'is_auto_tune_enabled': 'bool'
         }
 
         self.attribute_map = {
@@ -94,7 +99,8 @@ class CreateVolumeDetails(object):
             'size_in_gbs': 'sizeInGBs',
             'size_in_mbs': 'sizeInMBs',
             'source_details': 'sourceDetails',
-            'volume_backup_id': 'volumeBackupId'
+            'volume_backup_id': 'volumeBackupId',
+            'is_auto_tune_enabled': 'isAutoTuneEnabled'
         }
 
         self._availability_domain = None
@@ -109,6 +115,7 @@ class CreateVolumeDetails(object):
         self._size_in_mbs = None
         self._source_details = None
         self._volume_backup_id = None
+        self._is_auto_tune_enabled = None
 
     @property
     def availability_domain(self):
@@ -461,6 +468,30 @@ class CreateVolumeDetails(object):
         :type: str
         """
         self._volume_backup_id = volume_backup_id
+
+    @property
+    def is_auto_tune_enabled(self):
+        """
+        Gets the is_auto_tune_enabled of this CreateVolumeDetails.
+        Specifies whether the auto-tune performance is enabled for this volume.
+
+
+        :return: The is_auto_tune_enabled of this CreateVolumeDetails.
+        :rtype: bool
+        """
+        return self._is_auto_tune_enabled
+
+    @is_auto_tune_enabled.setter
+    def is_auto_tune_enabled(self, is_auto_tune_enabled):
+        """
+        Sets the is_auto_tune_enabled of this CreateVolumeDetails.
+        Specifies whether the auto-tune performance is enabled for this volume.
+
+
+        :param is_auto_tune_enabled: The is_auto_tune_enabled of this CreateVolumeDetails.
+        :type: bool
+        """
+        self._is_auto_tune_enabled = is_auto_tune_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/enum_integer_image_capability_descriptor.py
+++ b/src/oci/core/models/enum_integer_image_capability_descriptor.py
@@ -1,0 +1,118 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .image_capability_schema_descriptor import ImageCapabilitySchemaDescriptor
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EnumIntegerImageCapabilityDescriptor(ImageCapabilitySchemaDescriptor):
+    """
+    Enum Integer type CapabilityDescriptor
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EnumIntegerImageCapabilityDescriptor object with values from keyword arguments. The default value of the :py:attr:`~oci.core.models.EnumIntegerImageCapabilityDescriptor.descriptor_type` attribute
+        of this class is ``enuminteger`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param descriptor_type:
+            The value to assign to the descriptor_type property of this EnumIntegerImageCapabilityDescriptor.
+        :type descriptor_type: str
+
+        :param source:
+            The value to assign to the source property of this EnumIntegerImageCapabilityDescriptor.
+            Allowed values for this property are: "GLOBAL", "IMAGE"
+        :type source: str
+
+        :param values:
+            The value to assign to the values property of this EnumIntegerImageCapabilityDescriptor.
+        :type values: list[int]
+
+        :param default_value:
+            The value to assign to the default_value property of this EnumIntegerImageCapabilityDescriptor.
+        :type default_value: int
+
+        """
+        self.swagger_types = {
+            'descriptor_type': 'str',
+            'source': 'str',
+            'values': 'list[int]',
+            'default_value': 'int'
+        }
+
+        self.attribute_map = {
+            'descriptor_type': 'descriptorType',
+            'source': 'source',
+            'values': 'values',
+            'default_value': 'defaultValue'
+        }
+
+        self._descriptor_type = None
+        self._source = None
+        self._values = None
+        self._default_value = None
+        self._descriptor_type = 'enuminteger'
+
+    @property
+    def values(self):
+        """
+        **[Required]** Gets the values of this EnumIntegerImageCapabilityDescriptor.
+        the list of values for the enum
+
+
+        :return: The values of this EnumIntegerImageCapabilityDescriptor.
+        :rtype: list[int]
+        """
+        return self._values
+
+    @values.setter
+    def values(self, values):
+        """
+        Sets the values of this EnumIntegerImageCapabilityDescriptor.
+        the list of values for the enum
+
+
+        :param values: The values of this EnumIntegerImageCapabilityDescriptor.
+        :type: list[int]
+        """
+        self._values = values
+
+    @property
+    def default_value(self):
+        """
+        Gets the default_value of this EnumIntegerImageCapabilityDescriptor.
+        the default value
+
+
+        :return: The default_value of this EnumIntegerImageCapabilityDescriptor.
+        :rtype: int
+        """
+        return self._default_value
+
+    @default_value.setter
+    def default_value(self, default_value):
+        """
+        Sets the default_value of this EnumIntegerImageCapabilityDescriptor.
+        the default value
+
+
+        :param default_value: The default_value of this EnumIntegerImageCapabilityDescriptor.
+        :type: int
+        """
+        self._default_value = default_value
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/enum_string_image_capability_schema_descriptor.py
+++ b/src/oci/core/models/enum_string_image_capability_schema_descriptor.py
@@ -1,0 +1,118 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .image_capability_schema_descriptor import ImageCapabilitySchemaDescriptor
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EnumStringImageCapabilitySchemaDescriptor(ImageCapabilitySchemaDescriptor):
+    """
+    Enum String type of ImageCapabilitySchemaDescriptor
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EnumStringImageCapabilitySchemaDescriptor object with values from keyword arguments. The default value of the :py:attr:`~oci.core.models.EnumStringImageCapabilitySchemaDescriptor.descriptor_type` attribute
+        of this class is ``enumstring`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param descriptor_type:
+            The value to assign to the descriptor_type property of this EnumStringImageCapabilitySchemaDescriptor.
+        :type descriptor_type: str
+
+        :param source:
+            The value to assign to the source property of this EnumStringImageCapabilitySchemaDescriptor.
+            Allowed values for this property are: "GLOBAL", "IMAGE"
+        :type source: str
+
+        :param values:
+            The value to assign to the values property of this EnumStringImageCapabilitySchemaDescriptor.
+        :type values: list[str]
+
+        :param default_value:
+            The value to assign to the default_value property of this EnumStringImageCapabilitySchemaDescriptor.
+        :type default_value: str
+
+        """
+        self.swagger_types = {
+            'descriptor_type': 'str',
+            'source': 'str',
+            'values': 'list[str]',
+            'default_value': 'str'
+        }
+
+        self.attribute_map = {
+            'descriptor_type': 'descriptorType',
+            'source': 'source',
+            'values': 'values',
+            'default_value': 'defaultValue'
+        }
+
+        self._descriptor_type = None
+        self._source = None
+        self._values = None
+        self._default_value = None
+        self._descriptor_type = 'enumstring'
+
+    @property
+    def values(self):
+        """
+        **[Required]** Gets the values of this EnumStringImageCapabilitySchemaDescriptor.
+        the list of values for the enum
+
+
+        :return: The values of this EnumStringImageCapabilitySchemaDescriptor.
+        :rtype: list[str]
+        """
+        return self._values
+
+    @values.setter
+    def values(self, values):
+        """
+        Sets the values of this EnumStringImageCapabilitySchemaDescriptor.
+        the list of values for the enum
+
+
+        :param values: The values of this EnumStringImageCapabilitySchemaDescriptor.
+        :type: list[str]
+        """
+        self._values = values
+
+    @property
+    def default_value(self):
+        """
+        Gets the default_value of this EnumStringImageCapabilitySchemaDescriptor.
+        the default value
+
+
+        :return: The default_value of this EnumStringImageCapabilitySchemaDescriptor.
+        :rtype: str
+        """
+        return self._default_value
+
+    @default_value.setter
+    def default_value(self, default_value):
+        """
+        Sets the default_value of this EnumStringImageCapabilitySchemaDescriptor.
+        the default value
+
+
+        :param default_value: The default_value of this EnumStringImageCapabilitySchemaDescriptor.
+        :type: str
+        """
+        self._default_value = default_value
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/image.py
+++ b/src/oci/core/models/image.py
@@ -397,7 +397,7 @@ class Image(object):
         Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
         * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
         * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
         * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 
         Allowed values for this property are: "NATIVE", "EMULATED", "PARAVIRTUALIZED", "CUSTOM", 'UNKNOWN_ENUM_VALUE'.
@@ -416,7 +416,7 @@ class Image(object):
         Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
         * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
         * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
         * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 
 

--- a/src/oci/core/models/image_capability_schema_descriptor.py
+++ b/src/oci/core/models/image_capability_schema_descriptor.py
@@ -1,0 +1,138 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ImageCapabilitySchemaDescriptor(object):
+    """
+    Image Capability Schema Descriptor is a type of capability for an image.
+    """
+
+    #: A constant which can be used with the source property of a ImageCapabilitySchemaDescriptor.
+    #: This constant has a value of "GLOBAL"
+    SOURCE_GLOBAL = "GLOBAL"
+
+    #: A constant which can be used with the source property of a ImageCapabilitySchemaDescriptor.
+    #: This constant has a value of "IMAGE"
+    SOURCE_IMAGE = "IMAGE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ImageCapabilitySchemaDescriptor object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.core.models.EnumStringImageCapabilitySchemaDescriptor`
+        * :class:`~oci.core.models.EnumIntegerImageCapabilityDescriptor`
+        * :class:`~oci.core.models.BooleanImageCapabilitySchemaDescriptor`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param descriptor_type:
+            The value to assign to the descriptor_type property of this ImageCapabilitySchemaDescriptor.
+        :type descriptor_type: str
+
+        :param source:
+            The value to assign to the source property of this ImageCapabilitySchemaDescriptor.
+            Allowed values for this property are: "GLOBAL", "IMAGE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type source: str
+
+        """
+        self.swagger_types = {
+            'descriptor_type': 'str',
+            'source': 'str'
+        }
+
+        self.attribute_map = {
+            'descriptor_type': 'descriptorType',
+            'source': 'source'
+        }
+
+        self._descriptor_type = None
+        self._source = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['descriptorType']
+
+        if type == 'enumstring':
+            return 'EnumStringImageCapabilitySchemaDescriptor'
+
+        if type == 'enuminteger':
+            return 'EnumIntegerImageCapabilityDescriptor'
+
+        if type == 'boolean':
+            return 'BooleanImageCapabilitySchemaDescriptor'
+        else:
+            return 'ImageCapabilitySchemaDescriptor'
+
+    @property
+    def descriptor_type(self):
+        """
+        **[Required]** Gets the descriptor_type of this ImageCapabilitySchemaDescriptor.
+        The image capability schema descriptor type for the capability
+
+
+        :return: The descriptor_type of this ImageCapabilitySchemaDescriptor.
+        :rtype: str
+        """
+        return self._descriptor_type
+
+    @descriptor_type.setter
+    def descriptor_type(self, descriptor_type):
+        """
+        Sets the descriptor_type of this ImageCapabilitySchemaDescriptor.
+        The image capability schema descriptor type for the capability
+
+
+        :param descriptor_type: The descriptor_type of this ImageCapabilitySchemaDescriptor.
+        :type: str
+        """
+        self._descriptor_type = descriptor_type
+
+    @property
+    def source(self):
+        """
+        **[Required]** Gets the source of this ImageCapabilitySchemaDescriptor.
+        Allowed values for this property are: "GLOBAL", "IMAGE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The source of this ImageCapabilitySchemaDescriptor.
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """
+        Sets the source of this ImageCapabilitySchemaDescriptor.
+
+        :param source: The source of this ImageCapabilitySchemaDescriptor.
+        :type: str
+        """
+        allowed_values = ["GLOBAL", "IMAGE"]
+        if not value_allowed_none_or_none_sentinel(source, allowed_values):
+            source = 'UNKNOWN_ENUM_VALUE'
+        self._source = source
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/instance.py
+++ b/src/oci/core/models/instance.py
@@ -400,9 +400,11 @@ class Instance(object):
     def extended_metadata(self):
         """
         Gets the extended_metadata of this Instance.
-        Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
+        Additional metadata key/value pairs that you provide. They serve the same purpose and functionality
+        as fields in the `metadata` object.
 
-        They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+        They are distinguished from `metadata` fields in that these can be nested JSON objects (whereas `metadata`
+        fields are string/string maps only).
 
 
         :return: The extended_metadata of this Instance.
@@ -414,9 +416,11 @@ class Instance(object):
     def extended_metadata(self, extended_metadata):
         """
         Sets the extended_metadata of this Instance.
-        Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
+        Additional metadata key/value pairs that you provide. They serve the same purpose and functionality
+        as fields in the `metadata` object.
 
-        They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+        They are distinguished from `metadata` fields in that these can be nested JSON objects (whereas `metadata`
+        fields are string/string maps only).
 
 
         :param extended_metadata: The extended_metadata of this Instance.
@@ -436,8 +440,7 @@ class Instance(object):
         A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
         instances in other fault domains.
 
-        If you do not specify the fault domain, the system selects one for you. To change the fault
-        domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+        If you do not specify the fault domain, the system selects one for you.
 
         Example: `FAULT-DOMAIN-1`
 
@@ -459,8 +462,7 @@ class Instance(object):
         A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
         instances in other fault domains.
 
-        If you do not specify the fault domain, the system selects one for you. To change the fault
-        domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+        If you do not specify the fault domain, the system selects one for you.
 
         Example: `FAULT-DOMAIN-1`
 
@@ -629,7 +631,7 @@ class Instance(object):
         Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
         * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
         * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
         * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 
         Allowed values for this property are: "NATIVE", "EMULATED", "PARAVIRTUALIZED", "CUSTOM", 'UNKNOWN_ENUM_VALUE'.
@@ -648,7 +650,7 @@ class Instance(object):
         Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
         * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
         * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
         * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 
 

--- a/src/oci/core/models/instance_configuration_launch_instance_details.py
+++ b/src/oci/core/models/instance_configuration_launch_instance_details.py
@@ -336,9 +336,14 @@ class InstanceConfigurationLaunchInstanceDetails(object):
     def extended_metadata(self):
         """
         Gets the extended_metadata of this InstanceConfigurationLaunchInstanceDetails.
-        Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
+        Additional metadata key/value pairs that you provide. They serve the same purpose and
+        functionality as fields in the `metadata` object.
 
-        They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+        They are distinguished from `metadata` fields in that these can be nested JSON objects
+        (whereas `metadata` fields are string/string maps only).
+
+        The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+        32,000 bytes.
 
 
         :return: The extended_metadata of this InstanceConfigurationLaunchInstanceDetails.
@@ -350,9 +355,14 @@ class InstanceConfigurationLaunchInstanceDetails(object):
     def extended_metadata(self, extended_metadata):
         """
         Sets the extended_metadata of this InstanceConfigurationLaunchInstanceDetails.
-        Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
+        Additional metadata key/value pairs that you provide. They serve the same purpose and
+        functionality as fields in the `metadata` object.
 
-        They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+        They are distinguished from `metadata` fields in that these can be nested JSON objects
+        (whereas `metadata` fields are string/string maps only).
+
+        The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+        32,000 bytes.
 
 
         :param extended_metadata: The extended_metadata of this InstanceConfigurationLaunchInstanceDetails.
@@ -519,6 +529,8 @@ class InstanceConfigurationLaunchInstanceDetails(object):
          You'll get back a response that includes all the instance information; only the metadata information; or
          the metadata information for the specified key name, respectively.
 
+         The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of 32,000 bytes.
+
         __ https://cloudinit.readthedocs.org/en/latest/
         __ http://cloudinit.readthedocs.org/en/latest/topics/format.html
 
@@ -578,6 +590,8 @@ class InstanceConfigurationLaunchInstanceDetails(object):
 
          You'll get back a response that includes all the instance information; only the metadata information; or
          the metadata information for the specified key name, respectively.
+
+         The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of 32,000 bytes.
 
         __ https://cloudinit.readthedocs.org/en/latest/
         __ http://cloudinit.readthedocs.org/en/latest/topics/format.html
@@ -674,8 +688,8 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
         instances in other fault domains.
 
-        If you do not specify the fault domain, the system selects one for you. To change the fault
-        domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+        If you do not specify the fault domain, the system selects one for you.
+
 
         To get a list of fault domains, use the
         :func:`list_fault_domains` operation in the
@@ -699,8 +713,8 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
         instances in other fault domains.
 
-        If you do not specify the fault domain, the system selects one for you. To change the fault
-        domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+        If you do not specify the fault domain, the system selects one for you.
+
 
         To get a list of fault domains, use the
         :func:`list_fault_domains` operation in the
@@ -751,7 +765,7 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
         * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
         * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
         * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 
         Allowed values for this property are: "NATIVE", "EMULATED", "PARAVIRTUALIZED", "CUSTOM", 'UNKNOWN_ENUM_VALUE'.
@@ -770,7 +784,7 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
         * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
         * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
         * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 
 

--- a/src/oci/core/models/instance_configuration_launch_options.py
+++ b/src/oci/core/models/instance_configuration_launch_options.py
@@ -141,14 +141,14 @@ class InstanceConfigurationLaunchOptions(object):
     def boot_volume_type(self):
         """
         Gets the boot_volume_type of this InstanceConfigurationLaunchOptions.
-        Emulation type for volume.
+        Emulation type for the boot volume.
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
+        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
         volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+        storage volumes on Oracle-provided images.
 
         Allowed values for this property are: "ISCSI", "SCSI", "IDE", "VFIO", "PARAVIRTUALIZED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -163,14 +163,14 @@ class InstanceConfigurationLaunchOptions(object):
     def boot_volume_type(self, boot_volume_type):
         """
         Sets the boot_volume_type of this InstanceConfigurationLaunchOptions.
-        Emulation type for volume.
+        Emulation type for the boot volume.
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
+        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
         volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+        storage volumes on Oracle-provided images.
 
 
         :param boot_volume_type: The boot_volume_type of this InstanceConfigurationLaunchOptions.
@@ -189,7 +189,7 @@ class InstanceConfigurationLaunchOptions(object):
         * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
         systems that boot using MBR style bootloaders.
         * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
-        default for Oracle provided images.
+        default for Oracle-provided images.
 
         Allowed values for this property are: "BIOS", "UEFI_64", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -208,7 +208,7 @@ class InstanceConfigurationLaunchOptions(object):
         * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
         systems that boot using MBR style bootloaders.
         * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
-        default for Oracle provided images.
+        default for Oracle-provided images.
 
 
         :param firmware: The firmware of this InstanceConfigurationLaunchOptions.
@@ -227,7 +227,7 @@ class InstanceConfigurationLaunchOptions(object):
         * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
         * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
         when you launch an instance using hardware-assisted (SR-IOV) networking.
-        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 
         Allowed values for this property are: "E1000", "VFIO", "PARAVIRTUALIZED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -246,7 +246,7 @@ class InstanceConfigurationLaunchOptions(object):
         * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
         * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
         when you launch an instance using hardware-assisted (SR-IOV) networking.
-        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 
 
         :param network_type: The network_type of this InstanceConfigurationLaunchOptions.
@@ -265,10 +265,10 @@ class InstanceConfigurationLaunchOptions(object):
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
+        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
         volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+        storage volumes on Oracle-provided images.
 
         Allowed values for this property are: "ISCSI", "SCSI", "IDE", "VFIO", "PARAVIRTUALIZED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -287,10 +287,10 @@ class InstanceConfigurationLaunchOptions(object):
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
+        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
         volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+        storage volumes on Oracle-provided images.
 
 
         :param remote_data_volume_type: The remote_data_volume_type of this InstanceConfigurationLaunchOptions.

--- a/src/oci/core/models/instance_summary.py
+++ b/src/oci/core/models/instance_summary.py
@@ -203,7 +203,7 @@ class InstanceSummary(object):
     def fault_domain(self):
         """
         Gets the fault_domain of this InstanceSummary.
-        The name of the Fault Domain the instance is running in.
+        The fault domain the instance is running in.
 
 
         :return: The fault_domain of this InstanceSummary.
@@ -215,7 +215,7 @@ class InstanceSummary(object):
     def fault_domain(self, fault_domain):
         """
         Sets the fault_domain of this InstanceSummary.
-        The name of the Fault Domain the instance is running in.
+        The fault domain the instance is running in.
 
 
         :param fault_domain: The fault_domain of this InstanceSummary.

--- a/src/oci/core/models/launch_instance_details.py
+++ b/src/oci/core/models/launch_instance_details.py
@@ -337,9 +337,14 @@ class LaunchInstanceDetails(object):
     def extended_metadata(self):
         """
         Gets the extended_metadata of this LaunchInstanceDetails.
-        Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
+        Additional metadata key/value pairs that you provide. They serve the same purpose and
+        functionality as fields in the `metadata` object.
 
-        They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+        They are distinguished from `metadata` fields in that these can be nested JSON objects
+        (whereas `metadata` fields are string/string maps only).
+
+        The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+        32,000 bytes.
 
 
         :return: The extended_metadata of this LaunchInstanceDetails.
@@ -351,9 +356,14 @@ class LaunchInstanceDetails(object):
     def extended_metadata(self, extended_metadata):
         """
         Sets the extended_metadata of this LaunchInstanceDetails.
-        Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
+        Additional metadata key/value pairs that you provide. They serve the same purpose and
+        functionality as fields in the `metadata` object.
 
-        They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+        They are distinguished from `metadata` fields in that these can be nested JSON objects
+        (whereas `metadata` fields are string/string maps only).
+
+        The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+        32,000 bytes.
 
 
         :param extended_metadata: The extended_metadata of this LaunchInstanceDetails.
@@ -371,8 +381,8 @@ class LaunchInstanceDetails(object):
         A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
         instances in other fault domains.
 
-        If you do not specify the fault domain, the system selects one for you. To change the fault
-        domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+        If you do not specify the fault domain, the system selects one for you.
+
 
         To get a list of fault domains, use the
         :func:`list_fault_domains` operation in the
@@ -396,8 +406,8 @@ class LaunchInstanceDetails(object):
         A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
         instances in other fault domains.
 
-        If you do not specify the fault domain, the system selects one for you. To change the fault
-        domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+        If you do not specify the fault domain, the system selects one for you.
+
 
         To get a list of fault domains, use the
         :func:`list_fault_domains` operation in the
@@ -650,6 +660,8 @@ class LaunchInstanceDetails(object):
          You'll get back a response that includes all the instance information; only the metadata information; or
          the metadata information for the specified key name, respectively.
 
+         The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of 32,000 bytes.
+
         __ https://cloudinit.readthedocs.org/en/latest/
         __ http://cloudinit.readthedocs.org/en/latest/topics/format.html
 
@@ -709,6 +721,8 @@ class LaunchInstanceDetails(object):
 
          You'll get back a response that includes all the instance information; only the metadata information; or
          the metadata information for the specified key name, respectively.
+
+         The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of 32,000 bytes.
 
         __ https://cloudinit.readthedocs.org/en/latest/
         __ http://cloudinit.readthedocs.org/en/latest/topics/format.html

--- a/src/oci/core/models/launch_options.py
+++ b/src/oci/core/models/launch_options.py
@@ -141,14 +141,14 @@ class LaunchOptions(object):
     def boot_volume_type(self):
         """
         Gets the boot_volume_type of this LaunchOptions.
-        Emulation type for volume.
+        Emulation type for the boot volume.
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
-        volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+        volumes on Oracle-provided images.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+        storage volumes on Oracle-provided images.
 
         Allowed values for this property are: "ISCSI", "SCSI", "IDE", "VFIO", "PARAVIRTUALIZED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -163,14 +163,14 @@ class LaunchOptions(object):
     def boot_volume_type(self, boot_volume_type):
         """
         Sets the boot_volume_type of this LaunchOptions.
-        Emulation type for volume.
+        Emulation type for the boot volume.
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
-        volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+        volumes on Oracle-provided images.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+        storage volumes on Oracle-provided images.
 
 
         :param boot_volume_type: The boot_volume_type of this LaunchOptions.
@@ -189,7 +189,7 @@ class LaunchOptions(object):
         * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
         systems that boot using MBR style bootloaders.
         * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
-        default for Oracle provided images.
+        default for Oracle-provided images.
 
         Allowed values for this property are: "BIOS", "UEFI_64", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -208,7 +208,7 @@ class LaunchOptions(object):
         * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
         systems that boot using MBR style bootloaders.
         * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
-        default for Oracle provided images.
+        default for Oracle-provided images.
 
 
         :param firmware: The firmware of this LaunchOptions.
@@ -227,7 +227,7 @@ class LaunchOptions(object):
         * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
         * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
         when you launch an instance using hardware-assisted (SR-IOV) networking.
-        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 
         Allowed values for this property are: "E1000", "VFIO", "PARAVIRTUALIZED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -246,7 +246,7 @@ class LaunchOptions(object):
         * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
         * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
         when you launch an instance using hardware-assisted (SR-IOV) networking.
-        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 
 
         :param network_type: The network_type of this LaunchOptions.
@@ -265,10 +265,10 @@ class LaunchOptions(object):
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
-        volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk.This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+        volumes on Oracle-provided images.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+        storage volumes on Oracle-provided images.
 
         Allowed values for this property are: "ISCSI", "SCSI", "IDE", "VFIO", "PARAVIRTUALIZED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -287,10 +287,10 @@ class LaunchOptions(object):
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
-        volumes on Oracle provided images.
-        * `PARAVIRTUALIZED` - Paravirtualized disk.This is the default for Boot Volumes and Remote Block
-        Storage volumes on Oracle provided images.
+        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+        volumes on Oracle-provided images.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+        storage volumes on Oracle-provided images.
 
 
         :param remote_data_volume_type: The remote_data_volume_type of this LaunchOptions.

--- a/src/oci/core/models/update_boot_volume_details.py
+++ b/src/oci/core/models/update_boot_volume_details.py
@@ -38,13 +38,18 @@ class UpdateBootVolumeDetails(object):
             The value to assign to the vpus_per_gb property of this UpdateBootVolumeDetails.
         :type vpus_per_gb: int
 
+        :param is_auto_tune_enabled:
+            The value to assign to the is_auto_tune_enabled property of this UpdateBootVolumeDetails.
+        :type is_auto_tune_enabled: bool
+
         """
         self.swagger_types = {
             'defined_tags': 'dict(str, dict(str, object))',
             'display_name': 'str',
             'freeform_tags': 'dict(str, str)',
             'size_in_gbs': 'int',
-            'vpus_per_gb': 'int'
+            'vpus_per_gb': 'int',
+            'is_auto_tune_enabled': 'bool'
         }
 
         self.attribute_map = {
@@ -52,7 +57,8 @@ class UpdateBootVolumeDetails(object):
             'display_name': 'displayName',
             'freeform_tags': 'freeformTags',
             'size_in_gbs': 'sizeInGBs',
-            'vpus_per_gb': 'vpusPerGB'
+            'vpus_per_gb': 'vpusPerGB',
+            'is_auto_tune_enabled': 'isAutoTuneEnabled'
         }
 
         self._defined_tags = None
@@ -60,6 +66,7 @@ class UpdateBootVolumeDetails(object):
         self._freeform_tags = None
         self._size_in_gbs = None
         self._vpus_per_gb = None
+        self._is_auto_tune_enabled = None
 
     @property
     def defined_tags(self):
@@ -222,6 +229,30 @@ class UpdateBootVolumeDetails(object):
         :type: int
         """
         self._vpus_per_gb = vpus_per_gb
+
+    @property
+    def is_auto_tune_enabled(self):
+        """
+        Gets the is_auto_tune_enabled of this UpdateBootVolumeDetails.
+        Specifies whether the auto-tune performance is enabled for this boot volume.
+
+
+        :return: The is_auto_tune_enabled of this UpdateBootVolumeDetails.
+        :rtype: bool
+        """
+        return self._is_auto_tune_enabled
+
+    @is_auto_tune_enabled.setter
+    def is_auto_tune_enabled(self, is_auto_tune_enabled):
+        """
+        Sets the is_auto_tune_enabled of this UpdateBootVolumeDetails.
+        Specifies whether the auto-tune performance is enabled for this boot volume.
+
+
+        :param is_auto_tune_enabled: The is_auto_tune_enabled of this UpdateBootVolumeDetails.
+        :type: bool
+        """
+        self._is_auto_tune_enabled = is_auto_tune_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/update_compute_image_capability_schema_details.py
+++ b/src/oci/core/models/update_compute_image_capability_schema_details.py
@@ -1,0 +1,183 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateComputeImageCapabilitySchemaDetails(object):
+    """
+    Create Image Capability Schema for an image.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateComputeImageCapabilitySchemaDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateComputeImageCapabilitySchemaDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateComputeImageCapabilitySchemaDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param schema_data:
+            The value to assign to the schema_data property of this UpdateComputeImageCapabilitySchemaDetails.
+        :type schema_data: dict(str, ImageCapabilitySchemaDescriptor)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateComputeImageCapabilitySchemaDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'schema_data': 'dict(str, ImageCapabilitySchemaDescriptor)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'schema_data': 'schemaData',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._freeform_tags = None
+        self._schema_data = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateComputeImageCapabilitySchemaDetails.
+        A user-friendly name for the compute image capability schema
+
+
+        :return: The display_name of this UpdateComputeImageCapabilitySchemaDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateComputeImageCapabilitySchemaDetails.
+        A user-friendly name for the compute image capability schema
+
+
+        :param display_name: The display_name of this UpdateComputeImageCapabilitySchemaDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateComputeImageCapabilitySchemaDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateComputeImageCapabilitySchemaDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateComputeImageCapabilitySchemaDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateComputeImageCapabilitySchemaDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def schema_data(self):
+        """
+        Gets the schema_data of this UpdateComputeImageCapabilitySchemaDetails.
+        The map of each capability name to its ImageCapabilitySchemaDescriptor.
+
+
+        :return: The schema_data of this UpdateComputeImageCapabilitySchemaDetails.
+        :rtype: dict(str, ImageCapabilitySchemaDescriptor)
+        """
+        return self._schema_data
+
+    @schema_data.setter
+    def schema_data(self, schema_data):
+        """
+        Sets the schema_data of this UpdateComputeImageCapabilitySchemaDetails.
+        The map of each capability name to its ImageCapabilitySchemaDescriptor.
+
+
+        :param schema_data: The schema_data of this UpdateComputeImageCapabilitySchemaDetails.
+        :type: dict(str, ImageCapabilitySchemaDescriptor)
+        """
+        self._schema_data = schema_data
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateComputeImageCapabilitySchemaDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateComputeImageCapabilitySchemaDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateComputeImageCapabilitySchemaDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateComputeImageCapabilitySchemaDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/update_instance_details.py
+++ b/src/oci/core/models/update_instance_details.py
@@ -50,6 +50,14 @@ class UpdateInstanceDetails(object):
             The value to assign to the shape_config property of this UpdateInstanceDetails.
         :type shape_config: UpdateInstanceShapeConfigDetails
 
+        :param fault_domain:
+            The value to assign to the fault_domain property of this UpdateInstanceDetails.
+        :type fault_domain: str
+
+        :param launch_options:
+            The value to assign to the launch_options property of this UpdateInstanceDetails.
+        :type launch_options: UpdateLaunchOptions
+
         """
         self.swagger_types = {
             'defined_tags': 'dict(str, dict(str, object))',
@@ -59,7 +67,9 @@ class UpdateInstanceDetails(object):
             'metadata': 'dict(str, str)',
             'extended_metadata': 'dict(str, object)',
             'shape': 'str',
-            'shape_config': 'UpdateInstanceShapeConfigDetails'
+            'shape_config': 'UpdateInstanceShapeConfigDetails',
+            'fault_domain': 'str',
+            'launch_options': 'UpdateLaunchOptions'
         }
 
         self.attribute_map = {
@@ -70,7 +80,9 @@ class UpdateInstanceDetails(object):
             'metadata': 'metadata',
             'extended_metadata': 'extendedMetadata',
             'shape': 'shape',
-            'shape_config': 'shapeConfig'
+            'shape_config': 'shapeConfig',
+            'fault_domain': 'faultDomain',
+            'launch_options': 'launchOptions'
         }
 
         self._defined_tags = None
@@ -81,6 +93,8 @@ class UpdateInstanceDetails(object):
         self._extended_metadata = None
         self._shape = None
         self._shape_config = None
+        self._fault_domain = None
+        self._launch_options = None
 
     @property
     def defined_tags(self):
@@ -209,13 +223,16 @@ class UpdateInstanceDetails(object):
         """
         Gets the metadata of this UpdateInstanceDetails.
         Custom metadata key/value string pairs that you provide. Any set of key/value pairs
-        provided here will completely replace the current set of key/value pairs in the 'metadata'
+        provided here will completely replace the current set of key/value pairs in the `metadata`
         field on the instance.
 
-        Both the 'user_data' and 'ssh_authorized_keys' fields cannot be changed after an instance
-        has launched. Any request which updates, removes, or adds either of these fields will be
-        rejected. You must provide the same values for 'user_data' and 'ssh_authorized_keys' that
+        The \"user_data\" field and the \"ssh_authorized_keys\" field cannot be changed after an instance
+        has launched. Any request that updates, removes, or adds either of these fields will be
+        rejected. You must provide the same values for \"user_data\" and \"ssh_authorized_keys\" that
         already exist on the instance.
+
+        The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+        32,000 bytes.
 
 
         :return: The metadata of this UpdateInstanceDetails.
@@ -228,13 +245,16 @@ class UpdateInstanceDetails(object):
         """
         Sets the metadata of this UpdateInstanceDetails.
         Custom metadata key/value string pairs that you provide. Any set of key/value pairs
-        provided here will completely replace the current set of key/value pairs in the 'metadata'
+        provided here will completely replace the current set of key/value pairs in the `metadata`
         field on the instance.
 
-        Both the 'user_data' and 'ssh_authorized_keys' fields cannot be changed after an instance
-        has launched. Any request which updates, removes, or adds either of these fields will be
-        rejected. You must provide the same values for 'user_data' and 'ssh_authorized_keys' that
+        The \"user_data\" field and the \"ssh_authorized_keys\" field cannot be changed after an instance
+        has launched. Any request that updates, removes, or adds either of these fields will be
+        rejected. You must provide the same values for \"user_data\" and \"ssh_authorized_keys\" that
         already exist on the instance.
+
+        The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+        32,000 bytes.
 
 
         :param metadata: The metadata of this UpdateInstanceDetails.
@@ -247,15 +267,18 @@ class UpdateInstanceDetails(object):
         """
         Gets the extended_metadata of this UpdateInstanceDetails.
         Additional metadata key/value pairs that you provide. They serve the same purpose and
-        functionality as fields in the 'metadata' object.
+        functionality as fields in the `metadata` object.
 
-        They are distinguished from 'metadata' fields in that these can be nested JSON objects
-        (whereas 'metadata' fields are string/string maps only).
+        They are distinguished from `metadata` fields in that these can be nested JSON objects
+        (whereas `metadata` fields are string/string maps only).
 
-        Both the 'user_data' and 'ssh_authorized_keys' fields cannot be changed after an instance
-        has launched. Any request which updates, removes, or adds either of these fields will be
-        rejected. You must provide the same values for 'user_data' and 'ssh_authorized_keys' that
+        The \"user_data\" field and the \"ssh_authorized_keys\" field cannot be changed after an instance
+        has launched. Any request that updates, removes, or adds either of these fields will be
+        rejected. You must provide the same values for \"user_data\" and \"ssh_authorized_keys\" that
         already exist on the instance.
+
+        The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+        32,000 bytes.
 
 
         :return: The extended_metadata of this UpdateInstanceDetails.
@@ -268,15 +291,18 @@ class UpdateInstanceDetails(object):
         """
         Sets the extended_metadata of this UpdateInstanceDetails.
         Additional metadata key/value pairs that you provide. They serve the same purpose and
-        functionality as fields in the 'metadata' object.
+        functionality as fields in the `metadata` object.
 
-        They are distinguished from 'metadata' fields in that these can be nested JSON objects
-        (whereas 'metadata' fields are string/string maps only).
+        They are distinguished from `metadata` fields in that these can be nested JSON objects
+        (whereas `metadata` fields are string/string maps only).
 
-        Both the 'user_data' and 'ssh_authorized_keys' fields cannot be changed after an instance
-        has launched. Any request which updates, removes, or adds either of these fields will be
-        rejected. You must provide the same values for 'user_data' and 'ssh_authorized_keys' that
+        The \"user_data\" field and the \"ssh_authorized_keys\" field cannot be changed after an instance
+        has launched. Any request that updates, removes, or adds either of these fields will be
+        rejected. You must provide the same values for \"user_data\" and \"ssh_authorized_keys\" that
         already exist on the instance.
+
+        The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+        32,000 bytes.
 
 
         :param extended_metadata: The extended_metadata of this UpdateInstanceDetails.
@@ -291,7 +317,7 @@ class UpdateInstanceDetails(object):
         The shape of the instance. The shape determines the number of CPUs and the amount of memory
         allocated to the instance. For more information about how to change shapes, and a list of
         shapes that are supported, see
-        `Changing the Shape of an Instance`__.
+        `Editing an Instance`__.
 
         For details about the CPUs, memory, and other properties of each shape, see
         `Compute Shapes`__.
@@ -320,7 +346,7 @@ class UpdateInstanceDetails(object):
         The shape of the instance. The shape determines the number of CPUs and the amount of memory
         allocated to the instance. For more information about how to change shapes, and a list of
         shapes that are supported, see
-        `Changing the Shape of an Instance`__.
+        `Editing an Instance`__.
 
         For details about the CPUs, memory, and other properties of each shape, see
         `Compute Shapes`__.
@@ -361,6 +387,74 @@ class UpdateInstanceDetails(object):
         :type: UpdateInstanceShapeConfigDetails
         """
         self._shape_config = shape_config
+
+    @property
+    def fault_domain(self):
+        """
+        Gets the fault_domain of this UpdateInstanceDetails.
+        A fault domain is a grouping of hardware and infrastructure within an availability domain.
+        Each availability domain contains three fault domains. Fault domains let you distribute your
+        instances so that they are not on the same physical hardware within a single availability domain.
+        A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
+        instances in other fault domains.
+
+        To get a list of fault domains, use the
+        :func:`list_fault_domains` operation in the
+        Identity and Access Management Service API.
+
+        Example: `FAULT-DOMAIN-1`
+
+
+        :return: The fault_domain of this UpdateInstanceDetails.
+        :rtype: str
+        """
+        return self._fault_domain
+
+    @fault_domain.setter
+    def fault_domain(self, fault_domain):
+        """
+        Sets the fault_domain of this UpdateInstanceDetails.
+        A fault domain is a grouping of hardware and infrastructure within an availability domain.
+        Each availability domain contains three fault domains. Fault domains let you distribute your
+        instances so that they are not on the same physical hardware within a single availability domain.
+        A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
+        instances in other fault domains.
+
+        To get a list of fault domains, use the
+        :func:`list_fault_domains` operation in the
+        Identity and Access Management Service API.
+
+        Example: `FAULT-DOMAIN-1`
+
+
+        :param fault_domain: The fault_domain of this UpdateInstanceDetails.
+        :type: str
+        """
+        self._fault_domain = fault_domain
+
+    @property
+    def launch_options(self):
+        """
+        Gets the launch_options of this UpdateInstanceDetails.
+        Options for tuning the compatibility and performance of VM shapes.
+
+
+        :return: The launch_options of this UpdateInstanceDetails.
+        :rtype: UpdateLaunchOptions
+        """
+        return self._launch_options
+
+    @launch_options.setter
+    def launch_options(self, launch_options):
+        """
+        Sets the launch_options of this UpdateInstanceDetails.
+        Options for tuning the compatibility and performance of VM shapes.
+
+
+        :param launch_options: The launch_options of this UpdateInstanceDetails.
+        :type: UpdateLaunchOptions
+        """
+        self._launch_options = launch_options
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/update_launch_options.py
+++ b/src/oci/core/models/update_launch_options.py
@@ -1,0 +1,246 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateLaunchOptions(object):
+    """
+    Options for tuning the compatibility and performance of VM shapes.
+    """
+
+    #: A constant which can be used with the boot_volume_type property of a UpdateLaunchOptions.
+    #: This constant has a value of "ISCSI"
+    BOOT_VOLUME_TYPE_ISCSI = "ISCSI"
+
+    #: A constant which can be used with the boot_volume_type property of a UpdateLaunchOptions.
+    #: This constant has a value of "PARAVIRTUALIZED"
+    BOOT_VOLUME_TYPE_PARAVIRTUALIZED = "PARAVIRTUALIZED"
+
+    #: A constant which can be used with the network_type property of a UpdateLaunchOptions.
+    #: This constant has a value of "VFIO"
+    NETWORK_TYPE_VFIO = "VFIO"
+
+    #: A constant which can be used with the network_type property of a UpdateLaunchOptions.
+    #: This constant has a value of "PARAVIRTUALIZED"
+    NETWORK_TYPE_PARAVIRTUALIZED = "PARAVIRTUALIZED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateLaunchOptions object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param boot_volume_type:
+            The value to assign to the boot_volume_type property of this UpdateLaunchOptions.
+            Allowed values for this property are: "ISCSI", "PARAVIRTUALIZED"
+        :type boot_volume_type: str
+
+        :param network_type:
+            The value to assign to the network_type property of this UpdateLaunchOptions.
+            Allowed values for this property are: "VFIO", "PARAVIRTUALIZED"
+        :type network_type: str
+
+        :param is_pv_encryption_in_transit_enabled:
+            The value to assign to the is_pv_encryption_in_transit_enabled property of this UpdateLaunchOptions.
+        :type is_pv_encryption_in_transit_enabled: bool
+
+        """
+        self.swagger_types = {
+            'boot_volume_type': 'str',
+            'network_type': 'str',
+            'is_pv_encryption_in_transit_enabled': 'bool'
+        }
+
+        self.attribute_map = {
+            'boot_volume_type': 'bootVolumeType',
+            'network_type': 'networkType',
+            'is_pv_encryption_in_transit_enabled': 'isPvEncryptionInTransitEnabled'
+        }
+
+        self._boot_volume_type = None
+        self._network_type = None
+        self._is_pv_encryption_in_transit_enabled = None
+
+    @property
+    def boot_volume_type(self):
+        """
+        Gets the boot_volume_type of this UpdateLaunchOptions.
+        Emulation type for the boot volume.
+        * `ISCSI` - ISCSI attached block storage device.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+        storage volumes on Oracle-provided plaform images.
+
+        Before you change the boot volume attachment type, detach all block volumes and VNICs except for
+        the boot volume and the primary VNIC.
+
+        If the instance is running when you change the boot volume attachment type, it will be rebooted.
+
+        **Note:** Some instances might not function properly if you change the boot volume attachment type. After
+        the instance reboots and is running, connect to it. If the connection fails or the OS doesn't behave
+        as expected, the changes are not supported. Revert the instance to the original boot volume attachment type.
+
+        Allowed values for this property are: "ISCSI", "PARAVIRTUALIZED"
+
+
+        :return: The boot_volume_type of this UpdateLaunchOptions.
+        :rtype: str
+        """
+        return self._boot_volume_type
+
+    @boot_volume_type.setter
+    def boot_volume_type(self, boot_volume_type):
+        """
+        Sets the boot_volume_type of this UpdateLaunchOptions.
+        Emulation type for the boot volume.
+        * `ISCSI` - ISCSI attached block storage device.
+        * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+        storage volumes on Oracle-provided plaform images.
+
+        Before you change the boot volume attachment type, detach all block volumes and VNICs except for
+        the boot volume and the primary VNIC.
+
+        If the instance is running when you change the boot volume attachment type, it will be rebooted.
+
+        **Note:** Some instances might not function properly if you change the boot volume attachment type. After
+        the instance reboots and is running, connect to it. If the connection fails or the OS doesn't behave
+        as expected, the changes are not supported. Revert the instance to the original boot volume attachment type.
+
+
+        :param boot_volume_type: The boot_volume_type of this UpdateLaunchOptions.
+        :type: str
+        """
+        allowed_values = ["ISCSI", "PARAVIRTUALIZED"]
+        if not value_allowed_none_or_none_sentinel(boot_volume_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `boot_volume_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._boot_volume_type = boot_volume_type
+
+    @property
+    def network_type(self):
+        """
+        Gets the network_type of this UpdateLaunchOptions.
+        Emulation type for the physical network interface card (NIC).
+        * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+        when you launch an instance using hardware-assisted (SR-IOV) networking.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
+
+        Before you change the networking type, detach all VNICs and block volumes except for the primary
+        VNIC and the boot volume.
+
+        The image must have paravirtualized drivers installed. For more information, see
+        `Editing an Instance`__.
+
+        If the instance is running when you change the network type, it will be rebooted.
+
+        **Note:** Some instances might not function properly if you change the networking type. After
+        the instance reboots and is running, connect to it. If the connection fails or the OS doesn't behave
+        as expected, the changes are not supported. Revert the instance to the original networking type.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm
+
+        Allowed values for this property are: "VFIO", "PARAVIRTUALIZED"
+
+
+        :return: The network_type of this UpdateLaunchOptions.
+        :rtype: str
+        """
+        return self._network_type
+
+    @network_type.setter
+    def network_type(self, network_type):
+        """
+        Sets the network_type of this UpdateLaunchOptions.
+        Emulation type for the physical network interface card (NIC).
+        * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+        when you launch an instance using hardware-assisted (SR-IOV) networking.
+        * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
+
+        Before you change the networking type, detach all VNICs and block volumes except for the primary
+        VNIC and the boot volume.
+
+        The image must have paravirtualized drivers installed. For more information, see
+        `Editing an Instance`__.
+
+        If the instance is running when you change the network type, it will be rebooted.
+
+        **Note:** Some instances might not function properly if you change the networking type. After
+        the instance reboots and is running, connect to it. If the connection fails or the OS doesn't behave
+        as expected, the changes are not supported. Revert the instance to the original networking type.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm
+
+
+        :param network_type: The network_type of this UpdateLaunchOptions.
+        :type: str
+        """
+        allowed_values = ["VFIO", "PARAVIRTUALIZED"]
+        if not value_allowed_none_or_none_sentinel(network_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `network_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._network_type = network_type
+
+    @property
+    def is_pv_encryption_in_transit_enabled(self):
+        """
+        Gets the is_pv_encryption_in_transit_enabled of this UpdateLaunchOptions.
+        Whether to enable in-transit encryption for the boot volume's paravirtualized attachment.
+
+        Data in transit is transferred over an internal and highly secure network. If you have specific
+        compliance requirements related to the encryption of the data while it is moving between the
+        instance and the boot volume, you can enable in-transit encryption. In-transit encryption is
+        not enabled by default.
+
+        All boot volumes are encrypted at rest.
+
+        For more information, see `Block Volume Encryption`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm#Encrypti
+
+
+        :return: The is_pv_encryption_in_transit_enabled of this UpdateLaunchOptions.
+        :rtype: bool
+        """
+        return self._is_pv_encryption_in_transit_enabled
+
+    @is_pv_encryption_in_transit_enabled.setter
+    def is_pv_encryption_in_transit_enabled(self, is_pv_encryption_in_transit_enabled):
+        """
+        Sets the is_pv_encryption_in_transit_enabled of this UpdateLaunchOptions.
+        Whether to enable in-transit encryption for the boot volume's paravirtualized attachment.
+
+        Data in transit is transferred over an internal and highly secure network. If you have specific
+        compliance requirements related to the encryption of the data while it is moving between the
+        instance and the boot volume, you can enable in-transit encryption. In-transit encryption is
+        not enabled by default.
+
+        All boot volumes are encrypted at rest.
+
+        For more information, see `Block Volume Encryption`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm#Encrypti
+
+
+        :param is_pv_encryption_in_transit_enabled: The is_pv_encryption_in_transit_enabled of this UpdateLaunchOptions.
+        :type: bool
+        """
+        self._is_pv_encryption_in_transit_enabled = is_pv_encryption_in_transit_enabled
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/update_volume_details.py
+++ b/src/oci/core/models/update_volume_details.py
@@ -38,13 +38,18 @@ class UpdateVolumeDetails(object):
             The value to assign to the size_in_gbs property of this UpdateVolumeDetails.
         :type size_in_gbs: int
 
+        :param is_auto_tune_enabled:
+            The value to assign to the is_auto_tune_enabled property of this UpdateVolumeDetails.
+        :type is_auto_tune_enabled: bool
+
         """
         self.swagger_types = {
             'defined_tags': 'dict(str, dict(str, object))',
             'display_name': 'str',
             'freeform_tags': 'dict(str, str)',
             'vpus_per_gb': 'int',
-            'size_in_gbs': 'int'
+            'size_in_gbs': 'int',
+            'is_auto_tune_enabled': 'bool'
         }
 
         self.attribute_map = {
@@ -52,7 +57,8 @@ class UpdateVolumeDetails(object):
             'display_name': 'displayName',
             'freeform_tags': 'freeformTags',
             'vpus_per_gb': 'vpusPerGB',
-            'size_in_gbs': 'sizeInGBs'
+            'size_in_gbs': 'sizeInGBs',
+            'is_auto_tune_enabled': 'isAutoTuneEnabled'
         }
 
         self._defined_tags = None
@@ -60,6 +66,7 @@ class UpdateVolumeDetails(object):
         self._freeform_tags = None
         self._vpus_per_gb = None
         self._size_in_gbs = None
+        self._is_auto_tune_enabled = None
 
     @property
     def defined_tags(self):
@@ -226,6 +233,30 @@ class UpdateVolumeDetails(object):
         :type: int
         """
         self._size_in_gbs = size_in_gbs
+
+    @property
+    def is_auto_tune_enabled(self):
+        """
+        Gets the is_auto_tune_enabled of this UpdateVolumeDetails.
+        Specifies whether the auto-tune performance is enabled for this volume.
+
+
+        :return: The is_auto_tune_enabled of this UpdateVolumeDetails.
+        :rtype: bool
+        """
+        return self._is_auto_tune_enabled
+
+    @is_auto_tune_enabled.setter
+    def is_auto_tune_enabled(self, is_auto_tune_enabled):
+        """
+        Sets the is_auto_tune_enabled of this UpdateVolumeDetails.
+        Specifies whether the auto-tune performance is enabled for this volume.
+
+
+        :param is_auto_tune_enabled: The is_auto_tune_enabled of this UpdateVolumeDetails.
+        :type: bool
+        """
+        self._is_auto_tune_enabled = is_auto_tune_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/volume.py
+++ b/src/oci/core/models/volume.py
@@ -120,6 +120,14 @@ class Volume(object):
             The value to assign to the volume_group_id property of this Volume.
         :type volume_group_id: str
 
+        :param is_auto_tune_enabled:
+            The value to assign to the is_auto_tune_enabled property of this Volume.
+        :type is_auto_tune_enabled: bool
+
+        :param auto_tuned_vpus_per_gb:
+            The value to assign to the auto_tuned_vpus_per_gb property of this Volume.
+        :type auto_tuned_vpus_per_gb: int
+
         """
         self.swagger_types = {
             'availability_domain': 'str',
@@ -137,7 +145,9 @@ class Volume(object):
             'size_in_mbs': 'int',
             'source_details': 'VolumeSourceDetails',
             'time_created': 'datetime',
-            'volume_group_id': 'str'
+            'volume_group_id': 'str',
+            'is_auto_tune_enabled': 'bool',
+            'auto_tuned_vpus_per_gb': 'int'
         }
 
         self.attribute_map = {
@@ -156,7 +166,9 @@ class Volume(object):
             'size_in_mbs': 'sizeInMBs',
             'source_details': 'sourceDetails',
             'time_created': 'timeCreated',
-            'volume_group_id': 'volumeGroupId'
+            'volume_group_id': 'volumeGroupId',
+            'is_auto_tune_enabled': 'isAutoTuneEnabled',
+            'auto_tuned_vpus_per_gb': 'autoTunedVpusPerGB'
         }
 
         self._availability_domain = None
@@ -175,6 +187,8 @@ class Volume(object):
         self._source_details = None
         self._time_created = None
         self._volume_group_id = None
+        self._is_auto_tune_enabled = None
+        self._auto_tuned_vpus_per_gb = None
 
     @property
     def availability_domain(self):
@@ -623,6 +637,54 @@ class Volume(object):
         :type: str
         """
         self._volume_group_id = volume_group_id
+
+    @property
+    def is_auto_tune_enabled(self):
+        """
+        Gets the is_auto_tune_enabled of this Volume.
+        Specifies whether the auto-tune performance is enabled for this volume.
+
+
+        :return: The is_auto_tune_enabled of this Volume.
+        :rtype: bool
+        """
+        return self._is_auto_tune_enabled
+
+    @is_auto_tune_enabled.setter
+    def is_auto_tune_enabled(self, is_auto_tune_enabled):
+        """
+        Sets the is_auto_tune_enabled of this Volume.
+        Specifies whether the auto-tune performance is enabled for this volume.
+
+
+        :param is_auto_tune_enabled: The is_auto_tune_enabled of this Volume.
+        :type: bool
+        """
+        self._is_auto_tune_enabled = is_auto_tune_enabled
+
+    @property
+    def auto_tuned_vpus_per_gb(self):
+        """
+        Gets the auto_tuned_vpus_per_gb of this Volume.
+        The number of Volume Performance Units per GB that this volume is effectively tuned to when it's idle.
+
+
+        :return: The auto_tuned_vpus_per_gb of this Volume.
+        :rtype: int
+        """
+        return self._auto_tuned_vpus_per_gb
+
+    @auto_tuned_vpus_per_gb.setter
+    def auto_tuned_vpus_per_gb(self, auto_tuned_vpus_per_gb):
+        """
+        Sets the auto_tuned_vpus_per_gb of this Volume.
+        The number of Volume Performance Units per GB that this volume is effectively tuned to when it's idle.
+
+
+        :param auto_tuned_vpus_per_gb: The auto_tuned_vpus_per_gb of this Volume.
+        :type: int
+        """
+        self._auto_tuned_vpus_per_gb = auto_tuned_vpus_per_gb
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/update_maintenance_run_details.py
+++ b/src/oci/database/models/update_maintenance_run_details.py
@@ -26,19 +26,26 @@ class UpdateMaintenanceRunDetails(object):
             The value to assign to the time_scheduled property of this UpdateMaintenanceRunDetails.
         :type time_scheduled: datetime
 
+        :param is_patch_now_enabled:
+            The value to assign to the is_patch_now_enabled property of this UpdateMaintenanceRunDetails.
+        :type is_patch_now_enabled: bool
+
         """
         self.swagger_types = {
             'is_enabled': 'bool',
-            'time_scheduled': 'datetime'
+            'time_scheduled': 'datetime',
+            'is_patch_now_enabled': 'bool'
         }
 
         self.attribute_map = {
             'is_enabled': 'isEnabled',
-            'time_scheduled': 'timeScheduled'
+            'time_scheduled': 'timeScheduled',
+            'is_patch_now_enabled': 'isPatchNowEnabled'
         }
 
         self._is_enabled = None
         self._time_scheduled = None
+        self._is_patch_now_enabled = None
 
     @property
     def is_enabled(self):
@@ -87,6 +94,30 @@ class UpdateMaintenanceRunDetails(object):
         :type: datetime
         """
         self._time_scheduled = time_scheduled
+
+    @property
+    def is_patch_now_enabled(self):
+        """
+        Gets the is_patch_now_enabled of this UpdateMaintenanceRunDetails.
+        If set to `TRUE`, starts patching immediately.
+
+
+        :return: The is_patch_now_enabled of this UpdateMaintenanceRunDetails.
+        :rtype: bool
+        """
+        return self._is_patch_now_enabled
+
+    @is_patch_now_enabled.setter
+    def is_patch_now_enabled(self, is_patch_now_enabled):
+        """
+        Sets the is_patch_now_enabled of this UpdateMaintenanceRunDetails.
+        If set to `TRUE`, starts patching immediately.
+
+
+        :param is_patch_now_enabled: The is_patch_now_enabled of this UpdateMaintenanceRunDetails.
+        :type: bool
+        """
+        self._is_patch_now_enabled = is_patch_now_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/regions.py
+++ b/src/oci/regions.py
@@ -18,6 +18,7 @@ from oci._vendor.urllib3.util.retry import Retry
 REGIONS_SHORT_NAMES = {
     'phx': 'us-phoenix-1',
     'iad': 'us-ashburn-1',
+    'sjc': 'us-sanjose-1',
     'fra': 'eu-frankfurt-1',
     'zrh': 'eu-zurich-1',
     'lhr': 'uk-london-1',
@@ -47,6 +48,7 @@ REGION_REALMS = {
     'ap-chuncheon-1': 'oc1',
     'us-phoenix-1': 'oc1',
     'us-ashburn-1': 'oc1',
+    'us-sanjose-1': 'oc1',
     'eu-amsterdam-1': 'oc1',
     'eu-frankfurt-1': 'oc1',
     'eu-zurich-1': 'oc1',
@@ -82,6 +84,7 @@ REGIONS = [
     "ap-chuncheon-1",
     "us-phoenix-1",
     "us-ashburn-1",
+    "us-sanjose-1",
     "eu-amsterdam-1",
     "eu-frankfurt-1",
     "eu-zurich-1",

--- a/src/oci/resource_manager/models/create_config_source_details.py
+++ b/src/oci/resource_manager/models/create_config_source_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateConfigSourceDetails(object):
     """
-    Property details for the configuration source.
+    Property details for the configuration source used for the stack.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/resource_manager/models/create_gitlab_access_token_configuration_source_provider_details.py
+++ b/src/oci/resource_manager/models/create_gitlab_access_token_configuration_source_provider_details.py
@@ -90,7 +90,7 @@ class CreateGitlabAccessTokenConfigurationSourceProviderDetails(CreateConfigurat
         """
         **[Required]** Gets the api_endpoint of this CreateGitlabAccessTokenConfigurationSourceProviderDetails.
         The Git service API endpoint.
-        Example: `https://gitlab.com/api/v3/`
+        Example: `https://gitlab.com/api/v4/`
 
 
         :return: The api_endpoint of this CreateGitlabAccessTokenConfigurationSourceProviderDetails.
@@ -103,7 +103,7 @@ class CreateGitlabAccessTokenConfigurationSourceProviderDetails(CreateConfigurat
         """
         Sets the api_endpoint of this CreateGitlabAccessTokenConfigurationSourceProviderDetails.
         The Git service API endpoint.
-        Example: `https://gitlab.com/api/v3/`
+        Example: `https://gitlab.com/api/v4/`
 
 
         :param api_endpoint: The api_endpoint of this CreateGitlabAccessTokenConfigurationSourceProviderDetails.

--- a/src/oci/resource_manager/models/create_stack_details.py
+++ b/src/oci/resource_manager/models/create_stack_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateStackDetails(object):
     """
-    Properties provided for creating a stack.
+    The configuration details for creating a stack.
     """
 
     def __init__(self, **kwargs):
@@ -183,7 +183,7 @@ class CreateStackDetails(object):
         """
         Gets the variables of this CreateStackDetails.
         Terraform variables associated with this resource.
-        Maximum number of variables supported is 100.
+        Maximum number of variables supported is 250.
         The maximum size of each variable, including both name and value, is 4096 bytes.
         Example: `{\"CompartmentId\": \"compartment-id-value\"}`
 
@@ -198,7 +198,7 @@ class CreateStackDetails(object):
         """
         Sets the variables of this CreateStackDetails.
         Terraform variables associated with this resource.
-        Maximum number of variables supported is 100.
+        Maximum number of variables supported is 250.
         The maximum size of each variable, including both name and value, is 4096 bytes.
         Example: `{\"CompartmentId\": \"compartment-id-value\"}`
 

--- a/src/oci/resource_manager/models/gitlab_access_token_configuration_source_provider.py
+++ b/src/oci/resource_manager/models/gitlab_access_token_configuration_source_provider.py
@@ -62,10 +62,6 @@ class GitlabAccessTokenConfigurationSourceProvider(ConfigurationSourceProvider):
             The value to assign to the api_endpoint property of this GitlabAccessTokenConfigurationSourceProvider.
         :type api_endpoint: str
 
-        :param access_token:
-            The value to assign to the access_token property of this GitlabAccessTokenConfigurationSourceProvider.
-        :type access_token: str
-
         """
         self.swagger_types = {
             'id': 'str',
@@ -77,8 +73,7 @@ class GitlabAccessTokenConfigurationSourceProvider(ConfigurationSourceProvider):
             'config_source_provider_type': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
-            'api_endpoint': 'str',
-            'access_token': 'str'
+            'api_endpoint': 'str'
         }
 
         self.attribute_map = {
@@ -91,8 +86,7 @@ class GitlabAccessTokenConfigurationSourceProvider(ConfigurationSourceProvider):
             'config_source_provider_type': 'configSourceProviderType',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
-            'api_endpoint': 'apiEndpoint',
-            'access_token': 'accessToken'
+            'api_endpoint': 'apiEndpoint'
         }
 
         self._id = None
@@ -105,7 +99,6 @@ class GitlabAccessTokenConfigurationSourceProvider(ConfigurationSourceProvider):
         self._freeform_tags = None
         self._defined_tags = None
         self._api_endpoint = None
-        self._access_token = None
         self._config_source_provider_type = 'GITLAB_ACCESS_TOKEN'
 
     @property
@@ -113,7 +106,7 @@ class GitlabAccessTokenConfigurationSourceProvider(ConfigurationSourceProvider):
         """
         Gets the api_endpoint of this GitlabAccessTokenConfigurationSourceProvider.
         The Git service API endpoint.
-        Example: `https://gitlab.com/api/v3/`
+        Example: `https://gitlab.com/api/v4/`
 
 
         :return: The api_endpoint of this GitlabAccessTokenConfigurationSourceProvider.
@@ -126,37 +119,13 @@ class GitlabAccessTokenConfigurationSourceProvider(ConfigurationSourceProvider):
         """
         Sets the api_endpoint of this GitlabAccessTokenConfigurationSourceProvider.
         The Git service API endpoint.
-        Example: `https://gitlab.com/api/v3/`
+        Example: `https://gitlab.com/api/v4/`
 
 
         :param api_endpoint: The api_endpoint of this GitlabAccessTokenConfigurationSourceProvider.
         :type: str
         """
         self._api_endpoint = api_endpoint
-
-    @property
-    def access_token(self):
-        """
-        Gets the access_token of this GitlabAccessTokenConfigurationSourceProvider.
-        The personal access token configured on the Git repository.
-
-
-        :return: The access_token of this GitlabAccessTokenConfigurationSourceProvider.
-        :rtype: str
-        """
-        return self._access_token
-
-    @access_token.setter
-    def access_token(self, access_token):
-        """
-        Sets the access_token of this GitlabAccessTokenConfigurationSourceProvider.
-        The personal access token configured on the Git repository.
-
-
-        :param access_token: The access_token of this GitlabAccessTokenConfigurationSourceProvider.
-        :type: str
-        """
-        self._access_token = access_token
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/resource_manager/models/gitlab_access_token_configuration_source_provider_summary.py
+++ b/src/oci/resource_manager/models/gitlab_access_token_configuration_source_provider_summary.py
@@ -104,7 +104,7 @@ class GitlabAccessTokenConfigurationSourceProviderSummary(ConfigurationSourcePro
         """
         Gets the api_endpoint of this GitlabAccessTokenConfigurationSourceProviderSummary.
         The Git service API endpoint.
-        Example: `https://gitlab.com/api/v3/`
+        Example: `https://gitlab.com/api/v4/`
 
 
         :return: The api_endpoint of this GitlabAccessTokenConfigurationSourceProviderSummary.
@@ -117,7 +117,7 @@ class GitlabAccessTokenConfigurationSourceProviderSummary(ConfigurationSourcePro
         """
         Sets the api_endpoint of this GitlabAccessTokenConfigurationSourceProviderSummary.
         The Git service API endpoint.
-        Example: `https://gitlab.com/api/v3/`
+        Example: `https://gitlab.com/api/v4/`
 
 
         :param api_endpoint: The api_endpoint of this GitlabAccessTokenConfigurationSourceProviderSummary.

--- a/src/oci/resource_manager/models/job.py
+++ b/src/oci/resource_manager/models/job.py
@@ -523,7 +523,8 @@ class Job(object):
     def working_directory(self):
         """
         Gets the working_directory of this Job.
-        The file path to the directory within the configuration from which the job runs.
+        File path to the directory from which Terraform runs.
+        If not specified, the root directory is used.
 
 
         :return: The working_directory of this Job.
@@ -535,7 +536,8 @@ class Job(object):
     def working_directory(self, working_directory):
         """
         Sets the working_directory of this Job.
-        The file path to the directory within the configuration from which the job runs.
+        File path to the directory from which Terraform runs.
+        If not specified, the root directory is used.
 
 
         :param working_directory: The working_directory of this Job.
@@ -548,7 +550,7 @@ class Job(object):
         """
         Gets the variables of this Job.
         Terraform variables associated with this resource.
-        Maximum number of variables supported is 100.
+        Maximum number of variables supported is 250.
         The maximum size of each variable, including both name and value, is 4096 bytes.
         Example: `{\"CompartmentId\": \"compartment-id-value\"}`
 
@@ -563,7 +565,7 @@ class Job(object):
         """
         Sets the variables of this Job.
         Terraform variables associated with this resource.
-        Maximum number of variables supported is 100.
+        Maximum number of variables supported is 250.
         The maximum size of each variable, including both name and value, is 4096 bytes.
         Example: `{\"CompartmentId\": \"compartment-id-value\"}`
 

--- a/src/oci/resource_manager/models/stack.py
+++ b/src/oci/resource_manager/models/stack.py
@@ -345,7 +345,7 @@ class Stack(object):
         """
         Gets the variables of this Stack.
         Terraform variables associated with this resource.
-        Maximum number of variables supported is 100.
+        Maximum number of variables supported is 250.
         The maximum size of each variable, including both name and value, is 4096 bytes.
         Example: `{\"CompartmentId\": \"compartment-id-value\"}`
 
@@ -360,7 +360,7 @@ class Stack(object):
         """
         Sets the variables of this Stack.
         Terraform variables associated with this resource.
-        Maximum number of variables supported is 100.
+        Maximum number of variables supported is 250.
         The maximum size of each variable, including both name and value, is 4096 bytes.
         Example: `{\"CompartmentId\": \"compartment-id-value\"}`
 

--- a/src/oci/resource_manager/models/stack_resource_drift_collection.py
+++ b/src/oci/resource_manager/models/stack_resource_drift_collection.py
@@ -36,7 +36,7 @@ class StackResourceDriftCollection(object):
     @property
     def items(self):
         """
-        Gets the items of this StackResourceDriftCollection.
+        **[Required]** Gets the items of this StackResourceDriftCollection.
         Collection of drift status details for all resources defined in the stack.
 
 

--- a/src/oci/resource_manager/models/update_gitlab_access_token_configuration_source_provider_details.py
+++ b/src/oci/resource_manager/models/update_gitlab_access_token_configuration_source_provider_details.py
@@ -83,7 +83,7 @@ class UpdateGitlabAccessTokenConfigurationSourceProviderDetails(UpdateConfigurat
         """
         Gets the api_endpoint of this UpdateGitlabAccessTokenConfigurationSourceProviderDetails.
         The Git service API endpoint.
-        Example: `https://gitlab.com/api/v3/`
+        Example: `https://gitlab.com/api/v4/`
 
 
         :return: The api_endpoint of this UpdateGitlabAccessTokenConfigurationSourceProviderDetails.
@@ -96,7 +96,7 @@ class UpdateGitlabAccessTokenConfigurationSourceProviderDetails(UpdateConfigurat
         """
         Sets the api_endpoint of this UpdateGitlabAccessTokenConfigurationSourceProviderDetails.
         The Git service API endpoint.
-        Example: `https://gitlab.com/api/v3/`
+        Example: `https://gitlab.com/api/v4/`
 
 
         :param api_endpoint: The api_endpoint of this UpdateGitlabAccessTokenConfigurationSourceProviderDetails.

--- a/src/oci/resource_manager/models/update_stack_details.py
+++ b/src/oci/resource_manager/models/update_stack_details.py
@@ -148,7 +148,7 @@ class UpdateStackDetails(object):
         """
         Gets the variables of this UpdateStackDetails.
         Terraform variables associated with this resource.
-        The maximum number of variables supported is 100.
+        The maximum number of variables supported is 250.
         The maximum size of each variable, including both name and value, is 4096 bytes.
         Example: `{\"CompartmentId\": \"compartment-id-value\"}`
 
@@ -163,7 +163,7 @@ class UpdateStackDetails(object):
         """
         Sets the variables of this UpdateStackDetails.
         Terraform variables associated with this resource.
-        The maximum number of variables supported is 100.
+        The maximum number of variables supported is 250.
         The maximum size of each variable, including both name and value, is 4096 bytes.
         Example: `{\"CompartmentId\": \"compartment-id-value\"}`
 

--- a/src/oci/resource_manager/resource_manager_client.py
+++ b/src/oci/resource_manager/resource_manager_client.py
@@ -517,7 +517,8 @@ class ResourceManagerClient(object):
     def create_stack(self, create_stack_details, **kwargs):
         """
         Creates a stack in the specified compartment.
-        Specify the compartment using the compartment ID.
+        You can create a stack from a Terraform configuration file.
+        The Terraform configuration file can be directly uploaded or referenced from a source code control system.
         For more information, see
         `To create a stack`__.
 

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.18.1"
+__version__ = "2.19.0"


### PR DESCRIPTION
## Added

* Support for calling Oracle Cloud Infrastructure services in the us-sanjose-1 region

* Support for updating the fault domain and launch options of VM instances in the Compute service

* Support for image capability schemas and schema versions in the Compute service

* Support for 'Patch Now' maintenance runs for autonomous Exadata infrastructure and autonomous container database resources in the Database service

* Support for automatic performance and cost tuning on volumes in the Block Storage service



## Breaking

* Removed the accessToken field from the GitlabAccessTokenConfigurationSourceProvider model in the Resource Manager service




