### PR TITLE
Releasing version 2.21.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.21.0 - 2020-08-11
+====================
+
+Added
+-----
+* Support for autonomous json databases in the Database service
+* Support for cleaning up uncommitted multipart uploads in the Object Storage service
+* Support for additional list API filters in the Data Catalog service
+
+Breaking
+--------
+* Some unusable region enums were removed from the Support Management service
+* Parameter `opc_retry_token` was removed from the Support Management service
+
+====================
 2.20.0 - 2020-08-04
 ====================
 
@@ -18,6 +33,10 @@ Added
 Breaking
 --------
 * Param `life_cycle_details` renamed to `lifecycle_details` in models `BlockchainPlatformByHostname` and `BlockchainPlatformSummary` in the Blockchain service
+
+Changed
+-------
+* Restricted `pyOpenSSL` dependency to versions between 17.5.0 and 19.1.0, both inclusive. See `#255 <https://github.com/oracle/oci-python-sdk/issues/255>`_ for details.
 
 ====================
 2.19.0 - 2020-07-28

--- a/docs/api/cims.rst
+++ b/docs/api/cims.rst
@@ -7,7 +7,9 @@ Cims
     :template: autosummary/service_client.rst
 
     oci.cims.IncidentClient
+    oci.cims.UserClient
     oci.cims.IncidentClientCompositeOperations
+    oci.cims.UserClientCompositeOperations
 
 --------
  Models
@@ -23,6 +25,7 @@ Cims
     oci.cims.models.Classifier
     oci.cims.models.Contact
     oci.cims.models.ContactList
+    oci.cims.models.ContextualData
     oci.cims.models.CreateCategoryDetails
     oci.cims.models.CreateIncident
     oci.cims.models.CreateIssueTypeDetails
@@ -32,6 +35,7 @@ Cims
     oci.cims.models.CreateSubCategoryDetails
     oci.cims.models.CreateTechSupportItemDetails
     oci.cims.models.CreateTicketDetails
+    oci.cims.models.CreateUserDetails
     oci.cims.models.Incident
     oci.cims.models.IncidentResourceType
     oci.cims.models.IncidentSummary
@@ -51,4 +55,5 @@ Cims
     oci.cims.models.UpdateItemDetails
     oci.cims.models.UpdateResourceDetails
     oci.cims.models.UpdateTicketDetails
+    oci.cims.models.User
     oci.cims.models.ValidationResponse

--- a/docs/api/cims/client/oci.cims.UserClient.rst
+++ b/docs/api/cims/client/oci.cims.UserClient.rst
@@ -1,0 +1,8 @@
+UserClient
+==========
+
+.. currentmodule:: oci.cims
+
+.. autoclass:: UserClient
+    :special-members: __init__
+    :members:

--- a/docs/api/cims/client/oci.cims.UserClientCompositeOperations.rst
+++ b/docs/api/cims/client/oci.cims.UserClientCompositeOperations.rst
@@ -1,0 +1,8 @@
+UserClientCompositeOperations
+=============================
+
+.. currentmodule:: oci.cims
+
+.. autoclass:: UserClientCompositeOperations
+    :special-members: __init__
+    :members:

--- a/docs/api/cims/models/oci.cims.models.ContextualData.rst
+++ b/docs/api/cims/models/oci.cims.models.ContextualData.rst
@@ -1,0 +1,11 @@
+ContextualData
+==============
+
+.. currentmodule:: oci.cims.models
+
+.. autoclass:: ContextualData
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/cims/models/oci.cims.models.CreateUserDetails.rst
+++ b/docs/api/cims/models/oci.cims.models.CreateUserDetails.rst
@@ -1,0 +1,11 @@
+CreateUserDetails
+=================
+
+.. currentmodule:: oci.cims.models
+
+.. autoclass:: CreateUserDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/cims/models/oci.cims.models.User.rst
+++ b/docs/api/cims/models/oci.cims.models.User.rst
@@ -1,0 +1,11 @@
+User
+====
+
+.. currentmodule:: oci.cims.models
+
+.. autoclass:: User
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/landing.rst
+++ b/docs/api/landing.rst
@@ -15,6 +15,7 @@ API Reference
 * :doc:`Blockchain Platform <blockchain/client/oci.blockchain.BlockchainPlatformClient>`
 * :doc:`Budget <budget/client/oci.budget.BudgetClient>`
 * :doc:`Incident <cims/client/oci.cims.IncidentClient>`
+* :doc:`User <cims/client/oci.cims.UserClient>`
 * :doc:`Container Engine <container_engine/client/oci.container_engine.ContainerEngineClient>`
 * :doc:`Block Storage <core/client/oci.core.BlockstorageClient>`
 * :doc:`Compute <core/client/oci.core.ComputeClient>`

--- a/examples/check_lb_cert_validity.py
+++ b/examples/check_lb_cert_validity.py
@@ -1,0 +1,120 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+# This script checks all load balancer certificates in the tenancy if they will remain valid
+# after N (user supplied) number of days.  It traverses the compartment tree, locating
+# load balancer ctificates in each compartment.  It extracts the "Not Valid After" attribute
+# and checks if the certificate will expire after N (user supplied) days.
+#
+# Usage:
+# python check_lb_cert_validity.py -d 'expiry-in-the-next-days' -c 'compartment-ocid'
+#
+# The script uses the default OCI SDK/CLI configuration file ~/.oci/config .
+
+
+import argparse
+import oci
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from datetime import datetime, timedelta
+
+
+def verify_cert_expiry(compartment_id, load_balancer_id, cert_bundle):
+
+    pem_cert = cert_bundle.public_certificate
+    cert = x509.load_pem_x509_certificate(bytes(str(pem_cert), 'utf-8'), default_backend())
+    cert_not_valid_after = cert.not_valid_after.date()
+
+    validity_date = datetime.utcnow().date().today() + timedelta(days=int(cert_validity_days))
+
+    if cert_not_valid_after <= validity_date:
+        print("========================================================")
+        print("Compartment Id: ", compartment_id)
+        print("Load Balancer ID: ", load_balancer_id)
+        print("Certificate Name: ", cert_bundle.certificate_name)
+        print("Certificate Validity: ", cert.not_valid_after)
+        print("Certificate expiring within {0} days.".format(cert_validity_days))
+        print("========================================================\n")
+
+
+# Check certificates in a load balancer.
+def verify_certificates(compartment_id, load_balancer_id):
+
+    response = lb_client.list_certificates(load_balancer_id)
+
+    cert_list = response.data
+    for i in cert_list:
+        verify_cert_expiry(compartment_id, load_balancer_id, i)
+
+
+# Check certificates in all load balancers in a compartment.
+def inpect_lb_certs(compartment_id):
+
+    response = lb_client.list_load_balancers(compartment_id)
+    lb_list = response.data
+
+    for i in lb_list:
+        lb_id = i.id
+        verify_certificates(compartment_id, lb_id)
+
+
+# Traverse the compartment tree and identify any expired certificates.
+def traverse_compartment_tree(compartment_id):
+
+    response = identity_client.list_compartments(compartment_id)
+    child_compartment_list = response.data
+
+    length = len(child_compartment_list)
+
+    if length > 0:
+        for i in child_compartment_list:
+            child_compartment_id = i.id
+            traverse_compartment_tree(child_compartment_id)
+
+    # Look for expiring certificates in load balancers belonging to this compartment.
+    inpect_lb_certs(compartment_id)
+
+
+def main():
+
+    # Traverse the compartment heirarchy and identify the expiring certificates.
+    traverse_compartment_tree(top_compartment)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d",
+                        "--expiry-in-the-next-days",
+                        action="store",
+                        help="check certificates which will expire in the coming days",
+                        required=True)
+    parser.add_argument("-c",
+                        "--compartment-id",
+                        action="store",
+                        default="root",
+                        help="Compartment and its child compartments to be searched for expired load balancer certs ")
+
+    args = parser.parse_args()
+
+    # Get hold of the arguments.
+    cert_validity_days = args.expiry_in_the_next_days
+    top_compartment = args.compartment_id
+
+    try:
+        config = oci.config.from_file()
+    except oci.exceptions.ConfigFileNotFound as e:
+        print("")
+        print("ConfigFileNotFound: {}".format(e))
+        print("")
+        exit(-1)
+
+    # If compartment was not provided, default value is root.
+    if "root" == top_compartment:
+        top_compartment = config["tenancy"]
+
+    # Service clients
+    identity_client = oci.identity.IdentityClient(config)
+    lb_client = oci.load_balancer.LoadBalancerClient(config)
+
+    main()

--- a/examples/get_waf_log.py
+++ b/examples/get_waf_log.py
@@ -1,0 +1,157 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+# This script collects logs from WAF and uploads them to the Object Storage.  The tool will pick up log deltas.
+# That is, it will first determine when was the last time logs were fetched from WAF.  It will then fetch just
+# the logs from that day until yesterday. For example, say you last ran the tool on June 15, 2020.  The tool
+# had fetched logs until June 14, 2020 (i.e. the previous day).  Now if you run the tool today - June 25 - it
+# will fetch logs from June 15 until yesterday, i.e., June 24.
+#
+# So the idea is, if you run this tool everyday in a cron job, you will have WAF logs for each day.  You may
+# write an Object Storage retention policy to delete old log files or move them to Archive Storage.
+#
+# Usage:
+# python get_waf_log.py -w waf_policy_id -b object_storage_bucket_name
+#
+# The script uses the default OCI SDK/CLI configuration file ~/.oci/config .
+
+# import sys
+import argparse
+from datetime import datetime, timedelta
+import oci
+
+
+# Custom function for sorting list.
+def get_time_created_field(log_file):
+    return log_file.time_created
+
+
+# This function finds the date of the latest logfile uploaded to the Object Storage.
+# If there are no files, then it retuns None.
+def get_latest_logfile_date(object_storage, namespace):
+
+    # Log files uploaded on to the Object Storage are prefixed with "WafLogs".
+    list_log_objects = object_storage.list_objects(namespace, bucket_name, fields='name,timeCreated', prefix="WafLogs")
+    list_log_files = list_log_objects.data.objects
+    log_files_num = len(list_log_files)
+
+    if log_files_num == 0:
+        print("There are no log files in the Object Storage.")
+        return
+    else:
+        # Sort the list on "timeCreated" in descending order.
+        list_log_files.sort(key=get_time_created_field, reverse=True)
+
+        # Get the timestamp of the topmost element.
+        topmost_time_stamp = list_log_files[0].time_created
+        print("Timestamp of the latest log file {}".format(topmost_time_stamp))
+
+        time_stamp = datetime(topmost_time_stamp.year, topmost_time_stamp.month, topmost_time_stamp.day).date()
+
+        return time_stamp
+
+
+def upload_logs_to_object_storage(waf_logs):
+
+    object_storage = oci.object_storage.ObjectStorageClient(config)
+    namespace = object_storage.get_namespace().data
+
+    current_datetime = datetime.now()
+    object_name = "WafLogs-" + str(current_datetime)
+
+    print("Uploading new object to Object Storage - {!r}".format(object_name))
+    object_storage.put_object(namespace,
+                              bucket_name,
+                              object_name,
+                              bytes(str(waf_logs), 'utf-8'))
+
+
+def main():
+
+    # Create a service client.
+    waf_client = oci.waas.WaasClient(config)
+
+    # First we need to find out when was the last time logs were fetched from WAF.  We will then fetch
+    # logs from the next day until yesterday.  For this, we will query the Object Storage.
+    object_storage = oci.object_storage.ObjectStorageClient(config)
+    namespace = object_storage.get_namespace().data
+
+    # Start by getting hold of yesterday's time_stamp.
+    yesterday = datetime.utcnow().date().today() - timedelta(days=1)
+
+    # Query Object Storage.
+    latest_log_fetch_timestamp = get_latest_logfile_date(object_storage, namespace)
+
+    if latest_log_fetch_timestamp is None:
+        # No logs have been uploaded to the object Storage.  Fetch all logs from WAF for a week until
+        # yesterday and upload them to the Object Storage.
+        weekback = yesterday - timedelta(days=7)
+
+        fetch_logs_from_time = datetime(weekback.year,
+                                        weekback.month,
+                                        weekback.day)
+    else:
+        # If we fetched it today, do nothing.
+        if latest_log_fetch_timestamp == datetime.utcnow().date().today():
+            print("Skip fetching- already fetched today.")
+            return
+        else:
+            # Otherwise, fetch logs from the latest_log_fetch_date.
+            fetch_logs_from_time = datetime(latest_log_fetch_timestamp.year,
+                                            latest_log_fetch_timestamp.month,
+                                            latest_log_fetch_timestamp.day)
+
+    # Fetch the logs from the day when the logs were fetched last
+    # until yesterday 11:59:59:999999 pm, i.e. just before midnight.
+    fetch_logs_until_time = datetime(yesterday.year,
+                                     yesterday.month,
+                                     yesterday.day,
+                                     23,
+                                     59,
+                                     59,
+                                     999999)
+
+    print("Fetching logs from {0} until {1}".format(fetch_logs_from_time, fetch_logs_until_time))
+
+    response = waf_client.list_waf_logs(waf_policy_id,
+                                        time_observed_greater_than_or_equal_to=fetch_logs_from_time,
+                                        time_observed_less_than=fetch_logs_until_time)
+
+    if response.status == 200:
+        upload_logs_to_object_storage(response.data)
+    else:
+        print("Could not fetch logs from WAF - HTTP Status = {}.".format(response.status))
+        exit(-1)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-w",
+                        "--waf-policy-id",
+                        action="store",
+                        help="OCID of the WAF Policy",
+                        required=True)
+    parser.add_argument("-b",
+                        "--bucket-name",
+                        action="store",
+                        help="Name of Object Storage Bucket hosting the WAF log files",
+                        required=True)
+
+    args = parser.parse_args()
+
+    # Get hold of the arguments.
+    waf_policy_id = args.waf_policy_id
+    bucket_name = args.bucket_name
+
+    try:
+        # Set up config.
+        config = oci.config.from_file()
+    except oci.exceptions.ConfigFileNotFound as e:
+        print("")
+        print("ConfigFileNotFound: {}".format(e))
+        print("")
+        exit(-1)
+
+    main()

--- a/examples/list_resources_in_tenancy/how_to_run_in_cloud_shell.rst
+++ b/examples/list_resources_in_tenancy/how_to_run_in_cloud_shell.rst
@@ -20,5 +20,6 @@ Executing using Cloud Shell:
        python list_all_virtual_circuits_in_tenancy.py -dt
        python list_compute_tags_in_tenancy.py -dt
        python list_dbsystem_with_maintenance_in_tenancy.py -dt
+       python list_bv_backups_in_tenancy.py -dt
 
 

--- a/examples/list_resources_in_tenancy/list_bv_backups_in_tenancy.py
+++ b/examples/list_resources_in_tenancy/list_bv_backups_in_tenancy.py
@@ -1,0 +1,459 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+##########################################################################
+# list_bv_backups_in_tenancy.py
+#
+# @author: Adi Zohar
+#
+# Supports Python  3
+##########################################################################
+# Info:
+#    List all boot volumes backups, volume backups and volume group backups in Tenancy
+#
+# Connectivity:
+#    Option 1 - User Authentication
+#       $HOME/.oci/config, please follow - https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm
+#       OCI user part of ListComputeTagsGroup group with below Policy rules:
+#          Allow group ListComputeTagsGroup to inspect compartments in tenancy
+#          Allow group ListComputeTagsGroup to inspect tenancies in tenancy
+#          Allow group ListComputeTagsGroup to inspect boot-volume-backups in tenancy
+#          Allow group ListComputeTagsGroup to inspect volume-backups in tenancy
+#          Allow group ListComputeTagsGroup to inspect volume-group-backups in tenancy
+#
+#    Option 2 - Instance Principle
+#       Compute instance part of DynListComputeTagsGroup dynamic group with policy rules:
+#          Allow dynamic group DynListComputeTagsGroup to inspect compartments in tenancy
+#          Allow dynamic group DynListComputeTagsGroup to inspect tenancies in tenancy
+#          Allow dynamic group DynListComputeTagsGroup to inspect boot-volume-backups in tenancy
+#          Allow dynamic group DynListComputeTagsGroup to inspect volume-backups in tenancy
+#          Allow dynamic group DynListComputeTagsGroup to inspect volume-group-backups in tenancy
+#
+##########################################################################
+# Modules Included:
+# - oci.identity.IdentityClient
+#
+# APIs Used:
+# - IdentityClient.list_compartments         - Policy COMPARTMENT_INSPECT
+# - IdentityClient.get_tenancy               - Policy TENANCY_INSPECT
+# - IdentityClient.list_region_subscriptions - Policy TENANCY_INSPECT
+# - block_storage.list_boot_volume_backups   - Policy boot-volume-backups
+# - block_storage.list_volume_backups        - Policy volume-backups
+# - block_storage.list_volume_group_backups  - Policy volume-group-backups
+#
+##########################################################################
+# Application Command line parameters
+#
+#   -t config - Config file section to use (tenancy profile)
+#   -p proxy  - Set Proxy (i.e. www-proxy-server.com:80)
+#   -ip       - Use Instance Principals for Authentication
+#   -dt       - Use Instance Principals with delegation token for cloud shell
+##########################################################################
+
+from __future__ import print_function
+import sys
+import argparse
+import datetime
+import oci
+import json
+import os
+
+
+##########################################################################
+# Print header centered
+##########################################################################
+def print_header(name):
+    chars = int(90)
+    print("")
+    print('#' * chars)
+    print("#" + name.center(chars - 2, " ") + "#")
+    print('#' * chars)
+
+
+##########################################################################
+# check service error to warn instead of error
+##########################################################################
+def check_service_error(code):
+    return ('max retries exceeded' in str(code).lower() or
+            'auth' in str(code).lower() or
+            'notfound' in str(code).lower() or
+            code == 'Forbidden' or
+            code == 'TooManyRequests' or
+            code == 'IncorrectState' or
+            code == 'LimitExceeded'
+            )
+
+
+##########################################################################
+# Create signer for Authentication
+# Input - config_profile and is_instance_principals and is_delegation_token
+# Output - config and signer objects
+##########################################################################
+def create_signer(config_profile, is_instance_principals, is_delegation_token):
+
+    # if instance principals authentications
+    if is_instance_principals:
+        try:
+            signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+            config = {'region': signer.region, 'tenancy': signer.tenancy_id}
+            return config, signer
+
+        except Exception:
+            print_header("Error obtaining instance principals certificate, aborting")
+            raise SystemExit
+
+    # -----------------------------
+    # Delegation Token
+    # -----------------------------
+    elif is_delegation_token:
+
+        try:
+            # check if env variables OCI_CONFIG_FILE, OCI_CONFIG_PROFILE exist and use them
+            env_config_file = os.environ.get('OCI_CONFIG_FILE')
+            env_config_section = os.environ.get('OCI_CONFIG_PROFILE')
+
+            # check if file exist
+            if env_config_file is None or env_config_section is None:
+                print("*** OCI_CONFIG_FILE and OCI_CONFIG_PROFILE env variables not found, abort. ***")
+                print("")
+                raise SystemExit
+
+            # check if file exist
+            if not os.path.isfile(env_config_file):
+                print("*** Config File " + env_config_file + " does not exist, Abort. ***")
+                print("")
+                raise SystemExit
+
+            config = oci.config.from_file(env_config_file, env_config_section)
+            delegation_token_location = config["delegation_token_file"]
+
+            with open(delegation_token_location, 'r') as delegation_token_file:
+                delegation_token = delegation_token_file.read().strip()
+                # get signer from delegation token
+                signer = oci.auth.signers.InstancePrincipalsDelegationTokenSigner(delegation_token=delegation_token)
+
+                return config, signer
+
+        except KeyError:
+            print("* Key Error obtaining delegation_token_file")
+            raise SystemExit
+
+        except Exception:
+            raise
+
+    # -----------------------------
+    # config file authentication
+    # -----------------------------
+    else:
+        config = oci.config.from_file(
+            oci.config.DEFAULT_LOCATION,
+            (config_profile if config_profile else oci.config.DEFAULT_PROFILE)
+        )
+        signer = oci.signer.Signer(
+            tenancy=config["tenancy"],
+            user=config["user"],
+            fingerprint=config["fingerprint"],
+            private_key_file_location=config.get("key_file"),
+            pass_phrase=oci.config.get_config_value_or_default(config, "pass_phrase"),
+            private_key_content=config.get("key_content")
+        )
+        return config, signer
+
+
+##########################################################################
+# Load compartments
+##########################################################################
+def identity_read_compartments(identity, tenancy):
+
+    print("Loading Compartments...")
+    try:
+        compartments = oci.pagination.list_call_get_all_results(
+            identity.list_compartments,
+            tenancy.id,
+            compartment_id_in_subtree=True
+        ).data
+
+        # Add root compartment which is not part of the list_compartments
+        compartments.append(tenancy)
+
+        print("    Total " + str(len(compartments)) + " compartments loaded.")
+        return compartments
+
+    except Exception as e:
+        raise RuntimeError("Error in identity_read_compartments: " + str(e.args))
+
+
+##########################################################################
+# Main
+##########################################################################
+
+# Get Command Line Parser
+parser = argparse.ArgumentParser()
+parser.add_argument('-t', default="", dest='config_profile', help='Config file section to use (tenancy profile)')
+parser.add_argument('-p', default="", dest='proxy', help='Set Proxy (i.e. www-proxy-server.com:80) ')
+parser.add_argument('-ip', action='store_true', default=False, dest='is_instance_principals', help='Use Instance Principals for Authentication')
+parser.add_argument('-dt', action='store_true', default=False, dest='is_delegation_token', help='Use Delegation Token for Authentication')
+cmd = parser.parse_args()
+
+# Start print time info
+start_time = str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+print_header("Running List Block Storage Backups")
+print("Written By Adi Zohar, August 2020")
+print("Starts at " + str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")))
+print("Command Line : " + ' '.join(x for x in sys.argv[1:]))
+
+# Identity extract compartments
+config, signer = create_signer(cmd.config_profile, cmd.is_instance_principals, cmd.is_delegation_token)
+compartments = []
+tenancy = None
+try:
+    print("\nConnecting to Identity Service...")
+    identity = oci.identity.IdentityClient(config, signer=signer)
+    if cmd.proxy:
+        identity.base_client.session.proxies = {'https': cmd.proxy}
+
+    tenancy = identity.get_tenancy(config["tenancy"]).data
+    regions = identity.list_region_subscriptions(tenancy.id).data
+
+    print("Tenant Name : " + str(tenancy.name))
+    print("Tenant Id   : " + tenancy.id)
+    print("")
+
+    compartments = identity_read_compartments(identity, tenancy)
+
+except Exception as e:
+    raise RuntimeError("\nError extracting compartments section - " + str(e))
+
+############################################
+# Loop on all regions
+############################################
+print("\nLoading Compute Instances...")
+data = []
+warnings = 0
+backup_faulty = 0
+num_boot_volumes_backups = 0
+num_volumes_backups = 0
+num_volumes_groups_backups = 0
+
+for region_name in [str(es.region_name) for es in regions]:
+
+    print("\nRegion " + region_name + "...")
+
+    # set the region in the config and signer
+    config['region'] = region_name
+    signer.region = region_name
+
+    # connect to BlockstorageClient
+    block_storage = oci.core.BlockstorageClient(config, signer=signer)
+    if cmd.proxy:
+        block_storage.base_client.session.proxies = {'https': cmd.proxy}
+
+    ############################################
+    # Loop on all compartments
+    ############################################
+    try:
+        for compartment in compartments:
+
+            # skip non active compartments
+            if compartment.id != tenancy.id and compartment.lifecycle_state != oci.identity.models.Compartment.LIFECYCLE_STATE_ACTIVE:
+                continue
+            if compartment.name == "ManagedCompartmentForPaaS":
+                continue
+
+            print("    Compartment " + (str(compartment.name) + "... ").ljust(35), end="")
+            cnt = 0
+
+            ############################################
+            # Retrieve boot volume backups
+            ############################################
+            boot_volume_backups = []
+            try:
+                boot_volume_backups = oci.pagination.list_call_get_all_results(
+                    block_storage.list_boot_volume_backups,
+                    compartment.id,
+                    sort_by="DISPLAYNAME"
+                ).data
+            except oci.exceptions.ServiceError as e:
+                if check_service_error(e.code):
+                    warnings += 1
+                    print("Warnings ")
+                    continue
+                raise
+
+            print(".", end="")
+
+            # loop on array
+            # arr = oci.core.models.BootVolumeBackup
+            for arr in boot_volume_backups:
+                if arr.lifecycle_state != oci.core.models.BootVolumeBackup.LIFECYCLE_STATE_AVAILABLE and arr.lifecycle_state != oci.core.models.BootVolumeBackup.LIFECYCLE_STATE_FAULTY:
+                    continue
+
+                # if fault backup
+                if arr.lifecycle_state == oci.core.models.BootVolumeBackup.LIFECYCLE_STATE_FAULTY:
+                    backup_faulty += 1
+
+                value = {
+                    'region_name': region_name,
+                    'compartment_name': str(compartment.name),
+                    'compartment_id': str(compartment.id),
+                    'id': str(arr.id),
+                    'boot_volume_id': str(arr.boot_volume_id),
+                    'lifecycle_state': str(arr.lifecycle_state),
+                    'type': str(arr.type),
+                    'source_type': str(arr.source_type),
+                    'time_created': str(arr.time_created),
+                    'display_name': str(arr.display_name),
+                    'size_in_gbs': str(arr.size_in_gbs),
+                    'unique_size_in_gbs': str(arr.unique_size_in_gbs),
+                    'defined_tags': [] if arr.defined_tags is None else arr.defined_tags,
+                    'freeform_tags': [] if arr.freeform_tags is None else arr.freeform_tags,
+                    'backup_lifecycle_state': "",
+                    'expiration_time': "Keep" if str(arr.expiration_time) == "None" else str(arr.expiration_time)
+                }
+
+                data.append(value)
+                cnt += 1
+                num_boot_volumes_backups += 1
+
+            # print instances for the compartment
+            if cnt == 0:
+                print("(-)", end="")
+            else:
+                print("(" + str(cnt) + " Boot Volume Backups)", end="")
+
+            ############################################
+            # Retrieve block volume backups
+            ############################################
+            cnt = 0
+            block_volume_backups = []
+            try:
+                block_volume_backups = oci.pagination.list_call_get_all_results(
+                    block_storage.list_volume_backups,
+                    compartment.id,
+                    sort_by="DISPLAYNAME"
+                ).data
+            except oci.exceptions.ServiceError as e:
+                if check_service_error(e.code):
+                    warnings += 1
+                    print("Warnings ")
+                    continue
+                raise
+
+            print(" ", end="")
+
+            # loop on array
+            # arr = oci.core.models.BootVolumeBackup
+            for arr in block_volume_backups:
+                if arr.lifecycle_state != oci.core.models.VolumeBackup.LIFECYCLE_STATE_AVAILABLE and arr.lifecycle_state != oci.core.models.VolumeBackup.LIFECYCLE_STATE_FAULTY:
+                    continue
+
+                # if fault backup
+                if arr.lifecycle_state == oci.core.models.VolumeBackup.LIFECYCLE_STATE_FAULTY:
+                    backup_faulty += 1
+
+                value = {
+                    'region_name': region_name,
+                    'compartment_name': str(compartment.name),
+                    'compartment_id': str(compartment.id),
+                    'id': str(arr.id),
+                    'volume_id': str(arr.volume_id),
+                    'lifecycle_state': str(arr.lifecycle_state),
+                    'type': str(arr.type),
+                    'source_type': str(arr.source_type),
+                    'time_created': str(arr.time_created),
+                    'display_name': str(arr.display_name),
+                    'size_in_gbs': str(arr.size_in_gbs),
+                    'unique_size_in_gbs': str(arr.unique_size_in_gbs),
+                    'defined_tags': [] if arr.defined_tags is None else arr.defined_tags,
+                    'freeform_tags': [] if arr.freeform_tags is None else arr.freeform_tags,
+                    'backup_lifecycle_state': "",
+                    'expiration_time': "Keep" if str(arr.expiration_time) == "None" else str(arr.expiration_time)
+                }
+
+                data.append(value)
+                cnt += 1
+                num_volumes_backups += 1
+
+            # print instances for the compartment
+            if cnt == 0:
+                print("(-)", end="")
+            else:
+                print("(" + str(cnt) + " Block Volume Backups)", end="")
+
+            ############################################
+            # Retrieve volume group backups
+            ############################################
+            cnt = 0
+            volume_group_backups = []
+            try:
+                block_volume_backups = oci.pagination.list_call_get_all_results(
+                    block_storage.list_volume_group_backups,
+                    compartment.id,
+                    sort_by="DISPLAYNAME"
+                ).data
+            except oci.exceptions.ServiceError as e:
+                if check_service_error(e.code):
+                    warnings += 1
+                    print("Warnings ")
+                    continue
+                raise
+
+            print(" ", end="")
+
+            # loop on array
+            # arr = oci.core.models.VolumeGroupBackup
+            for arr in volume_group_backups:
+                if arr.lifecycle_state != oci.core.models.VolumeGroupBackup.LIFECYCLE_STATE_AVAILABLE and arr.lifecycle_state != oci.core.models.VolumeGroupBackup.LIFECYCLE_STATE_FAULTY:
+                    continue
+
+                # if fault backup
+                if arr.lifecycle_state == oci.core.models.VolumeGroupBackup.LIFECYCLE_STATE_FAULTY:
+                    backup_faulty += 1
+
+                value = {
+                    'region_name': region_name,
+                    'compartment_name': str(compartment.name),
+                    'compartment_id': str(compartment.id),
+                    'id': str(arr.id),
+                    'volume_group_id': str(arr.volume_group_id),
+                    'volume_backup_ids': arr.volume_backup_ids,
+                    'lifecycle_state': str(arr.lifecycle_state),
+                    'type': str(arr.type),
+                    'source_type': str(arr.source_type),
+                    'time_created': str(arr.time_created),
+                    'display_name': str(arr.display_name),
+                    'size_in_gbs': str(arr.size_in_gbs),
+                    'unique_size_in_gbs': str(arr.unique_size_in_gbs),
+                    'defined_tags': [] if arr.defined_tags is None else arr.defined_tags,
+                    'freeform_tags': [] if arr.freeform_tags is None else arr.freeform_tags,
+                    'backup_lifecycle_state': "",
+                    'expiration_time': "Keep" if str(arr.expiration_time) == "None" else str(arr.expiration_time)
+                }
+
+                data.append(value)
+                cnt += 1
+                num_volumes_groups_backups += 1
+
+            # print instances for the compartment
+            if cnt == 0:
+                print("(-)")
+            else:
+                print("(" + str(cnt) + " Volume Group Backups)")
+
+    except Exception as e:
+        raise RuntimeError("\nError extracting Instances - " + str(e))
+
+############################################
+# Print Output as JSON
+############################################
+print_header("Output")
+print(json.dumps(data, indent=4, sort_keys=False))
+
+if warnings > 0:
+    print_header(str(warnings) + " Warnings appeared")
+
+print_header(str(num_boot_volumes_backups) + " Boot Backups, " + str(num_volumes_backups) + " Volume Backups, " + str(num_volumes_groups_backups) + " Volume Group Backups")
+print_header(str(backup_faulty) + " faulty backups")
+
+print_header("Completed at " + str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")))

--- a/examples/usage_reports_to_adw/CHANGELOG.rst
+++ b/examples/usage_reports_to_adw/CHANGELOG.rst
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 =====================
+20.08.04 - 2020-08-04
+=====================
+* Aligned to APEX Version 20.1
+* Aligned to one cost instead of Paygo/Monthly
+* Added monthly consumption in the Data Statistics tab
+
+=====================
 20.07.28 - 2020-07-28
 =====================
 * Added sleep 0.5 to the public API call to avoid too many requests error

--- a/examples/usage_reports_to_adw/apex_demo_app/usage.demo.apex.sql
+++ b/examples/usage_reports_to_adw/apex_demo_app/usage.demo.apex.sql
@@ -6,15 +6,15 @@ whenever sqlerror exit sql.sqlcode rollback
 -- ORACLE Application Express (APEX) export file
 --
 -- You should run the script connected to SQL*Plus as the Oracle user
--- APEX_190200 or as the owner (parsing schema) of the application.
+-- APEX_200100 or as the owner (parsing schema) of the application.
 --
 -- NOTE: Calls to apex_application_install override the defaults below.
 --
 --------------------------------------------------------------------------------
 begin
 wwv_flow_api.import_begin (
- p_version_yyyy_mm_dd=>'2019.10.04'
-,p_release=>'19.2.0.00.18'
+ p_version_yyyy_mm_dd=>'2020.03.31'
+,p_release=>'20.1.0.00.13'
 ,p_default_workspace_id=>9710643564672463
 ,p_default_application_id=>100
 ,p_default_id_offset=>0
@@ -28,15 +28,15 @@ prompt APPLICATION 100 - OCI Usage and Cost Report
 -- Application Export:
 --   Application:     100
 --   Name:            OCI Usage and Cost Report
---   Date and Time:   19:46 Tuesday July 7, 2020
+--   Date and Time:   12:44 Wednesday July 29, 2020
 --   Exported By:     ADIZOHAR
 --   Flashback:       0
 --   Export Type:     Application Export
 --     Pages:                      9
---       Items:                   77
---       Computations:            21
+--       Items:                   83
+--       Computations:            27
 --       Processes:                4
---       Regions:                 59
+--       Regions:                 60
 --       Buttons:                  5
 --       Dynamic Actions:         31
 --     Shared Components:
@@ -69,7 +69,7 @@ prompt APPLICATION 100 - OCI Usage and Cost Report
 --       Reports:
 --       E-Mail:
 --     Supporting Objects:  Excluded
---   Version:         19.2.0.00.18
+--   Version:         20.1.0.00.13
 --   Instance ID:     9710412995014033
 --
 
@@ -105,7 +105,7 @@ wwv_flow_api.create_flow(
 ,p_public_user=>'APEX_PUBLIC_USER'
 ,p_proxy_server=>nvl(wwv_flow_application_install.get_proxy,'')
 ,p_no_proxy_domains=>nvl(wwv_flow_application_install.get_no_proxy_domains,'')
-,p_flow_version=>'Release 20.07.14'
+,p_flow_version=>'Release 20.08.04'
 ,p_flow_status=>'AVAILABLE_W_EDIT_LINK'
 ,p_flow_unavailable_text=>'This application is currently unavailable at this time.'
 ,p_exact_substitutions_only=>'Y'
@@ -116,10 +116,11 @@ wwv_flow_api.create_flow(
 ,p_rejoin_existing_sessions=>'N'
 ,p_csv_encoding=>'Y'
 ,p_auto_time_zone=>'N'
+,p_friendly_url=>'N'
 ,p_substitution_string_01=>'APP_NAME'
 ,p_substitution_value_01=>'OCI Usage and Cost Report'
 ,p_last_updated_by=>'ADIZOHAR'
-,p_last_upd_yyyymmddhh24miss=>'20200707194554'
+,p_last_upd_yyyymmddhh24miss=>'20200729124407'
 ,p_file_prefix => nvl(wwv_flow_application_install.get_static_app_file_prefix,'')
 ,p_files_version=>3
 ,p_ui_type_name => null
@@ -414,16 +415,6 @@ wwv_flow_api.create_acl_role(
 end;
 /
 prompt --application/shared_components/navigation/navigation_bar
-begin
-null;
-end;
-/
-prompt --application/shared_components/logic/application_items
-begin
-null;
-end;
-/
-prompt --application/shared_components/logic/application_computations
 begin
 null;
 end;
@@ -10320,7 +10311,7 @@ wwv_flow_api.create_page(
 ,p_autocomplete_on_off=>'OFF'
 ,p_page_template_options=>'#DEFAULT#'
 ,p_last_updated_by=>'ADIZOHAR'
-,p_last_upd_yyyymmddhh24miss=>'20200506201919'
+,p_last_upd_yyyymmddhh24miss=>'20200729121552'
 );
 wwv_flow_api.create_page_plug(
  p_id=>wwv_flow_api.id(9905068422740501)
@@ -10444,8 +10435,10 @@ wwv_flow_api.create_worksheet(
 ,p_show_nulls_as=>'-'
 ,p_pagination_type=>'ROWS_X_TO_Y'
 ,p_pagination_display_pos=>'BOTTOM_RIGHT'
+,p_show_display_row_count=>'Y'
 ,p_report_list_mode=>'TABS'
 ,p_show_detail_link=>'N'
+,p_show_rows_per_page=>'N'
 ,p_show_notify=>'Y'
 ,p_download_formats=>'CSV:HTML:EMAIL:XLS:PDF:RTF'
 ,p_owner=>'USAGE'
@@ -10669,6 +10662,27 @@ wwv_flow_api.create_jet_chart_series(
 ,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(9906780581740518)
+,p_chart_id=>wwv_flow_api.id(9906423826740515)
+,p_axis=>'y'
+,p_is_rendered=>'on'
+,p_format_scaling=>'none'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_position=>'auto'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'off'
+,p_tick_label_rendered=>'on'
+,p_zoom_order_seconds=>false
+,p_zoom_order_minutes=>false
+,p_zoom_order_hours=>false
+,p_zoom_order_days=>false
+,p_zoom_order_weeks=>false
+,p_zoom_order_months=>false
+,p_zoom_order_quarters=>false
+,p_zoom_order_years=>false
+);
+wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(9906673387740517)
 ,p_chart_id=>wwv_flow_api.id(9906423826740515)
 ,p_axis=>'x'
@@ -10681,27 +10695,6 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_tick_label_rendered=>'on'
 ,p_tick_label_rotation=>'auto'
 ,p_tick_label_position=>'outside'
-,p_zoom_order_seconds=>false
-,p_zoom_order_minutes=>false
-,p_zoom_order_hours=>false
-,p_zoom_order_days=>false
-,p_zoom_order_weeks=>false
-,p_zoom_order_months=>false
-,p_zoom_order_quarters=>false
-,p_zoom_order_years=>false
-);
-wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(9906780581740518)
-,p_chart_id=>wwv_flow_api.id(9906423826740515)
-,p_axis=>'y'
-,p_is_rendered=>'on'
-,p_format_scaling=>'none'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_position=>'auto'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'off'
-,p_tick_label_rendered=>'on'
 ,p_zoom_order_seconds=>false
 ,p_zoom_order_minutes=>false
 ,p_zoom_order_hours=>false
@@ -10833,6 +10826,27 @@ wwv_flow_api.create_jet_chart_series(
 ,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(9907262849740523)
+,p_chart_id=>wwv_flow_api.id(9906988781740520)
+,p_axis=>'y'
+,p_is_rendered=>'on'
+,p_format_scaling=>'none'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_position=>'auto'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'off'
+,p_tick_label_rendered=>'on'
+,p_zoom_order_seconds=>false
+,p_zoom_order_minutes=>false
+,p_zoom_order_hours=>false
+,p_zoom_order_days=>false
+,p_zoom_order_weeks=>false
+,p_zoom_order_months=>false
+,p_zoom_order_quarters=>false
+,p_zoom_order_years=>false
+);
+wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(9907197005740522)
 ,p_chart_id=>wwv_flow_api.id(9906988781740520)
 ,p_axis=>'x'
@@ -10845,27 +10859,6 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_tick_label_rendered=>'on'
 ,p_tick_label_rotation=>'auto'
 ,p_tick_label_position=>'outside'
-,p_zoom_order_seconds=>false
-,p_zoom_order_minutes=>false
-,p_zoom_order_hours=>false
-,p_zoom_order_days=>false
-,p_zoom_order_weeks=>false
-,p_zoom_order_months=>false
-,p_zoom_order_quarters=>false
-,p_zoom_order_years=>false
-);
-wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(9907262849740523)
-,p_chart_id=>wwv_flow_api.id(9906988781740520)
-,p_axis=>'y'
-,p_is_rendered=>'on'
-,p_format_scaling=>'none'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_position=>'auto'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'off'
-,p_tick_label_rendered=>'on'
 ,p_zoom_order_seconds=>false
 ,p_zoom_order_minutes=>false
 ,p_zoom_order_hours=>false
@@ -11113,6 +11106,27 @@ wwv_flow_api.create_jet_chart_series(
 ,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(9923476916716106)
+,p_chart_id=>wwv_flow_api.id(9923190243716103)
+,p_axis=>'y'
+,p_is_rendered=>'on'
+,p_format_scaling=>'none'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_position=>'auto'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'off'
+,p_tick_label_rendered=>'on'
+,p_zoom_order_seconds=>false
+,p_zoom_order_minutes=>false
+,p_zoom_order_hours=>false
+,p_zoom_order_days=>false
+,p_zoom_order_weeks=>false
+,p_zoom_order_months=>false
+,p_zoom_order_quarters=>false
+,p_zoom_order_years=>false
+);
+wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(9923304855716105)
 ,p_chart_id=>wwv_flow_api.id(9923190243716103)
 ,p_axis=>'x'
@@ -11125,27 +11139,6 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_tick_label_rendered=>'on'
 ,p_tick_label_rotation=>'auto'
 ,p_tick_label_position=>'outside'
-,p_zoom_order_seconds=>false
-,p_zoom_order_minutes=>false
-,p_zoom_order_hours=>false
-,p_zoom_order_days=>false
-,p_zoom_order_weeks=>false
-,p_zoom_order_months=>false
-,p_zoom_order_quarters=>false
-,p_zoom_order_years=>false
-);
-wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(9923476916716106)
-,p_chart_id=>wwv_flow_api.id(9923190243716103)
-,p_axis=>'y'
-,p_is_rendered=>'on'
-,p_format_scaling=>'none'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_position=>'auto'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'off'
-,p_tick_label_rendered=>'on'
 ,p_zoom_order_seconds=>false
 ,p_zoom_order_minutes=>false
 ,p_zoom_order_hours=>false
@@ -11273,6 +11266,27 @@ end;
 /
 begin
 wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(9923915405716111)
+,p_chart_id=>wwv_flow_api.id(9923640328716108)
+,p_axis=>'y'
+,p_is_rendered=>'on'
+,p_format_scaling=>'none'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_position=>'auto'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'off'
+,p_tick_label_rendered=>'on'
+,p_zoom_order_seconds=>false
+,p_zoom_order_minutes=>false
+,p_zoom_order_hours=>false
+,p_zoom_order_days=>false
+,p_zoom_order_weeks=>false
+,p_zoom_order_months=>false
+,p_zoom_order_quarters=>false
+,p_zoom_order_years=>false
+);
+wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(9923836203716110)
 ,p_chart_id=>wwv_flow_api.id(9923640328716108)
 ,p_axis=>'x'
@@ -11285,27 +11299,6 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_tick_label_rendered=>'on'
 ,p_tick_label_rotation=>'auto'
 ,p_tick_label_position=>'outside'
-,p_zoom_order_seconds=>false
-,p_zoom_order_minutes=>false
-,p_zoom_order_hours=>false
-,p_zoom_order_days=>false
-,p_zoom_order_weeks=>false
-,p_zoom_order_months=>false
-,p_zoom_order_quarters=>false
-,p_zoom_order_years=>false
-);
-wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(9923915405716111)
-,p_chart_id=>wwv_flow_api.id(9923640328716108)
-,p_axis=>'y'
-,p_is_rendered=>'on'
-,p_format_scaling=>'none'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_position=>'auto'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'off'
-,p_tick_label_rendered=>'on'
 ,p_zoom_order_seconds=>false
 ,p_zoom_order_minutes=>false
 ,p_zoom_order_hours=>false
@@ -11432,6 +11425,27 @@ wwv_flow_api.create_jet_chart_series(
 ,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(10813796398165709)
+,p_chart_id=>wwv_flow_api.id(10813427444165706)
+,p_axis=>'y'
+,p_is_rendered=>'on'
+,p_format_scaling=>'none'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_position=>'auto'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'off'
+,p_tick_label_rendered=>'on'
+,p_zoom_order_seconds=>false
+,p_zoom_order_minutes=>false
+,p_zoom_order_hours=>false
+,p_zoom_order_days=>false
+,p_zoom_order_weeks=>false
+,p_zoom_order_months=>false
+,p_zoom_order_quarters=>false
+,p_zoom_order_years=>false
+);
+wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(10813694012165708)
 ,p_chart_id=>wwv_flow_api.id(10813427444165706)
 ,p_axis=>'x'
@@ -11444,27 +11458,6 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_tick_label_rendered=>'on'
 ,p_tick_label_rotation=>'auto'
 ,p_tick_label_position=>'outside'
-,p_zoom_order_seconds=>false
-,p_zoom_order_minutes=>false
-,p_zoom_order_hours=>false
-,p_zoom_order_days=>false
-,p_zoom_order_weeks=>false
-,p_zoom_order_months=>false
-,p_zoom_order_quarters=>false
-,p_zoom_order_years=>false
-);
-wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(10813796398165709)
-,p_chart_id=>wwv_flow_api.id(10813427444165706)
-,p_axis=>'y'
-,p_is_rendered=>'on'
-,p_format_scaling=>'none'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_position=>'auto'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'off'
-,p_tick_label_rendered=>'on'
 ,p_zoom_order_seconds=>false
 ,p_zoom_order_minutes=>false
 ,p_zoom_order_hours=>false
@@ -12838,7 +12831,7 @@ wwv_flow_api.create_page(
 '#P4_REPORT_SELECTOR { background-color: #F5FBB4; font-weight: bold; font-size: 13px;}'))
 ,p_page_template_options=>'#DEFAULT#'
 ,p_last_updated_by=>'ADIZOHAR'
-,p_last_upd_yyyymmddhh24miss=>'20200707194444'
+,p_last_upd_yyyymmddhh24miss=>'20200729122158'
 );
 wwv_flow_api.create_page_plug(
  p_id=>wwv_flow_api.id(10816553122165737)
@@ -13073,28 +13066,6 @@ wwv_flow_api.create_jet_chart_series(
 ,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(10816181831165733)
-,p_chart_id=>wwv_flow_api.id(10815918798165731)
-,p_axis=>'x'
-,p_is_rendered=>'on'
-,p_format_scaling=>'auto'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'off'
-,p_tick_label_rendered=>'on'
-,p_tick_label_rotation=>'auto'
-,p_tick_label_position=>'outside'
-,p_zoom_order_seconds=>false
-,p_zoom_order_minutes=>false
-,p_zoom_order_hours=>false
-,p_zoom_order_days=>false
-,p_zoom_order_weeks=>false
-,p_zoom_order_months=>false
-,p_zoom_order_quarters=>false
-,p_zoom_order_years=>false
-);
-wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(10816213077165734)
 ,p_chart_id=>wwv_flow_api.id(10815918798165731)
 ,p_axis=>'y'
@@ -13108,6 +13079,28 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_major_tick_rendered=>'on'
 ,p_minor_tick_rendered=>'off'
 ,p_tick_label_rendered=>'on'
+,p_zoom_order_seconds=>false
+,p_zoom_order_minutes=>false
+,p_zoom_order_hours=>false
+,p_zoom_order_days=>false
+,p_zoom_order_weeks=>false
+,p_zoom_order_months=>false
+,p_zoom_order_quarters=>false
+,p_zoom_order_years=>false
+);
+wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(10816181831165733)
+,p_chart_id=>wwv_flow_api.id(10815918798165731)
+,p_axis=>'x'
+,p_is_rendered=>'on'
+,p_format_scaling=>'auto'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'off'
+,p_tick_label_rendered=>'on'
+,p_tick_label_rotation=>'auto'
+,p_tick_label_position=>'outside'
 ,p_zoom_order_seconds=>false
 ,p_zoom_order_minutes=>false
 ,p_zoom_order_hours=>false
@@ -13221,6 +13214,29 @@ wwv_flow_api.create_jet_chart_series(
 ,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(11932208487191615)
+,p_chart_id=>wwv_flow_api.id(11931950151191612)
+,p_axis=>'y'
+,p_is_rendered=>'on'
+,p_format_type=>'decimal'
+,p_decimal_places=>1
+,p_format_scaling=>'none'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_position=>'auto'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'off'
+,p_tick_label_rendered=>'on'
+,p_zoom_order_seconds=>false
+,p_zoom_order_minutes=>false
+,p_zoom_order_hours=>false
+,p_zoom_order_days=>false
+,p_zoom_order_weeks=>false
+,p_zoom_order_months=>false
+,p_zoom_order_quarters=>false
+,p_zoom_order_years=>false
+);
+wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(11932199654191614)
 ,p_chart_id=>wwv_flow_api.id(11931950151191612)
 ,p_axis=>'x'
@@ -13236,29 +13252,6 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_tick_label_rotation=>'auto'
 ,p_tick_label_position=>'outside'
 ,p_tick_label_font_size=>'10'
-,p_zoom_order_seconds=>false
-,p_zoom_order_minutes=>false
-,p_zoom_order_hours=>false
-,p_zoom_order_days=>false
-,p_zoom_order_weeks=>false
-,p_zoom_order_months=>false
-,p_zoom_order_quarters=>false
-,p_zoom_order_years=>false
-);
-wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(11932208487191615)
-,p_chart_id=>wwv_flow_api.id(11931950151191612)
-,p_axis=>'y'
-,p_is_rendered=>'on'
-,p_format_type=>'decimal'
-,p_decimal_places=>1
-,p_format_scaling=>'none'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_position=>'auto'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'off'
-,p_tick_label_rendered=>'on'
 ,p_zoom_order_seconds=>false
 ,p_zoom_order_minutes=>false
 ,p_zoom_order_hours=>false
@@ -13449,11 +13442,14 @@ wwv_flow_api.create_worksheet(
  p_id=>wwv_flow_api.id(12317206225646736)
 ,p_max_row_count=>'1000000'
 ,p_max_rows_per_page=>'20'
+,p_allow_save_rpt_public=>'Y'
 ,p_show_nulls_as=>'-'
 ,p_pagination_type=>'ROWS_X_TO_Y'
 ,p_pagination_display_pos=>'BOTTOM_RIGHT'
+,p_show_display_row_count=>'Y'
 ,p_report_list_mode=>'TABS'
 ,p_show_detail_link=>'N'
+,p_show_rows_per_page=>'N'
 ,p_show_notify=>'Y'
 ,p_download_formats=>'CSV:HTML:EMAIL:XLS:PDF:RTF'
 ,p_owner=>'ADI.ZOHAR@ORACLE.COM'
@@ -13820,6 +13816,30 @@ wwv_flow_api.create_jet_chart_series(
 ,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(13974468820041421)
+,p_chart_id=>wwv_flow_api.id(13974102550041418)
+,p_axis=>'y'
+,p_is_rendered=>'on'
+,p_title=>'Cost Accumulated'
+,p_format_type=>'decimal'
+,p_decimal_places=>1
+,p_format_scaling=>'none'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_position=>'bottom'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'on'
+,p_tick_label_rendered=>'on'
+,p_zoom_order_seconds=>false
+,p_zoom_order_minutes=>false
+,p_zoom_order_hours=>false
+,p_zoom_order_days=>false
+,p_zoom_order_weeks=>false
+,p_zoom_order_months=>false
+,p_zoom_order_quarters=>false
+,p_zoom_order_years=>false
+);
+wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(13974384360041420)
 ,p_chart_id=>wwv_flow_api.id(13974102550041418)
 ,p_axis=>'x'
@@ -13835,30 +13855,6 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_tick_label_rotation=>'auto'
 ,p_tick_label_position=>'outside'
 ,p_tick_label_font_size=>'10'
-,p_zoom_order_seconds=>false
-,p_zoom_order_minutes=>false
-,p_zoom_order_hours=>false
-,p_zoom_order_days=>false
-,p_zoom_order_weeks=>false
-,p_zoom_order_months=>false
-,p_zoom_order_quarters=>false
-,p_zoom_order_years=>false
-);
-wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(13974468820041421)
-,p_chart_id=>wwv_flow_api.id(13974102550041418)
-,p_axis=>'y'
-,p_is_rendered=>'on'
-,p_title=>'Cost Accumulated'
-,p_format_type=>'decimal'
-,p_decimal_places=>1
-,p_format_scaling=>'none'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_position=>'bottom'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'on'
-,p_tick_label_rendered=>'on'
 ,p_zoom_order_seconds=>false
 ,p_zoom_order_minutes=>false
 ,p_zoom_order_hours=>false
@@ -13933,10 +13929,6 @@ wwv_flow_api.create_page_plug(
 '	CASE WHEN RATE_MONTHLY_FLEX_PRICE > 0  AND RATE_MONTHLY_FLEX_PRICE IS NOT NULL and RATE>0 THEN',
 '	    ROUND((RATE_MONTHLY_FLEX_PRICE - RATE )/RATE_MONTHLY_FLEX_PRICE * 100,1)',
 '	ELSE NULL END PCT_MONTH,',
-'    case when RATE_PAYGO_PRICE = 0 then null else RATE_PAYGO_PRICE end PUBLIC_PAYGO_RATE,',
-'	CASE WHEN RATE_PAYGO_PRICE > 0  AND RATE_PAYGO_PRICE IS NOT NULL and RATE>0 THEN',
-'	    ROUND((RATE_PAYGO_PRICE - RATE )/RATE_PAYGO_PRICE * 100,1)',
-'	ELSE NULL END PCT_PAYGO,',
 '    RATE,',
 '    CURRENCY,',
 '    SINGLE_QUANTITY,',
@@ -13989,11 +13981,14 @@ wwv_flow_api.create_page_plug(
 wwv_flow_api.create_worksheet(
  p_id=>wwv_flow_api.id(11934457225191637)
 ,p_max_row_count=>'1000000'
+,p_allow_save_rpt_public=>'Y'
 ,p_show_nulls_as=>'-'
 ,p_pagination_type=>'ROWS_X_TO_Y'
 ,p_pagination_display_pos=>'BOTTOM_RIGHT'
+,p_show_display_row_count=>'Y'
 ,p_report_list_mode=>'TABS'
 ,p_show_detail_link=>'N'
+,p_show_rows_per_page=>'N'
 ,p_show_notify=>'Y'
 ,p_download_formats=>'CSV:HTML:EMAIL:XLS:PDF:RTF'
 ,p_owner=>'ADI.ZOHAR@ORACLE.COM'
@@ -14032,7 +14027,7 @@ wwv_flow_api.create_worksheet_column(
 ,p_db_column_name=>'PCT_MONTH'
 ,p_display_order=>40
 ,p_column_identifier=>'M'
-,p_column_label=>'% Discount MonFlex'
+,p_column_label=>'% Discount'
 ,p_column_type=>'NUMBER'
 ,p_column_alignment=>'RIGHT'
 ,p_format_mask=>'999G999G999G999G990D0'
@@ -14128,26 +14123,6 @@ wwv_flow_api.create_worksheet_column(
 ,p_column_alignment=>'RIGHT'
 ,p_format_mask=>'999G999G999G999G990D00'
 );
-wwv_flow_api.create_worksheet_column(
- p_id=>wwv_flow_api.id(14188462327270025)
-,p_db_column_name=>'PUBLIC_PAYGO_RATE'
-,p_display_order=>140
-,p_column_identifier=>'N'
-,p_column_label=>'Public PayGo Rate'
-,p_column_type=>'NUMBER'
-,p_column_alignment=>'RIGHT'
-,p_format_mask=>'999G999G999G999G990D0000'
-);
-wwv_flow_api.create_worksheet_column(
- p_id=>wwv_flow_api.id(14188587079270026)
-,p_db_column_name=>'PCT_PAYGO'
-,p_display_order=>150
-,p_column_identifier=>'O'
-,p_column_label=>'% DIscount Vs Paygo'
-,p_column_type=>'NUMBER'
-,p_column_alignment=>'RIGHT'
-,p_format_mask=>'999G999G999G999G990D0'
-);
 wwv_flow_api.create_worksheet_rpt(
  p_id=>wwv_flow_api.id(12264955888332662)
 ,p_application_user=>'APXWS_DEFAULT'
@@ -14155,7 +14130,7 @@ wwv_flow_api.create_worksheet_rpt(
 ,p_report_alias=>'122650'
 ,p_status=>'PUBLIC'
 ,p_is_default=>'Y'
-,p_report_columns=>'PRODUCT:COST_BILLING_UNIT:CURRENCY:PUBLIC_RATE:PCT_MONTH:RATE:SINGLE_QUANTITY:OVERAGE_COST:USAGE_COST:ESTIMATE_MONTH_31:ESTIMATE_YEAR:'
+,p_report_columns=>'PRODUCT:COST_BILLING_UNIT:CURRENCY:PUBLIC_RATE:PCT_MONTH:RATE:SINGLE_QUANTITY:OVERAGE_COST:USAGE_COST:ESTIMATE_MONTH_31:ESTIMATE_YEAR'
 ,p_sum_columns_on_break=>'OVERAGE_COST:USAGE_COST:ESTIMATE_MONTH_31:ESTIMATE_YEAR'
 );
 wwv_flow_api.create_worksheet_rpt(
@@ -14166,7 +14141,7 @@ wwv_flow_api.create_worksheet_rpt(
 ,p_report_alias=>'164423'
 ,p_status=>'PUBLIC'
 ,p_is_default=>'Y'
-,p_report_columns=>'PRODUCT:CURRENCY:PCT_MONTH:RATE:SINGLE_QUANTITY:OVERAGE_COST:USAGE_COST:ESTIMATE_MONTH_31:ESTIMATE_YEAR:'
+,p_report_columns=>'PRODUCT:CURRENCY:PCT_MONTH:RATE:SINGLE_QUANTITY:OVERAGE_COST:USAGE_COST:ESTIMATE_MONTH_31:ESTIMATE_YEAR'
 ,p_sum_columns_on_break=>'OVERAGE_COST:USAGE_COST:ESTIMATE_MONTH_31:ESTIMATE_YEAR'
 );
 wwv_flow_api.create_page_plug(
@@ -14260,28 +14235,6 @@ wwv_flow_api.create_jet_chart_series(
 ,p_threshold_display=>'onIndicator'
 );
 wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(11711229189773204)
-,p_chart_id=>wwv_flow_api.id(11710134020773204)
-,p_axis=>'x'
-,p_is_rendered=>'on'
-,p_format_scaling=>'auto'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'off'
-,p_tick_label_rendered=>'on'
-,p_tick_label_rotation=>'auto'
-,p_tick_label_position=>'outside'
-,p_zoom_order_seconds=>false
-,p_zoom_order_minutes=>false
-,p_zoom_order_hours=>false
-,p_zoom_order_days=>false
-,p_zoom_order_weeks=>false
-,p_zoom_order_months=>false
-,p_zoom_order_quarters=>false
-,p_zoom_order_years=>false
-);
-wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(11710677057773204)
 ,p_chart_id=>wwv_flow_api.id(11710134020773204)
 ,p_axis=>'y'
@@ -14295,6 +14248,28 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_major_tick_rendered=>'on'
 ,p_minor_tick_rendered=>'off'
 ,p_tick_label_rendered=>'on'
+,p_zoom_order_seconds=>false
+,p_zoom_order_minutes=>false
+,p_zoom_order_hours=>false
+,p_zoom_order_days=>false
+,p_zoom_order_weeks=>false
+,p_zoom_order_months=>false
+,p_zoom_order_quarters=>false
+,p_zoom_order_years=>false
+);
+wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(11711229189773204)
+,p_chart_id=>wwv_flow_api.id(11710134020773204)
+,p_axis=>'x'
+,p_is_rendered=>'on'
+,p_format_scaling=>'auto'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'off'
+,p_tick_label_rendered=>'on'
+,p_tick_label_rotation=>'auto'
+,p_tick_label_position=>'outside'
 ,p_zoom_order_seconds=>false
 ,p_zoom_order_minutes=>false
 ,p_zoom_order_hours=>false
@@ -14636,9 +14611,6 @@ wwv_flow_api.create_page_item(
 ,p_attribute_02=>'VALUE'
 ,p_attribute_04=>'Y'
 );
-end;
-/
-begin
 wwv_flow_api.create_page_item(
  p_id=>wwv_flow_api.id(11704902453773194)
 ,p_name=>'P4_PRODUCT_REGION'
@@ -14666,6 +14638,9 @@ wwv_flow_api.create_page_item(
 ,p_attribute_01=>'NONE'
 ,p_attribute_02=>'N'
 );
+end;
+/
+begin
 wwv_flow_api.create_page_item(
  p_id=>wwv_flow_api.id(11705301552773194)
 ,p_name=>'P4_COMPARTMENT_NAME'
@@ -17883,29 +17858,6 @@ wwv_flow_api.create_jet_chart_series(
 ,p_items_label_font_size=>'10'
 );
 wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(13977108905041448)
-,p_chart_id=>wwv_flow_api.id(13976741456041444)
-,p_axis=>'y'
-,p_is_rendered=>'on'
-,p_format_type=>'decimal'
-,p_decimal_places=>1
-,p_format_scaling=>'auto'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_position=>'auto'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'off'
-,p_tick_label_rendered=>'on'
-,p_zoom_order_seconds=>false
-,p_zoom_order_minutes=>false
-,p_zoom_order_hours=>false
-,p_zoom_order_days=>false
-,p_zoom_order_weeks=>false
-,p_zoom_order_months=>false
-,p_zoom_order_quarters=>false
-,p_zoom_order_years=>false
-);
-wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(13977078966041447)
 ,p_chart_id=>wwv_flow_api.id(13976741456041444)
 ,p_axis=>'x'
@@ -17920,6 +17872,29 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_tick_label_rendered=>'on'
 ,p_tick_label_rotation=>'auto'
 ,p_tick_label_position=>'outside'
+,p_zoom_order_seconds=>false
+,p_zoom_order_minutes=>false
+,p_zoom_order_hours=>false
+,p_zoom_order_days=>false
+,p_zoom_order_weeks=>false
+,p_zoom_order_months=>false
+,p_zoom_order_quarters=>false
+,p_zoom_order_years=>false
+);
+wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(13977108905041448)
+,p_chart_id=>wwv_flow_api.id(13976741456041444)
+,p_axis=>'y'
+,p_is_rendered=>'on'
+,p_format_type=>'decimal'
+,p_decimal_places=>1
+,p_format_scaling=>'auto'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_position=>'auto'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'off'
+,p_tick_label_rendered=>'on'
 ,p_zoom_order_seconds=>false
 ,p_zoom_order_minutes=>false
 ,p_zoom_order_hours=>false
@@ -18027,29 +18002,6 @@ wwv_flow_api.create_jet_chart_series(
 ,p_items_label_font_size=>'10'
 );
 wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(14186775683270008)
-,p_chart_id=>wwv_flow_api.id(14186570488270006)
-,p_axis=>'y'
-,p_is_rendered=>'on'
-,p_format_type=>'decimal'
-,p_decimal_places=>1
-,p_format_scaling=>'auto'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_position=>'auto'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'off'
-,p_tick_label_rendered=>'on'
-,p_zoom_order_seconds=>false
-,p_zoom_order_minutes=>false
-,p_zoom_order_hours=>false
-,p_zoom_order_days=>false
-,p_zoom_order_weeks=>false
-,p_zoom_order_months=>false
-,p_zoom_order_quarters=>false
-,p_zoom_order_years=>false
-);
-wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(14186828501270009)
 ,p_chart_id=>wwv_flow_api.id(14186570488270006)
 ,p_axis=>'x'
@@ -18064,6 +18016,29 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_tick_label_rendered=>'on'
 ,p_tick_label_rotation=>'auto'
 ,p_tick_label_position=>'outside'
+,p_zoom_order_seconds=>false
+,p_zoom_order_minutes=>false
+,p_zoom_order_hours=>false
+,p_zoom_order_days=>false
+,p_zoom_order_weeks=>false
+,p_zoom_order_months=>false
+,p_zoom_order_quarters=>false
+,p_zoom_order_years=>false
+);
+wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(14186775683270008)
+,p_chart_id=>wwv_flow_api.id(14186570488270006)
+,p_axis=>'y'
+,p_is_rendered=>'on'
+,p_format_type=>'decimal'
+,p_decimal_places=>1
+,p_format_scaling=>'auto'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_position=>'auto'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'off'
+,p_tick_label_rendered=>'on'
 ,p_zoom_order_seconds=>false
 ,p_zoom_order_minutes=>false
 ,p_zoom_order_hours=>false
@@ -18161,29 +18136,6 @@ wwv_flow_api.create_jet_chart_series(
 ,p_items_label_font_size=>'10'
 );
 wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(15051263494989904)
-,p_chart_id=>wwv_flow_api.id(15051010405989902)
-,p_axis=>'y'
-,p_is_rendered=>'on'
-,p_format_type=>'decimal'
-,p_decimal_places=>1
-,p_format_scaling=>'auto'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_position=>'auto'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'off'
-,p_tick_label_rendered=>'on'
-,p_zoom_order_seconds=>false
-,p_zoom_order_minutes=>false
-,p_zoom_order_hours=>false
-,p_zoom_order_days=>false
-,p_zoom_order_weeks=>false
-,p_zoom_order_months=>false
-,p_zoom_order_quarters=>false
-,p_zoom_order_years=>false
-);
-wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(15051343629989905)
 ,p_chart_id=>wwv_flow_api.id(15051010405989902)
 ,p_axis=>'x'
@@ -18198,6 +18150,29 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_tick_label_rendered=>'on'
 ,p_tick_label_rotation=>'auto'
 ,p_tick_label_position=>'outside'
+,p_zoom_order_seconds=>false
+,p_zoom_order_minutes=>false
+,p_zoom_order_hours=>false
+,p_zoom_order_days=>false
+,p_zoom_order_weeks=>false
+,p_zoom_order_months=>false
+,p_zoom_order_quarters=>false
+,p_zoom_order_years=>false
+);
+wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(15051263494989904)
+,p_chart_id=>wwv_flow_api.id(15051010405989902)
+,p_axis=>'y'
+,p_is_rendered=>'on'
+,p_format_type=>'decimal'
+,p_decimal_places=>1
+,p_format_scaling=>'auto'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_position=>'auto'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'off'
+,p_tick_label_rendered=>'on'
 ,p_zoom_order_seconds=>false
 ,p_zoom_order_minutes=>false
 ,p_zoom_order_hours=>false
@@ -18292,29 +18267,6 @@ wwv_flow_api.create_jet_chart_series(
 ,p_items_label_font_size=>'10'
 );
 wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(15052096900989912)
-,p_chart_id=>wwv_flow_api.id(15051899660989910)
-,p_axis=>'y'
-,p_is_rendered=>'on'
-,p_format_type=>'decimal'
-,p_decimal_places=>1
-,p_format_scaling=>'auto'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_position=>'auto'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'off'
-,p_tick_label_rendered=>'on'
-,p_zoom_order_seconds=>false
-,p_zoom_order_minutes=>false
-,p_zoom_order_hours=>false
-,p_zoom_order_days=>false
-,p_zoom_order_weeks=>false
-,p_zoom_order_months=>false
-,p_zoom_order_quarters=>false
-,p_zoom_order_years=>false
-);
-wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(15052126213989913)
 ,p_chart_id=>wwv_flow_api.id(15051899660989910)
 ,p_axis=>'x'
@@ -18329,6 +18281,29 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_tick_label_rendered=>'on'
 ,p_tick_label_rotation=>'auto'
 ,p_tick_label_position=>'outside'
+,p_zoom_order_seconds=>false
+,p_zoom_order_minutes=>false
+,p_zoom_order_hours=>false
+,p_zoom_order_days=>false
+,p_zoom_order_weeks=>false
+,p_zoom_order_months=>false
+,p_zoom_order_quarters=>false
+,p_zoom_order_years=>false
+);
+wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(15052096900989912)
+,p_chart_id=>wwv_flow_api.id(15051899660989910)
+,p_axis=>'y'
+,p_is_rendered=>'on'
+,p_format_type=>'decimal'
+,p_decimal_places=>1
+,p_format_scaling=>'auto'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_position=>'auto'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'off'
+,p_tick_label_rendered=>'on'
 ,p_zoom_order_seconds=>false
 ,p_zoom_order_minutes=>false
 ,p_zoom_order_hours=>false
@@ -20268,21 +20243,6 @@ wwv_flow_api.create_jet_chart_series(
 ,p_items_label_font_size=>'10'
 );
 wwv_flow_api.create_jet_chart_axis(
- p_id=>wwv_flow_api.id(16360289843490327)
-,p_chart_id=>wwv_flow_api.id(16360042364490325)
-,p_axis=>'y'
-,p_is_rendered=>'on'
-,p_format_type=>'decimal'
-,p_decimal_places=>1
-,p_format_scaling=>'auto'
-,p_scaling=>'linear'
-,p_baseline_scaling=>'zero'
-,p_position=>'auto'
-,p_major_tick_rendered=>'on'
-,p_minor_tick_rendered=>'off'
-,p_tick_label_rendered=>'on'
-);
-wwv_flow_api.create_jet_chart_axis(
  p_id=>wwv_flow_api.id(16360351214490328)
 ,p_chart_id=>wwv_flow_api.id(16360042364490325)
 ,p_axis=>'x'
@@ -20297,6 +20257,21 @@ wwv_flow_api.create_jet_chart_axis(
 ,p_tick_label_rendered=>'on'
 ,p_tick_label_rotation=>'auto'
 ,p_tick_label_position=>'outside'
+);
+wwv_flow_api.create_jet_chart_axis(
+ p_id=>wwv_flow_api.id(16360289843490327)
+,p_chart_id=>wwv_flow_api.id(16360042364490325)
+,p_axis=>'y'
+,p_is_rendered=>'on'
+,p_format_type=>'decimal'
+,p_decimal_places=>1
+,p_format_scaling=>'auto'
+,p_scaling=>'linear'
+,p_baseline_scaling=>'zero'
+,p_position=>'auto'
+,p_major_tick_rendered=>'on'
+,p_minor_tick_rendered=>'off'
+,p_tick_label_rendered=>'on'
 );
 wwv_flow_api.create_report_region(
  p_id=>wwv_flow_api.id(16361917406490344)
@@ -22805,14 +22780,210 @@ wwv_flow_api.create_page(
 '}'))
 ,p_page_template_options=>'#DEFAULT#'
 ,p_last_updated_by=>'ADIZOHAR'
-,p_last_upd_yyyymmddhh24miss=>'20200601123606'
+,p_last_upd_yyyymmddhh24miss=>'20200729124407'
+);
+wwv_flow_api.create_page_plug(
+ p_id=>wwv_flow_api.id(11208064619636616)
+,p_plug_name=>'Cost Summary Monthly'
+,p_region_template_options=>'#DEFAULT#:t-Region--accent15:t-Region--scrollBody'
+,p_component_template_options=>'#DEFAULT#'
+,p_plug_template=>wwv_flow_api.id(9765042323688020)
+,p_plug_display_sequence=>40
+,p_include_in_reg_disp_sel_yn=>'Y'
+,p_plug_display_point=>'BODY'
+,p_query_type=>'SQL'
+,p_plug_source=>wwv_flow_string.join(wwv_flow_t_varchar2(
+'select ',
+'	tenant_name, ',
+'	month6, ',
+'	month5, ',
+'	month4, ',
+'	month3, ',
+'	month2, ',
+'	month1, ',
+'	case when trunc(greatest(month1,month2,month3,month4,month5,month6)) = trunc(month1) then ''background-color:#CCFFCC;font-weight:bold;'' else ''background-color:#FFFFFF'' END as month1_color,',
+'	case when trunc(greatest(month1,month2,month3,month4,month5,month6)) = trunc(month2) then ''background-color:#CCFFCC;font-weight:bold;'' else ''background-color:#FFFFFF'' END as month2_color,',
+'	case when trunc(greatest(month1,month2,month3,month4,month5,month6)) = trunc(month3) then ''background-color:#CCFFCC;font-weight:bold;'' else ''background-color:#FFFFFF'' END as month3_color,',
+'	case when trunc(greatest(month1,month2,month3,month4,month5,month6)) = trunc(month4) then ''background-color:#CCFFCC;font-weight:bold;'' else ''background-color:#FFFFFF'' END as month4_color,',
+'	case when trunc(greatest(month1,month2,month3,month4,month5,month6)) = trunc(month5) then ''background-color:#CCFFCC;font-weight:bold;'' else ''background-color:#FFFFFF'' END as month5_color,',
+'	case when trunc(greatest(month1,month2,month3,month4,month5,month6)) = trunc(month6) then ''background-color:#CCFFCC;font-weight:bold;'' else ''background-color:#FFFFFF'' END as month6_color',
+'from',
+'(',
+'    select ',
+'        tenant_name,',
+'        sum(case when trunc(USAGE_INTERVAL_START,''MM'') = add_months(trunc(sysdate,''MM''),-5) then COST_MY_COST else 0 end) month6,',
+'        sum(case when trunc(USAGE_INTERVAL_START,''MM'') = add_months(trunc(sysdate,''MM''),-4) then COST_MY_COST else 0 end) month5,',
+'        sum(case when trunc(USAGE_INTERVAL_START,''MM'') = add_months(trunc(sysdate,''MM''),-3) then COST_MY_COST else 0 end) month4,',
+'        sum(case when trunc(USAGE_INTERVAL_START,''MM'') = add_months(trunc(sysdate,''MM''),-2) then COST_MY_COST else 0 end) month3,',
+'        sum(case when trunc(USAGE_INTERVAL_START,''MM'') = add_months(trunc(sysdate,''MM''),-1) then COST_MY_COST else 0 end) month2,',
+'        sum(case when trunc(USAGE_INTERVAL_START,''MM'') = add_months(trunc(sysdate,''MM''), 0) then COST_MY_COST else 0 end) month1',
+'    from oci_cost_stats',
+'    where ',
+'        tenant_name like ''%'' and',
+'        USAGE_INTERVAL_START >= add_months(trunc(sysdate,''MM''),-5)',
+'    group by tenant_name',
+')',
+'order by 1'))
+,p_plug_source_type=>'NATIVE_IR'
+,p_plug_query_options=>'DERIVED_REPORT_COLUMNS'
+);
+wwv_flow_api.create_worksheet(
+ p_id=>wwv_flow_api.id(11208874726636624)
+,p_max_row_count=>'1000000'
+,p_show_nulls_as=>'-'
+,p_pagination_type=>'ROWS_X_TO_Y'
+,p_pagination_display_pos=>'BOTTOM_RIGHT'
+,p_show_search_bar=>'N'
+,p_report_list_mode=>'TABS'
+,p_show_detail_link=>'N'
+,p_owner=>'ADIZOHAR'
+,p_internal_uid=>11208874726636624
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(11208958434636625)
+,p_db_column_name=>'TENANT_NAME'
+,p_display_order=>10
+,p_column_identifier=>'A'
+,p_column_label=>'Tenant Name'
+,p_column_type=>'STRING'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(11211127457636647)
+,p_db_column_name=>'MONTH6'
+,p_display_order=>20
+,p_column_identifier=>'B'
+,p_column_label=>'&P6_MONTH6.'
+,p_column_html_expression=>'<span  style="#MONTH6_COLOR#">#MONTH6#</span>'
+,p_column_type=>'NUMBER'
+,p_column_alignment=>'RIGHT'
+,p_format_mask=>'999G999G999G999G990'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(11211295849636648)
+,p_db_column_name=>'MONTH5'
+,p_display_order=>30
+,p_column_identifier=>'C'
+,p_column_label=>'&P6_MONTH5.'
+,p_column_html_expression=>'<span  style="#MONTH5_COLOR#">#MONTH5#</span>'
+,p_column_type=>'NUMBER'
+,p_column_alignment=>'RIGHT'
+,p_format_mask=>'999G999G999G999G990'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(11211379215636649)
+,p_db_column_name=>'MONTH4'
+,p_display_order=>40
+,p_column_identifier=>'D'
+,p_column_label=>'&P6_MONTH4.'
+,p_column_html_expression=>wwv_flow_string.join(wwv_flow_t_varchar2(
+'<span style="#MONTH4_COLOR#">#MONTH4#</span>',
+''))
+,p_column_type=>'NUMBER'
+,p_column_alignment=>'RIGHT'
+,p_format_mask=>'999G999G999G999G990'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(11211494413636650)
+,p_db_column_name=>'MONTH3'
+,p_display_order=>50
+,p_column_identifier=>'E'
+,p_column_label=>'&P6_MONTH3.'
+,p_column_html_expression=>'<span  style="#MONTH3_COLOR#">#MONTH3#</span>'
+,p_column_type=>'NUMBER'
+,p_column_alignment=>'RIGHT'
+,p_format_mask=>'999G999G999G999G990'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(12302959449574201)
+,p_db_column_name=>'MONTH2'
+,p_display_order=>60
+,p_column_identifier=>'F'
+,p_column_label=>'&P6_MONTH2.'
+,p_column_html_expression=>'<span style="#MONTH2_COLOR#">#MONTH2#</span>'
+,p_column_type=>'NUMBER'
+,p_column_alignment=>'RIGHT'
+,p_format_mask=>'999G999G999G999G990'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(12303005990574202)
+,p_db_column_name=>'MONTH1'
+,p_display_order=>70
+,p_column_identifier=>'G'
+,p_column_label=>'&P6_MONTH1.'
+,p_column_html_expression=>'<span  style="#MONTH1_COLOR#">#MONTH1#</span>'
+,p_column_type=>'NUMBER'
+,p_column_alignment=>'RIGHT'
+,p_format_mask=>'999G999G999G999G990'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(12303171514574203)
+,p_db_column_name=>'MONTH1_COLOR'
+,p_display_order=>80
+,p_column_identifier=>'H'
+,p_column_label=>'Month1 Color'
+,p_column_type=>'STRING'
+,p_display_text_as=>'HIDDEN'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(12303287884574204)
+,p_db_column_name=>'MONTH2_COLOR'
+,p_display_order=>90
+,p_column_identifier=>'I'
+,p_column_label=>'Month2 Color'
+,p_column_type=>'STRING'
+,p_display_text_as=>'HIDDEN'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(12303344220574205)
+,p_db_column_name=>'MONTH3_COLOR'
+,p_display_order=>100
+,p_column_identifier=>'J'
+,p_column_label=>'Month3 Color'
+,p_column_type=>'STRING'
+,p_display_text_as=>'HIDDEN'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(12303498895574206)
+,p_db_column_name=>'MONTH4_COLOR'
+,p_display_order=>110
+,p_column_identifier=>'K'
+,p_column_label=>'Month4 Color'
+,p_column_type=>'STRING'
+,p_display_text_as=>'HIDDEN'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(12303540909574207)
+,p_db_column_name=>'MONTH5_COLOR'
+,p_display_order=>120
+,p_column_identifier=>'L'
+,p_column_label=>'Month5 Color'
+,p_column_type=>'STRING'
+,p_display_text_as=>'HIDDEN'
+);
+wwv_flow_api.create_worksheet_column(
+ p_id=>wwv_flow_api.id(12303610921574208)
+,p_db_column_name=>'MONTH6_COLOR'
+,p_display_order=>130
+,p_column_identifier=>'M'
+,p_column_label=>'Month6 Color'
+,p_column_type=>'STRING'
+,p_display_text_as=>'HIDDEN'
+);
+wwv_flow_api.create_worksheet_rpt(
+ p_id=>wwv_flow_api.id(12307939956592577)
+,p_application_user=>'APXWS_DEFAULT'
+,p_report_seq=>10
+,p_report_alias=>'123080'
+,p_status=>'PUBLIC'
+,p_is_default=>'Y'
+,p_report_columns=>'TENANT_NAME:MONTH6:MONTH5:MONTH4:MONTH3:MONTH2:MONTH1:MONTH1_COLOR:MONTH2_COLOR:MONTH3_COLOR:MONTH4_COLOR:MONTH5_COLOR:MONTH6_COLOR'
 );
 wwv_flow_api.create_page_plug(
  p_id=>wwv_flow_api.id(12552815670313326)
 ,p_plug_name=>'Usage Statistics - &P6_USAGE_SIZE.'
 ,p_region_template_options=>'#DEFAULT#:t-Region--accent15:t-Region--scrollBody'
 ,p_plug_template=>wwv_flow_api.id(9765042323688020)
-,p_plug_display_sequence=>40
+,p_plug_display_sequence=>50
 ,p_plug_display_point=>'BODY'
 ,p_query_type=>'SQL'
 ,p_plug_source=>wwv_flow_string.join(wwv_flow_t_varchar2(
@@ -23236,7 +23407,7 @@ wwv_flow_api.create_worksheet_rpt(
 wwv_flow_api.create_page_plug(
  p_id=>wwv_flow_api.id(14188632778270027)
 ,p_plug_name=>'Cost Summary Last 7 Days'
-,p_region_template_options=>'#DEFAULT#:t-Region--noPadding:t-Region--accent15:t-Region--scrollBody:margin-top-none:margin-bottom-none:margin-left-none:margin-right-none'
+,p_region_template_options=>'#DEFAULT#:t-Region--accent15:t-Region--scrollBody'
 ,p_component_template_options=>'#DEFAULT#'
 ,p_plug_template=>wwv_flow_api.id(9765042323688020)
 ,p_plug_display_sequence=>30
@@ -23491,6 +23662,57 @@ wwv_flow_api.create_worksheet_rpt(
 ,p_report_columns=>'TENANT_NAME:DAY7:DAY6:DAY5:DAY4:DAY3:DAY2:DAY1:YEAR::DAY1_COLOR:DAY2_COLOR:DAY3_COLOR:DAY4_COLOR:DAY5_COLOR:DAY6_COLOR:DAY7_COLOR'
 );
 wwv_flow_api.create_page_item(
+ p_id=>wwv_flow_api.id(11208116210636617)
+,p_name=>'P6_MONTH1'
+,p_item_sequence=>10
+,p_item_plug_id=>wwv_flow_api.id(11208064619636616)
+,p_display_as=>'NATIVE_HIDDEN'
+,p_attribute_01=>'Y'
+);
+wwv_flow_api.create_page_item(
+ p_id=>wwv_flow_api.id(11208271476636618)
+,p_name=>'P6_MONTH2'
+,p_item_sequence=>20
+,p_item_plug_id=>wwv_flow_api.id(11208064619636616)
+,p_display_as=>'NATIVE_HIDDEN'
+,p_attribute_01=>'Y'
+);
+wwv_flow_api.create_page_item(
+ p_id=>wwv_flow_api.id(11208351769636619)
+,p_name=>'P6_MONTH3'
+,p_item_sequence=>30
+,p_item_plug_id=>wwv_flow_api.id(11208064619636616)
+,p_display_as=>'NATIVE_HIDDEN'
+,p_attribute_01=>'Y'
+);
+wwv_flow_api.create_page_item(
+ p_id=>wwv_flow_api.id(11208489651636620)
+,p_name=>'P6_MONTH4'
+,p_item_sequence=>40
+,p_item_plug_id=>wwv_flow_api.id(11208064619636616)
+,p_display_as=>'NATIVE_HIDDEN'
+,p_attribute_01=>'Y'
+);
+wwv_flow_api.create_page_item(
+ p_id=>wwv_flow_api.id(11208533441636621)
+,p_name=>'P6_MONTH5'
+,p_item_sequence=>50
+,p_item_plug_id=>wwv_flow_api.id(11208064619636616)
+,p_display_as=>'NATIVE_HIDDEN'
+,p_attribute_01=>'Y'
+);
+end;
+/
+begin
+wwv_flow_api.create_page_item(
+ p_id=>wwv_flow_api.id(11208672205636622)
+,p_name=>'P6_MONTH6'
+,p_item_sequence=>60
+,p_item_plug_id=>wwv_flow_api.id(11208064619636616)
+,p_display_as=>'NATIVE_HIDDEN'
+,p_attribute_01=>'Y'
+);
+wwv_flow_api.create_page_item(
  p_id=>wwv_flow_api.id(12555202081313350)
 ,p_name=>'P6_USAGE_SIZE'
 ,p_item_sequence=>10
@@ -23624,6 +23846,54 @@ wwv_flow_api.create_page_computation(
 ,p_computation_type=>'QUERY'
 ,p_computation=>'select to_char(trunc(sysdate-7),''DD-MON-YYYY'') val from dual'
 );
+wwv_flow_api.create_page_computation(
+ p_id=>wwv_flow_api.id(11210536697636641)
+,p_computation_sequence=>80
+,p_computation_item=>'P6_MONTH1'
+,p_computation_point=>'BEFORE_BOX_BODY'
+,p_computation_type=>'QUERY'
+,p_computation=>'select to_char(add_months(trunc(sysdate,''MM''),0),''MON-YYYY'') val from dual'
+);
+wwv_flow_api.create_page_computation(
+ p_id=>wwv_flow_api.id(11210694543636642)
+,p_computation_sequence=>90
+,p_computation_item=>'P6_MONTH2'
+,p_computation_point=>'BEFORE_BOX_BODY'
+,p_computation_type=>'QUERY'
+,p_computation=>'select to_char(add_months(trunc(sysdate,''MM''),-1),''MON-YYYY'') val from dual'
+);
+wwv_flow_api.create_page_computation(
+ p_id=>wwv_flow_api.id(11210745364636643)
+,p_computation_sequence=>100
+,p_computation_item=>'P6_MONTH3'
+,p_computation_point=>'BEFORE_BOX_BODY'
+,p_computation_type=>'QUERY'
+,p_computation=>'select to_char(add_months(trunc(sysdate,''MM''),-2),''MON-YYYY'') val from dual'
+);
+wwv_flow_api.create_page_computation(
+ p_id=>wwv_flow_api.id(11210851820636644)
+,p_computation_sequence=>110
+,p_computation_item=>'P6_MONTH4'
+,p_computation_point=>'BEFORE_BOX_BODY'
+,p_computation_type=>'QUERY'
+,p_computation=>'select to_char(add_months(trunc(sysdate,''MM''),-3),''MON-YYYY'') val from dual'
+);
+wwv_flow_api.create_page_computation(
+ p_id=>wwv_flow_api.id(11210940658636645)
+,p_computation_sequence=>120
+,p_computation_item=>'P6_MONTH5'
+,p_computation_point=>'BEFORE_BOX_BODY'
+,p_computation_type=>'QUERY'
+,p_computation=>'select to_char(add_months(trunc(sysdate,''MM''),-4),''MON-YYYY'') val from dual'
+);
+wwv_flow_api.create_page_computation(
+ p_id=>wwv_flow_api.id(11211038784636646)
+,p_computation_sequence=>130
+,p_computation_item=>'P6_MONTH6'
+,p_computation_point=>'BEFORE_BOX_BODY'
+,p_computation_type=>'QUERY'
+,p_computation=>'select to_char(add_months(trunc(sysdate,''MM''),-5),''MON-YYYY'') val from dual'
+);
 end;
 /
 prompt --application/pages/page_00007
@@ -23647,7 +23917,7 @@ wwv_flow_api.create_page(
 ''))
 ,p_page_template_options=>'#DEFAULT#'
 ,p_last_updated_by=>'ADIZOHAR'
-,p_last_upd_yyyymmddhh24miss=>'20200514125242'
+,p_last_upd_yyyymmddhh24miss=>'20200729121951'
 );
 wwv_flow_api.create_page_plug(
  p_id=>wwv_flow_api.id(72369311697812384)
@@ -23692,10 +23962,6 @@ wwv_flow_api.create_page_plug(
 '    COST_UNIT_PRICE           COST_PRICE,',
 '    COST_LAST_UPDATE,',
 '	RATE_DESCRIPTION,',
-'    RATE_PAYGO_PRICE          RATE_PAYGO,',
-'	CASE WHEN RATE_PAYGO_PRICE > 0 AND RATE_PAYGO_PRICE IS NOT NULL and COST_UNIT_PRICE > 0 THEN',
-'	    ROUND((RATE_PAYGO_PRICE - COST_UNIT_PRICE )/RATE_PAYGO_PRICE * 100,1)',
-'	ELSE NULL END PCT_PAYGO,',
 '    ROUND(RATE_MONTHLY_FLEX_PRICE,4) RATE_MONTHLY,',
 '	CASE WHEN RATE_MONTHLY_FLEX_PRICE > 0  AND RATE_MONTHLY_FLEX_PRICE IS NOT NULL and COST_UNIT_PRICE>0 THEN',
 '	    ROUND((RATE_MONTHLY_FLEX_PRICE - COST_UNIT_PRICE )/RATE_MONTHLY_FLEX_PRICE * 100,1)',
@@ -23739,11 +24005,14 @@ wwv_flow_api.create_page_plug(
 wwv_flow_api.create_worksheet(
  p_id=>wwv_flow_api.id(16358400984490309)
 ,p_max_row_count=>'1000000'
+,p_allow_save_rpt_public=>'Y'
 ,p_show_nulls_as=>'-'
 ,p_pagination_type=>'ROWS_X_TO_Y'
 ,p_pagination_display_pos=>'BOTTOM_RIGHT'
+,p_show_display_row_count=>'Y'
 ,p_report_list_mode=>'TABS'
 ,p_show_detail_link=>'N'
+,p_show_rows_per_page=>'N'
 ,p_show_notify=>'Y'
 ,p_download_formats=>'CSV:HTML:EMAIL:XLS:PDF:RTF'
 ,p_owner=>'ADIZOHAR'
@@ -23816,32 +24085,11 @@ wwv_flow_api.create_worksheet_column(
 ,p_column_type=>'STRING'
 );
 wwv_flow_api.create_worksheet_column(
- p_id=>wwv_flow_api.id(16359237070490317)
-,p_db_column_name=>'RATE_PAYGO'
-,p_display_order=>80
-,p_column_identifier=>'H'
-,p_column_label=>'Public Rate PayGo'
-,p_column_type=>'NUMBER'
-,p_column_alignment=>'RIGHT'
-,p_format_mask=>'999G999G999G999G990D0000'
-);
-wwv_flow_api.create_worksheet_column(
- p_id=>wwv_flow_api.id(16359398402490318)
-,p_db_column_name=>'PCT_PAYGO'
-,p_display_order=>90
-,p_column_identifier=>'I'
-,p_column_label=>'% Discount PayGo'
-,p_column_type=>'NUMBER'
-,p_column_alignment=>'RIGHT'
-,p_format_mask=>'999G999G999G999G990D00'
-,p_static_id=>'rep_col_blue'
-);
-wwv_flow_api.create_worksheet_column(
  p_id=>wwv_flow_api.id(16359449849490319)
 ,p_db_column_name=>'RATE_MONTHLY'
 ,p_display_order=>100
 ,p_column_identifier=>'J'
-,p_column_label=>'Public Rate MonFlex'
+,p_column_label=>'Public Rate'
 ,p_column_type=>'NUMBER'
 ,p_column_alignment=>'RIGHT'
 ,p_format_mask=>'999G999G999G999G990D0000'
@@ -23852,7 +24100,7 @@ wwv_flow_api.create_worksheet_column(
 ,p_db_column_name=>'PCT_MONTH'
 ,p_display_order=>110
 ,p_column_identifier=>'K'
-,p_column_label=>'% Discount MonFlex'
+,p_column_label=>'% Discount'
 ,p_column_type=>'NUMBER'
 ,p_column_alignment=>'RIGHT'
 ,p_format_mask=>'999G999G999G999G990D00'
@@ -23877,27 +24125,7 @@ wwv_flow_api.create_worksheet_rpt(
 ,p_report_alias=>'163928'
 ,p_status=>'PUBLIC'
 ,p_is_default=>'Y'
-,p_report_columns=>'SKU:PRODUCT:CURRENCY:COST_PRICE:PCT_MONTH:RATE_MONTHLY:RATE_DESCRIPTION:RATE_UPDATE_DATE:'
-);
-wwv_flow_api.create_worksheet_rpt(
- p_id=>wwv_flow_api.id(16440462414039910)
-,p_application_user=>'APXWS_ALTERNATIVE'
-,p_name=>'PayGo'
-,p_report_seq=>10
-,p_report_alias=>'164405'
-,p_status=>'PUBLIC'
-,p_is_default=>'Y'
-,p_report_columns=>'SKU:PRODUCT:CURRENCY:COST_PRICE:RATE_PAYGO:PCT_PAYGO:RATE_DESCRIPTION:RATE_UPDATE_DATE:'
-);
-wwv_flow_api.create_worksheet_rpt(
- p_id=>wwv_flow_api.id(16440945673042259)
-,p_application_user=>'APXWS_ALTERNATIVE'
-,p_name=>'Monthly Flex'
-,p_report_seq=>10
-,p_report_alias=>'164410'
-,p_status=>'PUBLIC'
-,p_is_default=>'Y'
-,p_report_columns=>'SKU:PRODUCT:CURRENCY:COST_PRICE:PCT_MONTH:RATE_MONTHLY:RATE_DESCRIPTION:RATE_UPDATE_DATE:'
+,p_report_columns=>'SKU:PRODUCT:CURRENCY:RATE_MONTHLY:PCT_MONTH:COST_PRICE:RATE_DESCRIPTION:RATE_UPDATE_DATE:'
 );
 wwv_flow_api.create_page_item(
  p_id=>wwv_flow_api.id(16372411599522248)

--- a/src/oci/cims/__init__.py
+++ b/src/oci/cims/__init__.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import
 
 from .incident_client import IncidentClient
 from .incident_client_composite_operations import IncidentClientCompositeOperations
+from .user_client import UserClient
+from .user_client_composite_operations import UserClientCompositeOperations
 from . import models
 
-__all__ = ["IncidentClient", "IncidentClientCompositeOperations", "models"]
+__all__ = ["IncidentClient", "IncidentClientCompositeOperations", "UserClient", "UserClientCompositeOperations", "models"]

--- a/src/oci/cims/incident_client.py
+++ b/src/oci/cims/incident_client.py
@@ -83,20 +83,20 @@ class IncidentClient(object):
 
     def create_incident(self, create_incident_details, ocid, **kwargs):
         """
-        This API enables the customer to Create an Incident
+        Enables the customer to create an support ticket.
 
 
         :param CreateIncident create_incident_details: (required)
             Incident information
 
         :param str ocid: (required)
-            User OCID for IDCS users that have a shadow in OCI
-
-        :param str opc_retry_token: (optional)
-            Retry token
+            User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
 
         :param str opc_request_id: (optional)
-            Unique Header for request id
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param str homeregion: (optional)
+            The region of the tenancy.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -115,8 +115,8 @@ class IncidentClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
-            "opc_retry_token",
-            "opc_request_id"
+            "opc_request_id",
+            "homeregion"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -126,9 +126,9 @@ class IncidentClient(object):
         header_params = {
             "accept": "application/json",
             "content-type": "application/json",
-            "opc-retry-token": kwargs.get("opc_retry_token", missing),
             "opc-request-id": kwargs.get("opc_request_id", missing),
-            "ocid": ocid
+            "ocid": ocid,
+            "homeregion": kwargs.get("homeregion", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
@@ -137,8 +137,6 @@ class IncidentClient(object):
             retry_strategy = kwargs.get('retry_strategy')
 
         if retry_strategy:
-            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
-                self.base_client.add_opc_retry_token_if_needed(header_params)
             return retry_strategy.make_retrying_call(
                 self.base_client.call_api,
                 resource_path=resource_path,
@@ -156,20 +154,26 @@ class IncidentClient(object):
 
     def get_incident(self, incident_key, csi, ocid, **kwargs):
         """
-        This API fetches the details of a requested Incident
+        Gets the details of the support ticket.
 
 
         :param str incident_key: (required)
-            Unique ID that identifies an incident
+            Unique identifier for the support ticket.
 
         :param str csi: (required)
-            Customer Support Identifier of the support account
+            The Customer Support Identifier associated with the support account.
 
         :param str ocid: (required)
-            User OCID for IDCS users that have a shadow in OCI
+            User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
 
         :param str opc_request_id: (optional)
-            Unique Header for request id
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param str homeregion: (optional)
+            The region of the tenancy.
+
+        :param str problem_type: (optional)
+            The kind of support request.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -188,7 +192,9 @@ class IncidentClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
-            "opc_request_id"
+            "opc_request_id",
+            "homeregion",
+            "problem_type"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -210,7 +216,9 @@ class IncidentClient(object):
             "content-type": "application/json",
             "opc-request-id": kwargs.get("opc_request_id", missing),
             "csi": csi,
-            "ocid": ocid
+            "ocid": ocid,
+            "homeregion": kwargs.get("homeregion", missing),
+            "problem-type": kwargs.get("problem_type", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
@@ -236,17 +244,20 @@ class IncidentClient(object):
 
     def get_status(self, source, ocid, **kwargs):
         """
-        GetStatus of the Service
+        Gets the status of the service.
 
 
         :param str source: (required)
-            Source is a downstream system. Eg: JIRA or MOS or any other source in future.
+            The system that generated the support ticket, such as My Oracle Support.
 
         :param str ocid: (required)
-            User OCID for IDCS users that have a shadow in OCI
+            User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
 
         :param str opc_request_id: (optional)
-            Unique Header for request id
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param str homeregion: (optional)
+            The region of the tenancy.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -265,7 +276,8 @@ class IncidentClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
-            "opc_request_id"
+            "opc_request_id",
+            "homeregion"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -286,7 +298,8 @@ class IncidentClient(object):
             "accept": "application/json",
             "content-type": "application/json",
             "opc-request-id": kwargs.get("opc_request_id", missing),
-            "ocid": ocid
+            "ocid": ocid,
+            "homeregion": kwargs.get("homeregion", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
@@ -312,42 +325,49 @@ class IncidentClient(object):
 
     def list_incident_resource_types(self, problem_type, compartment_id, csi, ocid, **kwargs):
         """
-        This API returns the list of all possible product that OCI supports, while creating an incident
+        During support ticket creation, returns the list of all possible products that Oracle Cloud Infrastructure supports.
 
 
         :param str problem_type: (required)
-            Problem Type of Taxonomy - tech/limit
+            The kind of support request.
 
         :param str compartment_id: (required)
-            Tenancy Ocid
+            The OCID of the tenancy.
 
         :param str csi: (required)
-            Customer Support Identifier of the support account
+            The Customer Support Identifier associated with the support account.
 
         :param str ocid: (required)
-            User OCID for IDCS users that have a shadow in OCI
+            User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
 
         :param str opc_request_id: (optional)
-            Unique Header for request id
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
 
         :param int limit: (optional)
-            Limit query for number of returned results
+            For list pagination. The maximum number of results per page, or items to return in a paginated \"List\" call. For important details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            Pagination for Incident list
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_by: (optional)
-            The key to sort the returned items by
+            The key to use to sort the returned items.
 
             Allowed values are: "dateUpdated", "severity"
 
         :param str sort_order: (optional)
-            The order in which to sort the results
+            The order to sort the results in.
 
             Allowed values are: "ASC", "DESC"
 
         :param str name: (optional)
-            Name of Incident Type. eg: Limit Increase
+            The user-friendly name of the incident type.
+
+        :param str homeregion: (optional)
+            The region of the tenancy.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -371,7 +391,8 @@ class IncidentClient(object):
             "page",
             "sort_by",
             "sort_order",
-            "name"
+            "name",
+            "homeregion"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -408,7 +429,8 @@ class IncidentClient(object):
             "content-type": "application/json",
             "opc-request-id": kwargs.get("opc_request_id", missing),
             "csi": csi,
-            "ocid": ocid
+            "ocid": ocid,
+            "homeregion": kwargs.get("homeregion", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
@@ -434,41 +456,51 @@ class IncidentClient(object):
 
     def list_incidents(self, csi, compartment_id, ocid, **kwargs):
         """
-        This API returns the list of incidents raised by the tenant
+        Returns the list of support tickets raised by the tenancy.
 
 
         :param str csi: (required)
-            Customer Support Identifier of the support account
+            The Customer Support Identifier associated with the support account.
 
         :param str compartment_id: (required)
-            Tenancy Ocid
+            The OCID of the tenancy.
 
         :param str ocid: (required)
-            User OCID for IDCS users that have a shadow in OCI
+            User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
 
         :param int limit: (optional)
-            Limit query for number of returned results
+            For list pagination. The maximum number of results per page, or items to return in a paginated \"List\" call. For important details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_by: (optional)
-            The key to sort the returned items by
+            The key to use to sort the returned items.
 
             Allowed values are: "dateUpdated", "severity"
 
         :param str sort_order: (optional)
-            The order in which to sort the results
+            The order to sort the results in.
 
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            The order in which to sort the results
+            The current state of the ticket.
 
             Allowed values are: "ACTIVE", "CLOSED"
 
         :param str page: (optional)
-            Pagination for Incident list
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str opc_request_id: (optional)
-            Unique Header for request id
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param str homeregion: (optional)
+            The region of the tenancy.
+
+        :param str problem_type: (optional)
+            The kind of support request.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -492,7 +524,9 @@ class IncidentClient(object):
             "sort_order",
             "lifecycle_state",
             "page",
-            "opc_request_id"
+            "opc_request_id",
+            "homeregion",
+            "problem_type"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -526,7 +560,8 @@ class IncidentClient(object):
             "sortBy": kwargs.get("sort_by", missing),
             "sortOrder": kwargs.get("sort_order", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
-            "page": kwargs.get("page", missing)
+            "page": kwargs.get("page", missing),
+            "problemType": kwargs.get("problem_type", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -535,7 +570,8 @@ class IncidentClient(object):
             "content-type": "application/json",
             "csi": csi,
             "opc-request-id": kwargs.get("opc_request_id", missing),
-            "ocid": ocid
+            "ocid": ocid,
+            "homeregion": kwargs.get("homeregion", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
@@ -561,29 +597,29 @@ class IncidentClient(object):
 
     def update_incident(self, incident_key, csi, update_incident_details, ocid, **kwargs):
         """
-        This API updates an existing incident
+        Updates the specified support ticket's information.
 
 
         :param str incident_key: (required)
-            Unique ID that identifies an incident
+            Unique identifier for the support ticket.
 
         :param str csi: (required)
-            Customer Support Identifier of the support account
+            The Customer Support Identifier associated with the support account.
 
         :param UpdateIncident update_incident_details: (required)
-            Details of Resource to be updated
+            Details about the support ticket being updated.
 
         :param str ocid: (required)
-            User OCID for IDCS users that have a shadow in OCI
-
-        :param str opc_retry_token: (optional)
-            Retry token
+            User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
 
         :param str opc_request_id: (optional)
-            Unique Header for request id
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
 
         :param str if_match: (optional)
-            if-match check
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource. The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str homeregion: (optional)
+            The region of the tenancy.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -602,9 +638,9 @@ class IncidentClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
-            "opc_retry_token",
             "opc_request_id",
-            "if_match"
+            "if_match",
+            "homeregion"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -625,10 +661,10 @@ class IncidentClient(object):
             "accept": "application/json",
             "content-type": "application/json",
             "csi": csi,
-            "opc-retry-token": kwargs.get("opc_retry_token", missing),
             "opc-request-id": kwargs.get("opc_request_id", missing),
             "if-match": kwargs.get("if_match", missing),
-            "ocid": ocid
+            "ocid": ocid,
+            "homeregion": kwargs.get("homeregion", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
@@ -637,8 +673,6 @@ class IncidentClient(object):
             retry_strategy = kwargs.get('retry_strategy')
 
         if retry_strategy:
-            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
-                self.base_client.add_opc_retry_token_if_needed(header_params)
             return retry_strategy.make_retrying_call(
                 self.base_client.call_api,
                 resource_path=resource_path,
@@ -658,23 +692,23 @@ class IncidentClient(object):
 
     def validate_user(self, csi, ocid, **kwargs):
         """
-        ValidateUser
+        Checks whether the requested user is valid.
 
 
         :param str csi: (required)
-            Customer support identifier of the support account
+            The Customer Support Identifier number for the support account.
 
         :param str ocid: (required)
-            User OCID for IDCS users that have a shadow in OCI
-
-        :param str opc_retry_token: (optional)
-            Retry-token header
+            User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
 
         :param str opc_request_id: (optional)
-            Unique request id
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
 
         :param str problem_type: (optional)
-            Problem Type of Taxonomy - tech/limit
+            The kind of support request.
+
+        :param str homeregion: (optional)
+            The region of the tenancy.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -693,9 +727,9 @@ class IncidentClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
-            "opc_retry_token",
             "opc_request_id",
-            "problem_type"
+            "problem_type",
+            "homeregion"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -711,9 +745,9 @@ class IncidentClient(object):
             "accept": "application/json",
             "content-type": "application/json",
             "csi": csi,
-            "opc-retry-token": kwargs.get("opc_retry_token", missing),
             "opc-request-id": kwargs.get("opc_request_id", missing),
-            "ocid": ocid
+            "ocid": ocid,
+            "homeregion": kwargs.get("homeregion", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
@@ -722,8 +756,6 @@ class IncidentClient(object):
             retry_strategy = kwargs.get('retry_strategy')
 
         if retry_strategy:
-            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
-                self.base_client.add_opc_retry_token_if_needed(header_params)
             return retry_strategy.make_retrying_call(
                 self.base_client.call_api,
                 resource_path=resource_path,

--- a/src/oci/cims/models/__init__.py
+++ b/src/oci/cims/models/__init__.py
@@ -9,6 +9,7 @@ from .category import Category
 from .classifier import Classifier
 from .contact import Contact
 from .contact_list import ContactList
+from .contextual_data import ContextualData
 from .create_category_details import CreateCategoryDetails
 from .create_incident import CreateIncident
 from .create_issue_type_details import CreateIssueTypeDetails
@@ -18,6 +19,7 @@ from .create_resource_details import CreateResourceDetails
 from .create_sub_category_details import CreateSubCategoryDetails
 from .create_tech_support_item_details import CreateTechSupportItemDetails
 from .create_ticket_details import CreateTicketDetails
+from .create_user_details import CreateUserDetails
 from .incident import Incident
 from .incident_resource_type import IncidentResourceType
 from .incident_summary import IncidentSummary
@@ -37,6 +39,7 @@ from .update_incident import UpdateIncident
 from .update_item_details import UpdateItemDetails
 from .update_resource_details import UpdateResourceDetails
 from .update_ticket_details import UpdateTicketDetails
+from .user import User
 from .validation_response import ValidationResponse
 
 # Maps type names to classes for cims services.
@@ -46,6 +49,7 @@ cims_type_mapping = {
     "Classifier": Classifier,
     "Contact": Contact,
     "ContactList": ContactList,
+    "ContextualData": ContextualData,
     "CreateCategoryDetails": CreateCategoryDetails,
     "CreateIncident": CreateIncident,
     "CreateIssueTypeDetails": CreateIssueTypeDetails,
@@ -55,6 +59,7 @@ cims_type_mapping = {
     "CreateSubCategoryDetails": CreateSubCategoryDetails,
     "CreateTechSupportItemDetails": CreateTechSupportItemDetails,
     "CreateTicketDetails": CreateTicketDetails,
+    "CreateUserDetails": CreateUserDetails,
     "Incident": Incident,
     "IncidentResourceType": IncidentResourceType,
     "IncidentSummary": IncidentSummary,
@@ -74,5 +79,6 @@ cims_type_mapping = {
     "UpdateItemDetails": UpdateItemDetails,
     "UpdateResourceDetails": UpdateResourceDetails,
     "UpdateTicketDetails": UpdateTicketDetails,
+    "User": User,
     "ValidationResponse": ValidationResponse
 }

--- a/src/oci/cims/models/activity_item.py
+++ b/src/oci/cims/models/activity_item.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ActivityItem(Item):
     """
-    Details of Activity Item
+    Details about the ActivityItem object.
     """
 
     #: A constant which can be used with the activity_type property of a ActivityItem.
@@ -137,7 +137,7 @@ class ActivityItem(Item):
     def comments(self):
         """
         Gets the comments of this ActivityItem.
-        Comments to update as part of Activity
+        Comments added with the activity on the support ticket.
 
 
         :return: The comments of this ActivityItem.
@@ -149,7 +149,7 @@ class ActivityItem(Item):
     def comments(self, comments):
         """
         Sets the comments of this ActivityItem.
-        Comments to update as part of Activity
+        Comments added with the activity on the support ticket.
 
 
         :param comments: The comments of this ActivityItem.
@@ -161,7 +161,7 @@ class ActivityItem(Item):
     def time_created(self):
         """
         Gets the time_created of this ActivityItem.
-        Epoch time when activity was created
+        The time when the activity was created, in milliseconds since epoch time.
 
 
         :return: The time_created of this ActivityItem.
@@ -173,7 +173,7 @@ class ActivityItem(Item):
     def time_created(self, time_created):
         """
         Sets the time_created of this ActivityItem.
-        Epoch time when activity was created
+        The time when the activity was created, in milliseconds since epoch time.
 
 
         :param time_created: The time_created of this ActivityItem.
@@ -185,7 +185,7 @@ class ActivityItem(Item):
     def time_updated(self):
         """
         Gets the time_updated of this ActivityItem.
-        Epoch time when activity was updated
+        The time when the activity was updated, in milliseconds since epoch time.
 
 
         :return: The time_updated of this ActivityItem.
@@ -197,7 +197,7 @@ class ActivityItem(Item):
     def time_updated(self, time_updated):
         """
         Sets the time_updated of this ActivityItem.
-        Epoch time when activity was updated
+        The time when the activity was updated, in milliseconds since epoch time.
 
 
         :param time_updated: The time_updated of this ActivityItem.
@@ -209,7 +209,7 @@ class ActivityItem(Item):
     def activity_type(self):
         """
         Gets the activity_type of this ActivityItem.
-        Type of activity. eg: NOTES, UPDATE
+        The type of activity occuring on the support ticket.
 
         Allowed values for this property are: "NOTES", "PROBLEM_DESCRIPTION", "UPDATE", "CLOSE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -224,7 +224,7 @@ class ActivityItem(Item):
     def activity_type(self, activity_type):
         """
         Sets the activity_type of this ActivityItem.
-        Type of activity. eg: NOTES, UPDATE
+        The type of activity occuring on the support ticket.
 
 
         :param activity_type: The activity_type of this ActivityItem.
@@ -239,7 +239,7 @@ class ActivityItem(Item):
     def activity_author(self):
         """
         Gets the activity_author of this ActivityItem.
-        Person who updates the activity
+        The person who updates the activity on the support ticket.
 
         Allowed values for this property are: "CUSTOMER", "ORACLE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -254,7 +254,7 @@ class ActivityItem(Item):
     def activity_author(self, activity_author):
         """
         Sets the activity_author of this ActivityItem.
-        Person who updates the activity
+        The person who updates the activity on the support ticket.
 
 
         :param activity_author: The activity_author of this ActivityItem.

--- a/src/oci/cims/models/category.py
+++ b/src/oci/cims/models/category.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Category(object):
     """
-    Details of Category of the incident
+    Details about the category associated with the support ticket.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,7 @@ class Category(object):
     def category_key(self):
         """
         Gets the category_key of this Category.
-        Unique ID that identifies a Category
+        Unique identifier for the category.
 
 
         :return: The category_key of this Category.
@@ -56,7 +56,7 @@ class Category(object):
     def category_key(self, category_key):
         """
         Sets the category_key of this Category.
-        Unique ID that identifies a Category
+        Unique identifier for the category.
 
 
         :param category_key: The category_key of this Category.
@@ -68,7 +68,7 @@ class Category(object):
     def name(self):
         """
         Gets the name of this Category.
-        Name of category. eg: Compute, Identity
+        The name of the category. For example, `Compute` or `Identity`.
 
 
         :return: The name of this Category.
@@ -80,7 +80,7 @@ class Category(object):
     def name(self, name):
         """
         Sets the name of this Category.
-        Name of category. eg: Compute, Identity
+        The name of the category. For example, `Compute` or `Identity`.
 
 
         :param name: The name of this Category.

--- a/src/oci/cims/models/classifier.py
+++ b/src/oci/cims/models/classifier.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Classifier(object):
     """
-    Incident Classifier details
+    Details about the incident classifier object.
     """
 
     #: A constant which can be used with the scope property of a Classifier.
@@ -111,7 +111,7 @@ class Classifier(object):
     def id(self):
         """
         Gets the id of this Classifier.
-        Unique ID that identifies a classifier
+        Unique identifier of the classifier.
 
 
         :return: The id of this Classifier.
@@ -123,7 +123,7 @@ class Classifier(object):
     def id(self, id):
         """
         Sets the id of this Classifier.
-        Unique ID that identifies a classifier
+        Unique identifier of the classifier.
 
 
         :param id: The id of this Classifier.
@@ -135,7 +135,7 @@ class Classifier(object):
     def name(self):
         """
         Gets the name of this Classifier.
-        Name of classifier. eg: LIMIT Increase
+        The display name of the classifier.
 
 
         :return: The name of this Classifier.
@@ -147,7 +147,7 @@ class Classifier(object):
     def name(self, name):
         """
         Sets the name of this Classifier.
-        Name of classifier. eg: LIMIT Increase
+        The display name of the classifier.
 
 
         :param name: The name of this Classifier.
@@ -159,7 +159,7 @@ class Classifier(object):
     def label(self):
         """
         Gets the label of this Classifier.
-        Label of classifier
+        The label associated with the classifier.
 
 
         :return: The label of this Classifier.
@@ -171,7 +171,7 @@ class Classifier(object):
     def label(self, label):
         """
         Sets the label of this Classifier.
-        Label of classifier
+        The label associated with the classifier.
 
 
         :param label: The label of this Classifier.
@@ -183,7 +183,7 @@ class Classifier(object):
     def description(self):
         """
         Gets the description of this Classifier.
-        Description of classifier
+        The description of the classifier.
 
 
         :return: The description of this Classifier.
@@ -195,7 +195,7 @@ class Classifier(object):
     def description(self, description):
         """
         Sets the description of this Classifier.
-        Description of classifier
+        The description of the classifier.
 
 
         :param description: The description of this Classifier.
@@ -207,7 +207,7 @@ class Classifier(object):
     def issue_type_list(self):
         """
         Gets the issue_type_list of this Classifier.
-        List of Issues
+        The list of issues.
 
 
         :return: The issue_type_list of this Classifier.
@@ -219,7 +219,7 @@ class Classifier(object):
     def issue_type_list(self, issue_type_list):
         """
         Sets the issue_type_list of this Classifier.
-        List of Issues
+        The list of issues.
 
 
         :param issue_type_list: The issue_type_list of this Classifier.
@@ -231,7 +231,7 @@ class Classifier(object):
     def scope(self):
         """
         Gets the scope of this Classifier.
-        Scope of Service category/resource
+        The scope of the service category or resource.
 
         Allowed values for this property are: "AD", "REGION", "TENANCY", "NONE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -246,7 +246,7 @@ class Classifier(object):
     def scope(self, scope):
         """
         Sets the scope of this Classifier.
-        Scope of Service category/resource
+        The scope of the service category or resource.
 
 
         :param scope: The scope of this Classifier.
@@ -261,7 +261,7 @@ class Classifier(object):
     def unit(self):
         """
         Gets the unit of this Classifier.
-        Unit to measure Service category/ resource
+        The unit to use to measure the service category or resource.
 
         Allowed values for this property are: "COUNT", "GB", "NONE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -276,7 +276,7 @@ class Classifier(object):
     def unit(self, unit):
         """
         Sets the unit of this Classifier.
-        Unit to measure Service category/ resource
+        The unit to use to measure the service category or resource.
 
 
         :param unit: The unit of this Classifier.

--- a/src/oci/cims/models/contact.py
+++ b/src/oci/cims/models/contact.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Contact(object):
     """
-    Contact Details of the Customer
+    Contact details for the customer.
     """
 
     #: A constant which can be used with the contact_type property of a Contact.
@@ -80,7 +80,7 @@ class Contact(object):
     def contact_name(self):
         """
         Gets the contact_name of this Contact.
-        Contact person name
+        The name of the contact person.
 
 
         :return: The contact_name of this Contact.
@@ -92,7 +92,7 @@ class Contact(object):
     def contact_name(self, contact_name):
         """
         Sets the contact_name of this Contact.
-        Contact person name
+        The name of the contact person.
 
 
         :param contact_name: The contact_name of this Contact.
@@ -104,7 +104,7 @@ class Contact(object):
     def contact_email(self):
         """
         Gets the contact_email of this Contact.
-        Contact person email
+        The email of the contact person.
 
 
         :return: The contact_email of this Contact.
@@ -116,7 +116,7 @@ class Contact(object):
     def contact_email(self, contact_email):
         """
         Sets the contact_email of this Contact.
-        Contact person email
+        The email of the contact person.
 
 
         :param contact_email: The contact_email of this Contact.
@@ -128,7 +128,7 @@ class Contact(object):
     def contact_phone(self):
         """
         Gets the contact_phone of this Contact.
-        Contact person phone number
+        The phone number of the contact person.
 
 
         :return: The contact_phone of this Contact.
@@ -140,7 +140,7 @@ class Contact(object):
     def contact_phone(self, contact_phone):
         """
         Sets the contact_phone of this Contact.
-        Contact person phone number
+        The phone number of the contact person.
 
 
         :param contact_phone: The contact_phone of this Contact.
@@ -152,7 +152,7 @@ class Contact(object):
     def contact_type(self):
         """
         Gets the contact_type of this Contact.
-        ContactType enum. eg: MANAGER, PRIMARY
+        The type of contact, such as primary or alternate.
 
         Allowed values for this property are: "PRIMARY", "ALTERNATE", "SECONDARY", "ADMIN", "MANAGER", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -167,7 +167,7 @@ class Contact(object):
     def contact_type(self, contact_type):
         """
         Sets the contact_type of this Contact.
-        ContactType enum. eg: MANAGER, PRIMARY
+        The type of contact, such as primary or alternate.
 
 
         :param contact_type: The contact_type of this Contact.

--- a/src/oci/cims/models/contact_list.py
+++ b/src/oci/cims/models/contact_list.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ContactList(object):
     """
-    List of contacts
+    The list of contacts for the ticket.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +37,7 @@ class ContactList(object):
     def contact_list(self):
         """
         **[Required]** Gets the contact_list of this ContactList.
-        List of contacts
+        The list of contacts.
 
 
         :return: The contact_list of this ContactList.
@@ -49,7 +49,7 @@ class ContactList(object):
     def contact_list(self, contact_list):
         """
         Sets the contact_list of this ContactList.
-        List of contacts
+        The list of contacts.
 
 
         :param contact_list: The contact_list of this ContactList.

--- a/src/oci/cims/models/contextual_data.py
+++ b/src/oci/cims/models/contextual_data.py
@@ -1,0 +1,163 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ContextualData(object):
+    """
+    ContextualData model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ContextualData object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param client_id:
+            The value to assign to the client_id property of this ContextualData.
+        :type client_id: str
+
+        :param schema_name:
+            The value to assign to the schema_name property of this ContextualData.
+        :type schema_name: str
+
+        :param schema_version:
+            The value to assign to the schema_version property of this ContextualData.
+        :type schema_version: str
+
+        :param payload:
+            The value to assign to the payload property of this ContextualData.
+        :type payload: str
+
+        """
+        self.swagger_types = {
+            'client_id': 'str',
+            'schema_name': 'str',
+            'schema_version': 'str',
+            'payload': 'str'
+        }
+
+        self.attribute_map = {
+            'client_id': 'clientId',
+            'schema_name': 'schemaName',
+            'schema_version': 'schemaVersion',
+            'payload': 'payload'
+        }
+
+        self._client_id = None
+        self._schema_name = None
+        self._schema_version = None
+        self._payload = None
+
+    @property
+    def client_id(self):
+        """
+        **[Required]** Gets the client_id of this ContextualData.
+        The unique client identifier
+
+
+        :return: The client_id of this ContextualData.
+        :rtype: str
+        """
+        return self._client_id
+
+    @client_id.setter
+    def client_id(self, client_id):
+        """
+        Sets the client_id of this ContextualData.
+        The unique client identifier
+
+
+        :param client_id: The client_id of this ContextualData.
+        :type: str
+        """
+        self._client_id = client_id
+
+    @property
+    def schema_name(self):
+        """
+        **[Required]** Gets the schema_name of this ContextualData.
+        The schema name
+
+
+        :return: The schema_name of this ContextualData.
+        :rtype: str
+        """
+        return self._schema_name
+
+    @schema_name.setter
+    def schema_name(self, schema_name):
+        """
+        Sets the schema_name of this ContextualData.
+        The schema name
+
+
+        :param schema_name: The schema_name of this ContextualData.
+        :type: str
+        """
+        self._schema_name = schema_name
+
+    @property
+    def schema_version(self):
+        """
+        **[Required]** Gets the schema_version of this ContextualData.
+        The schema version
+
+
+        :return: The schema_version of this ContextualData.
+        :rtype: str
+        """
+        return self._schema_version
+
+    @schema_version.setter
+    def schema_version(self, schema_version):
+        """
+        Sets the schema_version of this ContextualData.
+        The schema version
+
+
+        :param schema_version: The schema_version of this ContextualData.
+        :type: str
+        """
+        self._schema_version = schema_version
+
+    @property
+    def payload(self):
+        """
+        **[Required]** Gets the payload of this ContextualData.
+        The context data payload
+
+
+        :return: The payload of this ContextualData.
+        :rtype: str
+        """
+        return self._payload
+
+    @payload.setter
+    def payload(self, payload):
+        """
+        Sets the payload of this ContextualData.
+        The context data payload
+
+
+        :param payload: The payload of this ContextualData.
+        :type: str
+        """
+        self._payload = payload
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/cims/models/create_category_details.py
+++ b/src/oci/cims/models/create_category_details.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateCategoryDetails(object):
     """
-    Details of Category of the incident
+    Details for creating the category of the support ticket.
+
+    **Caution:** Avoid using any confidential information when you supply string values using the API.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +39,7 @@ class CreateCategoryDetails(object):
     def category_key(self):
         """
         Gets the category_key of this CreateCategoryDetails.
-        Unique ID that identifies a Category
+        Unique identifier for the category.
 
 
         :return: The category_key of this CreateCategoryDetails.
@@ -49,7 +51,7 @@ class CreateCategoryDetails(object):
     def category_key(self, category_key):
         """
         Sets the category_key of this CreateCategoryDetails.
-        Unique ID that identifies a Category
+        Unique identifier for the category.
 
 
         :param category_key: The category_key of this CreateCategoryDetails.

--- a/src/oci/cims/models/create_incident.py
+++ b/src/oci/cims/models/create_incident.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateIncident(object):
     """
-    Details of Incident
+    Details gathered during the creation of the support ticket.
+
+    **Caution:** Avoid using any confidential information when you supply string values using the API.
     """
 
     #: A constant which can be used with the problem_type property of a CreateIncident.
@@ -89,7 +91,7 @@ class CreateIncident(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this CreateIncident.
-        Tenancy Ocid
+        The OCID of the tenancy.
 
 
         :return: The compartment_id of this CreateIncident.
@@ -101,7 +103,7 @@ class CreateIncident(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this CreateIncident.
-        Tenancy Ocid
+        The OCID of the tenancy.
 
 
         :param compartment_id: The compartment_id of this CreateIncident.
@@ -133,7 +135,7 @@ class CreateIncident(object):
     def csi(self):
         """
         Gets the csi of this CreateIncident.
-        Customer Support Identifier of the support account
+        The Customer Support Identifier number for the support account.
 
 
         :return: The csi of this CreateIncident.
@@ -145,7 +147,7 @@ class CreateIncident(object):
     def csi(self, csi):
         """
         Sets the csi of this CreateIncident.
-        Customer Support Identifier of the support account
+        The Customer Support Identifier number for the support account.
 
 
         :param csi: The csi of this CreateIncident.
@@ -157,7 +159,7 @@ class CreateIncident(object):
     def problem_type(self):
         """
         **[Required]** Gets the problem_type of this CreateIncident.
-        States type of incident. eg: LIMIT, TECH
+        The kind of support ticket, such as a technical issue request.
 
         Allowed values for this property are: "LIMIT", "LEGACY_LIMIT", "TECH", "ACCOUNT"
 
@@ -171,7 +173,7 @@ class CreateIncident(object):
     def problem_type(self, problem_type):
         """
         Sets the problem_type of this CreateIncident.
-        States type of incident. eg: LIMIT, TECH
+        The kind of support ticket, such as a technical issue request.
 
 
         :param problem_type: The problem_type of this CreateIncident.
@@ -189,7 +191,7 @@ class CreateIncident(object):
     def contacts(self):
         """
         Gets the contacts of this CreateIncident.
-        List of contacts
+        The list of contacts.
 
 
         :return: The contacts of this CreateIncident.
@@ -201,7 +203,7 @@ class CreateIncident(object):
     def contacts(self, contacts):
         """
         Sets the contacts of this CreateIncident.
-        List of contacts
+        The list of contacts.
 
 
         :param contacts: The contacts of this CreateIncident.
@@ -213,7 +215,7 @@ class CreateIncident(object):
     def referrer(self):
         """
         Gets the referrer of this CreateIncident.
-        Referrer of the incident., its usually the URL for where the customer logged the incident
+        The incident referrer. This value is often the URL that the customer used when creating the support ticket.
 
 
         :return: The referrer of this CreateIncident.
@@ -225,7 +227,7 @@ class CreateIncident(object):
     def referrer(self, referrer):
         """
         Sets the referrer of this CreateIncident.
-        Referrer of the incident., its usually the URL for where the customer logged the incident
+        The incident referrer. This value is often the URL that the customer used when creating the support ticket.
 
 
         :param referrer: The referrer of this CreateIncident.

--- a/src/oci/cims/models/create_issue_type_details.py
+++ b/src/oci/cims/models/create_issue_type_details.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateIssueTypeDetails(object):
     """
-    Details Issue Type of the incident
+    Details for creating the issue type of the support ticket.
+
+    **Caution:** Avoid using any confidential information when you supply string values using the API.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +39,7 @@ class CreateIssueTypeDetails(object):
     def issue_type_key(self):
         """
         Gets the issue_type_key of this CreateIssueTypeDetails.
-        Unique ID that identifies an Issue Type
+        Unique identifier for the issue type.
 
 
         :return: The issue_type_key of this CreateIssueTypeDetails.
@@ -49,7 +51,7 @@ class CreateIssueTypeDetails(object):
     def issue_type_key(self, issue_type_key):
         """
         Sets the issue_type_key of this CreateIssueTypeDetails.
-        Unique ID that identifies an Issue Type
+        Unique identifier for the issue type.
 
 
         :param issue_type_key: The issue_type_key of this CreateIssueTypeDetails.

--- a/src/oci/cims/models/create_item_details.py
+++ b/src/oci/cims/models/create_item_details.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateItemDetails(object):
     """
-    Details of Item
+    Details gathered during item creation.
+
+    **Caution:** Avoid using any confidential information when you supply string values using the API.
     """
 
     def __init__(self, **kwargs):
@@ -86,7 +88,7 @@ class CreateItemDetails(object):
     def type(self):
         """
         Gets the type of this CreateItemDetails.
-        Type of item. eg: CreateTechSupportItemDetails, CreateLimitItemDetails
+        The type of the item.
 
 
         :return: The type of this CreateItemDetails.
@@ -98,7 +100,7 @@ class CreateItemDetails(object):
     def type(self, type):
         """
         Sets the type of this CreateItemDetails.
-        Type of item. eg: CreateTechSupportItemDetails, CreateLimitItemDetails
+        The type of the item.
 
 
         :param type: The type of this CreateItemDetails.
@@ -170,7 +172,7 @@ class CreateItemDetails(object):
     def name(self):
         """
         Gets the name of this CreateItemDetails.
-        Name of the item
+        The display name of the item.
 
 
         :return: The name of this CreateItemDetails.
@@ -182,7 +184,7 @@ class CreateItemDetails(object):
     def name(self, name):
         """
         Sets the name of this CreateItemDetails.
-        Name of the item
+        The display name of the item.
 
 
         :param name: The name of this CreateItemDetails.

--- a/src/oci/cims/models/create_limit_item_details.py
+++ b/src/oci/cims/models/create_limit_item_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateLimitItemDetails(CreateItemDetails):
     """
-    Details of Limit Item
+    Reserved for future use.
     """
 
     #: A constant which can be used with the limit_status property of a CreateLimitItemDetails.
@@ -108,7 +108,7 @@ class CreateLimitItemDetails(CreateItemDetails):
     def current_limit(self):
         """
         Gets the current_limit of this CreateLimitItemDetails.
-        Current available limit of the resource
+        The limit of the resource currently available.
 
 
         :return: The current_limit of this CreateLimitItemDetails.
@@ -120,7 +120,7 @@ class CreateLimitItemDetails(CreateItemDetails):
     def current_limit(self, current_limit):
         """
         Sets the current_limit of this CreateLimitItemDetails.
-        Current available limit of the resource
+        The limit of the resource currently available.
 
 
         :param current_limit: The current_limit of this CreateLimitItemDetails.
@@ -132,7 +132,7 @@ class CreateLimitItemDetails(CreateItemDetails):
     def current_usage(self):
         """
         Gets the current_usage of this CreateLimitItemDetails.
-        Current used limit of the resource
+        The current usage of the resource.
 
 
         :return: The current_usage of this CreateLimitItemDetails.
@@ -144,7 +144,7 @@ class CreateLimitItemDetails(CreateItemDetails):
     def current_usage(self, current_usage):
         """
         Sets the current_usage of this CreateLimitItemDetails.
-        Current used limit of the resource
+        The current usage of the resource.
 
 
         :param current_usage: The current_usage of this CreateLimitItemDetails.
@@ -156,7 +156,7 @@ class CreateLimitItemDetails(CreateItemDetails):
     def requested_limit(self):
         """
         Gets the requested_limit of this CreateLimitItemDetails.
-        Requested limit for the resource
+        Reserved for future use.
 
 
         :return: The requested_limit of this CreateLimitItemDetails.
@@ -168,7 +168,7 @@ class CreateLimitItemDetails(CreateItemDetails):
     def requested_limit(self, requested_limit):
         """
         Sets the requested_limit of this CreateLimitItemDetails.
-        Requested limit for the resource
+        Reserved for future use.
 
 
         :param requested_limit: The requested_limit of this CreateLimitItemDetails.
@@ -180,7 +180,7 @@ class CreateLimitItemDetails(CreateItemDetails):
     def limit_status(self):
         """
         Gets the limit_status of this CreateLimitItemDetails.
-        Status of the Limit
+        The current status of the request.
 
         Allowed values for this property are: "APPROVED", "PARTIALLY_APPROVED", "NOT_APPROVED"
 
@@ -194,7 +194,7 @@ class CreateLimitItemDetails(CreateItemDetails):
     def limit_status(self, limit_status):
         """
         Sets the limit_status of this CreateLimitItemDetails.
-        Status of the Limit
+        The current status of the request.
 
 
         :param limit_status: The limit_status of this CreateLimitItemDetails.

--- a/src/oci/cims/models/create_resource_details.py
+++ b/src/oci/cims/models/create_resource_details.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateResourceDetails(object):
     """
-    Details of Ticket Item
+    Details about the resource that the support ticket relates to.
+
+    **Caution:** Avoid using any confidential information when you supply string values using the API.
     """
 
     #: A constant which can be used with the region property of a CreateResourceDetails.
@@ -58,14 +60,6 @@ class CreateResourceDetails(object):
     REGION_NRT = "NRT"
 
     #: A constant which can be used with the region property of a CreateResourceDetails.
-    #: This constant has a value of "US_LANGLEY_1"
-    REGION_US_LANGLEY_1 = "US_LANGLEY_1"
-
-    #: A constant which can be used with the region property of a CreateResourceDetails.
-    #: This constant has a value of "US_LUKE_1"
-    REGION_US_LUKE_1 = "US_LUKE_1"
-
-    #: A constant which can be used with the region property of a CreateResourceDetails.
     #: This constant has a value of "ICN"
     REGION_ICN = "ICN"
 
@@ -76,18 +70,6 @@ class CreateResourceDetails(object):
     #: A constant which can be used with the region property of a CreateResourceDetails.
     #: This constant has a value of "GRU"
     REGION_GRU = "GRU"
-
-    #: A constant which can be used with the region property of a CreateResourceDetails.
-    #: This constant has a value of "US_GOV_ASHBURN_1"
-    REGION_US_GOV_ASHBURN_1 = "US_GOV_ASHBURN_1"
-
-    #: A constant which can be used with the region property of a CreateResourceDetails.
-    #: This constant has a value of "US_GOV_PHOENIX_1"
-    REGION_US_GOV_PHOENIX_1 = "US_GOV_PHOENIX_1"
-
-    #: A constant which can be used with the region property of a CreateResourceDetails.
-    #: This constant has a value of "US_GOV_CHICAGO_1"
-    REGION_US_GOV_CHICAGO_1 = "US_GOV_CHICAGO_1"
 
     #: A constant which can be used with the region property of a CreateResourceDetails.
     #: This constant has a value of "SYD"
@@ -124,10 +106,6 @@ class CreateResourceDetails(object):
     #: A constant which can be used with the region property of a CreateResourceDetails.
     #: This constant has a value of "YNY"
     REGION_YNY = "YNY"
-
-    #: A constant which can be used with the region property of a CreateResourceDetails.
-    #: This constant has a value of "TIW"
-    REGION_TIW = "TIW"
 
     #: A constant which can be used with the availability_domain property of a CreateResourceDetails.
     #: This constant has a value of "DEV_1"
@@ -234,14 +212,6 @@ class CreateResourceDetails(object):
     AVAILABILITY_DOMAIN_SA_SAOPAULO_1_AD_1 = "SA_SAOPAULO_1_AD_1"
 
     #: A constant which can be used with the availability_domain property of a CreateResourceDetails.
-    #: This constant has a value of "US_LUKE_1_AD_1"
-    AVAILABILITY_DOMAIN_US_LUKE_1_AD_1 = "US_LUKE_1_AD_1"
-
-    #: A constant which can be used with the availability_domain property of a CreateResourceDetails.
-    #: This constant has a value of "US_LANGLEY_1_AD_1"
-    AVAILABILITY_DOMAIN_US_LANGLEY_1_AD_1 = "US_LANGLEY_1_AD_1"
-
-    #: A constant which can be used with the availability_domain property of a CreateResourceDetails.
     #: This constant has a value of "ME_JEDDAH_1_AD_1"
     AVAILABILITY_DOMAIN_ME_JEDDAH_1_AD_1 = "ME_JEDDAH_1_AD_1"
 
@@ -278,10 +248,6 @@ class CreateResourceDetails(object):
     AVAILABILITY_DOMAIN_AP_CHUNCHEON_1_AD_1 = "AP_CHUNCHEON_1_AD_1"
 
     #: A constant which can be used with the availability_domain property of a CreateResourceDetails.
-    #: This constant has a value of "US_TACOMA_1_AD_1"
-    AVAILABILITY_DOMAIN_US_TACOMA_1_AD_1 = "US_TACOMA_1_AD_1"
-
-    #: A constant which can be used with the availability_domain property of a CreateResourceDetails.
     #: This constant has a value of "NO_AD"
     AVAILABILITY_DOMAIN_NO_AD = "NO_AD"
 
@@ -296,12 +262,12 @@ class CreateResourceDetails(object):
 
         :param region:
             The value to assign to the region property of this CreateResourceDetails.
-            Allowed values for this property are: "DEV", "SEA", "INTEG_NEXT", "INTEG_STABLE", "PHX", "IAD", "FRA", "EU_FRANKFURT_1", "LHR", "YYZ", "NRT", "US_LANGLEY_1", "US_LUKE_1", "ICN", "BOM", "GRU", "US_GOV_ASHBURN_1", "US_GOV_PHOENIX_1", "US_GOV_CHICAGO_1", "SYD", "ZRH", "JED", "AMS", "KIX", "MEL", "YUL", "HYD", "YNY", "TIW"
+            Allowed values for this property are: "DEV", "SEA", "INTEG_NEXT", "INTEG_STABLE", "PHX", "IAD", "FRA", "EU_FRANKFURT_1", "LHR", "YYZ", "NRT", "ICN", "BOM", "GRU", "SYD", "ZRH", "JED", "AMS", "KIX", "MEL", "YUL", "HYD", "YNY"
         :type region: str
 
         :param availability_domain:
             The value to assign to the availability_domain property of this CreateResourceDetails.
-            Allowed values for this property are: "DEV_1", "DEV_2", "DEV_3", "INTEG_NEXT_1", "INTEG_STABLE_1", "SEA_AD_1", "SEA_AD_2", "SEA_AD_3", "PHX_AD_1", "PHX_AD_2", "PHX_AD_3", "US_ASHBURN_AD_1", "US_ASHBURN_AD_2", "US_ASHBURN_AD_3", "US_ASHBURN_AD_4", "EU_FRANKFURT_1_AD_1", "EU_FRANKFURT_1_AD_2", "EU_FRANKFURT_1_AD_3", "UK_LONDON_1_AD_1", "UK_LONDON_1_AD_2", "UK_LONDON_1_AD_3", "CA_TORONTO_1_AD_1", "AP_TOKYO_1_AD_1", "AP_SEOUL_1_AD_1", "AP_MUMBAI_1_AD_1", "SA_SAOPAULO_1_AD_1", "US_LUKE_1_AD_1", "US_LANGLEY_1_AD_1", "ME_JEDDAH_1_AD_1", "AP_OSAKA_1_AD_1", "AP_SYDNEY_1_AD_1", "EU_ZURICH_1_AD_1", "EU_AMSTERDAM_1_AD_1", "AP_MELBOURNE_1_AD_1", "CA_MONTREAL_1_AD_1", "AP_HYDERABAD_1_AD_1", "AP_CHUNCHEON_1_AD_1", "US_TACOMA_1_AD_1", "NO_AD"
+            Allowed values for this property are: "DEV_1", "DEV_2", "DEV_3", "INTEG_NEXT_1", "INTEG_STABLE_1", "SEA_AD_1", "SEA_AD_2", "SEA_AD_3", "PHX_AD_1", "PHX_AD_2", "PHX_AD_3", "US_ASHBURN_AD_1", "US_ASHBURN_AD_2", "US_ASHBURN_AD_3", "US_ASHBURN_AD_4", "EU_FRANKFURT_1_AD_1", "EU_FRANKFURT_1_AD_2", "EU_FRANKFURT_1_AD_3", "UK_LONDON_1_AD_1", "UK_LONDON_1_AD_2", "UK_LONDON_1_AD_3", "CA_TORONTO_1_AD_1", "AP_TOKYO_1_AD_1", "AP_SEOUL_1_AD_1", "AP_MUMBAI_1_AD_1", "SA_SAOPAULO_1_AD_1", "ME_JEDDAH_1_AD_1", "AP_OSAKA_1_AD_1", "AP_SYDNEY_1_AD_1", "EU_ZURICH_1_AD_1", "EU_AMSTERDAM_1_AD_1", "AP_MELBOURNE_1_AD_1", "CA_MONTREAL_1_AD_1", "AP_HYDERABAD_1_AD_1", "AP_CHUNCHEON_1_AD_1", "NO_AD"
         :type availability_domain: str
 
         """
@@ -345,9 +311,9 @@ class CreateResourceDetails(object):
     def region(self):
         """
         Gets the region of this CreateResourceDetails.
-        List of OCI regions
+        The list of available Oracle Cloud Infrastructure regions.
 
-        Allowed values for this property are: "DEV", "SEA", "INTEG_NEXT", "INTEG_STABLE", "PHX", "IAD", "FRA", "EU_FRANKFURT_1", "LHR", "YYZ", "NRT", "US_LANGLEY_1", "US_LUKE_1", "ICN", "BOM", "GRU", "US_GOV_ASHBURN_1", "US_GOV_PHOENIX_1", "US_GOV_CHICAGO_1", "SYD", "ZRH", "JED", "AMS", "KIX", "MEL", "YUL", "HYD", "YNY", "TIW"
+        Allowed values for this property are: "DEV", "SEA", "INTEG_NEXT", "INTEG_STABLE", "PHX", "IAD", "FRA", "EU_FRANKFURT_1", "LHR", "YYZ", "NRT", "ICN", "BOM", "GRU", "SYD", "ZRH", "JED", "AMS", "KIX", "MEL", "YUL", "HYD", "YNY"
 
 
         :return: The region of this CreateResourceDetails.
@@ -359,13 +325,13 @@ class CreateResourceDetails(object):
     def region(self, region):
         """
         Sets the region of this CreateResourceDetails.
-        List of OCI regions
+        The list of available Oracle Cloud Infrastructure regions.
 
 
         :param region: The region of this CreateResourceDetails.
         :type: str
         """
-        allowed_values = ["DEV", "SEA", "INTEG_NEXT", "INTEG_STABLE", "PHX", "IAD", "FRA", "EU_FRANKFURT_1", "LHR", "YYZ", "NRT", "US_LANGLEY_1", "US_LUKE_1", "ICN", "BOM", "GRU", "US_GOV_ASHBURN_1", "US_GOV_PHOENIX_1", "US_GOV_CHICAGO_1", "SYD", "ZRH", "JED", "AMS", "KIX", "MEL", "YUL", "HYD", "YNY", "TIW"]
+        allowed_values = ["DEV", "SEA", "INTEG_NEXT", "INTEG_STABLE", "PHX", "IAD", "FRA", "EU_FRANKFURT_1", "LHR", "YYZ", "NRT", "ICN", "BOM", "GRU", "SYD", "ZRH", "JED", "AMS", "KIX", "MEL", "YUL", "HYD", "YNY"]
         if not value_allowed_none_or_none_sentinel(region, allowed_values):
             raise ValueError(
                 "Invalid value for `region`, must be None or one of {0}"
@@ -377,9 +343,9 @@ class CreateResourceDetails(object):
     def availability_domain(self):
         """
         Gets the availability_domain of this CreateResourceDetails.
-        List of OCI ADs
+        The list of available Oracle Cloud Infrastructure availability domains.
 
-        Allowed values for this property are: "DEV_1", "DEV_2", "DEV_3", "INTEG_NEXT_1", "INTEG_STABLE_1", "SEA_AD_1", "SEA_AD_2", "SEA_AD_3", "PHX_AD_1", "PHX_AD_2", "PHX_AD_3", "US_ASHBURN_AD_1", "US_ASHBURN_AD_2", "US_ASHBURN_AD_3", "US_ASHBURN_AD_4", "EU_FRANKFURT_1_AD_1", "EU_FRANKFURT_1_AD_2", "EU_FRANKFURT_1_AD_3", "UK_LONDON_1_AD_1", "UK_LONDON_1_AD_2", "UK_LONDON_1_AD_3", "CA_TORONTO_1_AD_1", "AP_TOKYO_1_AD_1", "AP_SEOUL_1_AD_1", "AP_MUMBAI_1_AD_1", "SA_SAOPAULO_1_AD_1", "US_LUKE_1_AD_1", "US_LANGLEY_1_AD_1", "ME_JEDDAH_1_AD_1", "AP_OSAKA_1_AD_1", "AP_SYDNEY_1_AD_1", "EU_ZURICH_1_AD_1", "EU_AMSTERDAM_1_AD_1", "AP_MELBOURNE_1_AD_1", "CA_MONTREAL_1_AD_1", "AP_HYDERABAD_1_AD_1", "AP_CHUNCHEON_1_AD_1", "US_TACOMA_1_AD_1", "NO_AD"
+        Allowed values for this property are: "DEV_1", "DEV_2", "DEV_3", "INTEG_NEXT_1", "INTEG_STABLE_1", "SEA_AD_1", "SEA_AD_2", "SEA_AD_3", "PHX_AD_1", "PHX_AD_2", "PHX_AD_3", "US_ASHBURN_AD_1", "US_ASHBURN_AD_2", "US_ASHBURN_AD_3", "US_ASHBURN_AD_4", "EU_FRANKFURT_1_AD_1", "EU_FRANKFURT_1_AD_2", "EU_FRANKFURT_1_AD_3", "UK_LONDON_1_AD_1", "UK_LONDON_1_AD_2", "UK_LONDON_1_AD_3", "CA_TORONTO_1_AD_1", "AP_TOKYO_1_AD_1", "AP_SEOUL_1_AD_1", "AP_MUMBAI_1_AD_1", "SA_SAOPAULO_1_AD_1", "ME_JEDDAH_1_AD_1", "AP_OSAKA_1_AD_1", "AP_SYDNEY_1_AD_1", "EU_ZURICH_1_AD_1", "EU_AMSTERDAM_1_AD_1", "AP_MELBOURNE_1_AD_1", "CA_MONTREAL_1_AD_1", "AP_HYDERABAD_1_AD_1", "AP_CHUNCHEON_1_AD_1", "NO_AD"
 
 
         :return: The availability_domain of this CreateResourceDetails.
@@ -391,13 +357,13 @@ class CreateResourceDetails(object):
     def availability_domain(self, availability_domain):
         """
         Sets the availability_domain of this CreateResourceDetails.
-        List of OCI ADs
+        The list of available Oracle Cloud Infrastructure availability domains.
 
 
         :param availability_domain: The availability_domain of this CreateResourceDetails.
         :type: str
         """
-        allowed_values = ["DEV_1", "DEV_2", "DEV_3", "INTEG_NEXT_1", "INTEG_STABLE_1", "SEA_AD_1", "SEA_AD_2", "SEA_AD_3", "PHX_AD_1", "PHX_AD_2", "PHX_AD_3", "US_ASHBURN_AD_1", "US_ASHBURN_AD_2", "US_ASHBURN_AD_3", "US_ASHBURN_AD_4", "EU_FRANKFURT_1_AD_1", "EU_FRANKFURT_1_AD_2", "EU_FRANKFURT_1_AD_3", "UK_LONDON_1_AD_1", "UK_LONDON_1_AD_2", "UK_LONDON_1_AD_3", "CA_TORONTO_1_AD_1", "AP_TOKYO_1_AD_1", "AP_SEOUL_1_AD_1", "AP_MUMBAI_1_AD_1", "SA_SAOPAULO_1_AD_1", "US_LUKE_1_AD_1", "US_LANGLEY_1_AD_1", "ME_JEDDAH_1_AD_1", "AP_OSAKA_1_AD_1", "AP_SYDNEY_1_AD_1", "EU_ZURICH_1_AD_1", "EU_AMSTERDAM_1_AD_1", "AP_MELBOURNE_1_AD_1", "CA_MONTREAL_1_AD_1", "AP_HYDERABAD_1_AD_1", "AP_CHUNCHEON_1_AD_1", "US_TACOMA_1_AD_1", "NO_AD"]
+        allowed_values = ["DEV_1", "DEV_2", "DEV_3", "INTEG_NEXT_1", "INTEG_STABLE_1", "SEA_AD_1", "SEA_AD_2", "SEA_AD_3", "PHX_AD_1", "PHX_AD_2", "PHX_AD_3", "US_ASHBURN_AD_1", "US_ASHBURN_AD_2", "US_ASHBURN_AD_3", "US_ASHBURN_AD_4", "EU_FRANKFURT_1_AD_1", "EU_FRANKFURT_1_AD_2", "EU_FRANKFURT_1_AD_3", "UK_LONDON_1_AD_1", "UK_LONDON_1_AD_2", "UK_LONDON_1_AD_3", "CA_TORONTO_1_AD_1", "AP_TOKYO_1_AD_1", "AP_SEOUL_1_AD_1", "AP_MUMBAI_1_AD_1", "SA_SAOPAULO_1_AD_1", "ME_JEDDAH_1_AD_1", "AP_OSAKA_1_AD_1", "AP_SYDNEY_1_AD_1", "EU_ZURICH_1_AD_1", "EU_AMSTERDAM_1_AD_1", "AP_MELBOURNE_1_AD_1", "CA_MONTREAL_1_AD_1", "AP_HYDERABAD_1_AD_1", "AP_CHUNCHEON_1_AD_1", "NO_AD"]
         if not value_allowed_none_or_none_sentinel(availability_domain, allowed_values):
             raise ValueError(
                 "Invalid value for `availability_domain`, must be None or one of {0}"

--- a/src/oci/cims/models/create_sub_category_details.py
+++ b/src/oci/cims/models/create_sub_category_details.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateSubCategoryDetails(object):
     """
-    Details of Sub Category of the incident
+    Details for creating the subcategory of the support ticket.
+
+    **Caution:** Avoid using any confidential information when you supply string values using the API.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +39,7 @@ class CreateSubCategoryDetails(object):
     def sub_category_key(self):
         """
         Gets the sub_category_key of this CreateSubCategoryDetails.
-        Unique ID that identifies a Sub Category
+        Unique identifier for the subcategory.
 
 
         :return: The sub_category_key of this CreateSubCategoryDetails.
@@ -49,7 +51,7 @@ class CreateSubCategoryDetails(object):
     def sub_category_key(self, sub_category_key):
         """
         Sets the sub_category_key of this CreateSubCategoryDetails.
-        Unique ID that identifies a Sub Category
+        Unique identifier for the subcategory.
 
 
         :param sub_category_key: The sub_category_key of this CreateSubCategoryDetails.

--- a/src/oci/cims/models/create_tech_support_item_details.py
+++ b/src/oci/cims/models/create_tech_support_item_details.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateTechSupportItemDetails(CreateItemDetails):
     """
-    Details of TechSupport Item
+    Details about the issue that the technical support request relates to.
+
+    **Caution:** Avoid using any confidential information when you supply string values using the API.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/cims/models/create_ticket_details.py
+++ b/src/oci/cims/models/create_ticket_details.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateTicketDetails(object):
     """
-    Details of Ticket created
+    Details relevant to the support ticket.
+
+    **Caution:** Avoid using any confidential information when you supply string values using the API.
     """
 
     #: A constant which can be used with the severity property of a CreateTicketDetails.
@@ -47,31 +49,38 @@ class CreateTicketDetails(object):
             The value to assign to the description property of this CreateTicketDetails.
         :type description: str
 
+        :param contextual_data:
+            The value to assign to the contextual_data property of this CreateTicketDetails.
+        :type contextual_data: ContextualData
+
         """
         self.swagger_types = {
             'severity': 'str',
             'resource_list': 'list[CreateResourceDetails]',
             'title': 'str',
-            'description': 'str'
+            'description': 'str',
+            'contextual_data': 'ContextualData'
         }
 
         self.attribute_map = {
             'severity': 'severity',
             'resource_list': 'resourceList',
             'title': 'title',
-            'description': 'description'
+            'description': 'description',
+            'contextual_data': 'contextualData'
         }
 
         self._severity = None
         self._resource_list = None
         self._title = None
         self._description = None
+        self._contextual_data = None
 
     @property
     def severity(self):
         """
         **[Required]** Gets the severity of this CreateTicketDetails.
-        Severity of the ticket. eg: HIGH, MEDIUM
+        The severity of the support ticket.
 
         Allowed values for this property are: "HIGHEST", "HIGH", "MEDIUM"
 
@@ -85,7 +94,7 @@ class CreateTicketDetails(object):
     def severity(self, severity):
         """
         Sets the severity of this CreateTicketDetails.
-        Severity of the ticket. eg: HIGH, MEDIUM
+        The severity of the support ticket.
 
 
         :param severity: The severity of this CreateTicketDetails.
@@ -103,7 +112,7 @@ class CreateTicketDetails(object):
     def resource_list(self):
         """
         Gets the resource_list of this CreateTicketDetails.
-        List of resources
+        The list of resources.
 
 
         :return: The resource_list of this CreateTicketDetails.
@@ -115,7 +124,7 @@ class CreateTicketDetails(object):
     def resource_list(self, resource_list):
         """
         Sets the resource_list of this CreateTicketDetails.
-        List of resources
+        The list of resources.
 
 
         :param resource_list: The resource_list of this CreateTicketDetails.
@@ -127,7 +136,7 @@ class CreateTicketDetails(object):
     def title(self):
         """
         **[Required]** Gets the title of this CreateTicketDetails.
-        Title of ticket
+        The title of the support ticket.
 
 
         :return: The title of this CreateTicketDetails.
@@ -139,7 +148,7 @@ class CreateTicketDetails(object):
     def title(self, title):
         """
         Sets the title of this CreateTicketDetails.
-        Title of ticket
+        The title of the support ticket.
 
 
         :param title: The title of this CreateTicketDetails.
@@ -151,7 +160,7 @@ class CreateTicketDetails(object):
     def description(self):
         """
         **[Required]** Gets the description of this CreateTicketDetails.
-        Details of ticket
+        The description of the support ticket.
 
 
         :return: The description of this CreateTicketDetails.
@@ -163,13 +172,37 @@ class CreateTicketDetails(object):
     def description(self, description):
         """
         Sets the description of this CreateTicketDetails.
-        Details of ticket
+        The description of the support ticket.
 
 
         :param description: The description of this CreateTicketDetails.
         :type: str
         """
         self._description = description
+
+    @property
+    def contextual_data(self):
+        """
+        Gets the contextual_data of this CreateTicketDetails.
+        The context from where the ticket is getting created.
+
+
+        :return: The contextual_data of this CreateTicketDetails.
+        :rtype: ContextualData
+        """
+        return self._contextual_data
+
+    @contextual_data.setter
+    def contextual_data(self, contextual_data):
+        """
+        Sets the contextual_data of this CreateTicketDetails.
+        The context from where the ticket is getting created.
+
+
+        :param contextual_data: The contextual_data of this CreateTicketDetails.
+        :type: ContextualData
+        """
+        self._contextual_data = contextual_data
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/cims/models/create_user_details.py
+++ b/src/oci/cims/models/create_user_details.py
@@ -1,0 +1,287 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateUserDetails(object):
+    """
+    Details about creation of user.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateUserDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateUserDetails.
+        :type compartment_id: str
+
+        :param first_name:
+            The value to assign to the first_name property of this CreateUserDetails.
+        :type first_name: str
+
+        :param last_name:
+            The value to assign to the last_name property of this CreateUserDetails.
+        :type last_name: str
+
+        :param country:
+            The value to assign to the country property of this CreateUserDetails.
+        :type country: str
+
+        :param csi:
+            The value to assign to the csi property of this CreateUserDetails.
+        :type csi: str
+
+        :param phone:
+            The value to assign to the phone property of this CreateUserDetails.
+        :type phone: str
+
+        :param timezone:
+            The value to assign to the timezone property of this CreateUserDetails.
+        :type timezone: str
+
+        :param organization_name:
+            The value to assign to the organization_name property of this CreateUserDetails.
+        :type organization_name: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'first_name': 'str',
+            'last_name': 'str',
+            'country': 'str',
+            'csi': 'str',
+            'phone': 'str',
+            'timezone': 'str',
+            'organization_name': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'first_name': 'firstName',
+            'last_name': 'lastName',
+            'country': 'country',
+            'csi': 'csi',
+            'phone': 'phone',
+            'timezone': 'timezone',
+            'organization_name': 'organizationName'
+        }
+
+        self._compartment_id = None
+        self._first_name = None
+        self._last_name = None
+        self._country = None
+        self._csi = None
+        self._phone = None
+        self._timezone = None
+        self._organization_name = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateUserDetails.
+        The OCID of the tenancy.
+
+
+        :return: The compartment_id of this CreateUserDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateUserDetails.
+        The OCID of the tenancy.
+
+
+        :param compartment_id: The compartment_id of this CreateUserDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def first_name(self):
+        """
+        **[Required]** Gets the first_name of this CreateUserDetails.
+        First name of the user.
+
+
+        :return: The first_name of this CreateUserDetails.
+        :rtype: str
+        """
+        return self._first_name
+
+    @first_name.setter
+    def first_name(self, first_name):
+        """
+        Sets the first_name of this CreateUserDetails.
+        First name of the user.
+
+
+        :param first_name: The first_name of this CreateUserDetails.
+        :type: str
+        """
+        self._first_name = first_name
+
+    @property
+    def last_name(self):
+        """
+        **[Required]** Gets the last_name of this CreateUserDetails.
+        Last name of the user.
+
+
+        :return: The last_name of this CreateUserDetails.
+        :rtype: str
+        """
+        return self._last_name
+
+    @last_name.setter
+    def last_name(self, last_name):
+        """
+        Sets the last_name of this CreateUserDetails.
+        Last name of the user.
+
+
+        :param last_name: The last_name of this CreateUserDetails.
+        :type: str
+        """
+        self._last_name = last_name
+
+    @property
+    def country(self):
+        """
+        **[Required]** Gets the country of this CreateUserDetails.
+        Country of the user.
+
+
+        :return: The country of this CreateUserDetails.
+        :rtype: str
+        """
+        return self._country
+
+    @country.setter
+    def country(self, country):
+        """
+        Sets the country of this CreateUserDetails.
+        Country of the user.
+
+
+        :param country: The country of this CreateUserDetails.
+        :type: str
+        """
+        self._country = country
+
+    @property
+    def csi(self):
+        """
+        **[Required]** Gets the csi of this CreateUserDetails.
+        CSI to be associated to the user.
+
+
+        :return: The csi of this CreateUserDetails.
+        :rtype: str
+        """
+        return self._csi
+
+    @csi.setter
+    def csi(self, csi):
+        """
+        Sets the csi of this CreateUserDetails.
+        CSI to be associated to the user.
+
+
+        :param csi: The csi of this CreateUserDetails.
+        :type: str
+        """
+        self._csi = csi
+
+    @property
+    def phone(self):
+        """
+        **[Required]** Gets the phone of this CreateUserDetails.
+        Contact number of the user.
+
+
+        :return: The phone of this CreateUserDetails.
+        :rtype: str
+        """
+        return self._phone
+
+    @phone.setter
+    def phone(self, phone):
+        """
+        Sets the phone of this CreateUserDetails.
+        Contact number of the user.
+
+
+        :param phone: The phone of this CreateUserDetails.
+        :type: str
+        """
+        self._phone = phone
+
+    @property
+    def timezone(self):
+        """
+        **[Required]** Gets the timezone of this CreateUserDetails.
+        Timezone of the user.
+
+
+        :return: The timezone of this CreateUserDetails.
+        :rtype: str
+        """
+        return self._timezone
+
+    @timezone.setter
+    def timezone(self, timezone):
+        """
+        Sets the timezone of this CreateUserDetails.
+        Timezone of the user.
+
+
+        :param timezone: The timezone of this CreateUserDetails.
+        :type: str
+        """
+        self._timezone = timezone
+
+    @property
+    def organization_name(self):
+        """
+        **[Required]** Gets the organization_name of this CreateUserDetails.
+        Organization of the user.
+
+
+        :return: The organization_name of this CreateUserDetails.
+        :rtype: str
+        """
+        return self._organization_name
+
+    @organization_name.setter
+    def organization_name(self, organization_name):
+        """
+        Sets the organization_name of this CreateUserDetails.
+        Organization of the user.
+
+
+        :param organization_name: The organization_name of this CreateUserDetails.
+        :type: str
+        """
+        self._organization_name = organization_name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/cims/models/incident.py
+++ b/src/oci/cims/models/incident.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Incident(object):
     """
-    Details of Incident
+    Details of about the incident object.
     """
 
     #: A constant which can be used with the problem_type property of a Incident.
@@ -104,7 +104,7 @@ class Incident(object):
     def key(self):
         """
         **[Required]** Gets the key of this Incident.
-        Unique ID that identifies an Incident
+        Unique identifier for the support ticket.
 
 
         :return: The key of this Incident.
@@ -116,7 +116,7 @@ class Incident(object):
     def key(self, key):
         """
         Sets the key of this Incident.
-        Unique ID that identifies an Incident
+        Unique identifier for the support ticket.
 
 
         :param key: The key of this Incident.
@@ -128,7 +128,7 @@ class Incident(object):
     def compartment_id(self):
         """
         Gets the compartment_id of this Incident.
-        Tenancy Ocid
+        The OCID of the tenancy.
 
 
         :return: The compartment_id of this Incident.
@@ -140,7 +140,7 @@ class Incident(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this Incident.
-        Tenancy Ocid
+        The OCID of the tenancy.
 
 
         :param compartment_id: The compartment_id of this Incident.
@@ -232,7 +232,7 @@ class Incident(object):
     def problem_type(self):
         """
         Gets the problem_type of this Incident.
-        States type of incident. eg: LIMIT, TECH
+        The kind of support ticket, such as a technical support request.
 
         Allowed values for this property are: "LIMIT", "LEGACY_LIMIT", "TECH", "ACCOUNT", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -247,7 +247,7 @@ class Incident(object):
     def problem_type(self, problem_type):
         """
         Sets the problem_type of this Incident.
-        States type of incident. eg: LIMIT, TECH
+        The kind of support ticket, such as a technical support request.
 
 
         :param problem_type: The problem_type of this Incident.
@@ -262,7 +262,7 @@ class Incident(object):
     def referrer(self):
         """
         Gets the referrer of this Incident.
-        Referrer of the incident., its usually the URL for where the customer logged the incident
+        The incident referrer. This value is often the URL that the customer used when creating the support ticket.
 
 
         :return: The referrer of this Incident.
@@ -274,7 +274,7 @@ class Incident(object):
     def referrer(self, referrer):
         """
         Sets the referrer of this Incident.
-        Referrer of the incident., its usually the URL for where the customer logged the incident
+        The incident referrer. This value is often the URL that the customer used when creating the support ticket.
 
 
         :param referrer: The referrer of this Incident.

--- a/src/oci/cims/models/incident_resource_type.py
+++ b/src/oci/cims/models/incident_resource_type.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class IncidentResourceType(object):
     """
-    Details of incident type
+    Details about the resource associated with the support request.
     """
 
     def __init__(self, **kwargs):
@@ -65,7 +65,7 @@ class IncidentResourceType(object):
     def resource_type_key(self):
         """
         Gets the resource_type_key of this IncidentResourceType.
-        Unique ID that identifies an Incident Type
+        Unique identifier of the resource.
 
 
         :return: The resource_type_key of this IncidentResourceType.
@@ -77,7 +77,7 @@ class IncidentResourceType(object):
     def resource_type_key(self, resource_type_key):
         """
         Sets the resource_type_key of this IncidentResourceType.
-        Unique ID that identifies an Incident Type
+        Unique identifier of the resource.
 
 
         :param resource_type_key: The resource_type_key of this IncidentResourceType.
@@ -89,7 +89,7 @@ class IncidentResourceType(object):
     def name(self):
         """
         Gets the name of this IncidentResourceType.
-        Name of Incident type
+        The display name of the resource.
 
 
         :return: The name of this IncidentResourceType.
@@ -101,7 +101,7 @@ class IncidentResourceType(object):
     def name(self, name):
         """
         Sets the name of this IncidentResourceType.
-        Name of Incident type
+        The display name of the resource.
 
 
         :param name: The name of this IncidentResourceType.
@@ -113,7 +113,7 @@ class IncidentResourceType(object):
     def label(self):
         """
         **[Required]** Gets the label of this IncidentResourceType.
-        Label associated with Incident Type
+        The label associated with the resource.
 
 
         :return: The label of this IncidentResourceType.
@@ -125,7 +125,7 @@ class IncidentResourceType(object):
     def label(self, label):
         """
         Sets the label of this IncidentResourceType.
-        Label associated with Incident Type
+        The label associated with the resource.
 
 
         :param label: The label of this IncidentResourceType.
@@ -137,7 +137,7 @@ class IncidentResourceType(object):
     def description(self):
         """
         Gets the description of this IncidentResourceType.
-        Details of Incident Type
+        The description of the resource.
 
 
         :return: The description of this IncidentResourceType.
@@ -149,7 +149,7 @@ class IncidentResourceType(object):
     def description(self, description):
         """
         Sets the description of this IncidentResourceType.
-        Details of Incident Type
+        The description of the resource.
 
 
         :param description: The description of this IncidentResourceType.
@@ -161,7 +161,7 @@ class IncidentResourceType(object):
     def service_category_list(self):
         """
         Gets the service_category_list of this IncidentResourceType.
-        Service Category List
+        The service category list.
 
 
         :return: The service_category_list of this IncidentResourceType.
@@ -173,7 +173,7 @@ class IncidentResourceType(object):
     def service_category_list(self, service_category_list):
         """
         Sets the service_category_list of this IncidentResourceType.
-        Service Category List
+        The service category list.
 
 
         :param service_category_list: The service_category_list of this IncidentResourceType.

--- a/src/oci/cims/models/incident_summary.py
+++ b/src/oci/cims/models/incident_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class IncidentSummary(object):
     """
-    Details of Incident
+    Details about the support ticket.
     """
 
     #: A constant which can be used with the problem_type property of a IncidentSummary.
@@ -97,7 +97,7 @@ class IncidentSummary(object):
     def key(self):
         """
         **[Required]** Gets the key of this IncidentSummary.
-        Unique ID that identifies an Incident
+        Unique identifier of the incident.
 
 
         :return: The key of this IncidentSummary.
@@ -109,7 +109,7 @@ class IncidentSummary(object):
     def key(self, key):
         """
         Sets the key of this IncidentSummary.
-        Unique ID that identifies an Incident
+        Unique identifier of the incident.
 
 
         :param key: The key of this IncidentSummary.
@@ -121,7 +121,7 @@ class IncidentSummary(object):
     def compartment_id(self):
         """
         Gets the compartment_id of this IncidentSummary.
-        Tenancy Ocid
+        The OCID of the tenancy.
 
 
         :return: The compartment_id of this IncidentSummary.
@@ -133,7 +133,7 @@ class IncidentSummary(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this IncidentSummary.
-        Tenancy Ocid
+        The OCID of the tenancy.
 
 
         :param compartment_id: The compartment_id of this IncidentSummary.
@@ -225,7 +225,7 @@ class IncidentSummary(object):
     def problem_type(self):
         """
         **[Required]** Gets the problem_type of this IncidentSummary.
-        States type of incident. eg: LIMIT, TECH
+        The kind of support ticket, such as a technical support request.
 
         Allowed values for this property are: "LIMIT", "LEGACY_LIMIT", "TECH", "ACCOUNT", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -240,7 +240,7 @@ class IncidentSummary(object):
     def problem_type(self, problem_type):
         """
         Sets the problem_type of this IncidentSummary.
-        States type of incident. eg: LIMIT, TECH
+        The kind of support ticket, such as a technical support request.
 
 
         :param problem_type: The problem_type of this IncidentSummary.

--- a/src/oci/cims/models/incident_type.py
+++ b/src/oci/cims/models/incident_type.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class IncidentType(object):
     """
-    Details of incident type
+    Details about the incident type object.
     """
 
     def __init__(self, **kwargs):
@@ -65,7 +65,7 @@ class IncidentType(object):
     def id(self):
         """
         Gets the id of this IncidentType.
-        Unique ID that identifies an Incident Type
+        Unique identifier for the incident type.
 
 
         :return: The id of this IncidentType.
@@ -77,7 +77,7 @@ class IncidentType(object):
     def id(self, id):
         """
         Sets the id of this IncidentType.
-        Unique ID that identifies an Incident Type
+        Unique identifier for the incident type.
 
 
         :param id: The id of this IncidentType.
@@ -89,7 +89,7 @@ class IncidentType(object):
     def name(self):
         """
         Gets the name of this IncidentType.
-        Name of Incident type
+        The name of the incident type.
 
 
         :return: The name of this IncidentType.
@@ -101,7 +101,7 @@ class IncidentType(object):
     def name(self, name):
         """
         Sets the name of this IncidentType.
-        Name of Incident type
+        The name of the incident type.
 
 
         :param name: The name of this IncidentType.
@@ -113,7 +113,7 @@ class IncidentType(object):
     def label(self):
         """
         Gets the label of this IncidentType.
-        Label associated with Incident Type
+        The label associated with the incident type.
 
 
         :return: The label of this IncidentType.
@@ -125,7 +125,7 @@ class IncidentType(object):
     def label(self, label):
         """
         Sets the label of this IncidentType.
-        Label associated with Incident Type
+        The label associated with the incident type.
 
 
         :param label: The label of this IncidentType.
@@ -137,7 +137,7 @@ class IncidentType(object):
     def description(self):
         """
         Gets the description of this IncidentType.
-        Details of Incident Type
+        The description of the incident type.
 
 
         :return: The description of this IncidentType.
@@ -149,7 +149,7 @@ class IncidentType(object):
     def description(self, description):
         """
         Sets the description of this IncidentType.
-        Details of Incident Type
+        The description of the incident type.
 
 
         :param description: The description of this IncidentType.
@@ -161,7 +161,7 @@ class IncidentType(object):
     def classifier_list(self):
         """
         Gets the classifier_list of this IncidentType.
-        List of classifiers
+        The list of classifiers.
 
 
         :return: The classifier_list of this IncidentType.
@@ -173,7 +173,7 @@ class IncidentType(object):
     def classifier_list(self, classifier_list):
         """
         Sets the classifier_list of this IncidentType.
-        List of classifiers
+        The list of classifiers.
 
 
         :param classifier_list: The classifier_list of this IncidentType.

--- a/src/oci/cims/models/issue_type.py
+++ b/src/oci/cims/models/issue_type.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class IssueType(object):
     """
-    Details Issue Type of the incident
+    Details about the issue type associated with the support ticket.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,7 @@ class IssueType(object):
     def issue_type_key(self):
         """
         Gets the issue_type_key of this IssueType.
-        Unique ID that identifies an Issue Type
+        Unique identifier for the issue type.
 
 
         :return: The issue_type_key of this IssueType.
@@ -56,7 +56,7 @@ class IssueType(object):
     def issue_type_key(self, issue_type_key):
         """
         Sets the issue_type_key of this IssueType.
-        Unique ID that identifies an Issue Type
+        Unique identifier for the issue type.
 
 
         :param issue_type_key: The issue_type_key of this IssueType.
@@ -68,7 +68,7 @@ class IssueType(object):
     def label(self):
         """
         Gets the label of this IssueType.
-        Label of issue type. eg: Instance Performance
+        The label for the issue type. For example, `Instance Performance`.
 
 
         :return: The label of this IssueType.
@@ -80,7 +80,7 @@ class IssueType(object):
     def label(self, label):
         """
         Sets the label of this IssueType.
-        Label of issue type. eg: Instance Performance
+        The label for the issue type. For example, `Instance Performance`.
 
 
         :param label: The label of this IssueType.

--- a/src/oci/cims/models/item.py
+++ b/src/oci/cims/models/item.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Item(object):
     """
-    Details of Item
+    Details about the item object.
     """
 
     def __init__(self, **kwargs):
@@ -97,7 +97,7 @@ class Item(object):
     def item_key(self):
         """
         **[Required]** Gets the item_key of this Item.
-        Unique ID that identifies an Item
+        Unique identifier for the item.
 
 
         :return: The item_key of this Item.
@@ -109,7 +109,7 @@ class Item(object):
     def item_key(self, item_key):
         """
         Sets the item_key of this Item.
-        Unique ID that identifies an Item
+        Unique identifier for the item.
 
 
         :param item_key: The item_key of this Item.
@@ -121,7 +121,7 @@ class Item(object):
     def name(self):
         """
         Gets the name of this Item.
-        Name of item
+        The display name of the item.
 
 
         :return: The name of this Item.
@@ -133,7 +133,7 @@ class Item(object):
     def name(self, name):
         """
         Sets the name of this Item.
-        Name of item
+        The display name of the item.
 
 
         :param name: The name of this Item.
@@ -145,7 +145,7 @@ class Item(object):
     def type(self):
         """
         Gets the type of this Item.
-        Type of item. eg: ActivityItem, LimitItem
+        The type of the support request.
 
 
         :return: The type of this Item.
@@ -157,7 +157,7 @@ class Item(object):
     def type(self, type):
         """
         Sets the type of this Item.
-        Type of item. eg: ActivityItem, LimitItem
+        The type of the support request.
 
 
         :param type: The type of this Item.

--- a/src/oci/cims/models/limit_item.py
+++ b/src/oci/cims/models/limit_item.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class LimitItem(Item):
     """
-    Details of Limit Item
+    Reserved for future use.
     """
 
     #: A constant which can be used with the limit_status property of a LimitItem.
@@ -116,7 +116,7 @@ class LimitItem(Item):
     def current_limit(self):
         """
         Gets the current_limit of this LimitItem.
-        Current available limit of the resource
+        The currently available limit of the resource.
 
 
         :return: The current_limit of this LimitItem.
@@ -128,7 +128,7 @@ class LimitItem(Item):
     def current_limit(self, current_limit):
         """
         Sets the current_limit of this LimitItem.
-        Current available limit of the resource
+        The currently available limit of the resource.
 
 
         :param current_limit: The current_limit of this LimitItem.
@@ -140,7 +140,7 @@ class LimitItem(Item):
     def current_usage(self):
         """
         Gets the current_usage of this LimitItem.
-        Current used limit of the resource
+        The current usage of the resource.
 
 
         :return: The current_usage of this LimitItem.
@@ -152,7 +152,7 @@ class LimitItem(Item):
     def current_usage(self, current_usage):
         """
         Sets the current_usage of this LimitItem.
-        Current used limit of the resource
+        The current usage of the resource.
 
 
         :param current_usage: The current_usage of this LimitItem.
@@ -164,7 +164,7 @@ class LimitItem(Item):
     def requested_limit(self):
         """
         Gets the requested_limit of this LimitItem.
-        Requested limit for the resource
+        The requested limit for the resource.
 
 
         :return: The requested_limit of this LimitItem.
@@ -176,7 +176,7 @@ class LimitItem(Item):
     def requested_limit(self, requested_limit):
         """
         Sets the requested_limit of this LimitItem.
-        Requested limit for the resource
+        The requested limit for the resource.
 
 
         :param requested_limit: The requested_limit of this LimitItem.
@@ -188,7 +188,7 @@ class LimitItem(Item):
     def limit_status(self):
         """
         Gets the limit_status of this LimitItem.
-        Status of the Limit
+        The status of the request.
 
         Allowed values for this property are: "APPROVED", "PARTIALLY_APPROVED", "NOT_APPROVED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -203,7 +203,7 @@ class LimitItem(Item):
     def limit_status(self, limit_status):
         """
         Sets the limit_status of this LimitItem.
-        Status of the Limit
+        The status of the request.
 
 
         :param limit_status: The limit_status of this LimitItem.

--- a/src/oci/cims/models/resource.py
+++ b/src/oci/cims/models/resource.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Resource(object):
     """
-    Details of Ticket Item
+    Details about the ticket item object.
     """
 
     #: A constant which can be used with the region property of a Resource.
@@ -58,14 +58,6 @@ class Resource(object):
     REGION_NRT = "NRT"
 
     #: A constant which can be used with the region property of a Resource.
-    #: This constant has a value of "US_LANGLEY_1"
-    REGION_US_LANGLEY_1 = "US_LANGLEY_1"
-
-    #: A constant which can be used with the region property of a Resource.
-    #: This constant has a value of "US_LUKE_1"
-    REGION_US_LUKE_1 = "US_LUKE_1"
-
-    #: A constant which can be used with the region property of a Resource.
     #: This constant has a value of "ICN"
     REGION_ICN = "ICN"
 
@@ -76,18 +68,6 @@ class Resource(object):
     #: A constant which can be used with the region property of a Resource.
     #: This constant has a value of "GRU"
     REGION_GRU = "GRU"
-
-    #: A constant which can be used with the region property of a Resource.
-    #: This constant has a value of "US_GOV_ASHBURN_1"
-    REGION_US_GOV_ASHBURN_1 = "US_GOV_ASHBURN_1"
-
-    #: A constant which can be used with the region property of a Resource.
-    #: This constant has a value of "US_GOV_PHOENIX_1"
-    REGION_US_GOV_PHOENIX_1 = "US_GOV_PHOENIX_1"
-
-    #: A constant which can be used with the region property of a Resource.
-    #: This constant has a value of "US_GOV_CHICAGO_1"
-    REGION_US_GOV_CHICAGO_1 = "US_GOV_CHICAGO_1"
 
     #: A constant which can be used with the region property of a Resource.
     #: This constant has a value of "SYD"
@@ -124,10 +104,6 @@ class Resource(object):
     #: A constant which can be used with the region property of a Resource.
     #: This constant has a value of "YNY"
     REGION_YNY = "YNY"
-
-    #: A constant which can be used with the region property of a Resource.
-    #: This constant has a value of "TIW"
-    REGION_TIW = "TIW"
 
     #: A constant which can be used with the availability_domain property of a Resource.
     #: This constant has a value of "DEV_1"
@@ -234,14 +210,6 @@ class Resource(object):
     AVAILABILITY_DOMAIN_SA_SAOPAULO_1_AD_1 = "SA_SAOPAULO_1_AD_1"
 
     #: A constant which can be used with the availability_domain property of a Resource.
-    #: This constant has a value of "US_LUKE_1_AD_1"
-    AVAILABILITY_DOMAIN_US_LUKE_1_AD_1 = "US_LUKE_1_AD_1"
-
-    #: A constant which can be used with the availability_domain property of a Resource.
-    #: This constant has a value of "US_LANGLEY_1_AD_1"
-    AVAILABILITY_DOMAIN_US_LANGLEY_1_AD_1 = "US_LANGLEY_1_AD_1"
-
-    #: A constant which can be used with the availability_domain property of a Resource.
     #: This constant has a value of "ME_JEDDAH_1_AD_1"
     AVAILABILITY_DOMAIN_ME_JEDDAH_1_AD_1 = "ME_JEDDAH_1_AD_1"
 
@@ -278,10 +246,6 @@ class Resource(object):
     AVAILABILITY_DOMAIN_AP_CHUNCHEON_1_AD_1 = "AP_CHUNCHEON_1_AD_1"
 
     #: A constant which can be used with the availability_domain property of a Resource.
-    #: This constant has a value of "US_TACOMA_1_AD_1"
-    AVAILABILITY_DOMAIN_US_TACOMA_1_AD_1 = "US_TACOMA_1_AD_1"
-
-    #: A constant which can be used with the availability_domain property of a Resource.
     #: This constant has a value of "NO_AD"
     AVAILABILITY_DOMAIN_NO_AD = "NO_AD"
 
@@ -296,13 +260,13 @@ class Resource(object):
 
         :param region:
             The value to assign to the region property of this Resource.
-            Allowed values for this property are: "DEV", "SEA", "INTEG_NEXT", "INTEG_STABLE", "PHX", "IAD", "FRA", "EU_FRANKFURT_1", "LHR", "YYZ", "NRT", "US_LANGLEY_1", "US_LUKE_1", "ICN", "BOM", "GRU", "US_GOV_ASHBURN_1", "US_GOV_PHOENIX_1", "US_GOV_CHICAGO_1", "SYD", "ZRH", "JED", "AMS", "KIX", "MEL", "YUL", "HYD", "YNY", "TIW", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "DEV", "SEA", "INTEG_NEXT", "INTEG_STABLE", "PHX", "IAD", "FRA", "EU_FRANKFURT_1", "LHR", "YYZ", "NRT", "ICN", "BOM", "GRU", "SYD", "ZRH", "JED", "AMS", "KIX", "MEL", "YUL", "HYD", "YNY", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type region: str
 
         :param availability_domain:
             The value to assign to the availability_domain property of this Resource.
-            Allowed values for this property are: "DEV_1", "DEV_2", "DEV_3", "INTEG_NEXT_1", "INTEG_STABLE_1", "SEA_AD_1", "SEA_AD_2", "SEA_AD_3", "PHX_AD_1", "PHX_AD_2", "PHX_AD_3", "US_ASHBURN_AD_1", "US_ASHBURN_AD_2", "US_ASHBURN_AD_3", "US_ASHBURN_AD_4", "EU_FRANKFURT_1_AD_1", "EU_FRANKFURT_1_AD_2", "EU_FRANKFURT_1_AD_3", "UK_LONDON_1_AD_1", "UK_LONDON_1_AD_2", "UK_LONDON_1_AD_3", "CA_TORONTO_1_AD_1", "AP_TOKYO_1_AD_1", "AP_SEOUL_1_AD_1", "AP_MUMBAI_1_AD_1", "SA_SAOPAULO_1_AD_1", "US_LUKE_1_AD_1", "US_LANGLEY_1_AD_1", "ME_JEDDAH_1_AD_1", "AP_OSAKA_1_AD_1", "AP_SYDNEY_1_AD_1", "EU_ZURICH_1_AD_1", "EU_AMSTERDAM_1_AD_1", "AP_MELBOURNE_1_AD_1", "CA_MONTREAL_1_AD_1", "AP_HYDERABAD_1_AD_1", "AP_CHUNCHEON_1_AD_1", "US_TACOMA_1_AD_1", "NO_AD", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "DEV_1", "DEV_2", "DEV_3", "INTEG_NEXT_1", "INTEG_STABLE_1", "SEA_AD_1", "SEA_AD_2", "SEA_AD_3", "PHX_AD_1", "PHX_AD_2", "PHX_AD_3", "US_ASHBURN_AD_1", "US_ASHBURN_AD_2", "US_ASHBURN_AD_3", "US_ASHBURN_AD_4", "EU_FRANKFURT_1_AD_1", "EU_FRANKFURT_1_AD_2", "EU_FRANKFURT_1_AD_3", "UK_LONDON_1_AD_1", "UK_LONDON_1_AD_2", "UK_LONDON_1_AD_3", "CA_TORONTO_1_AD_1", "AP_TOKYO_1_AD_1", "AP_SEOUL_1_AD_1", "AP_MUMBAI_1_AD_1", "SA_SAOPAULO_1_AD_1", "ME_JEDDAH_1_AD_1", "AP_OSAKA_1_AD_1", "AP_SYDNEY_1_AD_1", "EU_ZURICH_1_AD_1", "EU_AMSTERDAM_1_AD_1", "AP_MELBOURNE_1_AD_1", "CA_MONTREAL_1_AD_1", "AP_HYDERABAD_1_AD_1", "AP_CHUNCHEON_1_AD_1", "NO_AD", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type availability_domain: str
 
@@ -347,9 +311,9 @@ class Resource(object):
     def region(self):
         """
         Gets the region of this Resource.
-        List of OCI regions
+        The list of available Oracle Cloud Infrastructure regions.
 
-        Allowed values for this property are: "DEV", "SEA", "INTEG_NEXT", "INTEG_STABLE", "PHX", "IAD", "FRA", "EU_FRANKFURT_1", "LHR", "YYZ", "NRT", "US_LANGLEY_1", "US_LUKE_1", "ICN", "BOM", "GRU", "US_GOV_ASHBURN_1", "US_GOV_PHOENIX_1", "US_GOV_CHICAGO_1", "SYD", "ZRH", "JED", "AMS", "KIX", "MEL", "YUL", "HYD", "YNY", "TIW", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "DEV", "SEA", "INTEG_NEXT", "INTEG_STABLE", "PHX", "IAD", "FRA", "EU_FRANKFURT_1", "LHR", "YYZ", "NRT", "ICN", "BOM", "GRU", "SYD", "ZRH", "JED", "AMS", "KIX", "MEL", "YUL", "HYD", "YNY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -362,13 +326,13 @@ class Resource(object):
     def region(self, region):
         """
         Sets the region of this Resource.
-        List of OCI regions
+        The list of available Oracle Cloud Infrastructure regions.
 
 
         :param region: The region of this Resource.
         :type: str
         """
-        allowed_values = ["DEV", "SEA", "INTEG_NEXT", "INTEG_STABLE", "PHX", "IAD", "FRA", "EU_FRANKFURT_1", "LHR", "YYZ", "NRT", "US_LANGLEY_1", "US_LUKE_1", "ICN", "BOM", "GRU", "US_GOV_ASHBURN_1", "US_GOV_PHOENIX_1", "US_GOV_CHICAGO_1", "SYD", "ZRH", "JED", "AMS", "KIX", "MEL", "YUL", "HYD", "YNY", "TIW"]
+        allowed_values = ["DEV", "SEA", "INTEG_NEXT", "INTEG_STABLE", "PHX", "IAD", "FRA", "EU_FRANKFURT_1", "LHR", "YYZ", "NRT", "ICN", "BOM", "GRU", "SYD", "ZRH", "JED", "AMS", "KIX", "MEL", "YUL", "HYD", "YNY"]
         if not value_allowed_none_or_none_sentinel(region, allowed_values):
             region = 'UNKNOWN_ENUM_VALUE'
         self._region = region
@@ -377,9 +341,9 @@ class Resource(object):
     def availability_domain(self):
         """
         Gets the availability_domain of this Resource.
-        List of OCI ADs
+        The list of available Oracle Cloud Infrastructure availability domains.
 
-        Allowed values for this property are: "DEV_1", "DEV_2", "DEV_3", "INTEG_NEXT_1", "INTEG_STABLE_1", "SEA_AD_1", "SEA_AD_2", "SEA_AD_3", "PHX_AD_1", "PHX_AD_2", "PHX_AD_3", "US_ASHBURN_AD_1", "US_ASHBURN_AD_2", "US_ASHBURN_AD_3", "US_ASHBURN_AD_4", "EU_FRANKFURT_1_AD_1", "EU_FRANKFURT_1_AD_2", "EU_FRANKFURT_1_AD_3", "UK_LONDON_1_AD_1", "UK_LONDON_1_AD_2", "UK_LONDON_1_AD_3", "CA_TORONTO_1_AD_1", "AP_TOKYO_1_AD_1", "AP_SEOUL_1_AD_1", "AP_MUMBAI_1_AD_1", "SA_SAOPAULO_1_AD_1", "US_LUKE_1_AD_1", "US_LANGLEY_1_AD_1", "ME_JEDDAH_1_AD_1", "AP_OSAKA_1_AD_1", "AP_SYDNEY_1_AD_1", "EU_ZURICH_1_AD_1", "EU_AMSTERDAM_1_AD_1", "AP_MELBOURNE_1_AD_1", "CA_MONTREAL_1_AD_1", "AP_HYDERABAD_1_AD_1", "AP_CHUNCHEON_1_AD_1", "US_TACOMA_1_AD_1", "NO_AD", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "DEV_1", "DEV_2", "DEV_3", "INTEG_NEXT_1", "INTEG_STABLE_1", "SEA_AD_1", "SEA_AD_2", "SEA_AD_3", "PHX_AD_1", "PHX_AD_2", "PHX_AD_3", "US_ASHBURN_AD_1", "US_ASHBURN_AD_2", "US_ASHBURN_AD_3", "US_ASHBURN_AD_4", "EU_FRANKFURT_1_AD_1", "EU_FRANKFURT_1_AD_2", "EU_FRANKFURT_1_AD_3", "UK_LONDON_1_AD_1", "UK_LONDON_1_AD_2", "UK_LONDON_1_AD_3", "CA_TORONTO_1_AD_1", "AP_TOKYO_1_AD_1", "AP_SEOUL_1_AD_1", "AP_MUMBAI_1_AD_1", "SA_SAOPAULO_1_AD_1", "ME_JEDDAH_1_AD_1", "AP_OSAKA_1_AD_1", "AP_SYDNEY_1_AD_1", "EU_ZURICH_1_AD_1", "EU_AMSTERDAM_1_AD_1", "AP_MELBOURNE_1_AD_1", "CA_MONTREAL_1_AD_1", "AP_HYDERABAD_1_AD_1", "AP_CHUNCHEON_1_AD_1", "NO_AD", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -392,13 +356,13 @@ class Resource(object):
     def availability_domain(self, availability_domain):
         """
         Sets the availability_domain of this Resource.
-        List of OCI ADs
+        The list of available Oracle Cloud Infrastructure availability domains.
 
 
         :param availability_domain: The availability_domain of this Resource.
         :type: str
         """
-        allowed_values = ["DEV_1", "DEV_2", "DEV_3", "INTEG_NEXT_1", "INTEG_STABLE_1", "SEA_AD_1", "SEA_AD_2", "SEA_AD_3", "PHX_AD_1", "PHX_AD_2", "PHX_AD_3", "US_ASHBURN_AD_1", "US_ASHBURN_AD_2", "US_ASHBURN_AD_3", "US_ASHBURN_AD_4", "EU_FRANKFURT_1_AD_1", "EU_FRANKFURT_1_AD_2", "EU_FRANKFURT_1_AD_3", "UK_LONDON_1_AD_1", "UK_LONDON_1_AD_2", "UK_LONDON_1_AD_3", "CA_TORONTO_1_AD_1", "AP_TOKYO_1_AD_1", "AP_SEOUL_1_AD_1", "AP_MUMBAI_1_AD_1", "SA_SAOPAULO_1_AD_1", "US_LUKE_1_AD_1", "US_LANGLEY_1_AD_1", "ME_JEDDAH_1_AD_1", "AP_OSAKA_1_AD_1", "AP_SYDNEY_1_AD_1", "EU_ZURICH_1_AD_1", "EU_AMSTERDAM_1_AD_1", "AP_MELBOURNE_1_AD_1", "CA_MONTREAL_1_AD_1", "AP_HYDERABAD_1_AD_1", "AP_CHUNCHEON_1_AD_1", "US_TACOMA_1_AD_1", "NO_AD"]
+        allowed_values = ["DEV_1", "DEV_2", "DEV_3", "INTEG_NEXT_1", "INTEG_STABLE_1", "SEA_AD_1", "SEA_AD_2", "SEA_AD_3", "PHX_AD_1", "PHX_AD_2", "PHX_AD_3", "US_ASHBURN_AD_1", "US_ASHBURN_AD_2", "US_ASHBURN_AD_3", "US_ASHBURN_AD_4", "EU_FRANKFURT_1_AD_1", "EU_FRANKFURT_1_AD_2", "EU_FRANKFURT_1_AD_3", "UK_LONDON_1_AD_1", "UK_LONDON_1_AD_2", "UK_LONDON_1_AD_3", "CA_TORONTO_1_AD_1", "AP_TOKYO_1_AD_1", "AP_SEOUL_1_AD_1", "AP_MUMBAI_1_AD_1", "SA_SAOPAULO_1_AD_1", "ME_JEDDAH_1_AD_1", "AP_OSAKA_1_AD_1", "AP_SYDNEY_1_AD_1", "EU_ZURICH_1_AD_1", "EU_AMSTERDAM_1_AD_1", "AP_MELBOURNE_1_AD_1", "CA_MONTREAL_1_AD_1", "AP_HYDERABAD_1_AD_1", "AP_CHUNCHEON_1_AD_1", "NO_AD"]
         if not value_allowed_none_or_none_sentinel(availability_domain, allowed_values):
             availability_domain = 'UNKNOWN_ENUM_VALUE'
         self._availability_domain = availability_domain

--- a/src/oci/cims/models/service_category.py
+++ b/src/oci/cims/models/service_category.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ServiceCategory(object):
     """
-    Incident Classifier details
+    Information about the incident classifier.
     """
 
     #: A constant which can be used with the scope property of a ServiceCategory.
@@ -118,7 +118,7 @@ class ServiceCategory(object):
     def key(self):
         """
         Gets the key of this ServiceCategory.
-        Unique ID that identifies a classifier
+        The unique ID that identifies a classifier.
 
 
         :return: The key of this ServiceCategory.
@@ -130,7 +130,7 @@ class ServiceCategory(object):
     def key(self, key):
         """
         Sets the key of this ServiceCategory.
-        Unique ID that identifies a classifier
+        The unique ID that identifies a classifier.
 
 
         :param key: The key of this ServiceCategory.
@@ -142,7 +142,7 @@ class ServiceCategory(object):
     def name(self):
         """
         Gets the name of this ServiceCategory.
-        Name of classifier. eg: LIMIT Increase
+        The name of the classifier.
 
 
         :return: The name of this ServiceCategory.
@@ -154,7 +154,7 @@ class ServiceCategory(object):
     def name(self, name):
         """
         Sets the name of this ServiceCategory.
-        Name of classifier. eg: LIMIT Increase
+        The name of the classifier.
 
 
         :param name: The name of this ServiceCategory.
@@ -166,7 +166,7 @@ class ServiceCategory(object):
     def label(self):
         """
         Gets the label of this ServiceCategory.
-        Label of classifier
+        The label for the classifier.
 
 
         :return: The label of this ServiceCategory.
@@ -178,7 +178,7 @@ class ServiceCategory(object):
     def label(self, label):
         """
         Sets the label of this ServiceCategory.
-        Label of classifier
+        The label for the classifier.
 
 
         :param label: The label of this ServiceCategory.
@@ -190,7 +190,7 @@ class ServiceCategory(object):
     def description(self):
         """
         Gets the description of this ServiceCategory.
-        Description of classifier
+        The text describing the classifier.
 
 
         :return: The description of this ServiceCategory.
@@ -202,7 +202,7 @@ class ServiceCategory(object):
     def description(self, description):
         """
         Sets the description of this ServiceCategory.
-        Description of classifier
+        The text describing the classifier.
 
 
         :param description: The description of this ServiceCategory.
@@ -214,7 +214,7 @@ class ServiceCategory(object):
     def issue_type_list(self):
         """
         Gets the issue_type_list of this ServiceCategory.
-        List of Issues
+        The list of issues.
 
 
         :return: The issue_type_list of this ServiceCategory.
@@ -226,7 +226,7 @@ class ServiceCategory(object):
     def issue_type_list(self, issue_type_list):
         """
         Sets the issue_type_list of this ServiceCategory.
-        List of Issues
+        The list of issues.
 
 
         :param issue_type_list: The issue_type_list of this ServiceCategory.
@@ -238,7 +238,7 @@ class ServiceCategory(object):
     def scope(self):
         """
         Gets the scope of this ServiceCategory.
-        List of Scope
+        The scope of the incident.
 
         Allowed values for this property are: "AD", "REGION", "TENANCY", "NONE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -253,7 +253,7 @@ class ServiceCategory(object):
     def scope(self, scope):
         """
         Sets the scope of this ServiceCategory.
-        List of Scope
+        The scope of the incident.
 
 
         :param scope: The scope of this ServiceCategory.
@@ -268,7 +268,7 @@ class ServiceCategory(object):
     def unit(self):
         """
         Gets the unit of this ServiceCategory.
-        List of Units
+        The unit to use to measure the service category or resource.
 
         Allowed values for this property are: "COUNT", "GB", "NONE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -283,7 +283,7 @@ class ServiceCategory(object):
     def unit(self, unit):
         """
         Sets the unit of this ServiceCategory.
-        List of Units
+        The unit to use to measure the service category or resource.
 
 
         :param unit: The unit of this ServiceCategory.
@@ -298,7 +298,7 @@ class ServiceCategory(object):
     def limit_id(self):
         """
         Gets the limit_id of this ServiceCategory.
-        Limit's unique id
+        The unique ID for the limit.
 
 
         :return: The limit_id of this ServiceCategory.
@@ -310,7 +310,7 @@ class ServiceCategory(object):
     def limit_id(self, limit_id):
         """
         Sets the limit_id of this ServiceCategory.
-        Limit's unique id
+        The unique ID for the limit.
 
 
         :param limit_id: The limit_id of this ServiceCategory.

--- a/src/oci/cims/models/status.py
+++ b/src/oci/cims/models/status.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Status(object):
     """
-    Details of Ticket Status
+    Details about the status of the support ticket.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,7 @@ class Status(object):
     def code(self):
         """
         **[Required]** Gets the code of this Status.
-        Unique code
+        The code unique to this ticket status.
 
 
         :return: The code of this Status.
@@ -56,7 +56,7 @@ class Status(object):
     def code(self, code):
         """
         Sets the code of this Status.
-        Unique code
+        The code unique to this ticket status.
 
 
         :param code: The code of this Status.
@@ -68,7 +68,7 @@ class Status(object):
     def message(self):
         """
         **[Required]** Gets the message of this Status.
-        Status message
+        The status message for this ticket.
 
 
         :return: The message of this Status.
@@ -80,7 +80,7 @@ class Status(object):
     def message(self, message):
         """
         Sets the message of this Status.
-        Status message
+        The status message for this ticket.
 
 
         :param message: The message of this Status.

--- a/src/oci/cims/models/sub_category.py
+++ b/src/oci/cims/models/sub_category.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class SubCategory(object):
     """
-    Details of Sub Category of the incident
+    Details about the subcategory associated with the support ticket.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,7 @@ class SubCategory(object):
     def sub_category_key(self):
         """
         Gets the sub_category_key of this SubCategory.
-        Unique ID that identifies a Sub Category
+        Unique identifier for the subcategory.
 
 
         :return: The sub_category_key of this SubCategory.
@@ -56,7 +56,7 @@ class SubCategory(object):
     def sub_category_key(self, sub_category_key):
         """
         Sets the sub_category_key of this SubCategory.
-        Unique ID that identifies a Sub Category
+        Unique identifier for the subcategory.
 
 
         :param sub_category_key: The sub_category_key of this SubCategory.
@@ -68,7 +68,7 @@ class SubCategory(object):
     def name(self):
         """
         Gets the name of this SubCategory.
-        Name of sub category. eg: Backup Count, Custom Image Count
+        The name of the subcategory. For example, `Backup Count` or `Custom Image Count`.
 
 
         :return: The name of this SubCategory.
@@ -80,7 +80,7 @@ class SubCategory(object):
     def name(self, name):
         """
         Sets the name of this SubCategory.
-        Name of sub category. eg: Backup Count, Custom Image Count
+        The name of the subcategory. For example, `Backup Count` or `Custom Image Count`.
 
 
         :param name: The name of this SubCategory.

--- a/src/oci/cims/models/tech_support_item.py
+++ b/src/oci/cims/models/tech_support_item.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class TechSupportItem(Item):
     """
-    Details of TechSupport Item
+    Details about the TechSupportItem object.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/cims/models/tenancy_information.py
+++ b/src/oci/cims/models/tenancy_information.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class TenancyInformation(object):
     """
-    Details of Customer Tenant
+    Details about the customer's tenancy.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,7 @@ class TenancyInformation(object):
     def customer_support_key(self):
         """
         **[Required]** Gets the customer_support_key of this TenancyInformation.
-        Tenant customer support identifier
+        The Customer Support Identifier number associated with the tenancy.
 
 
         :return: The customer_support_key of this TenancyInformation.
@@ -56,7 +56,7 @@ class TenancyInformation(object):
     def customer_support_key(self, customer_support_key):
         """
         Sets the customer_support_key of this TenancyInformation.
-        Tenant customer support identifier
+        The Customer Support Identifier number associated with the tenancy.
 
 
         :param customer_support_key: The customer_support_key of this TenancyInformation.
@@ -68,7 +68,7 @@ class TenancyInformation(object):
     def tenancy_id(self):
         """
         **[Required]** Gets the tenancy_id of this TenancyInformation.
-        Tenant OCID
+        The OCID of the tenancy.
 
 
         :return: The tenancy_id of this TenancyInformation.
@@ -80,7 +80,7 @@ class TenancyInformation(object):
     def tenancy_id(self, tenancy_id):
         """
         Sets the tenancy_id of this TenancyInformation.
-        Tenant OCID
+        The OCID of the tenancy.
 
 
         :param tenancy_id: The tenancy_id of this TenancyInformation.

--- a/src/oci/cims/models/ticket.py
+++ b/src/oci/cims/models/ticket.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Ticket(object):
     """
-    Details of Ticket created
+    Details about the ticket created.
     """
 
     #: A constant which can be used with the severity property of a Ticket.
@@ -135,7 +135,7 @@ class Ticket(object):
     def ticket_number(self):
         """
         Gets the ticket_number of this Ticket.
-        Unique ID that identifies a Ticket
+        Unique identifier for the ticket.
 
 
         :return: The ticket_number of this Ticket.
@@ -147,7 +147,7 @@ class Ticket(object):
     def ticket_number(self, ticket_number):
         """
         Sets the ticket_number of this Ticket.
-        Unique ID that identifies a Ticket
+        Unique identifier for the ticket.
 
 
         :param ticket_number: The ticket_number of this Ticket.
@@ -159,7 +159,7 @@ class Ticket(object):
     def severity(self):
         """
         **[Required]** Gets the severity of this Ticket.
-        Severity of the ticket. eg: HIGH, MEDIUM
+        The severity assigned to the ticket.
 
         Allowed values for this property are: "HIGHEST", "HIGH", "MEDIUM", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -174,7 +174,7 @@ class Ticket(object):
     def severity(self, severity):
         """
         Sets the severity of this Ticket.
-        Severity of the ticket. eg: HIGH, MEDIUM
+        The severity assigned to the ticket.
 
 
         :param severity: The severity of this Ticket.
@@ -189,7 +189,7 @@ class Ticket(object):
     def resource_list(self):
         """
         Gets the resource_list of this Ticket.
-        List of resources
+        The list of resources associated with the ticket.
 
 
         :return: The resource_list of this Ticket.
@@ -201,7 +201,7 @@ class Ticket(object):
     def resource_list(self, resource_list):
         """
         Sets the resource_list of this Ticket.
-        List of resources
+        The list of resources associated with the ticket.
 
 
         :param resource_list: The resource_list of this Ticket.
@@ -213,7 +213,7 @@ class Ticket(object):
     def title(self):
         """
         **[Required]** Gets the title of this Ticket.
-        Title of ticket
+        The title of the ticket.
 
 
         :return: The title of this Ticket.
@@ -225,7 +225,7 @@ class Ticket(object):
     def title(self, title):
         """
         Sets the title of this Ticket.
-        Title of ticket
+        The title of the ticket.
 
 
         :param title: The title of this Ticket.
@@ -237,7 +237,7 @@ class Ticket(object):
     def description(self):
         """
         **[Required]** Gets the description of this Ticket.
-        Details of ticket
+        The description of the issue addressed in the ticket.
 
 
         :return: The description of this Ticket.
@@ -249,7 +249,7 @@ class Ticket(object):
     def description(self, description):
         """
         Sets the description of this Ticket.
-        Details of ticket
+        The description of the issue addressed in the ticket.
 
 
         :param description: The description of this Ticket.
@@ -261,7 +261,7 @@ class Ticket(object):
     def time_created(self):
         """
         Gets the time_created of this Ticket.
-        Epoch time of ticket creation
+        The time when the ticket was created, in milliseconds since epoch time.
 
 
         :return: The time_created of this Ticket.
@@ -273,7 +273,7 @@ class Ticket(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Ticket.
-        Epoch time of ticket creation
+        The time when the ticket was created, in milliseconds since epoch time.
 
 
         :param time_created: The time_created of this Ticket.
@@ -285,7 +285,7 @@ class Ticket(object):
     def time_updated(self):
         """
         Gets the time_updated of this Ticket.
-        Epoch time of ticket updated
+        The time when the ticket was updated, in milliseconds since epoch time.
 
 
         :return: The time_updated of this Ticket.
@@ -297,7 +297,7 @@ class Ticket(object):
     def time_updated(self, time_updated):
         """
         Sets the time_updated of this Ticket.
-        Epoch time of ticket updated
+        The time when the ticket was updated, in milliseconds since epoch time.
 
 
         :param time_updated: The time_updated of this Ticket.
@@ -309,7 +309,7 @@ class Ticket(object):
     def lifecycle_state(self):
         """
         Gets the lifecycle_state of this Ticket.
-        Describes the lifecycles of a ticket
+        The current state of the ticket.
 
         Allowed values for this property are: "ACTIVE", "CLOSED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -324,7 +324,7 @@ class Ticket(object):
     def lifecycle_state(self, lifecycle_state):
         """
         Sets the lifecycle_state of this Ticket.
-        Describes the lifecycles of a ticket
+        The current state of the ticket.
 
 
         :param lifecycle_state: The lifecycle_state of this Ticket.
@@ -339,7 +339,7 @@ class Ticket(object):
     def lifecycle_details(self):
         """
         Gets the lifecycle_details of this Ticket.
-        Describes the lifecycle details of a ticket
+        Additional information about the current `lifecycleState`.
 
         Allowed values for this property are: "PENDING_WITH_ORACLE", "PENDING_WITH_CUSTOMER", "CLOSE_REQUESTED", "CLOSED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -354,7 +354,7 @@ class Ticket(object):
     def lifecycle_details(self, lifecycle_details):
         """
         Sets the lifecycle_details of this Ticket.
-        Describes the lifecycle details of a ticket
+        Additional information about the current `lifecycleState`.
 
 
         :param lifecycle_details: The lifecycle_details of this Ticket.

--- a/src/oci/cims/models/update_activity_item_details.py
+++ b/src/oci/cims/models/update_activity_item_details.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateActivityItemDetails(UpdateItemDetails):
     """
-    Details of Activity Item
+    Details for udpating the support ticket activity.
+
+    **Caution:** Avoid using any confidential information when you supply string values using the API.
     """
 
     #: A constant which can be used with the activity_type property of a UpdateActivityItemDetails.
@@ -70,7 +72,7 @@ class UpdateActivityItemDetails(UpdateItemDetails):
     def comments(self):
         """
         Gets the comments of this UpdateActivityItemDetails.
-        Comments to update as part of Activity
+        Comments updated at the time that the activity occurs.
 
 
         :return: The comments of this UpdateActivityItemDetails.
@@ -82,7 +84,7 @@ class UpdateActivityItemDetails(UpdateItemDetails):
     def comments(self, comments):
         """
         Sets the comments of this UpdateActivityItemDetails.
-        Comments to update as part of Activity
+        Comments updated at the time that the activity occurs.
 
 
         :param comments: The comments of this UpdateActivityItemDetails.
@@ -94,7 +96,7 @@ class UpdateActivityItemDetails(UpdateItemDetails):
     def activity_type(self):
         """
         Gets the activity_type of this UpdateActivityItemDetails.
-        Type of activity. eg: NOTES, UPDATE
+        The type of activity occurring.
 
         Allowed values for this property are: "NOTES", "PROBLEM_DESCRIPTION", "UPDATE", "CLOSE"
 
@@ -108,7 +110,7 @@ class UpdateActivityItemDetails(UpdateItemDetails):
     def activity_type(self, activity_type):
         """
         Sets the activity_type of this UpdateActivityItemDetails.
-        Type of activity. eg: NOTES, UPDATE
+        The type of activity occurring.
 
 
         :param activity_type: The activity_type of this UpdateActivityItemDetails.

--- a/src/oci/cims/models/update_incident.py
+++ b/src/oci/cims/models/update_incident.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateIncident(object):
     """
-    Details of Resource Item to be updated
+    Details about the support ticket being updated.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/cims/models/update_item_details.py
+++ b/src/oci/cims/models/update_item_details.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateItemDetails(object):
     """
-    Details of Item
+    Details for udpating an item.
+
+    **Caution:** Avoid using any confidential information when you supply string values using the API.
     """
 
     def __init__(self, **kwargs):
@@ -54,7 +56,7 @@ class UpdateItemDetails(object):
     def type(self):
         """
         Gets the type of this UpdateItemDetails.
-        Type of item. eg: UpdateActivityItemDetails
+        The type of the item.
 
 
         :return: The type of this UpdateItemDetails.
@@ -66,7 +68,7 @@ class UpdateItemDetails(object):
     def type(self, type):
         """
         Sets the type of this UpdateItemDetails.
-        Type of item. eg: UpdateActivityItemDetails
+        The type of the item.
 
 
         :param type: The type of this UpdateItemDetails.

--- a/src/oci/cims/models/update_resource_details.py
+++ b/src/oci/cims/models/update_resource_details.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateResourceDetails(object):
     """
-    Update Resource details
+    Details about updates to the resource.
+
+    **Caution:** Avoid using any confidential information when you supply string values using the API.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/cims/models/update_ticket_details.py
+++ b/src/oci/cims/models/update_ticket_details.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateTicketDetails(object):
     """
-    Details of Ticket updated
+    Details about the ticket updated.
+
+    **Caution:** Avoid using any confidential information when you supply string values using the API.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +39,7 @@ class UpdateTicketDetails(object):
     def resource(self):
         """
         **[Required]** Gets the resource of this UpdateTicketDetails.
-        List of resources
+        The list of resources.
 
 
         :return: The resource of this UpdateTicketDetails.
@@ -49,7 +51,7 @@ class UpdateTicketDetails(object):
     def resource(self, resource):
         """
         Sets the resource of this UpdateTicketDetails.
-        List of resources
+        The list of resources.
 
 
         :param resource: The resource of this UpdateTicketDetails.

--- a/src/oci/cims/models/user.py
+++ b/src/oci/cims/models/user.py
@@ -1,0 +1,349 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class User(object):
+    """
+    Details about the user object.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new User object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this User.
+        :type key: str
+
+        :param first_name:
+            The value to assign to the first_name property of this User.
+        :type first_name: str
+
+        :param last_name:
+            The value to assign to the last_name property of this User.
+        :type last_name: str
+
+        :param country:
+            The value to assign to the country property of this User.
+        :type country: str
+
+        :param csi:
+            The value to assign to the csi property of this User.
+        :type csi: str
+
+        :param phone:
+            The value to assign to the phone property of this User.
+        :type phone: str
+
+        :param timezone:
+            The value to assign to the timezone property of this User.
+        :type timezone: str
+
+        :param organization_name:
+            The value to assign to the organization_name property of this User.
+        :type organization_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this User.
+        :type compartment_id: str
+
+        :param contact_email:
+            The value to assign to the contact_email property of this User.
+        :type contact_email: str
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'first_name': 'str',
+            'last_name': 'str',
+            'country': 'str',
+            'csi': 'str',
+            'phone': 'str',
+            'timezone': 'str',
+            'organization_name': 'str',
+            'compartment_id': 'str',
+            'contact_email': 'str'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'first_name': 'firstName',
+            'last_name': 'lastName',
+            'country': 'country',
+            'csi': 'csi',
+            'phone': 'phone',
+            'timezone': 'timezone',
+            'organization_name': 'organizationName',
+            'compartment_id': 'compartmentId',
+            'contact_email': 'contactEmail'
+        }
+
+        self._key = None
+        self._first_name = None
+        self._last_name = None
+        self._country = None
+        self._csi = None
+        self._phone = None
+        self._timezone = None
+        self._organization_name = None
+        self._compartment_id = None
+        self._contact_email = None
+
+    @property
+    def key(self):
+        """
+        **[Required]** Gets the key of this User.
+        Unique identifier for the user.
+
+
+        :return: The key of this User.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this User.
+        Unique identifier for the user.
+
+
+        :param key: The key of this User.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def first_name(self):
+        """
+        Gets the first_name of this User.
+        First name of the user.
+
+
+        :return: The first_name of this User.
+        :rtype: str
+        """
+        return self._first_name
+
+    @first_name.setter
+    def first_name(self, first_name):
+        """
+        Sets the first_name of this User.
+        First name of the user.
+
+
+        :param first_name: The first_name of this User.
+        :type: str
+        """
+        self._first_name = first_name
+
+    @property
+    def last_name(self):
+        """
+        Gets the last_name of this User.
+        Last name of the user.
+
+
+        :return: The last_name of this User.
+        :rtype: str
+        """
+        return self._last_name
+
+    @last_name.setter
+    def last_name(self, last_name):
+        """
+        Sets the last_name of this User.
+        Last name of the user.
+
+
+        :param last_name: The last_name of this User.
+        :type: str
+        """
+        self._last_name = last_name
+
+    @property
+    def country(self):
+        """
+        Gets the country of this User.
+        Country of the user.
+
+
+        :return: The country of this User.
+        :rtype: str
+        """
+        return self._country
+
+    @country.setter
+    def country(self, country):
+        """
+        Sets the country of this User.
+        Country of the user.
+
+
+        :param country: The country of this User.
+        :type: str
+        """
+        self._country = country
+
+    @property
+    def csi(self):
+        """
+        Gets the csi of this User.
+        CSI to be associated to the user.
+
+
+        :return: The csi of this User.
+        :rtype: str
+        """
+        return self._csi
+
+    @csi.setter
+    def csi(self, csi):
+        """
+        Sets the csi of this User.
+        CSI to be associated to the user.
+
+
+        :param csi: The csi of this User.
+        :type: str
+        """
+        self._csi = csi
+
+    @property
+    def phone(self):
+        """
+        Gets the phone of this User.
+        Contact number of the user.
+
+
+        :return: The phone of this User.
+        :rtype: str
+        """
+        return self._phone
+
+    @phone.setter
+    def phone(self, phone):
+        """
+        Sets the phone of this User.
+        Contact number of the user.
+
+
+        :param phone: The phone of this User.
+        :type: str
+        """
+        self._phone = phone
+
+    @property
+    def timezone(self):
+        """
+        Gets the timezone of this User.
+        Timezone of the user.
+
+
+        :return: The timezone of this User.
+        :rtype: str
+        """
+        return self._timezone
+
+    @timezone.setter
+    def timezone(self, timezone):
+        """
+        Sets the timezone of this User.
+        Timezone of the user.
+
+
+        :param timezone: The timezone of this User.
+        :type: str
+        """
+        self._timezone = timezone
+
+    @property
+    def organization_name(self):
+        """
+        Gets the organization_name of this User.
+        Organization of the user.
+
+
+        :return: The organization_name of this User.
+        :rtype: str
+        """
+        return self._organization_name
+
+    @organization_name.setter
+    def organization_name(self, organization_name):
+        """
+        Sets the organization_name of this User.
+        Organization of the user.
+
+
+        :param organization_name: The organization_name of this User.
+        :type: str
+        """
+        self._organization_name = organization_name
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this User.
+        The OCID of the tenancy.
+
+
+        :return: The compartment_id of this User.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this User.
+        The OCID of the tenancy.
+
+
+        :param compartment_id: The compartment_id of this User.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def contact_email(self):
+        """
+        Gets the contact_email of this User.
+        The email of the contact person.
+
+
+        :return: The contact_email of this User.
+        :rtype: str
+        """
+        return self._contact_email
+
+    @contact_email.setter
+    def contact_email(self, contact_email):
+        """
+        Sets the contact_email of this User.
+        The email of the contact person.
+
+
+        :param contact_email: The contact_email of this User.
+        :type: str
+        """
+        self._contact_email = contact_email
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/cims/models/validation_response.py
+++ b/src/oci/cims/models/validation_response.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ValidationResponse(object):
     """
-    Validation Response
+    The validation response returned when checking whether the requested user is valid.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +37,7 @@ class ValidationResponse(object):
     def is_valid_user(self):
         """
         Gets the is_valid_user of this ValidationResponse.
-        Boolean value to check whether requested user is valid or not
+        Boolean value that indicates whether the requested user is valid.
 
 
         :return: The is_valid_user of this ValidationResponse.
@@ -49,7 +49,7 @@ class ValidationResponse(object):
     def is_valid_user(self, is_valid_user):
         """
         Sets the is_valid_user of this ValidationResponse.
-        Boolean value to check whether requested user is valid or not
+        Boolean value that indicates whether the requested user is valid.
 
 
         :param is_valid_user: The is_valid_user of this ValidationResponse.

--- a/src/oci/cims/user_client.py
+++ b/src/oci/cims/user_client.py
@@ -1,0 +1,153 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel
+from .models import cims_type_mapping
+missing = Sentinel("Missing")
+
+
+class UserClient(object):
+    """
+    Use the Support Management API to manage support requests. For more information, see [Getting Help and Contacting Support](/iaas/Content/GSG/Tasks/contactingsupport.htm). **Note**: Before you can create service requests with this API, you need to have an Oracle Single Sign On (SSO) account, and you need to register your Customer Support Identifier (CSI) with My Oracle Support.
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20181231',
+            'service_endpoint_template': 'https://incidentmanagement.{region}.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("user", config, signer, cims_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def create_user(self, create_user_details, ocid, **kwargs):
+        """
+        Create user to request Customer Support Identifier(CSI) to Customer User Administrator(CUA).
+
+
+        :param CreateUserDetails create_user_details: (required)
+            User information
+
+        :param str ocid: (required)
+            User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param str homeregion: (optional)
+            The region of the tenancy.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.cims.models.User`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/v2/users"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "homeregion"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_user got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "ocid": ocid,
+            "homeregion": kwargs.get("homeregion", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_user_details,
+                response_type="User")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_user_details,
+                response_type="User")

--- a/src/oci/cims/user_client_composite_operations.py
+++ b/src/oci/cims/user_client_composite_operations.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class UserClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.cims.UserClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new UserClientCompositeOperations object
+
+        :param UserClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client

--- a/src/oci/data_catalog/data_catalog_client.py
+++ b/src/oci/data_catalog/data_catalog_client.py
@@ -3497,7 +3497,7 @@ class DataCatalogClient(object):
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
         header_params = {
-            "accept": "application/json",
+            "accept": "application/json, text/csv",
             "content-type": "application/json",
             "opc-request-id": kwargs.get("opc_request_id", missing),
             "opc-retry-token": kwargs.get("opc_retry_token", missing)
@@ -3548,7 +3548,7 @@ class DataCatalogClient(object):
         :param list[str] fields: (optional)
             Specifies the fields to return in an entity attribute response.
 
-            Allowed values are: "key", "displayName", "description", "entityKey", "lifecycleState", "timeCreated", "timeUpdated", "createdById", "updatedById", "externalDataType", "externalKey", "isIncrementalData", "isNullable", "length", "position", "precision", "scale", "timeExternal", "uri", "properties"
+            Allowed values are: "key", "displayName", "description", "entityKey", "lifecycleState", "timeCreated", "timeUpdated", "createdById", "updatedById", "externalDataType", "externalKey", "isIncrementalData", "isNullable", "length", "position", "precision", "scale", "timeExternal", "uri", "properties", "path", "minCollectionCount", "maxCollectionCount", "datatypeEntityKey", "externalDatatypeEntityKey", "parentAttributeKey", "externalParentAttributeKey"
 
         :param str opc_request_id: (optional)
             The client request ID for tracing.
@@ -3592,7 +3592,7 @@ class DataCatalogClient(object):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
 
         if 'fields' in kwargs:
-            fields_allowed_values = ["key", "displayName", "description", "entityKey", "lifecycleState", "timeCreated", "timeUpdated", "createdById", "updatedById", "externalDataType", "externalKey", "isIncrementalData", "isNullable", "length", "position", "precision", "scale", "timeExternal", "uri", "properties"]
+            fields_allowed_values = ["key", "displayName", "description", "entityKey", "lifecycleState", "timeCreated", "timeUpdated", "createdById", "updatedById", "externalDataType", "externalKey", "isIncrementalData", "isNullable", "length", "position", "precision", "scale", "timeExternal", "uri", "properties", "path", "minCollectionCount", "maxCollectionCount", "datatypeEntityKey", "externalDatatypeEntityKey", "parentAttributeKey", "externalParentAttributeKey"]
             for fields_item in kwargs['fields']:
                 if fields_item not in fields_allowed_values:
                     raise ValueError(
@@ -4202,7 +4202,7 @@ class DataCatalogClient(object):
         :param list[str] fields: (optional)
             Specifies the fields to return in an entity response.
 
-            Allowed values are: "key", "displayName", "description", "dataAssetKey", "timeCreated", "timeUpdated", "createdById", "updatedById", "lifecycleState", "externalKey", "timeExternal", "timeStatusUpdated", "isLogical", "isPartition", "folderKey", "typeKey", "path", "harvestStatus", "lastJobKey", "uri", "properties"
+            Allowed values are: "key", "displayName", "description", "dataAssetKey", "timeCreated", "timeUpdated", "createdById", "updatedById", "lifecycleState", "externalKey", "timeExternal", "timeStatusUpdated", "isLogical", "isPartition", "folderKey", "folderName", "typeKey", "path", "harvestStatus", "lastJobKey", "uri", "properties"
 
         :param str opc_request_id: (optional)
             The client request ID for tracing.
@@ -4245,7 +4245,7 @@ class DataCatalogClient(object):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
 
         if 'fields' in kwargs:
-            fields_allowed_values = ["key", "displayName", "description", "dataAssetKey", "timeCreated", "timeUpdated", "createdById", "updatedById", "lifecycleState", "externalKey", "timeExternal", "timeStatusUpdated", "isLogical", "isPartition", "folderKey", "typeKey", "path", "harvestStatus", "lastJobKey", "uri", "properties"]
+            fields_allowed_values = ["key", "displayName", "description", "dataAssetKey", "timeCreated", "timeUpdated", "createdById", "updatedById", "lifecycleState", "externalKey", "timeExternal", "timeStatusUpdated", "isLogical", "isPartition", "folderKey", "folderName", "typeKey", "path", "harvestStatus", "lastJobKey", "uri", "properties"]
             for fields_item in kwargs['fields']:
                 if fields_item not in fields_allowed_values:
                     raise ValueError(
@@ -4708,7 +4708,7 @@ class DataCatalogClient(object):
         :param list[str] fields: (optional)
             Specifies the fields to return in a job response.
 
-            Allowed values are: "key", "displayName", "description", "catalogId", "lifecycleState", "timeCreated", "timeUpdated", "jobType", "scheduleCronExpression", "timeScheduleBegin", "timeScheduleEnd", "scheduleType", "connectionKey", "jobDefinitionKey", "internalVersion", "executionCount", "timeOfLatestExecution", "executions", "createdById", "updatedById", "uri"
+            Allowed values are: "key", "displayName", "description", "catalogId", "lifecycleState", "timeCreated", "timeUpdated", "jobType", "scheduleCronExpression", "timeScheduleBegin", "timeScheduleEnd", "scheduleType", "connectionKey", "jobDefinitionKey", "internalVersion", "executionCount", "timeOfLatestExecution", "executions", "createdById", "updatedById", "uri", "jobDefinitionName", "errorCode", "errorMessage"
 
         :param str opc_request_id: (optional)
             The client request ID for tracing.
@@ -4750,7 +4750,7 @@ class DataCatalogClient(object):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
 
         if 'fields' in kwargs:
-            fields_allowed_values = ["key", "displayName", "description", "catalogId", "lifecycleState", "timeCreated", "timeUpdated", "jobType", "scheduleCronExpression", "timeScheduleBegin", "timeScheduleEnd", "scheduleType", "connectionKey", "jobDefinitionKey", "internalVersion", "executionCount", "timeOfLatestExecution", "executions", "createdById", "updatedById", "uri"]
+            fields_allowed_values = ["key", "displayName", "description", "catalogId", "lifecycleState", "timeCreated", "timeUpdated", "jobType", "scheduleCronExpression", "timeScheduleBegin", "timeScheduleEnd", "scheduleType", "connectionKey", "jobDefinitionKey", "internalVersion", "executionCount", "timeOfLatestExecution", "executions", "createdById", "updatedById", "uri", "jobDefinitionName", "errorCode", "errorMessage"]
             for fields_item in kwargs['fields']:
                 if fields_item not in fields_allowed_values:
                     raise ValueError(
@@ -4805,7 +4805,7 @@ class DataCatalogClient(object):
         :param list[str] fields: (optional)
             Specifies the fields to return in a job definition response.
 
-            Allowed values are: "key", "displayName", "description", "catalogId", "jobType", "isIncremental", "dataAssetKey", "connectionKey", "internalVersion", "lifecycleState", "timeCreated", "timeUpdated", "createdById", "updatedById", "uri", "isSampleDataExtracted", "sampleDataSizeInMBs", "properties"
+            Allowed values are: "key", "displayName", "description", "catalogId", "jobType", "isIncremental", "dataAssetKey", "connectionKey", "internalVersion", "lifecycleState", "timeCreated", "timeUpdated", "createdById", "updatedById", "uri", "isSampleDataExtracted", "sampleDataSizeInMBs", "timeLatestExecutionStarted", "timeLatestExecutionEnded", "jobExecutionState", "scheduleType", "properties"
 
         :param str opc_request_id: (optional)
             The client request ID for tracing.
@@ -4847,7 +4847,7 @@ class DataCatalogClient(object):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
 
         if 'fields' in kwargs:
-            fields_allowed_values = ["key", "displayName", "description", "catalogId", "jobType", "isIncremental", "dataAssetKey", "connectionKey", "internalVersion", "lifecycleState", "timeCreated", "timeUpdated", "createdById", "updatedById", "uri", "isSampleDataExtracted", "sampleDataSizeInMBs", "properties"]
+            fields_allowed_values = ["key", "displayName", "description", "catalogId", "jobType", "isIncremental", "dataAssetKey", "connectionKey", "internalVersion", "lifecycleState", "timeCreated", "timeUpdated", "createdById", "updatedById", "uri", "isSampleDataExtracted", "sampleDataSizeInMBs", "timeLatestExecutionStarted", "timeLatestExecutionEnded", "jobExecutionState", "scheduleType", "properties"]
             for fields_item in kwargs['fields']:
                 if fields_item not in fields_allowed_values:
                     raise ValueError(
@@ -5977,6 +5977,11 @@ class DataCatalogClient(object):
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
+        :param str display_name_contains: (optional)
+            A filter to return only resources that match display name pattern given. The match is not case sensitive.
+            For Example : /folders?displayNameContains=Cu.*
+            The above would match all folders with display name that starts with \"Cu\".
+
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
 
@@ -6028,7 +6033,7 @@ class DataCatalogClient(object):
         :param list[str] fields: (optional)
             Specifies the fields to return in an entity attribute summary response.
 
-            Allowed values are: "key", "displayName", "description", "entityKey", "lifecycleState", "timeCreated", "externalDataType", "externalKey", "length", "isNullable", "uri"
+            Allowed values are: "key", "displayName", "description", "entityKey", "lifecycleState", "timeCreated", "externalDataType", "externalKey", "length", "isNullable", "uri", "path", "minCollectionCount", "maxCollectionCount", "datatypeEntityKey", "externalDatatypeEntityKey", "parentAttributeKey", "externalParentAttributeKey"
 
         :param str sort_by: (optional)
             The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
@@ -6067,6 +6072,7 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "display_name_contains",
             "lifecycle_state",
             "time_created",
             "time_updated",
@@ -6113,7 +6119,7 @@ class DataCatalogClient(object):
                 )
 
         if 'fields' in kwargs:
-            fields_allowed_values = ["key", "displayName", "description", "entityKey", "lifecycleState", "timeCreated", "externalDataType", "externalKey", "length", "isNullable", "uri"]
+            fields_allowed_values = ["key", "displayName", "description", "entityKey", "lifecycleState", "timeCreated", "externalDataType", "externalKey", "length", "isNullable", "uri", "path", "minCollectionCount", "maxCollectionCount", "datatypeEntityKey", "externalDatatypeEntityKey", "parentAttributeKey", "externalParentAttributeKey"]
             for fields_item in kwargs['fields']:
                 if fields_item not in fields_allowed_values:
                     raise ValueError(
@@ -6136,6 +6142,7 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "displayNameContains": kwargs.get("display_name_contains", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "timeCreated": kwargs.get("time_created", missing),
             "timeUpdated": kwargs.get("time_updated", missing),
@@ -6449,6 +6456,11 @@ class DataCatalogClient(object):
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
+        :param str display_name_contains: (optional)
+            A filter to return only resources that match display name pattern given. The match is not case sensitive.
+            For Example : /folders?displayNameContains=Cu.*
+            The above would match all folders with display name that starts with \"Cu\".
+
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
 
@@ -6523,6 +6535,7 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "display_name_contains",
             "lifecycle_state",
             "time_created",
             "time_updated",
@@ -6585,6 +6598,7 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "displayNameContains": kwargs.get("display_name_contains", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "timeCreated": kwargs.get("time_created", missing),
             "timeUpdated": kwargs.get("time_updated", missing),
@@ -6817,6 +6831,11 @@ class DataCatalogClient(object):
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
+        :param str display_name_contains: (optional)
+            A filter to return only resources that match display name pattern given. The match is not case sensitive.
+            For Example : /folders?displayNameContains=Cu.*
+            The above would match all folders with display name that starts with \"Cu\".
+
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
 
@@ -6886,6 +6905,7 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "display_name_contains",
             "lifecycle_state",
             "time_created",
             "time_updated",
@@ -6946,6 +6966,7 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "displayNameContains": kwargs.get("display_name_contains", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "timeCreated": kwargs.get("time_created", missing),
             "timeUpdated": kwargs.get("time_updated", missing),
@@ -7004,6 +7025,11 @@ class DataCatalogClient(object):
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
+        :param str display_name_contains: (optional)
+            A filter to return only resources that match display name pattern given. The match is not case sensitive.
+            For Example : /folders?displayNameContains=Cu.*
+            The above would match all folders with display name that starts with \"Cu\".
+
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
 
@@ -7059,7 +7085,7 @@ class DataCatalogClient(object):
         :param list[str] fields: (optional)
             Specifies the fields to return in an entity summary response.
 
-            Allowed values are: "key", "displayName", "description", "dataAssetKey", "timeCreated", "timeUpdated", "updatedById", "lifecycleState", "folderKey", "externalKey", "path", "uri"
+            Allowed values are: "key", "displayName", "description", "dataAssetKey", "timeCreated", "timeUpdated", "updatedById", "lifecycleState", "folderKey", "folderName", "externalKey", "path", "uri"
 
         :param str sort_by: (optional)
             The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
@@ -7098,6 +7124,7 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "display_name_contains",
             "lifecycle_state",
             "time_created",
             "time_updated",
@@ -7150,7 +7177,7 @@ class DataCatalogClient(object):
                 )
 
         if 'fields' in kwargs:
-            fields_allowed_values = ["key", "displayName", "description", "dataAssetKey", "timeCreated", "timeUpdated", "updatedById", "lifecycleState", "folderKey", "externalKey", "path", "uri"]
+            fields_allowed_values = ["key", "displayName", "description", "dataAssetKey", "timeCreated", "timeUpdated", "updatedById", "lifecycleState", "folderKey", "folderName", "externalKey", "path", "uri"]
             for fields_item in kwargs['fields']:
                 if fields_item not in fields_allowed_values:
                     raise ValueError(
@@ -7173,6 +7200,7 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "displayNameContains": kwargs.get("display_name_contains", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "timeCreated": kwargs.get("time_created", missing),
             "timeUpdated": kwargs.get("time_updated", missing),
@@ -7598,6 +7626,11 @@ class DataCatalogClient(object):
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
+        :param str display_name_contains: (optional)
+            A filter to return only resources that match display name pattern given. The match is not case sensitive.
+            For Example : /folders?displayNameContains=Cu.*
+            The above would match all folders with display name that starts with \"Cu\".
+
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
 
@@ -7678,6 +7711,7 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "display_name_contains",
             "lifecycle_state",
             "parent_folder_key",
             "path",
@@ -7749,6 +7783,7 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "displayNameContains": kwargs.get("display_name_contains", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "parentFolderKey": kwargs.get("parent_folder_key", missing),
             "path": kwargs.get("path", missing),
@@ -7806,6 +7841,11 @@ class DataCatalogClient(object):
 
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param str display_name_contains: (optional)
+            A filter to return only resources that match display name pattern given. The match is not case sensitive.
+            For Example : /folders?displayNameContains=Cu.*
+            The above would match all folders with display name that starts with \"Cu\".
 
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
@@ -7870,6 +7910,7 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "display_name_contains",
             "lifecycle_state",
             "time_created",
             "time_updated",
@@ -7928,6 +7969,7 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "displayNameContains": kwargs.get("display_name_contains", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "timeCreated": kwargs.get("time_created", missing),
             "timeUpdated": kwargs.get("time_updated", missing),
@@ -7981,6 +8023,16 @@ class DataCatalogClient(object):
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
+        :param str display_name_contains: (optional)
+            A filter to return only resources that match display name pattern given. The match is not case sensitive.
+            For Example : /folders?displayNameContains=Cu.*
+            The above would match all folders with display name that starts with \"Cu\".
+
+        :param str job_execution_state: (optional)
+            Job execution state.
+
+            Allowed values are: "CREATED", "IN_PROGRESS", "INACTIVE", "FAILED", "SUCCEEDED", "CANCELED"
+
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
 
@@ -7989,7 +8041,7 @@ class DataCatalogClient(object):
         :param str job_type: (optional)
             Job type.
 
-            Allowed values are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
+            Allowed values are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
 
         :param bool is_incremental: (optional)
             Whether job definition is an incremental harvest (true) or a full harvest (false).
@@ -8022,12 +8074,12 @@ class DataCatalogClient(object):
         :param list[str] fields: (optional)
             Specifies the fields to return in a job definition summary response.
 
-            Allowed values are: "key", "displayName", "description", "catalogId", "jobType", "lifecycleState", "timeCreated", "isSampleDataExtracted", "uri"
+            Allowed values are: "key", "displayName", "description", "catalogId", "jobType", "connectionKey", "lifecycleState", "timeCreated", "isSampleDataExtracted", "uri", "timeLatestExecutionStarted", "timeLatestExecutionEnded", "jobExecutionState", "scheduleType"
 
         :param str sort_by: (optional)
-            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+            The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. Default order for TIMELATESTEXECUTIONSTARTED is descending. If no value is specified TIMECREATED is default.
 
-            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+            Allowed values are: "TIMECREATED", "DISPLAYNAME", "TIMELATESTEXECUTIONSTARTED"
 
         :param str sort_order: (optional)
             The sort order to use, either 'asc' or 'desc'.
@@ -8061,6 +8113,8 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "display_name_contains",
+            "job_execution_state",
             "lifecycle_state",
             "job_type",
             "is_incremental",
@@ -8093,6 +8147,13 @@ class DataCatalogClient(object):
             if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
 
+        if 'job_execution_state' in kwargs:
+            job_execution_state_allowed_values = ["CREATED", "IN_PROGRESS", "INACTIVE", "FAILED", "SUCCEEDED", "CANCELED"]
+            if kwargs['job_execution_state'] not in job_execution_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `job_execution_state`, must be one of {0}".format(job_execution_state_allowed_values)
+                )
+
         if 'lifecycle_state' in kwargs:
             lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "INACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED", "MOVING"]
             if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
@@ -8101,14 +8162,14 @@ class DataCatalogClient(object):
                 )
 
         if 'job_type' in kwargs:
-            job_type_allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
+            job_type_allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
             if kwargs['job_type'] not in job_type_allowed_values:
                 raise ValueError(
                     "Invalid value for `job_type`, must be one of {0}".format(job_type_allowed_values)
                 )
 
         if 'fields' in kwargs:
-            fields_allowed_values = ["key", "displayName", "description", "catalogId", "jobType", "lifecycleState", "timeCreated", "isSampleDataExtracted", "uri"]
+            fields_allowed_values = ["key", "displayName", "description", "catalogId", "jobType", "connectionKey", "lifecycleState", "timeCreated", "isSampleDataExtracted", "uri", "timeLatestExecutionStarted", "timeLatestExecutionEnded", "jobExecutionState", "scheduleType"]
             for fields_item in kwargs['fields']:
                 if fields_item not in fields_allowed_values:
                     raise ValueError(
@@ -8116,7 +8177,7 @@ class DataCatalogClient(object):
                     )
 
         if 'sort_by' in kwargs:
-            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME", "TIMELATESTEXECUTIONSTARTED"]
             if kwargs['sort_by'] not in sort_by_allowed_values:
                 raise ValueError(
                     "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
@@ -8131,6 +8192,8 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "displayNameContains": kwargs.get("display_name_contains", missing),
+            "jobExecutionState": kwargs.get("job_execution_state", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "jobType": kwargs.get("job_type", missing),
             "isIncremental": kwargs.get("is_incremental", missing),
@@ -8213,7 +8276,7 @@ class DataCatalogClient(object):
         :param str job_type: (optional)
             Job type.
 
-            Allowed values are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
+            Allowed values are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
 
         :param str sub_type: (optional)
             Sub-type of this job execution.
@@ -8339,7 +8402,7 @@ class DataCatalogClient(object):
                 )
 
         if 'job_type' in kwargs:
-            job_type_allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
+            job_type_allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
             if kwargs['job_type'] not in job_type_allowed_values:
                 raise ValueError(
                     "Invalid value for `job_type`, must be one of {0}".format(job_type_allowed_values)
@@ -8620,6 +8683,11 @@ class DataCatalogClient(object):
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
+        :param str display_name_contains: (optional)
+            A filter to return only resources that match display name pattern given. The match is not case sensitive.
+            For Example : /folders?displayNameContains=Cu.*
+            The above would match all folders with display name that starts with \"Cu\".
+
         :param str category: (optional)
             Category of this metric.
 
@@ -8699,6 +8767,7 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "display_name_contains",
             "category",
             "sub_category",
             "unit",
@@ -8757,6 +8826,7 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "displayNameContains": kwargs.get("display_name_contains", missing),
             "category": kwargs.get("category", missing),
             "subCategory": kwargs.get("sub_category", missing),
             "unit": kwargs.get("unit", missing),
@@ -8815,6 +8885,11 @@ class DataCatalogClient(object):
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
+        :param str display_name_contains: (optional)
+            A filter to return only resources that match display name pattern given. The match is not case sensitive.
+            For Example : /folders?displayNameContains=Cu.*
+            The above would match all folders with display name that starts with \"Cu\".
+
         :param str lifecycle_state: (optional)
             Job lifecycle state.
 
@@ -8839,7 +8914,7 @@ class DataCatalogClient(object):
         :param str job_type: (optional)
             Job type.
 
-            Allowed values are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
+            Allowed values are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
 
         :param str job_definition_key: (optional)
             Unique job definition key.
@@ -8870,7 +8945,7 @@ class DataCatalogClient(object):
         :param list[str] fields: (optional)
             Specifies the fields to return in a job summary response.
 
-            Allowed values are: "key", "displayName", "description", "catalogId", "jobDefinitionKey", "lifecycleState", "timeCreated", "timeUpdated", "createdById", "updatedById", "jobType", "scheduleCronExpression", "timeScheduleBegin", "scheduleType", "executionCount", "timeOfLatestExecution", "executions", "uri"
+            Allowed values are: "key", "displayName", "description", "catalogId", "jobDefinitionKey", "lifecycleState", "timeCreated", "timeUpdated", "createdById", "updatedById", "jobType", "scheduleCronExpression", "timeScheduleBegin", "scheduleType", "executionCount", "timeOfLatestExecution", "executions", "uri", "jobDefinitionName", "errorCode", "errorMessage"
 
         :param int execution_count: (optional)
             The total number of executions for this job schedule.
@@ -8918,6 +8993,7 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "display_name_contains",
             "lifecycle_state",
             "time_created",
             "time_updated",
@@ -8962,7 +9038,7 @@ class DataCatalogClient(object):
                 )
 
         if 'job_type' in kwargs:
-            job_type_allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
+            job_type_allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
             if kwargs['job_type'] not in job_type_allowed_values:
                 raise ValueError(
                     "Invalid value for `job_type`, must be one of {0}".format(job_type_allowed_values)
@@ -8976,7 +9052,7 @@ class DataCatalogClient(object):
                 )
 
         if 'fields' in kwargs:
-            fields_allowed_values = ["key", "displayName", "description", "catalogId", "jobDefinitionKey", "lifecycleState", "timeCreated", "timeUpdated", "createdById", "updatedById", "jobType", "scheduleCronExpression", "timeScheduleBegin", "scheduleType", "executionCount", "timeOfLatestExecution", "executions", "uri"]
+            fields_allowed_values = ["key", "displayName", "description", "catalogId", "jobDefinitionKey", "lifecycleState", "timeCreated", "timeUpdated", "createdById", "updatedById", "jobType", "scheduleCronExpression", "timeScheduleBegin", "scheduleType", "executionCount", "timeOfLatestExecution", "executions", "uri", "jobDefinitionName", "errorCode", "errorMessage"]
             for fields_item in kwargs['fields']:
                 if fields_item not in fields_allowed_values:
                     raise ValueError(
@@ -8999,6 +9075,7 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "displayNameContains": kwargs.get("display_name_contains", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "timeCreated": kwargs.get("time_created", missing),
             "timeUpdated": kwargs.get("time_updated", missing),
@@ -9061,6 +9138,11 @@ class DataCatalogClient(object):
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
+        :param str display_name_contains: (optional)
+            A filter to return only resources that match display name pattern given. The match is not case sensitive.
+            For Example : /folders?displayNameContains=Cu.*
+            The above would match all folders with display name that starts with \"Cu\".
+
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
 
@@ -9108,6 +9190,7 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "display_name_contains",
             "lifecycle_state",
             "fields",
             "sort_by",
@@ -9162,6 +9245,7 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "displayNameContains": kwargs.get("display_name_contains", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "fields": self.base_client.generate_collection_format_param(kwargs.get("fields", missing), 'multi'),
             "sortBy": kwargs.get("sort_by", missing),
@@ -9217,6 +9301,11 @@ class DataCatalogClient(object):
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
+        :param str display_name_contains: (optional)
+            A filter to return only resources that match display name pattern given. The match is not case sensitive.
+            For Example : /folders?displayNameContains=Cu.*
+            The above would match all folders with display name that starts with \"Cu\".
+
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
 
@@ -9264,6 +9353,7 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "display_name_contains",
             "lifecycle_state",
             "fields",
             "sort_by",
@@ -9320,6 +9410,7 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "displayNameContains": kwargs.get("display_name_contains", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "fields": self.base_client.generate_collection_format_param(kwargs.get("fields", missing), 'multi'),
             "sortBy": kwargs.get("sort_by", missing),
@@ -9371,6 +9462,11 @@ class DataCatalogClient(object):
 
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param str display_name_contains: (optional)
+            A filter to return only resources that match display name pattern given. The match is not case sensitive.
+            For Example : /folders?displayNameContains=Cu.*
+            The above would match all folders with display name that starts with \"Cu\".
 
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
@@ -9433,6 +9529,7 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "display_name_contains",
             "lifecycle_state",
             "parent_term_key",
             "is_allowed_to_have_child_terms",
@@ -9499,6 +9596,7 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "displayNameContains": kwargs.get("display_name_contains", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "parentTermKey": kwargs.get("parent_term_key", missing),
             "isAllowedToHaveChildTerms": kwargs.get("is_allowed_to_have_child_terms", missing),

--- a/src/oci/data_catalog/models/attribute.py
+++ b/src/oci/data_catalog/models/attribute.py
@@ -105,6 +105,30 @@ class Attribute(object):
             The value to assign to the is_nullable property of this Attribute.
         :type is_nullable: bool
 
+        :param min_collection_count:
+            The value to assign to the min_collection_count property of this Attribute.
+        :type min_collection_count: int
+
+        :param max_collection_count:
+            The value to assign to the max_collection_count property of this Attribute.
+        :type max_collection_count: int
+
+        :param datatype_entity_key:
+            The value to assign to the datatype_entity_key property of this Attribute.
+        :type datatype_entity_key: str
+
+        :param external_datatype_entity_key:
+            The value to assign to the external_datatype_entity_key property of this Attribute.
+        :type external_datatype_entity_key: str
+
+        :param parent_attribute_key:
+            The value to assign to the parent_attribute_key property of this Attribute.
+        :type parent_attribute_key: str
+
+        :param external_parent_attribute_key:
+            The value to assign to the external_parent_attribute_key property of this Attribute.
+        :type external_parent_attribute_key: str
+
         :param length:
             The value to assign to the length property of this Attribute.
         :type length: int
@@ -129,6 +153,10 @@ class Attribute(object):
             The value to assign to the uri property of this Attribute.
         :type uri: str
 
+        :param path:
+            The value to assign to the path property of this Attribute.
+        :type path: str
+
         :param properties:
             The value to assign to the properties property of this Attribute.
         :type properties: dict(str, dict(str, str))
@@ -148,12 +176,19 @@ class Attribute(object):
             'external_key': 'str',
             'is_incremental_data': 'bool',
             'is_nullable': 'bool',
+            'min_collection_count': 'int',
+            'max_collection_count': 'int',
+            'datatype_entity_key': 'str',
+            'external_datatype_entity_key': 'str',
+            'parent_attribute_key': 'str',
+            'external_parent_attribute_key': 'str',
             'length': 'int',
             'position': 'int',
             'precision': 'int',
             'scale': 'int',
             'time_external': 'datetime',
             'uri': 'str',
+            'path': 'str',
             'properties': 'dict(str, dict(str, str))'
         }
 
@@ -171,12 +206,19 @@ class Attribute(object):
             'external_key': 'externalKey',
             'is_incremental_data': 'isIncrementalData',
             'is_nullable': 'isNullable',
+            'min_collection_count': 'minCollectionCount',
+            'max_collection_count': 'maxCollectionCount',
+            'datatype_entity_key': 'datatypeEntityKey',
+            'external_datatype_entity_key': 'externalDatatypeEntityKey',
+            'parent_attribute_key': 'parentAttributeKey',
+            'external_parent_attribute_key': 'externalParentAttributeKey',
             'length': 'length',
             'position': 'position',
             'precision': 'precision',
             'scale': 'scale',
             'time_external': 'timeExternal',
             'uri': 'uri',
+            'path': 'path',
             'properties': 'properties'
         }
 
@@ -193,12 +235,19 @@ class Attribute(object):
         self._external_key = None
         self._is_incremental_data = None
         self._is_nullable = None
+        self._min_collection_count = None
+        self._max_collection_count = None
+        self._datatype_entity_key = None
+        self._external_datatype_entity_key = None
+        self._parent_attribute_key = None
+        self._external_parent_attribute_key = None
         self._length = None
         self._position = None
         self._precision = None
         self._scale = None
         self._time_external = None
         self._uri = None
+        self._path = None
         self._properties = None
 
     @property
@@ -538,6 +587,154 @@ class Attribute(object):
         self._is_nullable = is_nullable
 
     @property
+    def min_collection_count(self):
+        """
+        Gets the min_collection_count of this Attribute.
+        The minimum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+
+
+        :return: The min_collection_count of this Attribute.
+        :rtype: int
+        """
+        return self._min_collection_count
+
+    @min_collection_count.setter
+    def min_collection_count(self, min_collection_count):
+        """
+        Sets the min_collection_count of this Attribute.
+        The minimum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+
+
+        :param min_collection_count: The min_collection_count of this Attribute.
+        :type: int
+        """
+        self._min_collection_count = min_collection_count
+
+    @property
+    def max_collection_count(self):
+        """
+        Gets the max_collection_count of this Attribute.
+        The maximum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+        For type specifications in systems that specify only \"capacity\" without upper or lower bound , this property can also be used to just mean \"capacity\".
+        Some examples are Varray size in Oracle , Occurs Clause in Cobol , capacity in XmlSchemaObjectCollection , maxOccurs in  Xml , maxItems in Json
+
+
+        :return: The max_collection_count of this Attribute.
+        :rtype: int
+        """
+        return self._max_collection_count
+
+    @max_collection_count.setter
+    def max_collection_count(self, max_collection_count):
+        """
+        Sets the max_collection_count of this Attribute.
+        The maximum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+        For type specifications in systems that specify only \"capacity\" without upper or lower bound , this property can also be used to just mean \"capacity\".
+        Some examples are Varray size in Oracle , Occurs Clause in Cobol , capacity in XmlSchemaObjectCollection , maxOccurs in  Xml , maxItems in Json
+
+
+        :param max_collection_count: The max_collection_count of this Attribute.
+        :type: int
+        """
+        self._max_collection_count = max_collection_count
+
+    @property
+    def datatype_entity_key(self):
+        """
+        Gets the datatype_entity_key of this Attribute.
+        Entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+
+
+        :return: The datatype_entity_key of this Attribute.
+        :rtype: str
+        """
+        return self._datatype_entity_key
+
+    @datatype_entity_key.setter
+    def datatype_entity_key(self, datatype_entity_key):
+        """
+        Sets the datatype_entity_key of this Attribute.
+        Entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+
+
+        :param datatype_entity_key: The datatype_entity_key of this Attribute.
+        :type: str
+        """
+        self._datatype_entity_key = datatype_entity_key
+
+    @property
+    def external_datatype_entity_key(self):
+        """
+        Gets the external_datatype_entity_key of this Attribute.
+        External entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+
+
+        :return: The external_datatype_entity_key of this Attribute.
+        :rtype: str
+        """
+        return self._external_datatype_entity_key
+
+    @external_datatype_entity_key.setter
+    def external_datatype_entity_key(self, external_datatype_entity_key):
+        """
+        Sets the external_datatype_entity_key of this Attribute.
+        External entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+
+
+        :param external_datatype_entity_key: The external_datatype_entity_key of this Attribute.
+        :type: str
+        """
+        self._external_datatype_entity_key = external_datatype_entity_key
+
+    @property
+    def parent_attribute_key(self):
+        """
+        Gets the parent_attribute_key of this Attribute.
+        Attribute key that represents the parent attribute of this attribute , applicable if the parent attribute is of complex datatype.
+
+
+        :return: The parent_attribute_key of this Attribute.
+        :rtype: str
+        """
+        return self._parent_attribute_key
+
+    @parent_attribute_key.setter
+    def parent_attribute_key(self, parent_attribute_key):
+        """
+        Sets the parent_attribute_key of this Attribute.
+        Attribute key that represents the parent attribute of this attribute , applicable if the parent attribute is of complex datatype.
+
+
+        :param parent_attribute_key: The parent_attribute_key of this Attribute.
+        :type: str
+        """
+        self._parent_attribute_key = parent_attribute_key
+
+    @property
+    def external_parent_attribute_key(self):
+        """
+        Gets the external_parent_attribute_key of this Attribute.
+        External attribute key that represents the parent attribute  of this attribute , applicable if the parent attribute is of complex type.
+
+
+        :return: The external_parent_attribute_key of this Attribute.
+        :rtype: str
+        """
+        return self._external_parent_attribute_key
+
+    @external_parent_attribute_key.setter
+    def external_parent_attribute_key(self, external_parent_attribute_key):
+        """
+        Sets the external_parent_attribute_key of this Attribute.
+        External attribute key that represents the parent attribute  of this attribute , applicable if the parent attribute is of complex type.
+
+
+        :param external_parent_attribute_key: The external_parent_attribute_key of this Attribute.
+        :type: str
+        """
+        self._external_parent_attribute_key = external_parent_attribute_key
+
+    @property
     def length(self):
         """
         Gets the length of this Attribute.
@@ -680,6 +877,30 @@ class Attribute(object):
         :type: str
         """
         self._uri = uri
+
+    @property
+    def path(self):
+        """
+        Gets the path of this Attribute.
+        Full path of the attribute.
+
+
+        :return: The path of this Attribute.
+        :rtype: str
+        """
+        return self._path
+
+    @path.setter
+    def path(self, path):
+        """
+        Sets the path of this Attribute.
+        Full path of the attribute.
+
+
+        :param path: The path of this Attribute.
+        :type: str
+        """
+        self._path = path
 
     @property
     def properties(self):

--- a/src/oci/data_catalog/models/attribute_collection.py
+++ b/src/oci/data_catalog/models/attribute_collection.py
@@ -18,20 +18,51 @@ class AttributeCollection(object):
         Initializes a new AttributeCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this AttributeCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this AttributeCollection.
         :type items: list[AttributeSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[AttributeSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this AttributeCollection.
+        Total number of items returned.
+
+
+        :return: The count of this AttributeCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this AttributeCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this AttributeCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/attribute_summary.py
+++ b/src/oci/data_catalog/models/attribute_summary.py
@@ -96,6 +96,34 @@ class AttributeSummary(object):
             The value to assign to the external_data_type property of this AttributeSummary.
         :type external_data_type: str
 
+        :param min_collection_count:
+            The value to assign to the min_collection_count property of this AttributeSummary.
+        :type min_collection_count: int
+
+        :param max_collection_count:
+            The value to assign to the max_collection_count property of this AttributeSummary.
+        :type max_collection_count: int
+
+        :param datatype_entity_key:
+            The value to assign to the datatype_entity_key property of this AttributeSummary.
+        :type datatype_entity_key: str
+
+        :param external_datatype_entity_key:
+            The value to assign to the external_datatype_entity_key property of this AttributeSummary.
+        :type external_datatype_entity_key: str
+
+        :param parent_attribute_key:
+            The value to assign to the parent_attribute_key property of this AttributeSummary.
+        :type parent_attribute_key: str
+
+        :param external_parent_attribute_key:
+            The value to assign to the external_parent_attribute_key property of this AttributeSummary.
+        :type external_parent_attribute_key: str
+
+        :param path:
+            The value to assign to the path property of this AttributeSummary.
+        :type path: str
+
         """
         self.swagger_types = {
             'key': 'str',
@@ -108,7 +136,14 @@ class AttributeSummary(object):
             'uri': 'str',
             'lifecycle_state': 'str',
             'time_created': 'datetime',
-            'external_data_type': 'str'
+            'external_data_type': 'str',
+            'min_collection_count': 'int',
+            'max_collection_count': 'int',
+            'datatype_entity_key': 'str',
+            'external_datatype_entity_key': 'str',
+            'parent_attribute_key': 'str',
+            'external_parent_attribute_key': 'str',
+            'path': 'str'
         }
 
         self.attribute_map = {
@@ -122,7 +157,14 @@ class AttributeSummary(object):
             'uri': 'uri',
             'lifecycle_state': 'lifecycleState',
             'time_created': 'timeCreated',
-            'external_data_type': 'externalDataType'
+            'external_data_type': 'externalDataType',
+            'min_collection_count': 'minCollectionCount',
+            'max_collection_count': 'maxCollectionCount',
+            'datatype_entity_key': 'datatypeEntityKey',
+            'external_datatype_entity_key': 'externalDatatypeEntityKey',
+            'parent_attribute_key': 'parentAttributeKey',
+            'external_parent_attribute_key': 'externalParentAttributeKey',
+            'path': 'path'
         }
 
         self._key = None
@@ -136,6 +178,13 @@ class AttributeSummary(object):
         self._lifecycle_state = None
         self._time_created = None
         self._external_data_type = None
+        self._min_collection_count = None
+        self._max_collection_count = None
+        self._datatype_entity_key = None
+        self._external_datatype_entity_key = None
+        self._parent_attribute_key = None
+        self._external_parent_attribute_key = None
+        self._path = None
 
     @property
     def key(self):
@@ -414,6 +463,178 @@ class AttributeSummary(object):
         :type: str
         """
         self._external_data_type = external_data_type
+
+    @property
+    def min_collection_count(self):
+        """
+        Gets the min_collection_count of this AttributeSummary.
+        The minimum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+
+
+        :return: The min_collection_count of this AttributeSummary.
+        :rtype: int
+        """
+        return self._min_collection_count
+
+    @min_collection_count.setter
+    def min_collection_count(self, min_collection_count):
+        """
+        Sets the min_collection_count of this AttributeSummary.
+        The minimum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+
+
+        :param min_collection_count: The min_collection_count of this AttributeSummary.
+        :type: int
+        """
+        self._min_collection_count = min_collection_count
+
+    @property
+    def max_collection_count(self):
+        """
+        Gets the max_collection_count of this AttributeSummary.
+        The maximum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+        For type specifications in systems that specify only \"capacity\" without upper or lower bound , this property can also be used to just mean \"capacity\".
+        Some examples are Varray size in Oracle , Occurs Clause in Cobol , capacity in XmlSchemaObjectCollection , maxOccurs in  Xml , maxItems in Json
+
+
+        :return: The max_collection_count of this AttributeSummary.
+        :rtype: int
+        """
+        return self._max_collection_count
+
+    @max_collection_count.setter
+    def max_collection_count(self, max_collection_count):
+        """
+        Sets the max_collection_count of this AttributeSummary.
+        The maximum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+        For type specifications in systems that specify only \"capacity\" without upper or lower bound , this property can also be used to just mean \"capacity\".
+        Some examples are Varray size in Oracle , Occurs Clause in Cobol , capacity in XmlSchemaObjectCollection , maxOccurs in  Xml , maxItems in Json
+
+
+        :param max_collection_count: The max_collection_count of this AttributeSummary.
+        :type: int
+        """
+        self._max_collection_count = max_collection_count
+
+    @property
+    def datatype_entity_key(self):
+        """
+        Gets the datatype_entity_key of this AttributeSummary.
+        Entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+
+
+        :return: The datatype_entity_key of this AttributeSummary.
+        :rtype: str
+        """
+        return self._datatype_entity_key
+
+    @datatype_entity_key.setter
+    def datatype_entity_key(self, datatype_entity_key):
+        """
+        Sets the datatype_entity_key of this AttributeSummary.
+        Entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+
+
+        :param datatype_entity_key: The datatype_entity_key of this AttributeSummary.
+        :type: str
+        """
+        self._datatype_entity_key = datatype_entity_key
+
+    @property
+    def external_datatype_entity_key(self):
+        """
+        Gets the external_datatype_entity_key of this AttributeSummary.
+        External entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+
+
+        :return: The external_datatype_entity_key of this AttributeSummary.
+        :rtype: str
+        """
+        return self._external_datatype_entity_key
+
+    @external_datatype_entity_key.setter
+    def external_datatype_entity_key(self, external_datatype_entity_key):
+        """
+        Sets the external_datatype_entity_key of this AttributeSummary.
+        External entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+
+
+        :param external_datatype_entity_key: The external_datatype_entity_key of this AttributeSummary.
+        :type: str
+        """
+        self._external_datatype_entity_key = external_datatype_entity_key
+
+    @property
+    def parent_attribute_key(self):
+        """
+        Gets the parent_attribute_key of this AttributeSummary.
+        Attribute key that represents the parent attribute of this attribute , applicable if the parent attribute is of complex datatype.
+
+
+        :return: The parent_attribute_key of this AttributeSummary.
+        :rtype: str
+        """
+        return self._parent_attribute_key
+
+    @parent_attribute_key.setter
+    def parent_attribute_key(self, parent_attribute_key):
+        """
+        Sets the parent_attribute_key of this AttributeSummary.
+        Attribute key that represents the parent attribute of this attribute , applicable if the parent attribute is of complex datatype.
+
+
+        :param parent_attribute_key: The parent_attribute_key of this AttributeSummary.
+        :type: str
+        """
+        self._parent_attribute_key = parent_attribute_key
+
+    @property
+    def external_parent_attribute_key(self):
+        """
+        Gets the external_parent_attribute_key of this AttributeSummary.
+        External attribute key that represents the parent attribute  of this attribute , applicable if the parent attribute is of complex type.
+
+
+        :return: The external_parent_attribute_key of this AttributeSummary.
+        :rtype: str
+        """
+        return self._external_parent_attribute_key
+
+    @external_parent_attribute_key.setter
+    def external_parent_attribute_key(self, external_parent_attribute_key):
+        """
+        Sets the external_parent_attribute_key of this AttributeSummary.
+        External attribute key that represents the parent attribute  of this attribute , applicable if the parent attribute is of complex type.
+
+
+        :param external_parent_attribute_key: The external_parent_attribute_key of this AttributeSummary.
+        :type: str
+        """
+        self._external_parent_attribute_key = external_parent_attribute_key
+
+    @property
+    def path(self):
+        """
+        Gets the path of this AttributeSummary.
+        Full path of the attribute.
+
+
+        :return: The path of this AttributeSummary.
+        :rtype: str
+        """
+        return self._path
+
+    @path.setter
+    def path(self, path):
+        """
+        Sets the path of this AttributeSummary.
+        Full path of the attribute.
+
+
+        :param path: The path of this AttributeSummary.
+        :type: str
+        """
+        self._path = path
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_catalog/models/attribute_tag_collection.py
+++ b/src/oci/data_catalog/models/attribute_tag_collection.py
@@ -18,20 +18,51 @@ class AttributeTagCollection(object):
         Initializes a new AttributeTagCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this AttributeTagCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this AttributeTagCollection.
         :type items: list[AttributeTagSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[AttributeTagSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this AttributeTagCollection.
+        Total number of items returned.
+
+
+        :return: The count of this AttributeTagCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this AttributeTagCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this AttributeTagCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/connection_collection.py
+++ b/src/oci/data_catalog/models/connection_collection.py
@@ -18,20 +18,51 @@ class ConnectionCollection(object):
         Initializes a new ConnectionCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this ConnectionCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this ConnectionCollection.
         :type items: list[ConnectionSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[ConnectionSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this ConnectionCollection.
+        Total number of items returned.
+
+
+        :return: The count of this ConnectionCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this ConnectionCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this ConnectionCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/create_attribute_details.py
+++ b/src/oci/data_catalog/models/create_attribute_details.py
@@ -58,6 +58,22 @@ class CreateAttributeDetails(object):
             The value to assign to the time_external property of this CreateAttributeDetails.
         :type time_external: datetime
 
+        :param min_collection_count:
+            The value to assign to the min_collection_count property of this CreateAttributeDetails.
+        :type min_collection_count: int
+
+        :param max_collection_count:
+            The value to assign to the max_collection_count property of this CreateAttributeDetails.
+        :type max_collection_count: int
+
+        :param external_datatype_entity_key:
+            The value to assign to the external_datatype_entity_key property of this CreateAttributeDetails.
+        :type external_datatype_entity_key: str
+
+        :param external_parent_attribute_key:
+            The value to assign to the external_parent_attribute_key property of this CreateAttributeDetails.
+        :type external_parent_attribute_key: str
+
         :param properties:
             The value to assign to the properties property of this CreateAttributeDetails.
         :type properties: dict(str, dict(str, str))
@@ -74,6 +90,10 @@ class CreateAttributeDetails(object):
             'precision': 'int',
             'scale': 'int',
             'time_external': 'datetime',
+            'min_collection_count': 'int',
+            'max_collection_count': 'int',
+            'external_datatype_entity_key': 'str',
+            'external_parent_attribute_key': 'str',
             'properties': 'dict(str, dict(str, str))'
         }
 
@@ -88,6 +108,10 @@ class CreateAttributeDetails(object):
             'precision': 'precision',
             'scale': 'scale',
             'time_external': 'timeExternal',
+            'min_collection_count': 'minCollectionCount',
+            'max_collection_count': 'maxCollectionCount',
+            'external_datatype_entity_key': 'externalDatatypeEntityKey',
+            'external_parent_attribute_key': 'externalParentAttributeKey',
             'properties': 'properties'
         }
 
@@ -101,6 +125,10 @@ class CreateAttributeDetails(object):
         self._precision = None
         self._scale = None
         self._time_external = None
+        self._min_collection_count = None
+        self._max_collection_count = None
+        self._external_datatype_entity_key = None
+        self._external_parent_attribute_key = None
         self._properties = None
 
     @property
@@ -344,6 +372,106 @@ class CreateAttributeDetails(object):
         :type: datetime
         """
         self._time_external = time_external
+
+    @property
+    def min_collection_count(self):
+        """
+        Gets the min_collection_count of this CreateAttributeDetails.
+        The minimum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+
+
+        :return: The min_collection_count of this CreateAttributeDetails.
+        :rtype: int
+        """
+        return self._min_collection_count
+
+    @min_collection_count.setter
+    def min_collection_count(self, min_collection_count):
+        """
+        Sets the min_collection_count of this CreateAttributeDetails.
+        The minimum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+
+
+        :param min_collection_count: The min_collection_count of this CreateAttributeDetails.
+        :type: int
+        """
+        self._min_collection_count = min_collection_count
+
+    @property
+    def max_collection_count(self):
+        """
+        Gets the max_collection_count of this CreateAttributeDetails.
+        The maximum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+        For type specifications in systems that specify only \"capacity\" without upper or lower bound , this property can also be used to just mean \"capacity\".
+        Some examples are Varray size in Oracle , Occurs Clause in Cobol , capacity in XmlSchemaObjectCollection , maxOccurs in  Xml , maxItems in Json
+
+
+        :return: The max_collection_count of this CreateAttributeDetails.
+        :rtype: int
+        """
+        return self._max_collection_count
+
+    @max_collection_count.setter
+    def max_collection_count(self, max_collection_count):
+        """
+        Sets the max_collection_count of this CreateAttributeDetails.
+        The maximum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+        For type specifications in systems that specify only \"capacity\" without upper or lower bound , this property can also be used to just mean \"capacity\".
+        Some examples are Varray size in Oracle , Occurs Clause in Cobol , capacity in XmlSchemaObjectCollection , maxOccurs in  Xml , maxItems in Json
+
+
+        :param max_collection_count: The max_collection_count of this CreateAttributeDetails.
+        :type: int
+        """
+        self._max_collection_count = max_collection_count
+
+    @property
+    def external_datatype_entity_key(self):
+        """
+        Gets the external_datatype_entity_key of this CreateAttributeDetails.
+        External entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+
+
+        :return: The external_datatype_entity_key of this CreateAttributeDetails.
+        :rtype: str
+        """
+        return self._external_datatype_entity_key
+
+    @external_datatype_entity_key.setter
+    def external_datatype_entity_key(self, external_datatype_entity_key):
+        """
+        Sets the external_datatype_entity_key of this CreateAttributeDetails.
+        External entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+
+
+        :param external_datatype_entity_key: The external_datatype_entity_key of this CreateAttributeDetails.
+        :type: str
+        """
+        self._external_datatype_entity_key = external_datatype_entity_key
+
+    @property
+    def external_parent_attribute_key(self):
+        """
+        Gets the external_parent_attribute_key of this CreateAttributeDetails.
+        External attribute key that represents the parent attribute  of this attribute , applicable if the parent attribute is of complex type.
+
+
+        :return: The external_parent_attribute_key of this CreateAttributeDetails.
+        :rtype: str
+        """
+        return self._external_parent_attribute_key
+
+    @external_parent_attribute_key.setter
+    def external_parent_attribute_key(self, external_parent_attribute_key):
+        """
+        Sets the external_parent_attribute_key of this CreateAttributeDetails.
+        External attribute key that represents the parent attribute  of this attribute , applicable if the parent attribute is of complex type.
+
+
+        :param external_parent_attribute_key: The external_parent_attribute_key of this CreateAttributeDetails.
+        :type: str
+        """
+        self._external_parent_attribute_key = external_parent_attribute_key
 
     @property
     def properties(self):

--- a/src/oci/data_catalog/models/create_job_definition_details.py
+++ b/src/oci/data_catalog/models/create_job_definition_details.py
@@ -40,6 +40,14 @@ class CreateJobDefinitionDetails(object):
     JOB_TYPE_EXPORT = "EXPORT"
 
     #: A constant which can be used with the job_type property of a CreateJobDefinitionDetails.
+    #: This constant has a value of "IMPORT_GLOSSARY"
+    JOB_TYPE_IMPORT_GLOSSARY = "IMPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a CreateJobDefinitionDetails.
+    #: This constant has a value of "EXPORT_GLOSSARY"
+    JOB_TYPE_EXPORT_GLOSSARY = "EXPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a CreateJobDefinitionDetails.
     #: This constant has a value of "INTERNAL"
     JOB_TYPE_INTERNAL = "INTERNAL"
 
@@ -82,7 +90,7 @@ class CreateJobDefinitionDetails(object):
 
         :param job_type:
             The value to assign to the job_type property of this CreateJobDefinitionDetails.
-            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
+            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
         :type job_type: str
 
         :param is_incremental:
@@ -200,7 +208,7 @@ class CreateJobDefinitionDetails(object):
         **[Required]** Gets the job_type of this CreateJobDefinitionDetails.
         Type of the job definition.
 
-        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
+        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
 
 
         :return: The job_type of this CreateJobDefinitionDetails.
@@ -218,7 +226,7 @@ class CreateJobDefinitionDetails(object):
         :param job_type: The job_type of this CreateJobDefinitionDetails.
         :type: str
         """
-        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
+        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
         if not value_allowed_none_or_none_sentinel(job_type, allowed_values):
             raise ValueError(
                 "Invalid value for `job_type`, must be None or one of {0}"

--- a/src/oci/data_catalog/models/create_job_execution_details.py
+++ b/src/oci/data_catalog/models/create_job_execution_details.py
@@ -38,6 +38,14 @@ class CreateJobExecutionDetails(object):
     JOB_TYPE_EXPORT = "EXPORT"
 
     #: A constant which can be used with the job_type property of a CreateJobExecutionDetails.
+    #: This constant has a value of "IMPORT_GLOSSARY"
+    JOB_TYPE_IMPORT_GLOSSARY = "IMPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a CreateJobExecutionDetails.
+    #: This constant has a value of "EXPORT_GLOSSARY"
+    JOB_TYPE_EXPORT_GLOSSARY = "EXPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a CreateJobExecutionDetails.
     #: This constant has a value of "INTERNAL"
     JOB_TYPE_INTERNAL = "INTERNAL"
 
@@ -100,7 +108,7 @@ class CreateJobExecutionDetails(object):
 
         :param job_type:
             The value to assign to the job_type property of this CreateJobExecutionDetails.
-            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
+            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
         :type job_type: str
 
         :param parent_key:
@@ -232,7 +240,7 @@ class CreateJobExecutionDetails(object):
         Gets the job_type of this CreateJobExecutionDetails.
         Type of the job execution.
 
-        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
+        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"
 
 
         :return: The job_type of this CreateJobExecutionDetails.
@@ -250,7 +258,7 @@ class CreateJobExecutionDetails(object):
         :param job_type: The job_type of this CreateJobExecutionDetails.
         :type: str
         """
-        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
+        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
         if not value_allowed_none_or_none_sentinel(job_type, allowed_values):
             raise ValueError(
                 "Invalid value for `job_type`, must be None or one of {0}"

--- a/src/oci/data_catalog/models/data_asset_collection.py
+++ b/src/oci/data_catalog/models/data_asset_collection.py
@@ -18,20 +18,51 @@ class DataAssetCollection(object):
         Initializes a new DataAssetCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this DataAssetCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this DataAssetCollection.
         :type items: list[DataAssetSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[DataAssetSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this DataAssetCollection.
+        Total number of items returned.
+
+
+        :return: The count of this DataAssetCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this DataAssetCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this DataAssetCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/data_asset_tag_collection.py
+++ b/src/oci/data_catalog/models/data_asset_tag_collection.py
@@ -18,20 +18,51 @@ class DataAssetTagCollection(object):
         Initializes a new DataAssetTagCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this DataAssetTagCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this DataAssetTagCollection.
         :type items: list[DataAssetTagSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[DataAssetTagSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this DataAssetTagCollection.
+        Total number of items returned.
+
+
+        :return: The count of this DataAssetTagCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this DataAssetTagCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this DataAssetTagCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/entity.py
+++ b/src/oci/data_catalog/models/entity.py
@@ -130,6 +130,10 @@ class Entity(object):
             The value to assign to the folder_key property of this Entity.
         :type folder_key: str
 
+        :param folder_name:
+            The value to assign to the folder_name property of this Entity.
+        :type folder_name: str
+
         :param path:
             The value to assign to the path property of this Entity.
         :type path: str
@@ -173,6 +177,7 @@ class Entity(object):
             'is_partition': 'bool',
             'data_asset_key': 'str',
             'folder_key': 'str',
+            'folder_name': 'str',
             'path': 'str',
             'harvest_status': 'str',
             'last_job_key': 'str',
@@ -197,6 +202,7 @@ class Entity(object):
             'is_partition': 'isPartition',
             'data_asset_key': 'dataAssetKey',
             'folder_key': 'folderKey',
+            'folder_name': 'folderName',
             'path': 'path',
             'harvest_status': 'harvestStatus',
             'last_job_key': 'lastJobKey',
@@ -220,6 +226,7 @@ class Entity(object):
         self._is_partition = None
         self._data_asset_key = None
         self._folder_key = None
+        self._folder_name = None
         self._path = None
         self._harvest_status = None
         self._last_job_key = None
@@ -610,6 +617,30 @@ class Entity(object):
         :type: str
         """
         self._folder_key = folder_key
+
+    @property
+    def folder_name(self):
+        """
+        Gets the folder_name of this Entity.
+        Name of the associated folder. This name is harvested from the source data asset when the parent folder for the entiy is harvested.
+
+
+        :return: The folder_name of this Entity.
+        :rtype: str
+        """
+        return self._folder_name
+
+    @folder_name.setter
+    def folder_name(self, folder_name):
+        """
+        Sets the folder_name of this Entity.
+        Name of the associated folder. This name is harvested from the source data asset when the parent folder for the entiy is harvested.
+
+
+        :param folder_name: The folder_name of this Entity.
+        :type: str
+        """
+        self._folder_name = folder_name
 
     @property
     def path(self):

--- a/src/oci/data_catalog/models/entity_collection.py
+++ b/src/oci/data_catalog/models/entity_collection.py
@@ -18,20 +18,51 @@ class EntityCollection(object):
         Initializes a new EntityCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this EntityCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this EntityCollection.
         :type items: list[EntitySummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[EntitySummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this EntityCollection.
+        Total number of items returned.
+
+
+        :return: The count of this EntityCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this EntityCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this EntityCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/entity_summary.py
+++ b/src/oci/data_catalog/models/entity_summary.py
@@ -72,6 +72,10 @@ class EntitySummary(object):
             The value to assign to the folder_key property of this EntitySummary.
         :type folder_key: str
 
+        :param folder_name:
+            The value to assign to the folder_name property of this EntitySummary.
+        :type folder_name: str
+
         :param external_key:
             The value to assign to the external_key property of this EntitySummary.
         :type external_key: str
@@ -109,6 +113,7 @@ class EntitySummary(object):
             'description': 'str',
             'data_asset_key': 'str',
             'folder_key': 'str',
+            'folder_name': 'str',
             'external_key': 'str',
             'path': 'str',
             'time_created': 'datetime',
@@ -124,6 +129,7 @@ class EntitySummary(object):
             'description': 'description',
             'data_asset_key': 'dataAssetKey',
             'folder_key': 'folderKey',
+            'folder_name': 'folderName',
             'external_key': 'externalKey',
             'path': 'path',
             'time_created': 'timeCreated',
@@ -138,6 +144,7 @@ class EntitySummary(object):
         self._description = None
         self._data_asset_key = None
         self._folder_key = None
+        self._folder_name = None
         self._external_key = None
         self._path = None
         self._time_created = None
@@ -267,6 +274,30 @@ class EntitySummary(object):
         :type: str
         """
         self._folder_key = folder_key
+
+    @property
+    def folder_name(self):
+        """
+        Gets the folder_name of this EntitySummary.
+        Name of the associated folder. This name is harvested from the source data asset when the parent folder for the entiy is harvested.
+
+
+        :return: The folder_name of this EntitySummary.
+        :rtype: str
+        """
+        return self._folder_name
+
+    @folder_name.setter
+    def folder_name(self, folder_name):
+        """
+        Sets the folder_name of this EntitySummary.
+        Name of the associated folder. This name is harvested from the source data asset when the parent folder for the entiy is harvested.
+
+
+        :param folder_name: The folder_name of this EntitySummary.
+        :type: str
+        """
+        self._folder_name = folder_name
 
     @property
     def external_key(self):

--- a/src/oci/data_catalog/models/entity_tag_collection.py
+++ b/src/oci/data_catalog/models/entity_tag_collection.py
@@ -18,20 +18,51 @@ class EntityTagCollection(object):
         Initializes a new EntityTagCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this EntityTagCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this EntityTagCollection.
         :type items: list[EntityTagSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[EntityTagSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this EntityTagCollection.
+        Total number of items returned.
+
+
+        :return: The count of this EntityTagCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this EntityTagCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this EntityTagCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/folder_collection.py
+++ b/src/oci/data_catalog/models/folder_collection.py
@@ -18,20 +18,51 @@ class FolderCollection(object):
         Initializes a new FolderCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this FolderCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this FolderCollection.
         :type items: list[FolderSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[FolderSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this FolderCollection.
+        Total number of items returned.
+
+
+        :return: The count of this FolderCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this FolderCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this FolderCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/folder_tag_collection.py
+++ b/src/oci/data_catalog/models/folder_tag_collection.py
@@ -18,20 +18,51 @@ class FolderTagCollection(object):
         Initializes a new FolderTagCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this FolderTagCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this FolderTagCollection.
         :type items: list[FolderTagSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[FolderTagSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this FolderTagCollection.
+        Total number of items returned.
+
+
+        :return: The count of this FolderTagCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this FolderTagCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this FolderTagCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/glossary_collection.py
+++ b/src/oci/data_catalog/models/glossary_collection.py
@@ -18,20 +18,51 @@ class GlossaryCollection(object):
         Initializes a new GlossaryCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this GlossaryCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this GlossaryCollection.
         :type items: list[GlossarySummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[GlossarySummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this GlossaryCollection.
+        Total number of items returned.
+
+
+        :return: The count of this GlossaryCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this GlossaryCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this GlossaryCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/job.py
+++ b/src/oci/data_catalog/models/job.py
@@ -50,6 +50,14 @@ class Job(object):
     JOB_TYPE_EXPORT = "EXPORT"
 
     #: A constant which can be used with the job_type property of a Job.
+    #: This constant has a value of "IMPORT_GLOSSARY"
+    JOB_TYPE_IMPORT_GLOSSARY = "IMPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a Job.
+    #: This constant has a value of "EXPORT_GLOSSARY"
+    JOB_TYPE_EXPORT_GLOSSARY = "EXPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a Job.
     #: This constant has a value of "INTERNAL"
     JOB_TYPE_INTERNAL = "INTERNAL"
 
@@ -122,7 +130,7 @@ class Job(object):
 
         :param job_type:
             The value to assign to the job_type property of this Job.
-            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type job_type: str
 
@@ -172,6 +180,18 @@ class Job(object):
             The value to assign to the updated_by_id property of this Job.
         :type updated_by_id: str
 
+        :param job_definition_name:
+            The value to assign to the job_definition_name property of this Job.
+        :type job_definition_name: str
+
+        :param error_code:
+            The value to assign to the error_code property of this Job.
+        :type error_code: str
+
+        :param error_message:
+            The value to assign to the error_message property of this Job.
+        :type error_message: str
+
         :param uri:
             The value to assign to the uri property of this Job.
         :type uri: str
@@ -197,6 +217,9 @@ class Job(object):
             'time_of_latest_execution': 'datetime',
             'created_by_id': 'str',
             'updated_by_id': 'str',
+            'job_definition_name': 'str',
+            'error_code': 'str',
+            'error_message': 'str',
             'uri': 'str'
         }
 
@@ -220,6 +243,9 @@ class Job(object):
             'time_of_latest_execution': 'timeOfLatestExecution',
             'created_by_id': 'createdById',
             'updated_by_id': 'updatedById',
+            'job_definition_name': 'jobDefinitionName',
+            'error_code': 'errorCode',
+            'error_message': 'errorMessage',
             'uri': 'uri'
         }
 
@@ -242,6 +268,9 @@ class Job(object):
         self._time_of_latest_execution = None
         self._created_by_id = None
         self._updated_by_id = None
+        self._job_definition_name = None
+        self._error_code = None
+        self._error_message = None
         self._uri = None
 
     @property
@@ -436,7 +465,7 @@ class Job(object):
         Gets the job_type of this Job.
         Type of the job.
 
-        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -455,7 +484,7 @@ class Job(object):
         :param job_type: The job_type of this Job.
         :type: str
         """
-        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
+        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
         if not value_allowed_none_or_none_sentinel(job_type, allowed_values):
             job_type = 'UNKNOWN_ENUM_VALUE'
         self._job_type = job_type
@@ -749,6 +778,78 @@ class Job(object):
         :type: str
         """
         self._updated_by_id = updated_by_id
+
+    @property
+    def job_definition_name(self):
+        """
+        Gets the job_definition_name of this Job.
+        The display name of the job definition resource that defined the scope of this job.
+
+
+        :return: The job_definition_name of this Job.
+        :rtype: str
+        """
+        return self._job_definition_name
+
+    @job_definition_name.setter
+    def job_definition_name(self, job_definition_name):
+        """
+        Sets the job_definition_name of this Job.
+        The display name of the job definition resource that defined the scope of this job.
+
+
+        :param job_definition_name: The job_definition_name of this Job.
+        :type: str
+        """
+        self._job_definition_name = job_definition_name
+
+    @property
+    def error_code(self):
+        """
+        Gets the error_code of this Job.
+        Error code returned from the latest job execution for this job. Useful when the latest Job execution is in FAILED state.
+
+
+        :return: The error_code of this Job.
+        :rtype: str
+        """
+        return self._error_code
+
+    @error_code.setter
+    def error_code(self, error_code):
+        """
+        Sets the error_code of this Job.
+        Error code returned from the latest job execution for this job. Useful when the latest Job execution is in FAILED state.
+
+
+        :param error_code: The error_code of this Job.
+        :type: str
+        """
+        self._error_code = error_code
+
+    @property
+    def error_message(self):
+        """
+        Gets the error_message of this Job.
+        Error message returned from the latest job execution for this job. Useful when the latest Job Execution is in a FAILED state.
+
+
+        :return: The error_message of this Job.
+        :rtype: str
+        """
+        return self._error_message
+
+    @error_message.setter
+    def error_message(self, error_message):
+        """
+        Sets the error_message of this Job.
+        Error message returned from the latest job execution for this job. Useful when the latest Job Execution is in a FAILED state.
+
+
+        :param error_message: The error_message of this Job.
+        :type: str
+        """
+        self._error_message = error_message
 
     @property
     def uri(self):

--- a/src/oci/data_catalog/models/job_collection.py
+++ b/src/oci/data_catalog/models/job_collection.py
@@ -18,20 +18,51 @@ class JobCollection(object):
         Initializes a new JobCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this JobCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this JobCollection.
         :type items: list[JobSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[JobSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this JobCollection.
+        Total number of items returned.
+
+
+        :return: The count of this JobCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this JobCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this JobCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/job_definition.py
+++ b/src/oci/data_catalog/models/job_definition.py
@@ -40,6 +40,14 @@ class JobDefinition(object):
     JOB_TYPE_EXPORT = "EXPORT"
 
     #: A constant which can be used with the job_type property of a JobDefinition.
+    #: This constant has a value of "IMPORT_GLOSSARY"
+    JOB_TYPE_IMPORT_GLOSSARY = "IMPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a JobDefinition.
+    #: This constant has a value of "EXPORT_GLOSSARY"
+    JOB_TYPE_EXPORT_GLOSSARY = "EXPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a JobDefinition.
     #: This constant has a value of "INTERNAL"
     JOB_TYPE_INTERNAL = "INTERNAL"
 
@@ -99,6 +107,38 @@ class JobDefinition(object):
     #: This constant has a value of "MOVING"
     LIFECYCLE_STATE_MOVING = "MOVING"
 
+    #: A constant which can be used with the job_execution_state property of a JobDefinition.
+    #: This constant has a value of "CREATED"
+    JOB_EXECUTION_STATE_CREATED = "CREATED"
+
+    #: A constant which can be used with the job_execution_state property of a JobDefinition.
+    #: This constant has a value of "IN_PROGRESS"
+    JOB_EXECUTION_STATE_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the job_execution_state property of a JobDefinition.
+    #: This constant has a value of "INACTIVE"
+    JOB_EXECUTION_STATE_INACTIVE = "INACTIVE"
+
+    #: A constant which can be used with the job_execution_state property of a JobDefinition.
+    #: This constant has a value of "FAILED"
+    JOB_EXECUTION_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the job_execution_state property of a JobDefinition.
+    #: This constant has a value of "SUCCEEDED"
+    JOB_EXECUTION_STATE_SUCCEEDED = "SUCCEEDED"
+
+    #: A constant which can be used with the job_execution_state property of a JobDefinition.
+    #: This constant has a value of "CANCELED"
+    JOB_EXECUTION_STATE_CANCELED = "CANCELED"
+
+    #: A constant which can be used with the schedule_type property of a JobDefinition.
+    #: This constant has a value of "SCHEDULED"
+    SCHEDULE_TYPE_SCHEDULED = "SCHEDULED"
+
+    #: A constant which can be used with the schedule_type property of a JobDefinition.
+    #: This constant has a value of "IMMEDIATE"
+    SCHEDULE_TYPE_IMMEDIATE = "IMMEDIATE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new JobDefinition object with values from keyword arguments.
@@ -118,7 +158,7 @@ class JobDefinition(object):
 
         :param job_type:
             The value to assign to the job_type property of this JobDefinition.
-            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type job_type: str
 
@@ -176,6 +216,26 @@ class JobDefinition(object):
             The value to assign to the sample_data_size_in_mbs property of this JobDefinition.
         :type sample_data_size_in_mbs: int
 
+        :param time_latest_execution_started:
+            The value to assign to the time_latest_execution_started property of this JobDefinition.
+        :type time_latest_execution_started: datetime
+
+        :param time_latest_execution_ended:
+            The value to assign to the time_latest_execution_ended property of this JobDefinition.
+        :type time_latest_execution_ended: datetime
+
+        :param job_execution_state:
+            The value to assign to the job_execution_state property of this JobDefinition.
+            Allowed values for this property are: "CREATED", "IN_PROGRESS", "INACTIVE", "FAILED", "SUCCEEDED", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type job_execution_state: str
+
+        :param schedule_type:
+            The value to assign to the schedule_type property of this JobDefinition.
+            Allowed values for this property are: "SCHEDULED", "IMMEDIATE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type schedule_type: str
+
         :param properties:
             The value to assign to the properties property of this JobDefinition.
         :type properties: dict(str, dict(str, str))
@@ -199,6 +259,10 @@ class JobDefinition(object):
             'uri': 'str',
             'is_sample_data_extracted': 'bool',
             'sample_data_size_in_mbs': 'int',
+            'time_latest_execution_started': 'datetime',
+            'time_latest_execution_ended': 'datetime',
+            'job_execution_state': 'str',
+            'schedule_type': 'str',
             'properties': 'dict(str, dict(str, str))'
         }
 
@@ -220,6 +284,10 @@ class JobDefinition(object):
             'uri': 'uri',
             'is_sample_data_extracted': 'isSampleDataExtracted',
             'sample_data_size_in_mbs': 'sampleDataSizeInMBs',
+            'time_latest_execution_started': 'timeLatestExecutionStarted',
+            'time_latest_execution_ended': 'timeLatestExecutionEnded',
+            'job_execution_state': 'jobExecutionState',
+            'schedule_type': 'scheduleType',
             'properties': 'properties'
         }
 
@@ -240,6 +308,10 @@ class JobDefinition(object):
         self._uri = None
         self._is_sample_data_extracted = None
         self._sample_data_size_in_mbs = None
+        self._time_latest_execution_started = None
+        self._time_latest_execution_ended = None
+        self._job_execution_state = None
+        self._schedule_type = None
         self._properties = None
 
     @property
@@ -322,7 +394,7 @@ class JobDefinition(object):
         Gets the job_type of this JobDefinition.
         Type of the job definition.
 
-        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -341,7 +413,7 @@ class JobDefinition(object):
         :param job_type: The job_type of this JobDefinition.
         :type: str
         """
-        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
+        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
         if not value_allowed_none_or_none_sentinel(job_type, allowed_values):
             job_type = 'UNKNOWN_ENUM_VALUE'
         self._job_type = job_type
@@ -675,6 +747,124 @@ class JobDefinition(object):
         :type: int
         """
         self._sample_data_size_in_mbs = sample_data_size_in_mbs
+
+    @property
+    def time_latest_execution_started(self):
+        """
+        Gets the time_latest_execution_started of this JobDefinition.
+        Time that the latest job execution started. An `RFC3339`__ formatted datetime string.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_latest_execution_started of this JobDefinition.
+        :rtype: datetime
+        """
+        return self._time_latest_execution_started
+
+    @time_latest_execution_started.setter
+    def time_latest_execution_started(self, time_latest_execution_started):
+        """
+        Sets the time_latest_execution_started of this JobDefinition.
+        Time that the latest job execution started. An `RFC3339`__ formatted datetime string.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_latest_execution_started: The time_latest_execution_started of this JobDefinition.
+        :type: datetime
+        """
+        self._time_latest_execution_started = time_latest_execution_started
+
+    @property
+    def time_latest_execution_ended(self):
+        """
+        Gets the time_latest_execution_ended of this JobDefinition.
+        Time that the latest job execution ended or null if it hasn't yet completed.
+        An `RFC3339`__ formatted datetime string.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_latest_execution_ended of this JobDefinition.
+        :rtype: datetime
+        """
+        return self._time_latest_execution_ended
+
+    @time_latest_execution_ended.setter
+    def time_latest_execution_ended(self, time_latest_execution_ended):
+        """
+        Sets the time_latest_execution_ended of this JobDefinition.
+        Time that the latest job execution ended or null if it hasn't yet completed.
+        An `RFC3339`__ formatted datetime string.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_latest_execution_ended: The time_latest_execution_ended of this JobDefinition.
+        :type: datetime
+        """
+        self._time_latest_execution_ended = time_latest_execution_ended
+
+    @property
+    def job_execution_state(self):
+        """
+        Gets the job_execution_state of this JobDefinition.
+        Status of the latest job execution, such as running, paused, or completed.
+
+        Allowed values for this property are: "CREATED", "IN_PROGRESS", "INACTIVE", "FAILED", "SUCCEEDED", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The job_execution_state of this JobDefinition.
+        :rtype: str
+        """
+        return self._job_execution_state
+
+    @job_execution_state.setter
+    def job_execution_state(self, job_execution_state):
+        """
+        Sets the job_execution_state of this JobDefinition.
+        Status of the latest job execution, such as running, paused, or completed.
+
+
+        :param job_execution_state: The job_execution_state of this JobDefinition.
+        :type: str
+        """
+        allowed_values = ["CREATED", "IN_PROGRESS", "INACTIVE", "FAILED", "SUCCEEDED", "CANCELED"]
+        if not value_allowed_none_or_none_sentinel(job_execution_state, allowed_values):
+            job_execution_state = 'UNKNOWN_ENUM_VALUE'
+        self._job_execution_state = job_execution_state
+
+    @property
+    def schedule_type(self):
+        """
+        Gets the schedule_type of this JobDefinition.
+        Type of job schedule for the latest job executed.
+
+        Allowed values for this property are: "SCHEDULED", "IMMEDIATE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The schedule_type of this JobDefinition.
+        :rtype: str
+        """
+        return self._schedule_type
+
+    @schedule_type.setter
+    def schedule_type(self, schedule_type):
+        """
+        Sets the schedule_type of this JobDefinition.
+        Type of job schedule for the latest job executed.
+
+
+        :param schedule_type: The schedule_type of this JobDefinition.
+        :type: str
+        """
+        allowed_values = ["SCHEDULED", "IMMEDIATE"]
+        if not value_allowed_none_or_none_sentinel(schedule_type, allowed_values):
+            schedule_type = 'UNKNOWN_ENUM_VALUE'
+        self._schedule_type = schedule_type
 
     @property
     def properties(self):

--- a/src/oci/data_catalog/models/job_definition_collection.py
+++ b/src/oci/data_catalog/models/job_definition_collection.py
@@ -18,20 +18,51 @@ class JobDefinitionCollection(object):
         Initializes a new JobDefinitionCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this JobDefinitionCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this JobDefinitionCollection.
         :type items: list[JobDefinitionSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[JobDefinitionSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this JobDefinitionCollection.
+        Total number of items returned.
+
+
+        :return: The count of this JobDefinitionCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this JobDefinitionCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this JobDefinitionCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/job_definition_summary.py
+++ b/src/oci/data_catalog/models/job_definition_summary.py
@@ -40,6 +40,14 @@ class JobDefinitionSummary(object):
     JOB_TYPE_EXPORT = "EXPORT"
 
     #: A constant which can be used with the job_type property of a JobDefinitionSummary.
+    #: This constant has a value of "IMPORT_GLOSSARY"
+    JOB_TYPE_IMPORT_GLOSSARY = "IMPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a JobDefinitionSummary.
+    #: This constant has a value of "EXPORT_GLOSSARY"
+    JOB_TYPE_EXPORT_GLOSSARY = "EXPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a JobDefinitionSummary.
     #: This constant has a value of "INTERNAL"
     JOB_TYPE_INTERNAL = "INTERNAL"
 
@@ -99,6 +107,38 @@ class JobDefinitionSummary(object):
     #: This constant has a value of "MOVING"
     LIFECYCLE_STATE_MOVING = "MOVING"
 
+    #: A constant which can be used with the job_execution_state property of a JobDefinitionSummary.
+    #: This constant has a value of "CREATED"
+    JOB_EXECUTION_STATE_CREATED = "CREATED"
+
+    #: A constant which can be used with the job_execution_state property of a JobDefinitionSummary.
+    #: This constant has a value of "IN_PROGRESS"
+    JOB_EXECUTION_STATE_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the job_execution_state property of a JobDefinitionSummary.
+    #: This constant has a value of "INACTIVE"
+    JOB_EXECUTION_STATE_INACTIVE = "INACTIVE"
+
+    #: A constant which can be used with the job_execution_state property of a JobDefinitionSummary.
+    #: This constant has a value of "FAILED"
+    JOB_EXECUTION_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the job_execution_state property of a JobDefinitionSummary.
+    #: This constant has a value of "SUCCEEDED"
+    JOB_EXECUTION_STATE_SUCCEEDED = "SUCCEEDED"
+
+    #: A constant which can be used with the job_execution_state property of a JobDefinitionSummary.
+    #: This constant has a value of "CANCELED"
+    JOB_EXECUTION_STATE_CANCELED = "CANCELED"
+
+    #: A constant which can be used with the schedule_type property of a JobDefinitionSummary.
+    #: This constant has a value of "SCHEDULED"
+    SCHEDULE_TYPE_SCHEDULED = "SCHEDULED"
+
+    #: A constant which can be used with the schedule_type property of a JobDefinitionSummary.
+    #: This constant has a value of "IMMEDIATE"
+    SCHEDULE_TYPE_IMMEDIATE = "IMMEDIATE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new JobDefinitionSummary object with values from keyword arguments.
@@ -126,7 +166,7 @@ class JobDefinitionSummary(object):
 
         :param job_type:
             The value to assign to the job_type property of this JobDefinitionSummary.
-            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type job_type: str
 
@@ -144,6 +184,30 @@ class JobDefinitionSummary(object):
             The value to assign to the time_created property of this JobDefinitionSummary.
         :type time_created: datetime
 
+        :param connection_key:
+            The value to assign to the connection_key property of this JobDefinitionSummary.
+        :type connection_key: str
+
+        :param time_latest_execution_started:
+            The value to assign to the time_latest_execution_started property of this JobDefinitionSummary.
+        :type time_latest_execution_started: datetime
+
+        :param time_latest_execution_ended:
+            The value to assign to the time_latest_execution_ended property of this JobDefinitionSummary.
+        :type time_latest_execution_ended: datetime
+
+        :param job_execution_state:
+            The value to assign to the job_execution_state property of this JobDefinitionSummary.
+            Allowed values for this property are: "CREATED", "IN_PROGRESS", "INACTIVE", "FAILED", "SUCCEEDED", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type job_execution_state: str
+
+        :param schedule_type:
+            The value to assign to the schedule_type property of this JobDefinitionSummary.
+            Allowed values for this property are: "SCHEDULED", "IMMEDIATE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type schedule_type: str
+
         """
         self.swagger_types = {
             'key': 'str',
@@ -154,7 +218,12 @@ class JobDefinitionSummary(object):
             'job_type': 'str',
             'lifecycle_state': 'str',
             'is_sample_data_extracted': 'bool',
-            'time_created': 'datetime'
+            'time_created': 'datetime',
+            'connection_key': 'str',
+            'time_latest_execution_started': 'datetime',
+            'time_latest_execution_ended': 'datetime',
+            'job_execution_state': 'str',
+            'schedule_type': 'str'
         }
 
         self.attribute_map = {
@@ -166,7 +235,12 @@ class JobDefinitionSummary(object):
             'job_type': 'jobType',
             'lifecycle_state': 'lifecycleState',
             'is_sample_data_extracted': 'isSampleDataExtracted',
-            'time_created': 'timeCreated'
+            'time_created': 'timeCreated',
+            'connection_key': 'connectionKey',
+            'time_latest_execution_started': 'timeLatestExecutionStarted',
+            'time_latest_execution_ended': 'timeLatestExecutionEnded',
+            'job_execution_state': 'jobExecutionState',
+            'schedule_type': 'scheduleType'
         }
 
         self._key = None
@@ -178,6 +252,11 @@ class JobDefinitionSummary(object):
         self._lifecycle_state = None
         self._is_sample_data_extracted = None
         self._time_created = None
+        self._connection_key = None
+        self._time_latest_execution_started = None
+        self._time_latest_execution_ended = None
+        self._job_execution_state = None
+        self._schedule_type = None
 
     @property
     def key(self):
@@ -307,7 +386,7 @@ class JobDefinitionSummary(object):
         Gets the job_type of this JobDefinitionSummary.
         Type of the job definition.
 
-        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -326,7 +405,7 @@ class JobDefinitionSummary(object):
         :param job_type: The job_type of this JobDefinitionSummary.
         :type: str
         """
-        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
+        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
         if not value_allowed_none_or_none_sentinel(job_type, allowed_values):
             job_type = 'UNKNOWN_ENUM_VALUE'
         self._job_type = job_type
@@ -414,6 +493,148 @@ class JobDefinitionSummary(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def connection_key(self):
+        """
+        Gets the connection_key of this JobDefinitionSummary.
+        The key of the connection resource used in harvest, sampling, profiling jobs.
+
+
+        :return: The connection_key of this JobDefinitionSummary.
+        :rtype: str
+        """
+        return self._connection_key
+
+    @connection_key.setter
+    def connection_key(self, connection_key):
+        """
+        Sets the connection_key of this JobDefinitionSummary.
+        The key of the connection resource used in harvest, sampling, profiling jobs.
+
+
+        :param connection_key: The connection_key of this JobDefinitionSummary.
+        :type: str
+        """
+        self._connection_key = connection_key
+
+    @property
+    def time_latest_execution_started(self):
+        """
+        Gets the time_latest_execution_started of this JobDefinitionSummary.
+        Time that the latest job execution started. An `RFC3339`__ formatted datetime string.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_latest_execution_started of this JobDefinitionSummary.
+        :rtype: datetime
+        """
+        return self._time_latest_execution_started
+
+    @time_latest_execution_started.setter
+    def time_latest_execution_started(self, time_latest_execution_started):
+        """
+        Sets the time_latest_execution_started of this JobDefinitionSummary.
+        Time that the latest job execution started. An `RFC3339`__ formatted datetime string.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_latest_execution_started: The time_latest_execution_started of this JobDefinitionSummary.
+        :type: datetime
+        """
+        self._time_latest_execution_started = time_latest_execution_started
+
+    @property
+    def time_latest_execution_ended(self):
+        """
+        Gets the time_latest_execution_ended of this JobDefinitionSummary.
+        Time that the latest job execution ended or null if it hasn't yet completed.
+        An `RFC3339`__ formatted datetime string.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_latest_execution_ended of this JobDefinitionSummary.
+        :rtype: datetime
+        """
+        return self._time_latest_execution_ended
+
+    @time_latest_execution_ended.setter
+    def time_latest_execution_ended(self, time_latest_execution_ended):
+        """
+        Sets the time_latest_execution_ended of this JobDefinitionSummary.
+        Time that the latest job execution ended or null if it hasn't yet completed.
+        An `RFC3339`__ formatted datetime string.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_latest_execution_ended: The time_latest_execution_ended of this JobDefinitionSummary.
+        :type: datetime
+        """
+        self._time_latest_execution_ended = time_latest_execution_ended
+
+    @property
+    def job_execution_state(self):
+        """
+        Gets the job_execution_state of this JobDefinitionSummary.
+        Status of the latest job execution, such as running, paused, or completed.
+
+        Allowed values for this property are: "CREATED", "IN_PROGRESS", "INACTIVE", "FAILED", "SUCCEEDED", "CANCELED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The job_execution_state of this JobDefinitionSummary.
+        :rtype: str
+        """
+        return self._job_execution_state
+
+    @job_execution_state.setter
+    def job_execution_state(self, job_execution_state):
+        """
+        Sets the job_execution_state of this JobDefinitionSummary.
+        Status of the latest job execution, such as running, paused, or completed.
+
+
+        :param job_execution_state: The job_execution_state of this JobDefinitionSummary.
+        :type: str
+        """
+        allowed_values = ["CREATED", "IN_PROGRESS", "INACTIVE", "FAILED", "SUCCEEDED", "CANCELED"]
+        if not value_allowed_none_or_none_sentinel(job_execution_state, allowed_values):
+            job_execution_state = 'UNKNOWN_ENUM_VALUE'
+        self._job_execution_state = job_execution_state
+
+    @property
+    def schedule_type(self):
+        """
+        Gets the schedule_type of this JobDefinitionSummary.
+        Type of job schedule for the latest job executed.
+
+        Allowed values for this property are: "SCHEDULED", "IMMEDIATE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The schedule_type of this JobDefinitionSummary.
+        :rtype: str
+        """
+        return self._schedule_type
+
+    @schedule_type.setter
+    def schedule_type(self, schedule_type):
+        """
+        Sets the schedule_type of this JobDefinitionSummary.
+        Type of job schedule for the latest job executed.
+
+
+        :param schedule_type: The schedule_type of this JobDefinitionSummary.
+        :type: str
+        """
+        allowed_values = ["SCHEDULED", "IMMEDIATE"]
+        if not value_allowed_none_or_none_sentinel(schedule_type, allowed_values):
+            schedule_type = 'UNKNOWN_ENUM_VALUE'
+        self._schedule_type = schedule_type
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_catalog/models/job_execution.py
+++ b/src/oci/data_catalog/models/job_execution.py
@@ -38,6 +38,14 @@ class JobExecution(object):
     JOB_TYPE_EXPORT = "EXPORT"
 
     #: A constant which can be used with the job_type property of a JobExecution.
+    #: This constant has a value of "IMPORT_GLOSSARY"
+    JOB_TYPE_IMPORT_GLOSSARY = "IMPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a JobExecution.
+    #: This constant has a value of "EXPORT_GLOSSARY"
+    JOB_TYPE_EXPORT_GLOSSARY = "EXPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a JobExecution.
     #: This constant has a value of "INTERNAL"
     JOB_TYPE_INTERNAL = "INTERNAL"
 
@@ -104,7 +112,7 @@ class JobExecution(object):
 
         :param job_type:
             The value to assign to the job_type property of this JobExecution.
-            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type job_type: str
 
@@ -300,7 +308,7 @@ class JobExecution(object):
         Gets the job_type of this JobExecution.
         Type of the job execution.
 
-        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -319,7 +327,7 @@ class JobExecution(object):
         :param job_type: The job_type of this JobExecution.
         :type: str
         """
-        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
+        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
         if not value_allowed_none_or_none_sentinel(job_type, allowed_values):
             job_type = 'UNKNOWN_ENUM_VALUE'
         self._job_type = job_type

--- a/src/oci/data_catalog/models/job_execution_collection.py
+++ b/src/oci/data_catalog/models/job_execution_collection.py
@@ -18,20 +18,51 @@ class JobExecutionCollection(object):
         Initializes a new JobExecutionCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this JobExecutionCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this JobExecutionCollection.
         :type items: list[JobExecutionSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[JobExecutionSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this JobExecutionCollection.
+        Total number of items returned.
+
+
+        :return: The count of this JobExecutionCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this JobExecutionCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this JobExecutionCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/job_execution_summary.py
+++ b/src/oci/data_catalog/models/job_execution_summary.py
@@ -38,6 +38,14 @@ class JobExecutionSummary(object):
     JOB_TYPE_EXPORT = "EXPORT"
 
     #: A constant which can be used with the job_type property of a JobExecutionSummary.
+    #: This constant has a value of "IMPORT_GLOSSARY"
+    JOB_TYPE_IMPORT_GLOSSARY = "IMPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a JobExecutionSummary.
+    #: This constant has a value of "EXPORT_GLOSSARY"
+    JOB_TYPE_EXPORT_GLOSSARY = "EXPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a JobExecutionSummary.
     #: This constant has a value of "INTERNAL"
     JOB_TYPE_INTERNAL = "INTERNAL"
 
@@ -104,7 +112,7 @@ class JobExecutionSummary(object):
 
         :param job_type:
             The value to assign to the job_type property of this JobExecutionSummary.
-            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type job_type: str
 
@@ -230,7 +238,7 @@ class JobExecutionSummary(object):
         Gets the job_type of this JobExecutionSummary.
         Type of the job execution.
 
-        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -249,7 +257,7 @@ class JobExecutionSummary(object):
         :param job_type: The job_type of this JobExecutionSummary.
         :type: str
         """
-        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
+        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
         if not value_allowed_none_or_none_sentinel(job_type, allowed_values):
             job_type = 'UNKNOWN_ENUM_VALUE'
         self._job_type = job_type

--- a/src/oci/data_catalog/models/job_log_collection.py
+++ b/src/oci/data_catalog/models/job_log_collection.py
@@ -18,20 +18,51 @@ class JobLogCollection(object):
         Initializes a new JobLogCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this JobLogCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this JobLogCollection.
         :type items: list[JobLogSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[JobLogSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this JobLogCollection.
+        Total number of items returned.
+
+
+        :return: The count of this JobLogCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this JobLogCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this JobLogCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/job_metric_collection.py
+++ b/src/oci/data_catalog/models/job_metric_collection.py
@@ -18,20 +18,51 @@ class JobMetricCollection(object):
         Initializes a new JobMetricCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this JobMetricCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this JobMetricCollection.
         :type items: list[JobMetricSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[JobMetricSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this JobMetricCollection.
+        Total number of items returned.
+
+
+        :return: The count of this JobMetricCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this JobMetricCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this JobMetricCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/job_summary.py
+++ b/src/oci/data_catalog/models/job_summary.py
@@ -50,6 +50,14 @@ class JobSummary(object):
     JOB_TYPE_EXPORT = "EXPORT"
 
     #: A constant which can be used with the job_type property of a JobSummary.
+    #: This constant has a value of "IMPORT_GLOSSARY"
+    JOB_TYPE_IMPORT_GLOSSARY = "IMPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a JobSummary.
+    #: This constant has a value of "EXPORT_GLOSSARY"
+    JOB_TYPE_EXPORT_GLOSSARY = "EXPORT_GLOSSARY"
+
+    #: A constant which can be used with the job_type property of a JobSummary.
     #: This constant has a value of "INTERNAL"
     JOB_TYPE_INTERNAL = "INTERNAL"
 
@@ -110,7 +118,7 @@ class JobSummary(object):
 
         :param job_type:
             The value to assign to the job_type property of this JobSummary.
-            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type job_type: str
 
@@ -154,6 +162,18 @@ class JobSummary(object):
             The value to assign to the time_of_latest_execution property of this JobSummary.
         :type time_of_latest_execution: datetime
 
+        :param job_definition_name:
+            The value to assign to the job_definition_name property of this JobSummary.
+        :type job_definition_name: str
+
+        :param error_code:
+            The value to assign to the error_code property of this JobSummary.
+        :type error_code: str
+
+        :param error_message:
+            The value to assign to the error_message property of this JobSummary.
+        :type error_message: str
+
         :param executions:
             The value to assign to the executions property of this JobSummary.
         :type executions: list[JobExecutionSummary]
@@ -177,6 +197,9 @@ class JobSummary(object):
             'time_schedule_begin': 'datetime',
             'execution_count': 'int',
             'time_of_latest_execution': 'datetime',
+            'job_definition_name': 'str',
+            'error_code': 'str',
+            'error_message': 'str',
             'executions': 'list[JobExecutionSummary]'
         }
 
@@ -198,6 +221,9 @@ class JobSummary(object):
             'time_schedule_begin': 'timeScheduleBegin',
             'execution_count': 'executionCount',
             'time_of_latest_execution': 'timeOfLatestExecution',
+            'job_definition_name': 'jobDefinitionName',
+            'error_code': 'errorCode',
+            'error_message': 'errorMessage',
             'executions': 'executions'
         }
 
@@ -218,6 +244,9 @@ class JobSummary(object):
         self._time_schedule_begin = None
         self._execution_count = None
         self._time_of_latest_execution = None
+        self._job_definition_name = None
+        self._error_code = None
+        self._error_message = None
         self._executions = None
 
     @property
@@ -378,7 +407,7 @@ class JobSummary(object):
         Gets the job_type of this JobSummary.
         Type of the job.
 
-        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -397,7 +426,7 @@ class JobSummary(object):
         :param job_type: The job_type of this JobSummary.
         :type: str
         """
-        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
+        allowed_values = ["HARVEST", "PROFILING", "SAMPLING", "PREVIEW", "IMPORT", "EXPORT", "IMPORT_GLOSSARY", "EXPORT_GLOSSARY", "INTERNAL", "PURGE", "IMMEDIATE", "SCHEDULED", "IMMEDIATE_EXECUTION", "SCHEDULED_EXECUTION", "SCHEDULED_EXECUTION_INSTANCE"]
         if not value_allowed_none_or_none_sentinel(job_type, allowed_values):
             job_type = 'UNKNOWN_ENUM_VALUE'
         self._job_type = job_type
@@ -665,6 +694,78 @@ class JobSummary(object):
         :type: datetime
         """
         self._time_of_latest_execution = time_of_latest_execution
+
+    @property
+    def job_definition_name(self):
+        """
+        Gets the job_definition_name of this JobSummary.
+        The display name of the job definition resource that defined the scope of this job.
+
+
+        :return: The job_definition_name of this JobSummary.
+        :rtype: str
+        """
+        return self._job_definition_name
+
+    @job_definition_name.setter
+    def job_definition_name(self, job_definition_name):
+        """
+        Sets the job_definition_name of this JobSummary.
+        The display name of the job definition resource that defined the scope of this job.
+
+
+        :param job_definition_name: The job_definition_name of this JobSummary.
+        :type: str
+        """
+        self._job_definition_name = job_definition_name
+
+    @property
+    def error_code(self):
+        """
+        Gets the error_code of this JobSummary.
+        Error code returned from the latest job execution for this job. Useful when the latest Job execution is in FAILED state.
+
+
+        :return: The error_code of this JobSummary.
+        :rtype: str
+        """
+        return self._error_code
+
+    @error_code.setter
+    def error_code(self, error_code):
+        """
+        Sets the error_code of this JobSummary.
+        Error code returned from the latest job execution for this job. Useful when the latest Job execution is in FAILED state.
+
+
+        :param error_code: The error_code of this JobSummary.
+        :type: str
+        """
+        self._error_code = error_code
+
+    @property
+    def error_message(self):
+        """
+        Gets the error_message of this JobSummary.
+        Error message returned from the latest job execution for this job. Useful when the latest Job Execution is in a FAILED state.
+
+
+        :return: The error_message of this JobSummary.
+        :rtype: str
+        """
+        return self._error_message
+
+    @error_message.setter
+    def error_message(self, error_message):
+        """
+        Sets the error_message of this JobSummary.
+        Error message returned from the latest job execution for this job. Useful when the latest Job Execution is in a FAILED state.
+
+
+        :param error_message: The error_message of this JobSummary.
+        :type: str
+        """
+        self._error_message = error_message
 
     @property
     def executions(self):

--- a/src/oci/data_catalog/models/term_collection.py
+++ b/src/oci/data_catalog/models/term_collection.py
@@ -18,20 +18,51 @@ class TermCollection(object):
         Initializes a new TermCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this TermCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this TermCollection.
         :type items: list[TermSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[TermSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this TermCollection.
+        Total number of items returned.
+
+
+        :return: The count of this TermCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this TermCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this TermCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/term_relationship.py
+++ b/src/oci/data_catalog/models/term_relationship.py
@@ -74,6 +74,10 @@ class TermRelationship(object):
             The value to assign to the related_term_description property of this TermRelationship.
         :type related_term_description: str
 
+        :param related_term_path:
+            The value to assign to the related_term_path property of this TermRelationship.
+        :type related_term_path: str
+
         :param uri:
             The value to assign to the uri property of this TermRelationship.
         :type uri: str
@@ -89,6 +93,10 @@ class TermRelationship(object):
         :param parent_term_description:
             The value to assign to the parent_term_description property of this TermRelationship.
         :type parent_term_description: str
+
+        :param parent_term_path:
+            The value to assign to the parent_term_path property of this TermRelationship.
+        :type parent_term_path: str
 
         :param time_created:
             The value to assign to the time_created property of this TermRelationship.
@@ -108,10 +116,12 @@ class TermRelationship(object):
             'related_term_key': 'str',
             'related_term_display_name': 'str',
             'related_term_description': 'str',
+            'related_term_path': 'str',
             'uri': 'str',
             'parent_term_key': 'str',
             'parent_term_display_name': 'str',
             'parent_term_description': 'str',
+            'parent_term_path': 'str',
             'time_created': 'datetime',
             'lifecycle_state': 'str'
         }
@@ -123,10 +133,12 @@ class TermRelationship(object):
             'related_term_key': 'relatedTermKey',
             'related_term_display_name': 'relatedTermDisplayName',
             'related_term_description': 'relatedTermDescription',
+            'related_term_path': 'relatedTermPath',
             'uri': 'uri',
             'parent_term_key': 'parentTermKey',
             'parent_term_display_name': 'parentTermDisplayName',
             'parent_term_description': 'parentTermDescription',
+            'parent_term_path': 'parentTermPath',
             'time_created': 'timeCreated',
             'lifecycle_state': 'lifecycleState'
         }
@@ -137,10 +149,12 @@ class TermRelationship(object):
         self._related_term_key = None
         self._related_term_display_name = None
         self._related_term_description = None
+        self._related_term_path = None
         self._uri = None
         self._parent_term_key = None
         self._parent_term_display_name = None
         self._parent_term_description = None
+        self._parent_term_path = None
         self._time_created = None
         self._lifecycle_state = None
 
@@ -291,6 +305,30 @@ class TermRelationship(object):
         self._related_term_description = related_term_description
 
     @property
+    def related_term_path(self):
+        """
+        Gets the related_term_path of this TermRelationship.
+        Full path of the related term.
+
+
+        :return: The related_term_path of this TermRelationship.
+        :rtype: str
+        """
+        return self._related_term_path
+
+    @related_term_path.setter
+    def related_term_path(self, related_term_path):
+        """
+        Sets the related_term_path of this TermRelationship.
+        Full path of the related term.
+
+
+        :param related_term_path: The related_term_path of this TermRelationship.
+        :type: str
+        """
+        self._related_term_path = related_term_path
+
+    @property
     def uri(self):
         """
         Gets the uri of this TermRelationship.
@@ -385,6 +423,30 @@ class TermRelationship(object):
         :type: str
         """
         self._parent_term_description = parent_term_description
+
+    @property
+    def parent_term_path(self):
+        """
+        Gets the parent_term_path of this TermRelationship.
+        Full path of the parent term.
+
+
+        :return: The parent_term_path of this TermRelationship.
+        :rtype: str
+        """
+        return self._parent_term_path
+
+    @parent_term_path.setter
+    def parent_term_path(self, parent_term_path):
+        """
+        Sets the parent_term_path of this TermRelationship.
+        Full path of the parent term.
+
+
+        :param parent_term_path: The parent_term_path of this TermRelationship.
+        :type: str
+        """
+        self._parent_term_path = parent_term_path
 
     @property
     def time_created(self):

--- a/src/oci/data_catalog/models/term_relationship_collection.py
+++ b/src/oci/data_catalog/models/term_relationship_collection.py
@@ -18,20 +18,51 @@ class TermRelationshipCollection(object):
         Initializes a new TermRelationshipCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this TermRelationshipCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this TermRelationshipCollection.
         :type items: list[TermRelationshipSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[TermRelationshipSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this TermRelationshipCollection.
+        Total number of items returned.
+
+
+        :return: The count of this TermRelationshipCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this TermRelationshipCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this TermRelationshipCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/term_relationship_summary.py
+++ b/src/oci/data_catalog/models/term_relationship_summary.py
@@ -74,6 +74,10 @@ class TermRelationshipSummary(object):
             The value to assign to the related_term_description property of this TermRelationshipSummary.
         :type related_term_description: str
 
+        :param related_term_path:
+            The value to assign to the related_term_path property of this TermRelationshipSummary.
+        :type related_term_path: str
+
         :param uri:
             The value to assign to the uri property of this TermRelationshipSummary.
         :type uri: str
@@ -89,6 +93,10 @@ class TermRelationshipSummary(object):
         :param parent_term_description:
             The value to assign to the parent_term_description property of this TermRelationshipSummary.
         :type parent_term_description: str
+
+        :param parent_term_path:
+            The value to assign to the parent_term_path property of this TermRelationshipSummary.
+        :type parent_term_path: str
 
         :param time_created:
             The value to assign to the time_created property of this TermRelationshipSummary.
@@ -108,10 +116,12 @@ class TermRelationshipSummary(object):
             'related_term_key': 'str',
             'related_term_display_name': 'str',
             'related_term_description': 'str',
+            'related_term_path': 'str',
             'uri': 'str',
             'parent_term_key': 'str',
             'parent_term_display_name': 'str',
             'parent_term_description': 'str',
+            'parent_term_path': 'str',
             'time_created': 'datetime',
             'lifecycle_state': 'str'
         }
@@ -123,10 +133,12 @@ class TermRelationshipSummary(object):
             'related_term_key': 'relatedTermKey',
             'related_term_display_name': 'relatedTermDisplayName',
             'related_term_description': 'relatedTermDescription',
+            'related_term_path': 'relatedTermPath',
             'uri': 'uri',
             'parent_term_key': 'parentTermKey',
             'parent_term_display_name': 'parentTermDisplayName',
             'parent_term_description': 'parentTermDescription',
+            'parent_term_path': 'parentTermPath',
             'time_created': 'timeCreated',
             'lifecycle_state': 'lifecycleState'
         }
@@ -137,10 +149,12 @@ class TermRelationshipSummary(object):
         self._related_term_key = None
         self._related_term_display_name = None
         self._related_term_description = None
+        self._related_term_path = None
         self._uri = None
         self._parent_term_key = None
         self._parent_term_display_name = None
         self._parent_term_description = None
+        self._parent_term_path = None
         self._time_created = None
         self._lifecycle_state = None
 
@@ -291,6 +305,30 @@ class TermRelationshipSummary(object):
         self._related_term_description = related_term_description
 
     @property
+    def related_term_path(self):
+        """
+        Gets the related_term_path of this TermRelationshipSummary.
+        Full path of the related term.
+
+
+        :return: The related_term_path of this TermRelationshipSummary.
+        :rtype: str
+        """
+        return self._related_term_path
+
+    @related_term_path.setter
+    def related_term_path(self, related_term_path):
+        """
+        Sets the related_term_path of this TermRelationshipSummary.
+        Full path of the related term.
+
+
+        :param related_term_path: The related_term_path of this TermRelationshipSummary.
+        :type: str
+        """
+        self._related_term_path = related_term_path
+
+    @property
     def uri(self):
         """
         Gets the uri of this TermRelationshipSummary.
@@ -385,6 +423,30 @@ class TermRelationshipSummary(object):
         :type: str
         """
         self._parent_term_description = parent_term_description
+
+    @property
+    def parent_term_path(self):
+        """
+        Gets the parent_term_path of this TermRelationshipSummary.
+        Full path of the parent term.
+
+
+        :return: The parent_term_path of this TermRelationshipSummary.
+        :rtype: str
+        """
+        return self._parent_term_path
+
+    @parent_term_path.setter
+    def parent_term_path(self, parent_term_path):
+        """
+        Sets the parent_term_path of this TermRelationshipSummary.
+        Full path of the parent term.
+
+
+        :param parent_term_path: The parent_term_path of this TermRelationshipSummary.
+        :type: str
+        """
+        self._parent_term_path = parent_term_path
 
     @property
     def time_created(self):

--- a/src/oci/data_catalog/models/type_collection.py
+++ b/src/oci/data_catalog/models/type_collection.py
@@ -18,20 +18,51 @@ class TypeCollection(object):
         Initializes a new TypeCollection object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param count:
+            The value to assign to the count property of this TypeCollection.
+        :type count: int
+
         :param items:
             The value to assign to the items property of this TypeCollection.
         :type items: list[TypeSummary]
 
         """
         self.swagger_types = {
+            'count': 'int',
             'items': 'list[TypeSummary]'
         }
 
         self.attribute_map = {
+            'count': 'count',
             'items': 'items'
         }
 
+        self._count = None
         self._items = None
+
+    @property
+    def count(self):
+        """
+        Gets the count of this TypeCollection.
+        Total number of items returned.
+
+
+        :return: The count of this TypeCollection.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this TypeCollection.
+        Total number of items returned.
+
+
+        :param count: The count of this TypeCollection.
+        :type: int
+        """
+        self._count = count
 
     @property
     def items(self):

--- a/src/oci/data_catalog/models/update_attribute_details.py
+++ b/src/oci/data_catalog/models/update_attribute_details.py
@@ -58,6 +58,22 @@ class UpdateAttributeDetails(object):
             The value to assign to the time_external property of this UpdateAttributeDetails.
         :type time_external: datetime
 
+        :param min_collection_count:
+            The value to assign to the min_collection_count property of this UpdateAttributeDetails.
+        :type min_collection_count: int
+
+        :param max_collection_count:
+            The value to assign to the max_collection_count property of this UpdateAttributeDetails.
+        :type max_collection_count: int
+
+        :param external_datatype_entity_key:
+            The value to assign to the external_datatype_entity_key property of this UpdateAttributeDetails.
+        :type external_datatype_entity_key: str
+
+        :param external_parent_attribute_key:
+            The value to assign to the external_parent_attribute_key property of this UpdateAttributeDetails.
+        :type external_parent_attribute_key: str
+
         :param properties:
             The value to assign to the properties property of this UpdateAttributeDetails.
         :type properties: dict(str, dict(str, str))
@@ -74,6 +90,10 @@ class UpdateAttributeDetails(object):
             'precision': 'int',
             'scale': 'int',
             'time_external': 'datetime',
+            'min_collection_count': 'int',
+            'max_collection_count': 'int',
+            'external_datatype_entity_key': 'str',
+            'external_parent_attribute_key': 'str',
             'properties': 'dict(str, dict(str, str))'
         }
 
@@ -88,6 +108,10 @@ class UpdateAttributeDetails(object):
             'precision': 'precision',
             'scale': 'scale',
             'time_external': 'timeExternal',
+            'min_collection_count': 'minCollectionCount',
+            'max_collection_count': 'maxCollectionCount',
+            'external_datatype_entity_key': 'externalDatatypeEntityKey',
+            'external_parent_attribute_key': 'externalParentAttributeKey',
             'properties': 'properties'
         }
 
@@ -101,6 +125,10 @@ class UpdateAttributeDetails(object):
         self._precision = None
         self._scale = None
         self._time_external = None
+        self._min_collection_count = None
+        self._max_collection_count = None
+        self._external_datatype_entity_key = None
+        self._external_parent_attribute_key = None
         self._properties = None
 
     @property
@@ -344,6 +372,106 @@ class UpdateAttributeDetails(object):
         :type: datetime
         """
         self._time_external = time_external
+
+    @property
+    def min_collection_count(self):
+        """
+        Gets the min_collection_count of this UpdateAttributeDetails.
+        The minimum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+
+
+        :return: The min_collection_count of this UpdateAttributeDetails.
+        :rtype: int
+        """
+        return self._min_collection_count
+
+    @min_collection_count.setter
+    def min_collection_count(self, min_collection_count):
+        """
+        Sets the min_collection_count of this UpdateAttributeDetails.
+        The minimum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+
+
+        :param min_collection_count: The min_collection_count of this UpdateAttributeDetails.
+        :type: int
+        """
+        self._min_collection_count = min_collection_count
+
+    @property
+    def max_collection_count(self):
+        """
+        Gets the max_collection_count of this UpdateAttributeDetails.
+        The maximum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+        For type specifications in systems that specify only \"capacity\" without upper or lower bound , this property can also be used to just mean \"capacity\".
+        Some examples are Varray size in Oracle , Occurs Clause in Cobol , capacity in XmlSchemaObjectCollection , maxOccurs in  Xml , maxItems in Json
+
+
+        :return: The max_collection_count of this UpdateAttributeDetails.
+        :rtype: int
+        """
+        return self._max_collection_count
+
+    @max_collection_count.setter
+    def max_collection_count(self, max_collection_count):
+        """
+        Sets the max_collection_count of this UpdateAttributeDetails.
+        The maximum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+        For type specifications in systems that specify only \"capacity\" without upper or lower bound , this property can also be used to just mean \"capacity\".
+        Some examples are Varray size in Oracle , Occurs Clause in Cobol , capacity in XmlSchemaObjectCollection , maxOccurs in  Xml , maxItems in Json
+
+
+        :param max_collection_count: The max_collection_count of this UpdateAttributeDetails.
+        :type: int
+        """
+        self._max_collection_count = max_collection_count
+
+    @property
+    def external_datatype_entity_key(self):
+        """
+        Gets the external_datatype_entity_key of this UpdateAttributeDetails.
+        External entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+
+
+        :return: The external_datatype_entity_key of this UpdateAttributeDetails.
+        :rtype: str
+        """
+        return self._external_datatype_entity_key
+
+    @external_datatype_entity_key.setter
+    def external_datatype_entity_key(self, external_datatype_entity_key):
+        """
+        Sets the external_datatype_entity_key of this UpdateAttributeDetails.
+        External entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+
+
+        :param external_datatype_entity_key: The external_datatype_entity_key of this UpdateAttributeDetails.
+        :type: str
+        """
+        self._external_datatype_entity_key = external_datatype_entity_key
+
+    @property
+    def external_parent_attribute_key(self):
+        """
+        Gets the external_parent_attribute_key of this UpdateAttributeDetails.
+        External attribute key that represents the parent attribute  of this attribute , applicable if the parent attribute is of complex type.
+
+
+        :return: The external_parent_attribute_key of this UpdateAttributeDetails.
+        :rtype: str
+        """
+        return self._external_parent_attribute_key
+
+    @external_parent_attribute_key.setter
+    def external_parent_attribute_key(self, external_parent_attribute_key):
+        """
+        Sets the external_parent_attribute_key of this UpdateAttributeDetails.
+        External attribute key that represents the parent attribute  of this attribute , applicable if the parent attribute is of complex type.
+
+
+        :param external_parent_attribute_key: The external_parent_attribute_key of this UpdateAttributeDetails.
+        :type: str
+        """
+        self._external_parent_attribute_key = external_parent_attribute_key
 
     @property
     def properties(self):

--- a/src/oci/database/database_client.py
+++ b/src/oci/database/database_client.py
@@ -6780,7 +6780,7 @@ class DatabaseClient(object):
         :param str db_workload: (optional)
             A filter to return only autonomous database resources that match the specified workload type.
 
-            Allowed values are: "OLTP", "DW"
+            Allowed values are: "OLTP", "DW", "AJD"
 
         :param str db_version: (optional)
             A filter to return only autonomous database resources that match the specified dbVersion.
@@ -6863,7 +6863,7 @@ class DatabaseClient(object):
                 )
 
         if 'db_workload' in kwargs:
-            db_workload_allowed_values = ["OLTP", "DW"]
+            db_workload_allowed_values = ["OLTP", "DW", "AJD"]
             if kwargs['db_workload'] not in db_workload_allowed_values:
                 raise ValueError(
                     "Invalid value for `db_workload`, must be one of {0}".format(db_workload_allowed_values)
@@ -7047,7 +7047,7 @@ class DatabaseClient(object):
         :param str db_workload: (optional)
             A filter to return only autonomous database resources that match the specified workload type.
 
-            Allowed values are: "OLTP", "DW"
+            Allowed values are: "OLTP", "DW", "AJD"
 
         :param str sort_order: (optional)
             The sort order to use, either ascending (`ASC`) or descending (`DESC`).
@@ -7083,7 +7083,7 @@ class DatabaseClient(object):
                 "list_autonomous_db_versions got unknown kwargs: {!r}".format(extra_kwargs))
 
         if 'db_workload' in kwargs:
-            db_workload_allowed_values = ["OLTP", "DW"]
+            db_workload_allowed_values = ["OLTP", "DW", "AJD"]
             if kwargs['db_workload'] not in db_workload_allowed_values:
                 raise ValueError(
                     "Invalid value for `db_workload`, must be one of {0}".format(db_workload_allowed_values)

--- a/src/oci/database/models/autonomous_database.py
+++ b/src/oci/database/models/autonomous_database.py
@@ -113,6 +113,10 @@ class AutonomousDatabase(object):
     #: This constant has a value of "DW"
     DB_WORKLOAD_DW = "DW"
 
+    #: A constant which can be used with the db_workload property of a AutonomousDatabase.
+    #: This constant has a value of "AJD"
+    DB_WORKLOAD_AJD = "AJD"
+
     #: A constant which can be used with the data_safe_status property of a AutonomousDatabase.
     #: This constant has a value of "REGISTERING"
     DATA_SAFE_STATUS_REGISTERING = "REGISTERING"
@@ -266,7 +270,7 @@ class AutonomousDatabase(object):
 
         :param db_workload:
             The value to assign to the db_workload property of this AutonomousDatabase.
-            Allowed values for this property are: "OLTP", "DW", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "OLTP", "DW", "AJD", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type db_workload: str
 
@@ -1270,8 +1274,9 @@ class AutonomousDatabase(object):
 
         - OLTP - indicates an Autonomous Transaction Processing database
         - DW - indicates an Autonomous Data Warehouse database
+        - AJD - indicates an Autonomous JSON Database
 
-        Allowed values for this property are: "OLTP", "DW", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "OLTP", "DW", "AJD", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -1288,12 +1293,13 @@ class AutonomousDatabase(object):
 
         - OLTP - indicates an Autonomous Transaction Processing database
         - DW - indicates an Autonomous Data Warehouse database
+        - AJD - indicates an Autonomous JSON Database
 
 
         :param db_workload: The db_workload of this AutonomousDatabase.
         :type: str
         """
-        allowed_values = ["OLTP", "DW"]
+        allowed_values = ["OLTP", "DW", "AJD"]
         if not value_allowed_none_or_none_sentinel(db_workload, allowed_values):
             db_workload = 'UNKNOWN_ENUM_VALUE'
         self._db_workload = db_workload

--- a/src/oci/database/models/autonomous_database_summary.py
+++ b/src/oci/database/models/autonomous_database_summary.py
@@ -115,6 +115,10 @@ class AutonomousDatabaseSummary(object):
     #: This constant has a value of "DW"
     DB_WORKLOAD_DW = "DW"
 
+    #: A constant which can be used with the db_workload property of a AutonomousDatabaseSummary.
+    #: This constant has a value of "AJD"
+    DB_WORKLOAD_AJD = "AJD"
+
     #: A constant which can be used with the data_safe_status property of a AutonomousDatabaseSummary.
     #: This constant has a value of "REGISTERING"
     DATA_SAFE_STATUS_REGISTERING = "REGISTERING"
@@ -268,7 +272,7 @@ class AutonomousDatabaseSummary(object):
 
         :param db_workload:
             The value to assign to the db_workload property of this AutonomousDatabaseSummary.
-            Allowed values for this property are: "OLTP", "DW", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "OLTP", "DW", "AJD", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type db_workload: str
 
@@ -1272,8 +1276,9 @@ class AutonomousDatabaseSummary(object):
 
         - OLTP - indicates an Autonomous Transaction Processing database
         - DW - indicates an Autonomous Data Warehouse database
+        - AJD - indicates an Autonomous JSON Database
 
-        Allowed values for this property are: "OLTP", "DW", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "OLTP", "DW", "AJD", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -1290,12 +1295,13 @@ class AutonomousDatabaseSummary(object):
 
         - OLTP - indicates an Autonomous Transaction Processing database
         - DW - indicates an Autonomous Data Warehouse database
+        - AJD - indicates an Autonomous JSON Database
 
 
         :param db_workload: The db_workload of this AutonomousDatabaseSummary.
         :type: str
         """
-        allowed_values = ["OLTP", "DW"]
+        allowed_values = ["OLTP", "DW", "AJD"]
         if not value_allowed_none_or_none_sentinel(db_workload, allowed_values):
             db_workload = 'UNKNOWN_ENUM_VALUE'
         self._db_workload = db_workload

--- a/src/oci/database/models/autonomous_db_preview_version_summary.py
+++ b/src/oci/database/models/autonomous_db_preview_version_summary.py
@@ -23,6 +23,10 @@ class AutonomousDbPreviewVersionSummary(object):
     #: This constant has a value of "DW"
     DB_WORKLOAD_DW = "DW"
 
+    #: A constant which can be used with the db_workload property of a AutonomousDbPreviewVersionSummary.
+    #: This constant has a value of "AJD"
+    DB_WORKLOAD_AJD = "AJD"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AutonomousDbPreviewVersionSummary object with values from keyword arguments.
@@ -42,7 +46,7 @@ class AutonomousDbPreviewVersionSummary(object):
 
         :param db_workload:
             The value to assign to the db_workload property of this AutonomousDbPreviewVersionSummary.
-            Allowed values for this property are: "OLTP", "DW", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "OLTP", "DW", "AJD", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type db_workload: str
 
@@ -153,8 +157,9 @@ class AutonomousDbPreviewVersionSummary(object):
 
         - OLTP - indicates an Autonomous Transaction Processing database
         - DW - indicates an Autonomous Data Warehouse database
+        - AJD - indicates an Autonomous JSON Database
 
-        Allowed values for this property are: "OLTP", "DW", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "OLTP", "DW", "AJD", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -171,12 +176,13 @@ class AutonomousDbPreviewVersionSummary(object):
 
         - OLTP - indicates an Autonomous Transaction Processing database
         - DW - indicates an Autonomous Data Warehouse database
+        - AJD - indicates an Autonomous JSON Database
 
 
         :param db_workload: The db_workload of this AutonomousDbPreviewVersionSummary.
         :type: str
         """
-        allowed_values = ["OLTP", "DW"]
+        allowed_values = ["OLTP", "DW", "AJD"]
         if not value_allowed_none_or_none_sentinel(db_workload, allowed_values):
             db_workload = 'UNKNOWN_ENUM_VALUE'
         self._db_workload = db_workload

--- a/src/oci/database/models/autonomous_db_version_summary.py
+++ b/src/oci/database/models/autonomous_db_version_summary.py
@@ -21,6 +21,10 @@ class AutonomousDbVersionSummary(object):
     #: This constant has a value of "DW"
     DB_WORKLOAD_DW = "DW"
 
+    #: A constant which can be used with the db_workload property of a AutonomousDbVersionSummary.
+    #: This constant has a value of "AJD"
+    DB_WORKLOAD_AJD = "AJD"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AutonomousDbVersionSummary object with values from keyword arguments.
@@ -32,7 +36,7 @@ class AutonomousDbVersionSummary(object):
 
         :param db_workload:
             The value to assign to the db_workload property of this AutonomousDbVersionSummary.
-            Allowed values for this property are: "OLTP", "DW", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "OLTP", "DW", "AJD", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type db_workload: str
 
@@ -103,8 +107,9 @@ class AutonomousDbVersionSummary(object):
 
         - OLTP - indicates an Autonomous Transaction Processing database
         - DW - indicates an Autonomous Data Warehouse database
+        - AJD - indicates an Autonomous JSON Database
 
-        Allowed values for this property are: "OLTP", "DW", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "OLTP", "DW", "AJD", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -121,12 +126,13 @@ class AutonomousDbVersionSummary(object):
 
         - OLTP - indicates an Autonomous Transaction Processing database
         - DW - indicates an Autonomous Data Warehouse database
+        - AJD - indicates an Autonomous JSON Database
 
 
         :param db_workload: The db_workload of this AutonomousDbVersionSummary.
         :type: str
         """
-        allowed_values = ["OLTP", "DW"]
+        allowed_values = ["OLTP", "DW", "AJD"]
         if not value_allowed_none_or_none_sentinel(db_workload, allowed_values):
             db_workload = 'UNKNOWN_ENUM_VALUE'
         self._db_workload = db_workload

--- a/src/oci/database/models/create_autonomous_database_base.py
+++ b/src/oci/database/models/create_autonomous_database_base.py
@@ -23,6 +23,10 @@ class CreateAutonomousDatabaseBase(object):
     #: This constant has a value of "DW"
     DB_WORKLOAD_DW = "DW"
 
+    #: A constant which can be used with the db_workload property of a CreateAutonomousDatabaseBase.
+    #: This constant has a value of "AJD"
+    DB_WORKLOAD_AJD = "AJD"
+
     #: A constant which can be used with the license_model property of a CreateAutonomousDatabaseBase.
     #: This constant has a value of "LICENSE_INCLUDED"
     LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
@@ -73,7 +77,7 @@ class CreateAutonomousDatabaseBase(object):
 
         :param db_workload:
             The value to assign to the db_workload property of this CreateAutonomousDatabaseBase.
-            Allowed values for this property are: "OLTP", "DW"
+            Allowed values for this property are: "OLTP", "DW", "AJD"
         :type db_workload: str
 
         :param data_storage_size_in_tbs:
@@ -330,8 +334,9 @@ class CreateAutonomousDatabaseBase(object):
 
         - OLTP - indicates an Autonomous Transaction Processing database
         - DW - indicates an Autonomous Data Warehouse database
+        - AJD - indicates an Autonomous JSON Database
 
-        Allowed values for this property are: "OLTP", "DW"
+        Allowed values for this property are: "OLTP", "DW", "AJD"
 
 
         :return: The db_workload of this CreateAutonomousDatabaseBase.
@@ -347,12 +352,13 @@ class CreateAutonomousDatabaseBase(object):
 
         - OLTP - indicates an Autonomous Transaction Processing database
         - DW - indicates an Autonomous Data Warehouse database
+        - AJD - indicates an Autonomous JSON Database
 
 
         :param db_workload: The db_workload of this CreateAutonomousDatabaseBase.
         :type: str
         """
-        allowed_values = ["OLTP", "DW"]
+        allowed_values = ["OLTP", "DW", "AJD"]
         if not value_allowed_none_or_none_sentinel(db_workload, allowed_values):
             raise ValueError(
                 "Invalid value for `db_workload`, must be None or one of {0}"

--- a/src/oci/database/models/create_autonomous_database_clone_details.py
+++ b/src/oci/database/models/create_autonomous_database_clone_details.py
@@ -41,7 +41,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
 
         :param db_workload:
             The value to assign to the db_workload property of this CreateAutonomousDatabaseCloneDetails.
-            Allowed values for this property are: "OLTP", "DW"
+            Allowed values for this property are: "OLTP", "DW", "AJD"
         :type db_workload: str
 
         :param data_storage_size_in_tbs:

--- a/src/oci/database/models/create_autonomous_database_details.py
+++ b/src/oci/database/models/create_autonomous_database_details.py
@@ -33,7 +33,7 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
 
         :param db_workload:
             The value to assign to the db_workload property of this CreateAutonomousDatabaseDetails.
-            Allowed values for this property are: "OLTP", "DW"
+            Allowed values for this property are: "OLTP", "DW", "AJD"
         :type db_workload: str
 
         :param data_storage_size_in_tbs:

--- a/src/oci/database/models/create_autonomous_database_from_backup_details.py
+++ b/src/oci/database/models/create_autonomous_database_from_backup_details.py
@@ -41,7 +41,7 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
 
         :param db_workload:
             The value to assign to the db_workload property of this CreateAutonomousDatabaseFromBackupDetails.
-            Allowed values for this property are: "OLTP", "DW"
+            Allowed values for this property are: "OLTP", "DW", "AJD"
         :type db_workload: str
 
         :param data_storage_size_in_tbs:

--- a/src/oci/database/models/create_autonomous_database_from_backup_timestamp_details.py
+++ b/src/oci/database/models/create_autonomous_database_from_backup_timestamp_details.py
@@ -41,7 +41,7 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
 
         :param db_workload:
             The value to assign to the db_workload property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
-            Allowed values for this property are: "OLTP", "DW"
+            Allowed values for this property are: "OLTP", "DW", "AJD"
         :type db_workload: str
 
         :param data_storage_size_in_tbs:

--- a/src/oci/database/models/update_autonomous_database_details.py
+++ b/src/oci/database/models/update_autonomous_database_details.py
@@ -15,6 +15,18 @@ class UpdateAutonomousDatabaseDetails(object):
     **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
     """
 
+    #: A constant which can be used with the db_workload property of a UpdateAutonomousDatabaseDetails.
+    #: This constant has a value of "OLTP"
+    DB_WORKLOAD_OLTP = "OLTP"
+
+    #: A constant which can be used with the db_workload property of a UpdateAutonomousDatabaseDetails.
+    #: This constant has a value of "DW"
+    DB_WORKLOAD_DW = "DW"
+
+    #: A constant which can be used with the db_workload property of a UpdateAutonomousDatabaseDetails.
+    #: This constant has a value of "AJD"
+    DB_WORKLOAD_AJD = "AJD"
+
     #: A constant which can be used with the license_model property of a UpdateAutonomousDatabaseDetails.
     #: This constant has a value of "LICENSE_INCLUDED"
     LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
@@ -60,6 +72,11 @@ class UpdateAutonomousDatabaseDetails(object):
             The value to assign to the defined_tags property of this UpdateAutonomousDatabaseDetails.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param db_workload:
+            The value to assign to the db_workload property of this UpdateAutonomousDatabaseDetails.
+            Allowed values for this property are: "OLTP", "DW", "AJD"
+        :type db_workload: str
+
         :param license_model:
             The value to assign to the license_model property of this UpdateAutonomousDatabaseDetails.
             Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
@@ -103,6 +120,7 @@ class UpdateAutonomousDatabaseDetails(object):
             'db_name': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
+            'db_workload': 'str',
             'license_model': 'str',
             'whitelisted_ips': 'list[str]',
             'is_auto_scaling_enabled': 'bool',
@@ -122,6 +140,7 @@ class UpdateAutonomousDatabaseDetails(object):
             'db_name': 'dbName',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
+            'db_workload': 'dbWorkload',
             'license_model': 'licenseModel',
             'whitelisted_ips': 'whitelistedIps',
             'is_auto_scaling_enabled': 'isAutoScalingEnabled',
@@ -140,6 +159,7 @@ class UpdateAutonomousDatabaseDetails(object):
         self._db_name = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._db_workload = None
         self._license_model = None
         self._whitelisted_ips = None
         self._is_auto_scaling_enabled = None
@@ -362,6 +382,46 @@ class UpdateAutonomousDatabaseDetails(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def db_workload(self):
+        """
+        Gets the db_workload of this UpdateAutonomousDatabaseDetails.
+        The Autonomous Database workload type. The following values are valid:
+
+        - OLTP - indicates an Autonomous Transaction Processing database
+        - DW - indicates an Autonomous Data Warehouse database
+        - AJD - indicates an Autonomous JSON Database
+
+        Allowed values for this property are: "OLTP", "DW", "AJD"
+
+
+        :return: The db_workload of this UpdateAutonomousDatabaseDetails.
+        :rtype: str
+        """
+        return self._db_workload
+
+    @db_workload.setter
+    def db_workload(self, db_workload):
+        """
+        Sets the db_workload of this UpdateAutonomousDatabaseDetails.
+        The Autonomous Database workload type. The following values are valid:
+
+        - OLTP - indicates an Autonomous Transaction Processing database
+        - DW - indicates an Autonomous Data Warehouse database
+        - AJD - indicates an Autonomous JSON Database
+
+
+        :param db_workload: The db_workload of this UpdateAutonomousDatabaseDetails.
+        :type: str
+        """
+        allowed_values = ["OLTP", "DW", "AJD"]
+        if not value_allowed_none_or_none_sentinel(db_workload, allowed_values):
+            raise ValueError(
+                "Invalid value for `db_workload`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._db_workload = db_workload
 
     @property
     def license_model(self):

--- a/src/oci/object_storage/models/object_lifecycle_rule.py
+++ b/src/oci/object_storage/models/object_lifecycle_rule.py
@@ -34,6 +34,10 @@ class ObjectLifecycleRule(object):
             The value to assign to the name property of this ObjectLifecycleRule.
         :type name: str
 
+        :param target:
+            The value to assign to the target property of this ObjectLifecycleRule.
+        :type target: str
+
         :param action:
             The value to assign to the action property of this ObjectLifecycleRule.
         :type action: str
@@ -59,6 +63,7 @@ class ObjectLifecycleRule(object):
         """
         self.swagger_types = {
             'name': 'str',
+            'target': 'str',
             'action': 'str',
             'time_amount': 'int',
             'time_unit': 'str',
@@ -68,6 +73,7 @@ class ObjectLifecycleRule(object):
 
         self.attribute_map = {
             'name': 'name',
+            'target': 'target',
             'action': 'action',
             'time_amount': 'timeAmount',
             'time_unit': 'timeUnit',
@@ -76,6 +82,7 @@ class ObjectLifecycleRule(object):
         }
 
         self._name = None
+        self._target = None
         self._action = None
         self._time_amount = None
         self._time_unit = None
@@ -107,12 +114,37 @@ class ObjectLifecycleRule(object):
         self._name = name
 
     @property
+    def target(self):
+        """
+        Gets the target of this ObjectLifecycleRule.
+
+
+
+        :return: The target of this ObjectLifecycleRule.
+        :rtype: str
+        """
+        return self._target
+
+    @target.setter
+    def target(self, target):
+        """
+        Sets the target of this ObjectLifecycleRule.
+
+
+
+        :param target: The target of this ObjectLifecycleRule.
+        :type: str
+        """
+        self._target = target
+
+    @property
     def action(self):
         """
         **[Required]** Gets the action of this ObjectLifecycleRule.
         The action of the object lifecycle policy rule. Rules using the action 'ARCHIVE' move objects into the
         `Archive Storage tier`__. Rules using the action
-        'DELETE' permanently delete objects from buckets. 'ARCHIVE' and 'DELETE' are the only two supported
+        'DELETE' permanently delete objects from buckets. Rules using 'ABORT' abort the uncommitted multipart-uploads
+        and permanently delete their parts from buckets. 'ARCHIVE', 'DELETE' and 'ABORT' are the only three supported
         actions at this time.
 
         __ https://docs.cloud.oracle.com/Content/Archive/Concepts/archivestorageoverview.htm
@@ -129,7 +161,8 @@ class ObjectLifecycleRule(object):
         Sets the action of this ObjectLifecycleRule.
         The action of the object lifecycle policy rule. Rules using the action 'ARCHIVE' move objects into the
         `Archive Storage tier`__. Rules using the action
-        'DELETE' permanently delete objects from buckets. 'ARCHIVE' and 'DELETE' are the only two supported
+        'DELETE' permanently delete objects from buckets. Rules using 'ABORT' abort the uncommitted multipart-uploads
+        and permanently delete their parts from buckets. 'ARCHIVE', 'DELETE' and 'ABORT' are the only three supported
         actions at this time.
 
         __ https://docs.cloud.oracle.com/Content/Archive/Concepts/archivestorageoverview.htm

--- a/src/oci/object_storage/object_storage_client.py
+++ b/src/oci/object_storage/object_storage_client.py
@@ -3746,9 +3746,13 @@ class ObjectStorageClient(object):
         Creates a new object or overwrites an existing object with the same name. The maximum object size allowed by
         PutObject is 50 GiB.
 
+        See `Object Names`__
+        for object naming requirements.
+
         See `Special Instructions for Object Storage PUT`__
         for request signature requirements.
 
+        __ https://docs.cloud.oracle.com/Content/Object/Tasks/managingobjects.htm#namerequirements
         __ https://docs.cloud.oracle.com/Content/API/Concepts/signingrequests.htm#ObjectStoragePut
 
 
@@ -4251,6 +4255,11 @@ class ObjectStorageClient(object):
     def rename_object(self, namespace_name, bucket_name, rename_object_details, **kwargs):
         """
         Rename an object in the given Object Storage namespace.
+
+        See `Object Names`__
+        for object naming requirements.
+
+        __ https://docs.cloud.oracle.com/Content/Object/Tasks/managingobjects.htm#namerequirements
 
 
         :param str namespace_name: (required)

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.20.0"
+__version__ = "2.21.0"


### PR DESCRIPTION
## Added

* Support for autonomous json databases in the Database service

* Support for cleaning up uncommitted multipart uploads in the Object Storage service

* Support for additional list API filters in the Data Catalog service



## Breaking

* Some unusable region enums were removed from the Support Management service

* Parameter `opc_retry_token` was removed from the Support Management service
