### PR TITLE
Releasing version 2.21.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.21.1 - 2020-08-18
+====================
+
+Added
+-----
+* Support for custom boot volume size and other node pool updates in the Container Engine for Kubernetes service
+* Support for Data Guard on Exadata Cloud at Customer VM clusters in the Database service
+* Support for stopping VM instances after scheduled maintenance or hypervisor reboots in the Compute service
+* Support for creating and managing private endpoints in the Data Flow service
+
+====================
 2.21.0 - 2020-08-11
 ====================
 
@@ -85,7 +96,7 @@ Fixed
 Breaking
 --------
 * Parameter `vcn_id` changed from required to optional in methods `list_dhcp_options`, `list_local_peering_gateways`, `list_route_tables`, `list_security_lists`, `list_subnets` and `list_internet_gateways` in the virtual network client. If the VCN ID is not provided, then the list includes information of all VCNs in the specified compartment.
-* The operations for upload manager and multipart object assembler are NOT thread-safe, and you should provide the class with its own Object Storage client that isn't used elsewhere.
+* For upload manager and multipart object assembler, the timeout for the object storage client is overwritten to `None` for all operations which call object storage. For this reason, the operations are NOT thread-safe, and you should provide the class with its own Object Storage client that isn't used elsewhere.
 
 ====================
 2.17.2 - 2020-07-07

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -205,9 +205,11 @@ Core Services
     oci.core.models.Instance
     oci.core.models.InstanceAgentConfig
     oci.core.models.InstanceAgentFeatures
+    oci.core.models.InstanceAvailabilityConfig
     oci.core.models.InstanceConfiguration
     oci.core.models.InstanceConfigurationAttachVnicDetails
     oci.core.models.InstanceConfigurationAttachVolumeDetails
+    oci.core.models.InstanceConfigurationAvailabilityConfig
     oci.core.models.InstanceConfigurationBlockVolumeDetails
     oci.core.models.InstanceConfigurationCreateVnicDetails
     oci.core.models.InstanceConfigurationCreateVolumeDetails
@@ -241,6 +243,7 @@ Core Services
     oci.core.models.InternetGateway
     oci.core.models.Ipv6
     oci.core.models.LaunchInstanceAgentConfigDetails
+    oci.core.models.LaunchInstanceAvailabilityConfigDetails
     oci.core.models.LaunchInstanceDetails
     oci.core.models.LaunchInstanceShapeConfigDetails
     oci.core.models.LaunchOptions
@@ -294,6 +297,7 @@ Core Services
     oci.core.models.UpdateIPSecTunnelBgpSessionDetails
     oci.core.models.UpdateImageDetails
     oci.core.models.UpdateInstanceAgentConfigDetails
+    oci.core.models.UpdateInstanceAvailabilityConfigDetails
     oci.core.models.UpdateInstanceConfigurationDetails
     oci.core.models.UpdateInstanceDetails
     oci.core.models.UpdateInstancePoolDetails

--- a/docs/api/core/models/oci.core.models.InstanceAvailabilityConfig.rst
+++ b/docs/api/core/models/oci.core.models.InstanceAvailabilityConfig.rst
@@ -1,0 +1,11 @@
+InstanceAvailabilityConfig
+==========================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: InstanceAvailabilityConfig
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.InstanceConfigurationAvailabilityConfig.rst
+++ b/docs/api/core/models/oci.core.models.InstanceConfigurationAvailabilityConfig.rst
@@ -1,0 +1,11 @@
+InstanceConfigurationAvailabilityConfig
+=======================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: InstanceConfigurationAvailabilityConfig
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.LaunchInstanceAvailabilityConfigDetails.rst
+++ b/docs/api/core/models/oci.core.models.LaunchInstanceAvailabilityConfigDetails.rst
@@ -1,0 +1,11 @@
+LaunchInstanceAvailabilityConfigDetails
+=======================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: LaunchInstanceAvailabilityConfigDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.UpdateInstanceAvailabilityConfigDetails.rst
+++ b/docs/api/core/models/oci.core.models.UpdateInstanceAvailabilityConfigDetails.rst
@@ -1,0 +1,11 @@
+UpdateInstanceAvailabilityConfigDetails
+=======================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: UpdateInstanceAvailabilityConfigDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -73,6 +73,7 @@ Database
     oci.database.models.CreateConsoleConnectionDetails
     oci.database.models.CreateDataGuardAssociationDetails
     oci.database.models.CreateDataGuardAssociationToExistingDbSystemDetails
+    oci.database.models.CreateDataGuardAssociationToExistingVmClusterDetails
     oci.database.models.CreateDataGuardAssociationWithNewDbSystemDetails
     oci.database.models.CreateDatabaseBase
     oci.database.models.CreateDatabaseDetails

--- a/docs/api/database/models/oci.database.models.CreateDataGuardAssociationToExistingVmClusterDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateDataGuardAssociationToExistingVmClusterDetails.rst
@@ -1,0 +1,11 @@
+CreateDataGuardAssociationToExistingVmClusterDetails
+====================================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateDataGuardAssociationToExistingVmClusterDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/src/oci/container_engine/models/create_node_pool_details.py
+++ b/src/oci/container_engine/models/create_node_pool_details.py
@@ -217,7 +217,7 @@ class CreateNodePoolDetails(object):
     def node_metadata(self):
         """
         Gets the node_metadata of this CreateNodePoolDetails.
-        A list of key/value pairs to add to each underlying OCI instance in the node pool.
+        A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
 
 
         :return: The node_metadata of this CreateNodePoolDetails.
@@ -229,7 +229,7 @@ class CreateNodePoolDetails(object):
     def node_metadata(self, node_metadata):
         """
         Sets the node_metadata of this CreateNodePoolDetails.
-        A list of key/value pairs to add to each underlying OCI instance in the node pool.
+        A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
 
 
         :param node_metadata: The node_metadata of this CreateNodePoolDetails.
@@ -341,7 +341,7 @@ class CreateNodePoolDetails(object):
     def ssh_public_key(self):
         """
         Gets the ssh_public_key of this CreateNodePoolDetails.
-        The SSH public key to add to each node in the node pool.
+        The SSH public key on each node in the node pool on launch.
 
 
         :return: The ssh_public_key of this CreateNodePoolDetails.
@@ -353,7 +353,7 @@ class CreateNodePoolDetails(object):
     def ssh_public_key(self, ssh_public_key):
         """
         Sets the ssh_public_key of this CreateNodePoolDetails.
-        The SSH public key to add to each node in the node pool.
+        The SSH public key on each node in the node pool on launch.
 
 
         :param ssh_public_key: The ssh_public_key of this CreateNodePoolDetails.

--- a/src/oci/container_engine/models/node_pool.py
+++ b/src/oci/container_engine/models/node_pool.py
@@ -54,6 +54,10 @@ class NodePool(object):
             The value to assign to the node_source property of this NodePool.
         :type node_source: NodeSourceOption
 
+        :param node_source_details:
+            The value to assign to the node_source_details property of this NodePool.
+        :type node_source_details: NodeSourceDetails
+
         :param node_shape:
             The value to assign to the node_shape property of this NodePool.
         :type node_shape: str
@@ -93,6 +97,7 @@ class NodePool(object):
             'node_image_id': 'str',
             'node_image_name': 'str',
             'node_source': 'NodeSourceOption',
+            'node_source_details': 'NodeSourceDetails',
             'node_shape': 'str',
             'initial_node_labels': 'list[KeyValue]',
             'ssh_public_key': 'str',
@@ -112,6 +117,7 @@ class NodePool(object):
             'node_image_id': 'nodeImageId',
             'node_image_name': 'nodeImageName',
             'node_source': 'nodeSource',
+            'node_source_details': 'nodeSourceDetails',
             'node_shape': 'nodeShape',
             'initial_node_labels': 'initialNodeLabels',
             'ssh_public_key': 'sshPublicKey',
@@ -130,6 +136,7 @@ class NodePool(object):
         self._node_image_id = None
         self._node_image_name = None
         self._node_source = None
+        self._node_source_details = None
         self._node_shape = None
         self._initial_node_labels = None
         self._ssh_public_key = None
@@ -262,7 +269,7 @@ class NodePool(object):
     def node_metadata(self):
         """
         Gets the node_metadata of this NodePool.
-        A list of key/value pairs to add to each underlying OCI instance in the node pool.
+        A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
 
 
         :return: The node_metadata of this NodePool.
@@ -274,7 +281,7 @@ class NodePool(object):
     def node_metadata(self, node_metadata):
         """
         Sets the node_metadata of this NodePool.
-        A list of key/value pairs to add to each underlying OCI instance in the node pool.
+        A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
 
 
         :param node_metadata: The node_metadata of this NodePool.
@@ -334,7 +341,7 @@ class NodePool(object):
     def node_source(self):
         """
         Gets the node_source of this NodePool.
-        Source running on the nodes in the node pool.
+        Deprecated. see `nodeSourceDetails`. Source running on the nodes in the node pool.
 
 
         :return: The node_source of this NodePool.
@@ -346,13 +353,37 @@ class NodePool(object):
     def node_source(self, node_source):
         """
         Sets the node_source of this NodePool.
-        Source running on the nodes in the node pool.
+        Deprecated. see `nodeSourceDetails`. Source running on the nodes in the node pool.
 
 
         :param node_source: The node_source of this NodePool.
         :type: NodeSourceOption
         """
         self._node_source = node_source
+
+    @property
+    def node_source_details(self):
+        """
+        Gets the node_source_details of this NodePool.
+        Source running on the nodes in the node pool.
+
+
+        :return: The node_source_details of this NodePool.
+        :rtype: NodeSourceDetails
+        """
+        return self._node_source_details
+
+    @node_source_details.setter
+    def node_source_details(self, node_source_details):
+        """
+        Sets the node_source_details of this NodePool.
+        Source running on the nodes in the node pool.
+
+
+        :param node_source_details: The node_source_details of this NodePool.
+        :type: NodeSourceDetails
+        """
+        self._node_source_details = node_source_details
 
     @property
     def node_shape(self):
@@ -406,7 +437,7 @@ class NodePool(object):
     def ssh_public_key(self):
         """
         Gets the ssh_public_key of this NodePool.
-        The SSH public key on each node in the node pool.
+        The SSH public key on each node in the node pool on launch.
 
 
         :return: The ssh_public_key of this NodePool.
@@ -418,7 +449,7 @@ class NodePool(object):
     def ssh_public_key(self, ssh_public_key):
         """
         Sets the ssh_public_key of this NodePool.
-        The SSH public key on each node in the node pool.
+        The SSH public key on each node in the node pool on launch.
 
 
         :param ssh_public_key: The ssh_public_key of this NodePool.

--- a/src/oci/container_engine/models/node_pool_summary.py
+++ b/src/oci/container_engine/models/node_pool_summary.py
@@ -50,6 +50,10 @@ class NodePoolSummary(object):
             The value to assign to the node_source property of this NodePoolSummary.
         :type node_source: NodeSourceOption
 
+        :param node_source_details:
+            The value to assign to the node_source_details property of this NodePoolSummary.
+        :type node_source_details: NodeSourceDetails
+
         :param node_shape:
             The value to assign to the node_shape property of this NodePoolSummary.
         :type node_shape: str
@@ -84,6 +88,7 @@ class NodePoolSummary(object):
             'node_image_id': 'str',
             'node_image_name': 'str',
             'node_source': 'NodeSourceOption',
+            'node_source_details': 'NodeSourceDetails',
             'node_shape': 'str',
             'initial_node_labels': 'list[KeyValue]',
             'ssh_public_key': 'str',
@@ -101,6 +106,7 @@ class NodePoolSummary(object):
             'node_image_id': 'nodeImageId',
             'node_image_name': 'nodeImageName',
             'node_source': 'nodeSource',
+            'node_source_details': 'nodeSourceDetails',
             'node_shape': 'nodeShape',
             'initial_node_labels': 'initialNodeLabels',
             'ssh_public_key': 'sshPublicKey',
@@ -117,6 +123,7 @@ class NodePoolSummary(object):
         self._node_image_id = None
         self._node_image_name = None
         self._node_source = None
+        self._node_source_details = None
         self._node_shape = None
         self._initial_node_labels = None
         self._ssh_public_key = None
@@ -296,7 +303,7 @@ class NodePoolSummary(object):
     def node_source(self):
         """
         Gets the node_source of this NodePoolSummary.
-        Source running on the nodes in the node pool.
+        Deprecated. see `nodeSourceDetails`. Source running on the nodes in the node pool.
 
 
         :return: The node_source of this NodePoolSummary.
@@ -308,13 +315,37 @@ class NodePoolSummary(object):
     def node_source(self, node_source):
         """
         Sets the node_source of this NodePoolSummary.
-        Source running on the nodes in the node pool.
+        Deprecated. see `nodeSourceDetails`. Source running on the nodes in the node pool.
 
 
         :param node_source: The node_source of this NodePoolSummary.
         :type: NodeSourceOption
         """
         self._node_source = node_source
+
+    @property
+    def node_source_details(self):
+        """
+        Gets the node_source_details of this NodePoolSummary.
+        Source running on the nodes in the node pool.
+
+
+        :return: The node_source_details of this NodePoolSummary.
+        :rtype: NodeSourceDetails
+        """
+        return self._node_source_details
+
+    @node_source_details.setter
+    def node_source_details(self, node_source_details):
+        """
+        Sets the node_source_details of this NodePoolSummary.
+        Source running on the nodes in the node pool.
+
+
+        :param node_source_details: The node_source_details of this NodePoolSummary.
+        :type: NodeSourceDetails
+        """
+        self._node_source_details = node_source_details
 
     @property
     def node_shape(self):
@@ -368,7 +399,7 @@ class NodePoolSummary(object):
     def ssh_public_key(self):
         """
         Gets the ssh_public_key of this NodePoolSummary.
-        The SSH public key on each node in the node pool.
+        The SSH public key on each node in the node pool on launch.
 
 
         :return: The ssh_public_key of this NodePoolSummary.
@@ -380,7 +411,7 @@ class NodePoolSummary(object):
     def ssh_public_key(self, ssh_public_key):
         """
         Sets the ssh_public_key of this NodePoolSummary.
-        The SSH public key on each node in the node pool.
+        The SSH public key on each node in the node pool on launch.
 
 
         :param ssh_public_key: The ssh_public_key of this NodePoolSummary.

--- a/src/oci/container_engine/models/node_source_details.py
+++ b/src/oci/container_engine/models/node_source_details.py
@@ -28,7 +28,8 @@ class NodeSourceDetails(object):
 
         :param source_type:
             The value to assign to the source_type property of this NodeSourceDetails.
-            Allowed values for this property are: "IMAGE"
+            Allowed values for this property are: "IMAGE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type source_type: str
 
         """
@@ -62,7 +63,8 @@ class NodeSourceDetails(object):
         The source type for the node.
         Use `IMAGE` when specifying an OCID of an image.
 
-        Allowed values for this property are: "IMAGE"
+        Allowed values for this property are: "IMAGE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
         :return: The source_type of this NodeSourceDetails.
@@ -83,10 +85,7 @@ class NodeSourceDetails(object):
         """
         allowed_values = ["IMAGE"]
         if not value_allowed_none_or_none_sentinel(source_type, allowed_values):
-            raise ValueError(
-                "Invalid value for `source_type`, must be None or one of {0}"
-                .format(allowed_values)
-            )
+            source_type = 'UNKNOWN_ENUM_VALUE'
         self._source_type = source_type
 
     def __repr__(self):

--- a/src/oci/container_engine/models/node_source_via_image_details.py
+++ b/src/oci/container_engine/models/node_source_via_image_details.py
@@ -28,19 +28,26 @@ class NodeSourceViaImageDetails(NodeSourceDetails):
             The value to assign to the image_id property of this NodeSourceViaImageDetails.
         :type image_id: str
 
+        :param boot_volume_size_in_gbs:
+            The value to assign to the boot_volume_size_in_gbs property of this NodeSourceViaImageDetails.
+        :type boot_volume_size_in_gbs: int
+
         """
         self.swagger_types = {
             'source_type': 'str',
-            'image_id': 'str'
+            'image_id': 'str',
+            'boot_volume_size_in_gbs': 'int'
         }
 
         self.attribute_map = {
             'source_type': 'sourceType',
-            'image_id': 'imageId'
+            'image_id': 'imageId',
+            'boot_volume_size_in_gbs': 'bootVolumeSizeInGBs'
         }
 
         self._source_type = None
         self._image_id = None
+        self._boot_volume_size_in_gbs = None
         self._source_type = 'IMAGE'
 
     @property
@@ -66,6 +73,34 @@ class NodeSourceViaImageDetails(NodeSourceDetails):
         :type: str
         """
         self._image_id = image_id
+
+    @property
+    def boot_volume_size_in_gbs(self):
+        """
+        Gets the boot_volume_size_in_gbs of this NodeSourceViaImageDetails.
+        The size of the boot volume in GBs. Minimum value is 50 GB. See `here`__ for max custom boot volume sizing and OS-specific requirements.
+
+        __ https://docs.cloud.oracle.com/en-us/iaas/Content/Block/Concepts/bootvolumes.htm
+
+
+        :return: The boot_volume_size_in_gbs of this NodeSourceViaImageDetails.
+        :rtype: int
+        """
+        return self._boot_volume_size_in_gbs
+
+    @boot_volume_size_in_gbs.setter
+    def boot_volume_size_in_gbs(self, boot_volume_size_in_gbs):
+        """
+        Sets the boot_volume_size_in_gbs of this NodeSourceViaImageDetails.
+        The size of the boot volume in GBs. Minimum value is 50 GB. See `here`__ for max custom boot volume sizing and OS-specific requirements.
+
+        __ https://docs.cloud.oracle.com/en-us/iaas/Content/Block/Concepts/bootvolumes.htm
+
+
+        :param boot_volume_size_in_gbs: The boot_volume_size_in_gbs of this NodeSourceViaImageDetails.
+        :type: int
+        """
+        self._boot_volume_size_in_gbs = boot_volume_size_in_gbs
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/container_engine/models/update_node_pool_details.py
+++ b/src/oci/container_engine/models/update_node_pool_details.py
@@ -42,6 +42,22 @@ class UpdateNodePoolDetails(object):
             The value to assign to the node_config_details property of this UpdateNodePoolDetails.
         :type node_config_details: UpdateNodePoolNodeConfigDetails
 
+        :param node_metadata:
+            The value to assign to the node_metadata property of this UpdateNodePoolDetails.
+        :type node_metadata: dict(str, str)
+
+        :param node_source_details:
+            The value to assign to the node_source_details property of this UpdateNodePoolDetails.
+        :type node_source_details: NodeSourceDetails
+
+        :param ssh_public_key:
+            The value to assign to the ssh_public_key property of this UpdateNodePoolDetails.
+        :type ssh_public_key: str
+
+        :param node_shape:
+            The value to assign to the node_shape property of this UpdateNodePoolDetails.
+        :type node_shape: str
+
         """
         self.swagger_types = {
             'name': 'str',
@@ -49,7 +65,11 @@ class UpdateNodePoolDetails(object):
             'initial_node_labels': 'list[KeyValue]',
             'quantity_per_subnet': 'int',
             'subnet_ids': 'list[str]',
-            'node_config_details': 'UpdateNodePoolNodeConfigDetails'
+            'node_config_details': 'UpdateNodePoolNodeConfigDetails',
+            'node_metadata': 'dict(str, str)',
+            'node_source_details': 'NodeSourceDetails',
+            'ssh_public_key': 'str',
+            'node_shape': 'str'
         }
 
         self.attribute_map = {
@@ -58,7 +78,11 @@ class UpdateNodePoolDetails(object):
             'initial_node_labels': 'initialNodeLabels',
             'quantity_per_subnet': 'quantityPerSubnet',
             'subnet_ids': 'subnetIds',
-            'node_config_details': 'nodeConfigDetails'
+            'node_config_details': 'nodeConfigDetails',
+            'node_metadata': 'nodeMetadata',
+            'node_source_details': 'nodeSourceDetails',
+            'ssh_public_key': 'sshPublicKey',
+            'node_shape': 'nodeShape'
         }
 
         self._name = None
@@ -67,6 +91,10 @@ class UpdateNodePoolDetails(object):
         self._quantity_per_subnet = None
         self._subnet_ids = None
         self._node_config_details = None
+        self._node_metadata = None
+        self._node_source_details = None
+        self._ssh_public_key = None
+        self._node_shape = None
 
     @property
     def name(self):
@@ -229,6 +257,102 @@ class UpdateNodePoolDetails(object):
         :type: UpdateNodePoolNodeConfigDetails
         """
         self._node_config_details = node_config_details
+
+    @property
+    def node_metadata(self):
+        """
+        Gets the node_metadata of this UpdateNodePoolDetails.
+        A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
+
+
+        :return: The node_metadata of this UpdateNodePoolDetails.
+        :rtype: dict(str, str)
+        """
+        return self._node_metadata
+
+    @node_metadata.setter
+    def node_metadata(self, node_metadata):
+        """
+        Sets the node_metadata of this UpdateNodePoolDetails.
+        A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
+
+
+        :param node_metadata: The node_metadata of this UpdateNodePoolDetails.
+        :type: dict(str, str)
+        """
+        self._node_metadata = node_metadata
+
+    @property
+    def node_source_details(self):
+        """
+        Gets the node_source_details of this UpdateNodePoolDetails.
+        Specify the source to use to launch nodes in the node pool. Currently, image is the only supported source.
+
+
+        :return: The node_source_details of this UpdateNodePoolDetails.
+        :rtype: NodeSourceDetails
+        """
+        return self._node_source_details
+
+    @node_source_details.setter
+    def node_source_details(self, node_source_details):
+        """
+        Sets the node_source_details of this UpdateNodePoolDetails.
+        Specify the source to use to launch nodes in the node pool. Currently, image is the only supported source.
+
+
+        :param node_source_details: The node_source_details of this UpdateNodePoolDetails.
+        :type: NodeSourceDetails
+        """
+        self._node_source_details = node_source_details
+
+    @property
+    def ssh_public_key(self):
+        """
+        Gets the ssh_public_key of this UpdateNodePoolDetails.
+        The SSH public key to add to each node in the node pool on launch.
+
+
+        :return: The ssh_public_key of this UpdateNodePoolDetails.
+        :rtype: str
+        """
+        return self._ssh_public_key
+
+    @ssh_public_key.setter
+    def ssh_public_key(self, ssh_public_key):
+        """
+        Sets the ssh_public_key of this UpdateNodePoolDetails.
+        The SSH public key to add to each node in the node pool on launch.
+
+
+        :param ssh_public_key: The ssh_public_key of this UpdateNodePoolDetails.
+        :type: str
+        """
+        self._ssh_public_key = ssh_public_key
+
+    @property
+    def node_shape(self):
+        """
+        Gets the node_shape of this UpdateNodePoolDetails.
+        The name of the node shape of the nodes in the node pool used on launch.
+
+
+        :return: The node_shape of this UpdateNodePoolDetails.
+        :rtype: str
+        """
+        return self._node_shape
+
+    @node_shape.setter
+    def node_shape(self, node_shape):
+        """
+        Sets the node_shape of this UpdateNodePoolDetails.
+        The name of the node shape of the nodes in the node pool used on launch.
+
+
+        :param node_shape: The node_shape of this UpdateNodePoolDetails.
+        :type: str
+        """
+        self._node_shape = node_shape
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/__init__.py
+++ b/src/oci/core/models/__init__.py
@@ -185,9 +185,11 @@ from .ingress_security_rule import IngressSecurityRule
 from .instance import Instance
 from .instance_agent_config import InstanceAgentConfig
 from .instance_agent_features import InstanceAgentFeatures
+from .instance_availability_config import InstanceAvailabilityConfig
 from .instance_configuration import InstanceConfiguration
 from .instance_configuration_attach_vnic_details import InstanceConfigurationAttachVnicDetails
 from .instance_configuration_attach_volume_details import InstanceConfigurationAttachVolumeDetails
+from .instance_configuration_availability_config import InstanceConfigurationAvailabilityConfig
 from .instance_configuration_block_volume_details import InstanceConfigurationBlockVolumeDetails
 from .instance_configuration_create_vnic_details import InstanceConfigurationCreateVnicDetails
 from .instance_configuration_create_volume_details import InstanceConfigurationCreateVolumeDetails
@@ -221,6 +223,7 @@ from .instance_summary import InstanceSummary
 from .internet_gateway import InternetGateway
 from .ipv6 import Ipv6
 from .launch_instance_agent_config_details import LaunchInstanceAgentConfigDetails
+from .launch_instance_availability_config_details import LaunchInstanceAvailabilityConfigDetails
 from .launch_instance_details import LaunchInstanceDetails
 from .launch_instance_shape_config_details import LaunchInstanceShapeConfigDetails
 from .launch_options import LaunchOptions
@@ -274,6 +277,7 @@ from .update_ip_sec_connection_tunnel_shared_secret_details import UpdateIPSecCo
 from .update_ip_sec_tunnel_bgp_session_details import UpdateIPSecTunnelBgpSessionDetails
 from .update_image_details import UpdateImageDetails
 from .update_instance_agent_config_details import UpdateInstanceAgentConfigDetails
+from .update_instance_availability_config_details import UpdateInstanceAvailabilityConfigDetails
 from .update_instance_configuration_details import UpdateInstanceConfigurationDetails
 from .update_instance_details import UpdateInstanceDetails
 from .update_instance_pool_details import UpdateInstancePoolDetails
@@ -513,9 +517,11 @@ core_type_mapping = {
     "Instance": Instance,
     "InstanceAgentConfig": InstanceAgentConfig,
     "InstanceAgentFeatures": InstanceAgentFeatures,
+    "InstanceAvailabilityConfig": InstanceAvailabilityConfig,
     "InstanceConfiguration": InstanceConfiguration,
     "InstanceConfigurationAttachVnicDetails": InstanceConfigurationAttachVnicDetails,
     "InstanceConfigurationAttachVolumeDetails": InstanceConfigurationAttachVolumeDetails,
+    "InstanceConfigurationAvailabilityConfig": InstanceConfigurationAvailabilityConfig,
     "InstanceConfigurationBlockVolumeDetails": InstanceConfigurationBlockVolumeDetails,
     "InstanceConfigurationCreateVnicDetails": InstanceConfigurationCreateVnicDetails,
     "InstanceConfigurationCreateVolumeDetails": InstanceConfigurationCreateVolumeDetails,
@@ -549,6 +555,7 @@ core_type_mapping = {
     "InternetGateway": InternetGateway,
     "Ipv6": Ipv6,
     "LaunchInstanceAgentConfigDetails": LaunchInstanceAgentConfigDetails,
+    "LaunchInstanceAvailabilityConfigDetails": LaunchInstanceAvailabilityConfigDetails,
     "LaunchInstanceDetails": LaunchInstanceDetails,
     "LaunchInstanceShapeConfigDetails": LaunchInstanceShapeConfigDetails,
     "LaunchOptions": LaunchOptions,
@@ -602,6 +609,7 @@ core_type_mapping = {
     "UpdateIPSecTunnelBgpSessionDetails": UpdateIPSecTunnelBgpSessionDetails,
     "UpdateImageDetails": UpdateImageDetails,
     "UpdateInstanceAgentConfigDetails": UpdateInstanceAgentConfigDetails,
+    "UpdateInstanceAvailabilityConfigDetails": UpdateInstanceAvailabilityConfigDetails,
     "UpdateInstanceConfigurationDetails": UpdateInstanceConfigurationDetails,
     "UpdateInstanceDetails": UpdateInstanceDetails,
     "UpdateInstancePoolDetails": UpdateInstancePoolDetails,

--- a/src/oci/core/models/instance.py
+++ b/src/oci/core/models/instance.py
@@ -137,6 +137,10 @@ class Instance(object):
             The value to assign to the launch_options property of this Instance.
         :type launch_options: LaunchOptions
 
+        :param availability_config:
+            The value to assign to the availability_config property of this Instance.
+        :type availability_config: InstanceAvailabilityConfig
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this Instance.
             Allowed values for this property are: "MOVING", "PROVISIONING", "RUNNING", "STARTING", "STOPPING", "STOPPED", "CREATING_IMAGE", "TERMINATING", "TERMINATED", 'UNKNOWN_ENUM_VALUE'.
@@ -194,6 +198,7 @@ class Instance(object):
             'ipxe_script': 'str',
             'launch_mode': 'str',
             'launch_options': 'LaunchOptions',
+            'availability_config': 'InstanceAvailabilityConfig',
             'lifecycle_state': 'str',
             'metadata': 'dict(str, str)',
             'region': 'str',
@@ -220,6 +225,7 @@ class Instance(object):
             'ipxe_script': 'ipxeScript',
             'launch_mode': 'launchMode',
             'launch_options': 'launchOptions',
+            'availability_config': 'availabilityConfig',
             'lifecycle_state': 'lifecycleState',
             'metadata': 'metadata',
             'region': 'region',
@@ -245,6 +251,7 @@ class Instance(object):
         self._ipxe_script = None
         self._launch_mode = None
         self._launch_options = None
+        self._availability_config = None
         self._lifecycle_state = None
         self._metadata = None
         self._region = None
@@ -685,6 +692,26 @@ class Instance(object):
         :type: LaunchOptions
         """
         self._launch_options = launch_options
+
+    @property
+    def availability_config(self):
+        """
+        Gets the availability_config of this Instance.
+
+        :return: The availability_config of this Instance.
+        :rtype: InstanceAvailabilityConfig
+        """
+        return self._availability_config
+
+    @availability_config.setter
+    def availability_config(self, availability_config):
+        """
+        Sets the availability_config of this Instance.
+
+        :param availability_config: The availability_config of this Instance.
+        :type: InstanceAvailabilityConfig
+        """
+        self._availability_config = availability_config
 
     @property
     def lifecycle_state(self):

--- a/src/oci/core/models/instance_availability_config.py
+++ b/src/oci/core/models/instance_availability_config.py
@@ -1,0 +1,92 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class InstanceAvailabilityConfig(object):
+    """
+    Options for customers to define the general policy of how compute service perform maintenance on VM instances.
+    """
+
+    #: A constant which can be used with the recovery_action property of a InstanceAvailabilityConfig.
+    #: This constant has a value of "RESTORE_INSTANCE"
+    RECOVERY_ACTION_RESTORE_INSTANCE = "RESTORE_INSTANCE"
+
+    #: A constant which can be used with the recovery_action property of a InstanceAvailabilityConfig.
+    #: This constant has a value of "STOP_INSTANCE"
+    RECOVERY_ACTION_STOP_INSTANCE = "STOP_INSTANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new InstanceAvailabilityConfig object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param recovery_action:
+            The value to assign to the recovery_action property of this InstanceAvailabilityConfig.
+            Allowed values for this property are: "RESTORE_INSTANCE", "STOP_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type recovery_action: str
+
+        """
+        self.swagger_types = {
+            'recovery_action': 'str'
+        }
+
+        self.attribute_map = {
+            'recovery_action': 'recoveryAction'
+        }
+
+        self._recovery_action = None
+
+    @property
+    def recovery_action(self):
+        """
+        Gets the recovery_action of this InstanceAvailabilityConfig.
+        Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+        * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+        will be restored to the power state it was in before maintenance.
+        * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+
+        Allowed values for this property are: "RESTORE_INSTANCE", "STOP_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The recovery_action of this InstanceAvailabilityConfig.
+        :rtype: str
+        """
+        return self._recovery_action
+
+    @recovery_action.setter
+    def recovery_action(self, recovery_action):
+        """
+        Sets the recovery_action of this InstanceAvailabilityConfig.
+        Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+        * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+        will be restored to the power state it was in before maintenance.
+        * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+
+
+        :param recovery_action: The recovery_action of this InstanceAvailabilityConfig.
+        :type: str
+        """
+        allowed_values = ["RESTORE_INSTANCE", "STOP_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(recovery_action, allowed_values):
+            recovery_action = 'UNKNOWN_ENUM_VALUE'
+        self._recovery_action = recovery_action
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/instance_configuration_availability_config.py
+++ b/src/oci/core/models/instance_configuration_availability_config.py
@@ -1,0 +1,92 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class InstanceConfigurationAvailabilityConfig(object):
+    """
+    Options for customers to define the general policy of how compute service perform maintenance on VM instances.
+    """
+
+    #: A constant which can be used with the recovery_action property of a InstanceConfigurationAvailabilityConfig.
+    #: This constant has a value of "RESTORE_INSTANCE"
+    RECOVERY_ACTION_RESTORE_INSTANCE = "RESTORE_INSTANCE"
+
+    #: A constant which can be used with the recovery_action property of a InstanceConfigurationAvailabilityConfig.
+    #: This constant has a value of "STOP_INSTANCE"
+    RECOVERY_ACTION_STOP_INSTANCE = "STOP_INSTANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new InstanceConfigurationAvailabilityConfig object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param recovery_action:
+            The value to assign to the recovery_action property of this InstanceConfigurationAvailabilityConfig.
+            Allowed values for this property are: "RESTORE_INSTANCE", "STOP_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type recovery_action: str
+
+        """
+        self.swagger_types = {
+            'recovery_action': 'str'
+        }
+
+        self.attribute_map = {
+            'recovery_action': 'recoveryAction'
+        }
+
+        self._recovery_action = None
+
+    @property
+    def recovery_action(self):
+        """
+        Gets the recovery_action of this InstanceConfigurationAvailabilityConfig.
+        Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+        * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+        will be restored to the power state it was in before maintenance.
+        * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+
+        Allowed values for this property are: "RESTORE_INSTANCE", "STOP_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The recovery_action of this InstanceConfigurationAvailabilityConfig.
+        :rtype: str
+        """
+        return self._recovery_action
+
+    @recovery_action.setter
+    def recovery_action(self, recovery_action):
+        """
+        Sets the recovery_action of this InstanceConfigurationAvailabilityConfig.
+        Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+        * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+        will be restored to the power state it was in before maintenance.
+        * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+
+
+        :param recovery_action: The recovery_action of this InstanceConfigurationAvailabilityConfig.
+        :type: str
+        """
+        allowed_values = ["RESTORE_INSTANCE", "STOP_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(recovery_action, allowed_values):
+            recovery_action = 'UNKNOWN_ENUM_VALUE'
+        self._recovery_action = recovery_action
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/instance_configuration_launch_instance_details.py
+++ b/src/oci/core/models/instance_configuration_launch_instance_details.py
@@ -125,6 +125,10 @@ class InstanceConfigurationLaunchInstanceDetails(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type preferred_maintenance_action: str
 
+        :param availability_config:
+            The value to assign to the availability_config property of this InstanceConfigurationLaunchInstanceDetails.
+        :type availability_config: InstanceConfigurationAvailabilityConfig
+
         """
         self.swagger_types = {
             'availability_domain': 'str',
@@ -145,7 +149,8 @@ class InstanceConfigurationLaunchInstanceDetails(object):
             'launch_options': 'InstanceConfigurationLaunchOptions',
             'agent_config': 'InstanceConfigurationLaunchInstanceAgentConfigDetails',
             'is_pv_encryption_in_transit_enabled': 'bool',
-            'preferred_maintenance_action': 'str'
+            'preferred_maintenance_action': 'str',
+            'availability_config': 'InstanceConfigurationAvailabilityConfig'
         }
 
         self.attribute_map = {
@@ -167,7 +172,8 @@ class InstanceConfigurationLaunchInstanceDetails(object):
             'launch_options': 'launchOptions',
             'agent_config': 'agentConfig',
             'is_pv_encryption_in_transit_enabled': 'isPvEncryptionInTransitEnabled',
-            'preferred_maintenance_action': 'preferredMaintenanceAction'
+            'preferred_maintenance_action': 'preferredMaintenanceAction',
+            'availability_config': 'availabilityConfig'
         }
 
         self._availability_domain = None
@@ -189,6 +195,7 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         self._agent_config = None
         self._is_pv_encryption_in_transit_enabled = None
         self._preferred_maintenance_action = None
+        self._availability_config = None
 
     @property
     def availability_domain(self):
@@ -897,6 +904,26 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         if not value_allowed_none_or_none_sentinel(preferred_maintenance_action, allowed_values):
             preferred_maintenance_action = 'UNKNOWN_ENUM_VALUE'
         self._preferred_maintenance_action = preferred_maintenance_action
+
+    @property
+    def availability_config(self):
+        """
+        Gets the availability_config of this InstanceConfigurationLaunchInstanceDetails.
+
+        :return: The availability_config of this InstanceConfigurationLaunchInstanceDetails.
+        :rtype: InstanceConfigurationAvailabilityConfig
+        """
+        return self._availability_config
+
+    @availability_config.setter
+    def availability_config(self, availability_config):
+        """
+        Sets the availability_config of this InstanceConfigurationLaunchInstanceDetails.
+
+        :param availability_config: The availability_config of this InstanceConfigurationLaunchInstanceDetails.
+        :type: InstanceConfigurationAvailabilityConfig
+        """
+        self._availability_config = availability_config
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/launch_instance_availability_config_details.py
+++ b/src/oci/core/models/launch_instance_availability_config_details.py
@@ -1,0 +1,93 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class LaunchInstanceAvailabilityConfigDetails(object):
+    """
+    Options for customers to define the general policy of how compute service perform maintenance on VM instances.
+    """
+
+    #: A constant which can be used with the recovery_action property of a LaunchInstanceAvailabilityConfigDetails.
+    #: This constant has a value of "RESTORE_INSTANCE"
+    RECOVERY_ACTION_RESTORE_INSTANCE = "RESTORE_INSTANCE"
+
+    #: A constant which can be used with the recovery_action property of a LaunchInstanceAvailabilityConfigDetails.
+    #: This constant has a value of "STOP_INSTANCE"
+    RECOVERY_ACTION_STOP_INSTANCE = "STOP_INSTANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new LaunchInstanceAvailabilityConfigDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param recovery_action:
+            The value to assign to the recovery_action property of this LaunchInstanceAvailabilityConfigDetails.
+            Allowed values for this property are: "RESTORE_INSTANCE", "STOP_INSTANCE"
+        :type recovery_action: str
+
+        """
+        self.swagger_types = {
+            'recovery_action': 'str'
+        }
+
+        self.attribute_map = {
+            'recovery_action': 'recoveryAction'
+        }
+
+        self._recovery_action = None
+
+    @property
+    def recovery_action(self):
+        """
+        Gets the recovery_action of this LaunchInstanceAvailabilityConfigDetails.
+        Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+        * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+        will be restored to the power state it was in before maintenance.
+        * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+
+        Allowed values for this property are: "RESTORE_INSTANCE", "STOP_INSTANCE"
+
+
+        :return: The recovery_action of this LaunchInstanceAvailabilityConfigDetails.
+        :rtype: str
+        """
+        return self._recovery_action
+
+    @recovery_action.setter
+    def recovery_action(self, recovery_action):
+        """
+        Sets the recovery_action of this LaunchInstanceAvailabilityConfigDetails.
+        Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+        * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+        will be restored to the power state it was in before maintenance.
+        * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+
+
+        :param recovery_action: The recovery_action of this LaunchInstanceAvailabilityConfigDetails.
+        :type: str
+        """
+        allowed_values = ["RESTORE_INSTANCE", "STOP_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(recovery_action, allowed_values):
+            raise ValueError(
+                "Invalid value for `recovery_action`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._recovery_action = recovery_action
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/launch_instance_details.py
+++ b/src/oci/core/models/launch_instance_details.py
@@ -71,6 +71,10 @@ class LaunchInstanceDetails(object):
             The value to assign to the launch_options property of this LaunchInstanceDetails.
         :type launch_options: LaunchOptions
 
+        :param availability_config:
+            The value to assign to the availability_config property of this LaunchInstanceDetails.
+        :type availability_config: LaunchInstanceAvailabilityConfigDetails
+
         :param metadata:
             The value to assign to the metadata property of this LaunchInstanceDetails.
         :type metadata: dict(str, str)
@@ -114,6 +118,7 @@ class LaunchInstanceDetails(object):
             'image_id': 'str',
             'ipxe_script': 'str',
             'launch_options': 'LaunchOptions',
+            'availability_config': 'LaunchInstanceAvailabilityConfigDetails',
             'metadata': 'dict(str, str)',
             'agent_config': 'LaunchInstanceAgentConfigDetails',
             'shape': 'str',
@@ -137,6 +142,7 @@ class LaunchInstanceDetails(object):
             'image_id': 'imageId',
             'ipxe_script': 'ipxeScript',
             'launch_options': 'launchOptions',
+            'availability_config': 'availabilityConfig',
             'metadata': 'metadata',
             'agent_config': 'agentConfig',
             'shape': 'shape',
@@ -159,6 +165,7 @@ class LaunchInstanceDetails(object):
         self._image_id = None
         self._ipxe_script = None
         self._launch_options = None
+        self._availability_config = None
         self._metadata = None
         self._agent_config = None
         self._shape = None
@@ -608,6 +615,26 @@ class LaunchInstanceDetails(object):
         :type: LaunchOptions
         """
         self._launch_options = launch_options
+
+    @property
+    def availability_config(self):
+        """
+        Gets the availability_config of this LaunchInstanceDetails.
+
+        :return: The availability_config of this LaunchInstanceDetails.
+        :rtype: LaunchInstanceAvailabilityConfigDetails
+        """
+        return self._availability_config
+
+    @availability_config.setter
+    def availability_config(self, availability_config):
+        """
+        Sets the availability_config of this LaunchInstanceDetails.
+
+        :param availability_config: The availability_config of this LaunchInstanceDetails.
+        :type: LaunchInstanceAvailabilityConfigDetails
+        """
+        self._availability_config = availability_config
 
     @property
     def metadata(self):

--- a/src/oci/core/models/update_instance_availability_config_details.py
+++ b/src/oci/core/models/update_instance_availability_config_details.py
@@ -1,0 +1,93 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateInstanceAvailabilityConfigDetails(object):
+    """
+    Options for customers to define the general policy of how compute service perform maintenance on VM instances.
+    """
+
+    #: A constant which can be used with the recovery_action property of a UpdateInstanceAvailabilityConfigDetails.
+    #: This constant has a value of "RESTORE_INSTANCE"
+    RECOVERY_ACTION_RESTORE_INSTANCE = "RESTORE_INSTANCE"
+
+    #: A constant which can be used with the recovery_action property of a UpdateInstanceAvailabilityConfigDetails.
+    #: This constant has a value of "STOP_INSTANCE"
+    RECOVERY_ACTION_STOP_INSTANCE = "STOP_INSTANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateInstanceAvailabilityConfigDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param recovery_action:
+            The value to assign to the recovery_action property of this UpdateInstanceAvailabilityConfigDetails.
+            Allowed values for this property are: "RESTORE_INSTANCE", "STOP_INSTANCE"
+        :type recovery_action: str
+
+        """
+        self.swagger_types = {
+            'recovery_action': 'str'
+        }
+
+        self.attribute_map = {
+            'recovery_action': 'recoveryAction'
+        }
+
+        self._recovery_action = None
+
+    @property
+    def recovery_action(self):
+        """
+        Gets the recovery_action of this UpdateInstanceAvailabilityConfigDetails.
+        Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+        * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+        will be restored to the power state it was in before maintenance.
+        * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+
+        Allowed values for this property are: "RESTORE_INSTANCE", "STOP_INSTANCE"
+
+
+        :return: The recovery_action of this UpdateInstanceAvailabilityConfigDetails.
+        :rtype: str
+        """
+        return self._recovery_action
+
+    @recovery_action.setter
+    def recovery_action(self, recovery_action):
+        """
+        Sets the recovery_action of this UpdateInstanceAvailabilityConfigDetails.
+        Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+        * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+        will be restored to the power state it was in before maintenance.
+        * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+
+
+        :param recovery_action: The recovery_action of this UpdateInstanceAvailabilityConfigDetails.
+        :type: str
+        """
+        allowed_values = ["RESTORE_INSTANCE", "STOP_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(recovery_action, allowed_values):
+            raise ValueError(
+                "Invalid value for `recovery_action`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._recovery_action = recovery_action
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/update_instance_details.py
+++ b/src/oci/core/models/update_instance_details.py
@@ -58,6 +58,10 @@ class UpdateInstanceDetails(object):
             The value to assign to the launch_options property of this UpdateInstanceDetails.
         :type launch_options: UpdateLaunchOptions
 
+        :param availability_config:
+            The value to assign to the availability_config property of this UpdateInstanceDetails.
+        :type availability_config: UpdateInstanceAvailabilityConfigDetails
+
         """
         self.swagger_types = {
             'defined_tags': 'dict(str, dict(str, object))',
@@ -69,7 +73,8 @@ class UpdateInstanceDetails(object):
             'shape': 'str',
             'shape_config': 'UpdateInstanceShapeConfigDetails',
             'fault_domain': 'str',
-            'launch_options': 'UpdateLaunchOptions'
+            'launch_options': 'UpdateLaunchOptions',
+            'availability_config': 'UpdateInstanceAvailabilityConfigDetails'
         }
 
         self.attribute_map = {
@@ -82,7 +87,8 @@ class UpdateInstanceDetails(object):
             'shape': 'shape',
             'shape_config': 'shapeConfig',
             'fault_domain': 'faultDomain',
-            'launch_options': 'launchOptions'
+            'launch_options': 'launchOptions',
+            'availability_config': 'availabilityConfig'
         }
 
         self._defined_tags = None
@@ -95,6 +101,7 @@ class UpdateInstanceDetails(object):
         self._shape_config = None
         self._fault_domain = None
         self._launch_options = None
+        self._availability_config = None
 
     @property
     def defined_tags(self):
@@ -455,6 +462,26 @@ class UpdateInstanceDetails(object):
         :type: UpdateLaunchOptions
         """
         self._launch_options = launch_options
+
+    @property
+    def availability_config(self):
+        """
+        Gets the availability_config of this UpdateInstanceDetails.
+
+        :return: The availability_config of this UpdateInstanceDetails.
+        :rtype: UpdateInstanceAvailabilityConfigDetails
+        """
+        return self._availability_config
+
+    @availability_config.setter
+    def availability_config(self, availability_config):
+        """
+        Sets the availability_config of this UpdateInstanceDetails.
+
+        :param availability_config: The availability_config of this UpdateInstanceDetails.
+        :type: UpdateInstanceAvailabilityConfigDetails
+        """
+        self._availability_config = availability_config
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/__init__.py
+++ b/src/oci/database/models/__init__.py
@@ -59,6 +59,7 @@ from .create_backup_details import CreateBackupDetails
 from .create_console_connection_details import CreateConsoleConnectionDetails
 from .create_data_guard_association_details import CreateDataGuardAssociationDetails
 from .create_data_guard_association_to_existing_db_system_details import CreateDataGuardAssociationToExistingDbSystemDetails
+from .create_data_guard_association_to_existing_vm_cluster_details import CreateDataGuardAssociationToExistingVmClusterDetails
 from .create_data_guard_association_with_new_db_system_details import CreateDataGuardAssociationWithNewDbSystemDetails
 from .create_database_base import CreateDatabaseBase
 from .create_database_details import CreateDatabaseDetails
@@ -213,6 +214,7 @@ database_type_mapping = {
     "CreateConsoleConnectionDetails": CreateConsoleConnectionDetails,
     "CreateDataGuardAssociationDetails": CreateDataGuardAssociationDetails,
     "CreateDataGuardAssociationToExistingDbSystemDetails": CreateDataGuardAssociationToExistingDbSystemDetails,
+    "CreateDataGuardAssociationToExistingVmClusterDetails": CreateDataGuardAssociationToExistingVmClusterDetails,
     "CreateDataGuardAssociationWithNewDbSystemDetails": CreateDataGuardAssociationWithNewDbSystemDetails,
     "CreateDatabaseBase": CreateDatabaseBase,
     "CreateDatabaseDetails": CreateDatabaseDetails,

--- a/src/oci/database/models/create_data_guard_association_details.py
+++ b/src/oci/database/models/create_data_guard_association_details.py
@@ -45,6 +45,7 @@ class CreateDataGuardAssociationDetails(object):
         to a service operations then you should favor using a subclass over the base class:
 
         * :class:`~oci.database.models.CreateDataGuardAssociationWithNewDbSystemDetails`
+        * :class:`~oci.database.models.CreateDataGuardAssociationToExistingVmClusterDetails`
         * :class:`~oci.database.models.CreateDataGuardAssociationToExistingDbSystemDetails`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
@@ -97,6 +98,9 @@ class CreateDataGuardAssociationDetails(object):
 
         if type == 'NewDbSystem':
             return 'CreateDataGuardAssociationWithNewDbSystemDetails'
+
+        if type == 'ExistingVmCluster':
+            return 'CreateDataGuardAssociationToExistingVmClusterDetails'
 
         if type == 'ExistingDbSystem':
             return 'CreateDataGuardAssociationToExistingDbSystemDetails'

--- a/src/oci/database/models/create_data_guard_association_to_existing_vm_cluster_details.py
+++ b/src/oci/database/models/create_data_guard_association_to_existing_vm_cluster_details.py
@@ -1,0 +1,108 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_data_guard_association_details import CreateDataGuardAssociationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDataGuardAssociationToExistingVmClusterDetails(CreateDataGuardAssociationDetails):
+    """
+    The configuration details for creating a Data Guard association for a ExaCC Vmcluster database. For these types of vm cluster databases, the `creationType` should be `ExistingVmCluster`. A standby database will be created in the VM cluster you specify.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDataGuardAssociationToExistingVmClusterDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.CreateDataGuardAssociationToExistingVmClusterDetails.creation_type` attribute
+        of this class is ``ExistingVmCluster`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param database_admin_password:
+            The value to assign to the database_admin_password property of this CreateDataGuardAssociationToExistingVmClusterDetails.
+        :type database_admin_password: str
+
+        :param protection_mode:
+            The value to assign to the protection_mode property of this CreateDataGuardAssociationToExistingVmClusterDetails.
+            Allowed values for this property are: "MAXIMUM_AVAILABILITY", "MAXIMUM_PERFORMANCE", "MAXIMUM_PROTECTION"
+        :type protection_mode: str
+
+        :param transport_type:
+            The value to assign to the transport_type property of this CreateDataGuardAssociationToExistingVmClusterDetails.
+            Allowed values for this property are: "SYNC", "ASYNC", "FASTSYNC"
+        :type transport_type: str
+
+        :param creation_type:
+            The value to assign to the creation_type property of this CreateDataGuardAssociationToExistingVmClusterDetails.
+        :type creation_type: str
+
+        :param peer_vm_cluster_id:
+            The value to assign to the peer_vm_cluster_id property of this CreateDataGuardAssociationToExistingVmClusterDetails.
+        :type peer_vm_cluster_id: str
+
+        """
+        self.swagger_types = {
+            'database_admin_password': 'str',
+            'protection_mode': 'str',
+            'transport_type': 'str',
+            'creation_type': 'str',
+            'peer_vm_cluster_id': 'str'
+        }
+
+        self.attribute_map = {
+            'database_admin_password': 'databaseAdminPassword',
+            'protection_mode': 'protectionMode',
+            'transport_type': 'transportType',
+            'creation_type': 'creationType',
+            'peer_vm_cluster_id': 'peerVmClusterId'
+        }
+
+        self._database_admin_password = None
+        self._protection_mode = None
+        self._transport_type = None
+        self._creation_type = None
+        self._peer_vm_cluster_id = None
+        self._creation_type = 'ExistingVmCluster'
+
+    @property
+    def peer_vm_cluster_id(self):
+        """
+        Gets the peer_vm_cluster_id of this CreateDataGuardAssociationToExistingVmClusterDetails.
+        The `OCID`__ of the VM Cluster in which to create the standby database.
+        You must supply this value if creationType is `ExistingVmCluster`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The peer_vm_cluster_id of this CreateDataGuardAssociationToExistingVmClusterDetails.
+        :rtype: str
+        """
+        return self._peer_vm_cluster_id
+
+    @peer_vm_cluster_id.setter
+    def peer_vm_cluster_id(self, peer_vm_cluster_id):
+        """
+        Sets the peer_vm_cluster_id of this CreateDataGuardAssociationToExistingVmClusterDetails.
+        The `OCID`__ of the VM Cluster in which to create the standby database.
+        You must supply this value if creationType is `ExistingVmCluster`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param peer_vm_cluster_id: The peer_vm_cluster_id of this CreateDataGuardAssociationToExistingVmClusterDetails.
+        :type: str
+        """
+        self._peer_vm_cluster_id = peer_vm_cluster_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.21.0"
+__version__ = "2.21.1"

--- a/src/oci/waiter.py
+++ b/src/oci/waiter.py
@@ -24,7 +24,7 @@ def wait_until(client, response, property=None, state=None, max_interval_seconds
 
     The wait will poll at an increasing interval up to 'max_interval_seconds'
     for a maximum total time of 'max_wait_seconds'. If the maximum time
-    is exceeded, then it will raise a MaximumWaitTimeExceededError.
+    is exceeded, then it will raise a MaximumWaitTimeExceeded error.
 
     On successful completion the final Response object will be returned. The
     original Response object will not be altered.


### PR DESCRIPTION
## Added

* Support for custom boot volume size and other node pool updates in the Container Engine for Kubernetes service

* Support for Data Guard on Exadata Cloud at Customer VM clusters in the Database service

* Support for stopping VM instances after scheduled maintenance or hypervisor reboots in the Compute service

* Support for creating and managing private endpoints in the Data Flow service