### PR TITLE
Releasing version 2.21.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,17 @@ Added
 * Support for creating and managing private endpoints in the Data Flow service
 
 ====================
+2.21.1 - 2020-08-18
+====================
+
+Added
+-----
+* Support for custom boot volume size and other node pool updates in the Container Engine for Kubernetes service
+* Support for Data Guard on Exadata Cloud at Customer VM clusters in the Database service
+* Support for stopping VM instances after scheduled maintenance or hypervisor reboots in the Compute service
+* Support for creating and managing private endpoints in the Data Flow service
+
+====================
 2.21.0 - 2020-08-11
 ====================
 

--- a/docs/api/container_engine.rst
+++ b/docs/api/container_engine.rst
@@ -30,6 +30,7 @@ Container Engine
     oci.container_engine.models.CreateClusterKubeconfigContentDetails
     oci.container_engine.models.CreateNodePoolDetails
     oci.container_engine.models.CreateNodePoolNodeConfigDetails
+    oci.container_engine.models.CreateNodeShapeConfigDetails
     oci.container_engine.models.KeyValue
     oci.container_engine.models.KubernetesNetworkConfig
     oci.container_engine.models.Node
@@ -39,6 +40,7 @@ Container Engine
     oci.container_engine.models.NodePoolOptions
     oci.container_engine.models.NodePoolPlacementConfigDetails
     oci.container_engine.models.NodePoolSummary
+    oci.container_engine.models.NodeShapeConfig
     oci.container_engine.models.NodeSourceDetails
     oci.container_engine.models.NodeSourceOption
     oci.container_engine.models.NodeSourceViaImageDetails
@@ -47,6 +49,7 @@ Container Engine
     oci.container_engine.models.UpdateClusterOptionsDetails
     oci.container_engine.models.UpdateNodePoolDetails
     oci.container_engine.models.UpdateNodePoolNodeConfigDetails
+    oci.container_engine.models.UpdateNodeShapeConfigDetails
     oci.container_engine.models.WorkRequest
     oci.container_engine.models.WorkRequestError
     oci.container_engine.models.WorkRequestLogEntry

--- a/docs/api/container_engine/models/oci.container_engine.models.CreateNodeShapeConfigDetails.rst
+++ b/docs/api/container_engine/models/oci.container_engine.models.CreateNodeShapeConfigDetails.rst
@@ -1,0 +1,11 @@
+CreateNodeShapeConfigDetails
+============================
+
+.. currentmodule:: oci.container_engine.models
+
+.. autoclass:: CreateNodeShapeConfigDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/container_engine/models/oci.container_engine.models.NodeShapeConfig.rst
+++ b/docs/api/container_engine/models/oci.container_engine.models.NodeShapeConfig.rst
@@ -1,0 +1,11 @@
+NodeShapeConfig
+===============
+
+.. currentmodule:: oci.container_engine.models
+
+.. autoclass:: NodeShapeConfig
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/container_engine/models/oci.container_engine.models.UpdateNodeShapeConfigDetails.rst
+++ b/docs/api/container_engine/models/oci.container_engine.models.UpdateNodeShapeConfigDetails.rst
@@ -1,0 +1,11 @@
+UpdateNodeShapeConfigDetails
+============================
+
+.. currentmodule:: oci.container_engine.models
+
+.. autoclass:: UpdateNodeShapeConfigDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -36,6 +36,7 @@ Database
     oci.database.models.AutonomousDatabaseConnectionStrings
     oci.database.models.AutonomousDatabaseConnectionUrls
     oci.database.models.AutonomousDatabaseConsoleTokenDetails
+    oci.database.models.AutonomousDatabaseManualRefreshDetails
     oci.database.models.AutonomousDatabaseStandbySummary
     oci.database.models.AutonomousDatabaseSummary
     oci.database.models.AutonomousDatabaseWallet
@@ -80,10 +81,12 @@ Database
     oci.database.models.CreateDatabaseFromAnotherDatabaseDetails
     oci.database.models.CreateDatabaseFromBackup
     oci.database.models.CreateDatabaseFromBackupDetails
+    oci.database.models.CreateDatabaseFromDbSystemDetails
     oci.database.models.CreateDbHomeBase
     oci.database.models.CreateDbHomeDetails
     oci.database.models.CreateDbHomeFromBackupDetails
     oci.database.models.CreateDbHomeFromDatabaseDetails
+    oci.database.models.CreateDbHomeFromDbSystemDetails
     oci.database.models.CreateDbHomeWithDbSystemIdDetails
     oci.database.models.CreateDbHomeWithDbSystemIdFromBackupDetails
     oci.database.models.CreateDbHomeWithDbSystemIdFromDatabaseDetails
@@ -93,6 +96,7 @@ Database
     oci.database.models.CreateNFSBackupDestinationDetails
     oci.database.models.CreateNewDatabaseDetails
     oci.database.models.CreateRecoveryApplianceBackupDestinationDetails
+    oci.database.models.CreateRefreshableAutonomousDatabaseCloneDetails
     oci.database.models.CreateVmClusterDetails
     oci.database.models.DataGuardAssociation
     oci.database.models.DataGuardAssociationSummary
@@ -129,6 +133,7 @@ Database
     oci.database.models.LaunchDbSystemDetails
     oci.database.models.LaunchDbSystemFromBackupDetails
     oci.database.models.LaunchDbSystemFromDatabaseDetails
+    oci.database.models.LaunchDbSystemFromDbSystemDetails
     oci.database.models.MaintenanceRun
     oci.database.models.MaintenanceRunSummary
     oci.database.models.MaintenanceWindow

--- a/docs/api/database/models/oci.database.models.AutonomousDatabaseManualRefreshDetails.rst
+++ b/docs/api/database/models/oci.database.models.AutonomousDatabaseManualRefreshDetails.rst
@@ -1,0 +1,11 @@
+AutonomousDatabaseManualRefreshDetails
+======================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: AutonomousDatabaseManualRefreshDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateDatabaseFromDbSystemDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateDatabaseFromDbSystemDetails.rst
@@ -1,0 +1,11 @@
+CreateDatabaseFromDbSystemDetails
+=================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateDatabaseFromDbSystemDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateDbHomeFromDbSystemDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateDbHomeFromDbSystemDetails.rst
@@ -1,0 +1,11 @@
+CreateDbHomeFromDbSystemDetails
+===============================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateDbHomeFromDbSystemDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateRefreshableAutonomousDatabaseCloneDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateRefreshableAutonomousDatabaseCloneDetails.rst
@@ -1,0 +1,11 @@
+CreateRefreshableAutonomousDatabaseCloneDetails
+===============================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateRefreshableAutonomousDatabaseCloneDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.LaunchDbSystemFromDbSystemDetails.rst
+++ b/docs/api/database/models/oci.database.models.LaunchDbSystemFromDbSystemDetails.rst
@@ -1,0 +1,11 @@
+LaunchDbSystemFromDbSystemDetails
+=================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: LaunchDbSystemFromDbSystemDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/identity.rst
+++ b/docs/api/identity.rst
@@ -66,6 +66,7 @@ Identity
     oci.identity.models.MfaTotpDeviceSummary
     oci.identity.models.MfaTotpToken
     oci.identity.models.MoveCompartmentDetails
+    oci.identity.models.NetworkPolicy
     oci.identity.models.NetworkSources
     oci.identity.models.NetworkSourcesSummary
     oci.identity.models.NetworkSourcesVirtualSourceList

--- a/docs/api/identity/models/oci.identity.models.NetworkPolicy.rst
+++ b/docs/api/identity/models/oci.identity.models.NetworkPolicy.rst
@@ -1,0 +1,11 @@
+NetworkPolicy
+=============
+
+.. currentmodule:: oci.identity.models
+
+.. autoclass:: NetworkPolicy
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/load_balancer.rst
+++ b/docs/api/load_balancer.rst
@@ -40,6 +40,7 @@ Load Balancer
     oci.load_balancer.models.CreateLoadBalancerDetails
     oci.load_balancer.models.CreatePathRouteSetDetails
     oci.load_balancer.models.CreateRuleSetDetails
+    oci.load_balancer.models.CreateSSLCipherSuiteDetails
     oci.load_balancer.models.ExtendHttpRequestHeaderValueRule
     oci.load_balancer.models.ExtendHttpResponseHeaderValueRule
     oci.load_balancer.models.HealthCheckResult
@@ -72,6 +73,8 @@ Load Balancer
     oci.load_balancer.models.RuleCondition
     oci.load_balancer.models.RuleSet
     oci.load_balancer.models.RuleSetDetails
+    oci.load_balancer.models.SSLCipherSuite
+    oci.load_balancer.models.SSLCipherSuiteDetails
     oci.load_balancer.models.SSLConfiguration
     oci.load_balancer.models.SSLConfigurationDetails
     oci.load_balancer.models.SessionPersistenceConfigurationDetails
@@ -87,5 +90,6 @@ Load Balancer
     oci.load_balancer.models.UpdateNetworkSecurityGroupsDetails
     oci.load_balancer.models.UpdatePathRouteSetDetails
     oci.load_balancer.models.UpdateRuleSetDetails
+    oci.load_balancer.models.UpdateSSLCipherSuiteDetails
     oci.load_balancer.models.WorkRequest
     oci.load_balancer.models.WorkRequestError

--- a/docs/api/load_balancer/models/oci.load_balancer.models.CreateSSLCipherSuiteDetails.rst
+++ b/docs/api/load_balancer/models/oci.load_balancer.models.CreateSSLCipherSuiteDetails.rst
@@ -1,0 +1,11 @@
+CreateSSLCipherSuiteDetails
+===========================
+
+.. currentmodule:: oci.load_balancer.models
+
+.. autoclass:: CreateSSLCipherSuiteDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/load_balancer/models/oci.load_balancer.models.SSLCipherSuite.rst
+++ b/docs/api/load_balancer/models/oci.load_balancer.models.SSLCipherSuite.rst
@@ -1,0 +1,11 @@
+SSLCipherSuite
+==============
+
+.. currentmodule:: oci.load_balancer.models
+
+.. autoclass:: SSLCipherSuite
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/load_balancer/models/oci.load_balancer.models.SSLCipherSuiteDetails.rst
+++ b/docs/api/load_balancer/models/oci.load_balancer.models.SSLCipherSuiteDetails.rst
@@ -1,0 +1,11 @@
+SSLCipherSuiteDetails
+=====================
+
+.. currentmodule:: oci.load_balancer.models
+
+.. autoclass:: SSLCipherSuiteDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/load_balancer/models/oci.load_balancer.models.UpdateSSLCipherSuiteDetails.rst
+++ b/docs/api/load_balancer/models/oci.load_balancer.models.UpdateSSLCipherSuiteDetails.rst
@@ -1,0 +1,11 @@
+UpdateSSLCipherSuiteDetails
+===========================
+
+.. currentmodule:: oci.load_balancer.models
+
+.. autoclass:: UpdateSSLCipherSuiteDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/showoci/CHANGELOG.rst
+++ b/examples/showoci/CHANGELOG.rst
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
+
+=====================
+20.08.25 - 2020-08-25
+=====================
+* Fixed bug searching compartment by OCID
+* Fixed OIC information when printout
+
 =====================
 20.07.28 - 2020-07-28
 =====================

--- a/examples/showoci/showoci.py
+++ b/examples/showoci/showoci.py
@@ -86,7 +86,7 @@ import sys
 import argparse
 import datetime
 
-version = "20.07.28"
+version = "20.08.25"
 
 ##########################################################################
 # check OCI version

--- a/examples/showoci/showoci_output.py
+++ b/examples/showoci/showoci_output.py
@@ -1372,9 +1372,9 @@ class ShowOCIOutput(object):
                 self.print_header("OIC Native", 2)
                 for val in paas_services['oic']:
                     print(self.taba + val['display_name'] + ", (" + val['integration_instance_type'] + "), Created: " + val['time_created'][0:16] + " (" + val['lifecycle_state'] + ")")
-                    print(self.tabs + "Pack : " + val['message_packs'] + ", BYOL: " + str(val['is_byol']))
+                    print(self.tabs + "Pack : " + val['message_packs'] + ", " + ("BYOL License" if val['is_byol'] else "License Included"))
                     print(self.tabs + "URL  : " + val['instance_url'])
-                print("")
+                    print("")
 
             # OAC
             if 'oac' in paas_services:
@@ -1386,7 +1386,7 @@ class ShowOCIOutput(object):
                     print(self.tabs + "Email: " + val['email_notification'] + ", License: " + str(val['license_type']) + ", Capacity: " + val[
                         'capacity_type'] + ":" + val['capacity_value'])
                     print(self.tabs + "URL  : " + val['service_url'])
-                print("")
+                    print("")
 
             # OCE
             if 'oce' in paas_services:
@@ -1397,7 +1397,7 @@ class ShowOCIOutput(object):
                     if 'pod' in val['service']:
                         pod = val['service']['pod']
                         print(self.tabs + "Pod: " + str(pod['name']) + " (" + str(pod['version']) + ") ")
-                print("")
+                    print("")
 
         except Exception as e:
             self.__print_error("__print_paas_services_main", e)

--- a/examples/showoci/showoci_service.py
+++ b/examples/showoci/showoci_service.py
@@ -1165,7 +1165,16 @@ class ShowOCIService(object):
                     raise
 
             if compartment:
-                cvalue = {'id': str(compartment.id), 'name': str(compartment.name), 'path': str(compartment.name)}
+                cvalue = {
+                    'id': str(compartment.id),
+                    'name': str(compartment.name),
+                    'description': str(compartment.description),
+                    'time_created': str(compartment.time_created),
+                    'is_accessible': str(compartment.is_accessible),
+                    'path': str(compartment.name),
+                    'defined_tags': [] if compartment.defined_tags is None else compartment.defined_tags,
+                    'freeform_tags': [] if compartment.freeform_tags is None else compartment.freeform_tags
+                }
                 compartments.append(cvalue)
 
             self.data[self.C_IDENTITY][self.C_IDENTITY_COMPARTMENTS] = compartments
@@ -8401,7 +8410,7 @@ class ShowOCIService(object):
                                'instance_url': str(oic.instance_url),
                                'message_packs': str(oic.message_packs),
                                'is_byol': oic.is_byol,
-                               'sum_info': "PaaS OIC Native - Msg Pack",
+                               'sum_info': "PaaS OIC Native " + ("BYOL" if oic.is_byol else "INCL") + " - Msg Pack",
                                'sum_size_gb': str(oic.message_packs),
                                'compartment_name': str(compartment['name']),
                                'compartment_id': str(compartment['id']),

--- a/src/oci/auth/signers/instance_principals_security_token_signer.py
+++ b/src/oci/auth/signers/instance_principals_security_token_signer.py
@@ -102,7 +102,8 @@ class InstancePrincipalsSecurityTokenSigner(X509FederationClientBasedSecurityTok
             leaf_certificate_retriever=self.leaf_certificate_retriever,
             intermediate_certificate_retrievers=[self.intermediate_certificate_retriever],
             cert_bundle_verify=kwargs.get('federation_client_cert_bundle_verify', None),
-            retry_strategy=kwargs.get('federation_client_retry_strategy', None)
+            retry_strategy=kwargs.get('federation_client_retry_strategy', None),
+            purpose=kwargs.get('purpose', None)
         )
         if 'generic_headers' in kwargs:
             generic_headers = kwargs['generic_headers']

--- a/src/oci/config.py
+++ b/src/oci/config.py
@@ -111,7 +111,7 @@ def validate_config(config, **kwargs):
     errors = {}
     for required_key in REQUIRED:
         fallback_key = REQUIRED_FALLBACKS.get(required_key)
-        if (required_key not in config or config[required_key] is None) and (fallback_key not in config or config[fallback_key] is None):
+        if required_key not in config and fallback_key not in config:
             # If region is not provided, check the env variable
             if required_key == REGION_KEY_NAME:
                 logger.debug("Region not found in config, checking environment variable {}".format(REGION_ENV_VAR_NAME))

--- a/src/oci/container_engine/models/__init__.py
+++ b/src/oci/container_engine/models/__init__.py
@@ -16,6 +16,7 @@ from .create_cluster_details import CreateClusterDetails
 from .create_cluster_kubeconfig_content_details import CreateClusterKubeconfigContentDetails
 from .create_node_pool_details import CreateNodePoolDetails
 from .create_node_pool_node_config_details import CreateNodePoolNodeConfigDetails
+from .create_node_shape_config_details import CreateNodeShapeConfigDetails
 from .key_value import KeyValue
 from .kubernetes_network_config import KubernetesNetworkConfig
 from .node import Node
@@ -25,6 +26,7 @@ from .node_pool_node_config_details import NodePoolNodeConfigDetails
 from .node_pool_options import NodePoolOptions
 from .node_pool_placement_config_details import NodePoolPlacementConfigDetails
 from .node_pool_summary import NodePoolSummary
+from .node_shape_config import NodeShapeConfig
 from .node_source_details import NodeSourceDetails
 from .node_source_option import NodeSourceOption
 from .node_source_via_image_details import NodeSourceViaImageDetails
@@ -33,6 +35,7 @@ from .update_cluster_details import UpdateClusterDetails
 from .update_cluster_options_details import UpdateClusterOptionsDetails
 from .update_node_pool_details import UpdateNodePoolDetails
 from .update_node_pool_node_config_details import UpdateNodePoolNodeConfigDetails
+from .update_node_shape_config_details import UpdateNodeShapeConfigDetails
 from .work_request import WorkRequest
 from .work_request_error import WorkRequestError
 from .work_request_log_entry import WorkRequestLogEntry
@@ -53,6 +56,7 @@ container_engine_type_mapping = {
     "CreateClusterKubeconfigContentDetails": CreateClusterKubeconfigContentDetails,
     "CreateNodePoolDetails": CreateNodePoolDetails,
     "CreateNodePoolNodeConfigDetails": CreateNodePoolNodeConfigDetails,
+    "CreateNodeShapeConfigDetails": CreateNodeShapeConfigDetails,
     "KeyValue": KeyValue,
     "KubernetesNetworkConfig": KubernetesNetworkConfig,
     "Node": Node,
@@ -62,6 +66,7 @@ container_engine_type_mapping = {
     "NodePoolOptions": NodePoolOptions,
     "NodePoolPlacementConfigDetails": NodePoolPlacementConfigDetails,
     "NodePoolSummary": NodePoolSummary,
+    "NodeShapeConfig": NodeShapeConfig,
     "NodeSourceDetails": NodeSourceDetails,
     "NodeSourceOption": NodeSourceOption,
     "NodeSourceViaImageDetails": NodeSourceViaImageDetails,
@@ -70,6 +75,7 @@ container_engine_type_mapping = {
     "UpdateClusterOptionsDetails": UpdateClusterOptionsDetails,
     "UpdateNodePoolDetails": UpdateNodePoolDetails,
     "UpdateNodePoolNodeConfigDetails": UpdateNodePoolNodeConfigDetails,
+    "UpdateNodeShapeConfigDetails": UpdateNodeShapeConfigDetails,
     "WorkRequest": WorkRequest,
     "WorkRequestError": WorkRequestError,
     "WorkRequestLogEntry": WorkRequestLogEntry,

--- a/src/oci/container_engine/models/create_node_pool_details.py
+++ b/src/oci/container_engine/models/create_node_pool_details.py
@@ -50,6 +50,10 @@ class CreateNodePoolDetails(object):
             The value to assign to the node_shape property of this CreateNodePoolDetails.
         :type node_shape: str
 
+        :param node_shape_config:
+            The value to assign to the node_shape_config property of this CreateNodePoolDetails.
+        :type node_shape_config: CreateNodeShapeConfigDetails
+
         :param initial_node_labels:
             The value to assign to the initial_node_labels property of this CreateNodePoolDetails.
         :type initial_node_labels: list[KeyValue]
@@ -80,6 +84,7 @@ class CreateNodePoolDetails(object):
             'node_image_name': 'str',
             'node_source_details': 'NodeSourceDetails',
             'node_shape': 'str',
+            'node_shape_config': 'CreateNodeShapeConfigDetails',
             'initial_node_labels': 'list[KeyValue]',
             'ssh_public_key': 'str',
             'quantity_per_subnet': 'int',
@@ -96,6 +101,7 @@ class CreateNodePoolDetails(object):
             'node_image_name': 'nodeImageName',
             'node_source_details': 'nodeSourceDetails',
             'node_shape': 'nodeShape',
+            'node_shape_config': 'nodeShapeConfig',
             'initial_node_labels': 'initialNodeLabels',
             'ssh_public_key': 'sshPublicKey',
             'quantity_per_subnet': 'quantityPerSubnet',
@@ -111,6 +117,7 @@ class CreateNodePoolDetails(object):
         self._node_image_name = None
         self._node_source_details = None
         self._node_shape = None
+        self._node_shape_config = None
         self._initial_node_labels = None
         self._ssh_public_key = None
         self._quantity_per_subnet = None
@@ -312,6 +319,30 @@ class CreateNodePoolDetails(object):
         :type: str
         """
         self._node_shape = node_shape
+
+    @property
+    def node_shape_config(self):
+        """
+        Gets the node_shape_config of this CreateNodePoolDetails.
+        Specify the configuration of the shape to launch nodes in the node pool.
+
+
+        :return: The node_shape_config of this CreateNodePoolDetails.
+        :rtype: CreateNodeShapeConfigDetails
+        """
+        return self._node_shape_config
+
+    @node_shape_config.setter
+    def node_shape_config(self, node_shape_config):
+        """
+        Sets the node_shape_config of this CreateNodePoolDetails.
+        Specify the configuration of the shape to launch nodes in the node pool.
+
+
+        :param node_shape_config: The node_shape_config of this CreateNodePoolDetails.
+        :type: CreateNodeShapeConfigDetails
+        """
+        self._node_shape_config = node_shape_config
 
     @property
     def initial_node_labels(self):

--- a/src/oci/container_engine/models/create_node_shape_config_details.py
+++ b/src/oci/container_engine/models/create_node_shape_config_details.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateNodeShapeConfigDetails(object):
+    """
+    The shape configuration of the nodes.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateNodeShapeConfigDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param ocpus:
+            The value to assign to the ocpus property of this CreateNodeShapeConfigDetails.
+        :type ocpus: float
+
+        """
+        self.swagger_types = {
+            'ocpus': 'float'
+        }
+
+        self.attribute_map = {
+            'ocpus': 'ocpus'
+        }
+
+        self._ocpus = None
+
+    @property
+    def ocpus(self):
+        """
+        Gets the ocpus of this CreateNodeShapeConfigDetails.
+        The total number of OCPUs available to each node in the node pool.
+        See `here`__ for details.
+
+        __ https://docs.cloud.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Shape/
+
+
+        :return: The ocpus of this CreateNodeShapeConfigDetails.
+        :rtype: float
+        """
+        return self._ocpus
+
+    @ocpus.setter
+    def ocpus(self, ocpus):
+        """
+        Sets the ocpus of this CreateNodeShapeConfigDetails.
+        The total number of OCPUs available to each node in the node pool.
+        See `here`__ for details.
+
+        __ https://docs.cloud.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Shape/
+
+
+        :param ocpus: The ocpus of this CreateNodeShapeConfigDetails.
+        :type: float
+        """
+        self._ocpus = ocpus
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/container_engine/models/node.py
+++ b/src/oci/container_engine/models/node.py
@@ -54,6 +54,10 @@ class Node(object):
             The value to assign to the name property of this Node.
         :type name: str
 
+        :param kubernetes_version:
+            The value to assign to the kubernetes_version property of this Node.
+        :type kubernetes_version: str
+
         :param availability_domain:
             The value to assign to the availability_domain property of this Node.
         :type availability_domain: str
@@ -96,6 +100,7 @@ class Node(object):
         self.swagger_types = {
             'id': 'str',
             'name': 'str',
+            'kubernetes_version': 'str',
             'availability_domain': 'str',
             'subnet_id': 'str',
             'node_pool_id': 'str',
@@ -110,6 +115,7 @@ class Node(object):
         self.attribute_map = {
             'id': 'id',
             'name': 'name',
+            'kubernetes_version': 'kubernetesVersion',
             'availability_domain': 'availabilityDomain',
             'subnet_id': 'subnetId',
             'node_pool_id': 'nodePoolId',
@@ -123,6 +129,7 @@ class Node(object):
 
         self._id = None
         self._name = None
+        self._kubernetes_version = None
         self._availability_domain = None
         self._subnet_id = None
         self._node_pool_id = None
@@ -180,6 +187,30 @@ class Node(object):
         :type: str
         """
         self._name = name
+
+    @property
+    def kubernetes_version(self):
+        """
+        Gets the kubernetes_version of this Node.
+        The version of Kubernetes this node is running.
+
+
+        :return: The kubernetes_version of this Node.
+        :rtype: str
+        """
+        return self._kubernetes_version
+
+    @kubernetes_version.setter
+    def kubernetes_version(self, kubernetes_version):
+        """
+        Sets the kubernetes_version of this Node.
+        The version of Kubernetes this node is running.
+
+
+        :param kubernetes_version: The kubernetes_version of this Node.
+        :type: str
+        """
+        self._kubernetes_version = kubernetes_version
 
     @property
     def availability_domain(self):

--- a/src/oci/container_engine/models/node_pool.py
+++ b/src/oci/container_engine/models/node_pool.py
@@ -50,6 +50,10 @@ class NodePool(object):
             The value to assign to the node_image_name property of this NodePool.
         :type node_image_name: str
 
+        :param node_shape_config:
+            The value to assign to the node_shape_config property of this NodePool.
+        :type node_shape_config: NodeShapeConfig
+
         :param node_source:
             The value to assign to the node_source property of this NodePool.
         :type node_source: NodeSourceOption
@@ -96,6 +100,7 @@ class NodePool(object):
             'node_metadata': 'dict(str, str)',
             'node_image_id': 'str',
             'node_image_name': 'str',
+            'node_shape_config': 'NodeShapeConfig',
             'node_source': 'NodeSourceOption',
             'node_source_details': 'NodeSourceDetails',
             'node_shape': 'str',
@@ -116,6 +121,7 @@ class NodePool(object):
             'node_metadata': 'nodeMetadata',
             'node_image_id': 'nodeImageId',
             'node_image_name': 'nodeImageName',
+            'node_shape_config': 'nodeShapeConfig',
             'node_source': 'nodeSource',
             'node_source_details': 'nodeSourceDetails',
             'node_shape': 'nodeShape',
@@ -135,6 +141,7 @@ class NodePool(object):
         self._node_metadata = None
         self._node_image_id = None
         self._node_image_name = None
+        self._node_shape_config = None
         self._node_source = None
         self._node_source_details = None
         self._node_shape = None
@@ -336,6 +343,30 @@ class NodePool(object):
         :type: str
         """
         self._node_image_name = node_image_name
+
+    @property
+    def node_shape_config(self):
+        """
+        Gets the node_shape_config of this NodePool.
+        The shape configuration of the nodes.
+
+
+        :return: The node_shape_config of this NodePool.
+        :rtype: NodeShapeConfig
+        """
+        return self._node_shape_config
+
+    @node_shape_config.setter
+    def node_shape_config(self, node_shape_config):
+        """
+        Sets the node_shape_config of this NodePool.
+        The shape configuration of the nodes.
+
+
+        :param node_shape_config: The node_shape_config of this NodePool.
+        :type: NodeShapeConfig
+        """
+        self._node_shape_config = node_shape_config
 
     @property
     def node_source(self):

--- a/src/oci/container_engine/models/node_pool_summary.py
+++ b/src/oci/container_engine/models/node_pool_summary.py
@@ -46,6 +46,10 @@ class NodePoolSummary(object):
             The value to assign to the node_image_name property of this NodePoolSummary.
         :type node_image_name: str
 
+        :param node_shape_config:
+            The value to assign to the node_shape_config property of this NodePoolSummary.
+        :type node_shape_config: NodeShapeConfig
+
         :param node_source:
             The value to assign to the node_source property of this NodePoolSummary.
         :type node_source: NodeSourceOption
@@ -87,6 +91,7 @@ class NodePoolSummary(object):
             'kubernetes_version': 'str',
             'node_image_id': 'str',
             'node_image_name': 'str',
+            'node_shape_config': 'NodeShapeConfig',
             'node_source': 'NodeSourceOption',
             'node_source_details': 'NodeSourceDetails',
             'node_shape': 'str',
@@ -105,6 +110,7 @@ class NodePoolSummary(object):
             'kubernetes_version': 'kubernetesVersion',
             'node_image_id': 'nodeImageId',
             'node_image_name': 'nodeImageName',
+            'node_shape_config': 'nodeShapeConfig',
             'node_source': 'nodeSource',
             'node_source_details': 'nodeSourceDetails',
             'node_shape': 'nodeShape',
@@ -122,6 +128,7 @@ class NodePoolSummary(object):
         self._kubernetes_version = None
         self._node_image_id = None
         self._node_image_name = None
+        self._node_shape_config = None
         self._node_source = None
         self._node_source_details = None
         self._node_shape = None
@@ -298,6 +305,30 @@ class NodePoolSummary(object):
         :type: str
         """
         self._node_image_name = node_image_name
+
+    @property
+    def node_shape_config(self):
+        """
+        Gets the node_shape_config of this NodePoolSummary.
+        The shape configuration of the nodes.
+
+
+        :return: The node_shape_config of this NodePoolSummary.
+        :rtype: NodeShapeConfig
+        """
+        return self._node_shape_config
+
+    @node_shape_config.setter
+    def node_shape_config(self, node_shape_config):
+        """
+        Sets the node_shape_config of this NodePoolSummary.
+        The shape configuration of the nodes.
+
+
+        :param node_shape_config: The node_shape_config of this NodePoolSummary.
+        :type: NodeShapeConfig
+        """
+        self._node_shape_config = node_shape_config
 
     @property
     def node_source(self):

--- a/src/oci/container_engine/models/node_shape_config.py
+++ b/src/oci/container_engine/models/node_shape_config.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class NodeShapeConfig(object):
+    """
+    The shape configuration of the nodes.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new NodeShapeConfig object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param ocpus:
+            The value to assign to the ocpus property of this NodeShapeConfig.
+        :type ocpus: float
+
+        """
+        self.swagger_types = {
+            'ocpus': 'float'
+        }
+
+        self.attribute_map = {
+            'ocpus': 'ocpus'
+        }
+
+        self._ocpus = None
+
+    @property
+    def ocpus(self):
+        """
+        Gets the ocpus of this NodeShapeConfig.
+        The total number of OCPUs available to each node in the node pool.
+        See `here`__ for details.
+
+        __ https://docs.cloud.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Shape/
+
+
+        :return: The ocpus of this NodeShapeConfig.
+        :rtype: float
+        """
+        return self._ocpus
+
+    @ocpus.setter
+    def ocpus(self, ocpus):
+        """
+        Sets the ocpus of this NodeShapeConfig.
+        The total number of OCPUs available to each node in the node pool.
+        See `here`__ for details.
+
+        __ https://docs.cloud.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Shape/
+
+
+        :param ocpus: The ocpus of this NodeShapeConfig.
+        :type: float
+        """
+        self._ocpus = ocpus
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/container_engine/models/update_node_pool_details.py
+++ b/src/oci/container_engine/models/update_node_pool_details.py
@@ -58,6 +58,10 @@ class UpdateNodePoolDetails(object):
             The value to assign to the node_shape property of this UpdateNodePoolDetails.
         :type node_shape: str
 
+        :param node_shape_config:
+            The value to assign to the node_shape_config property of this UpdateNodePoolDetails.
+        :type node_shape_config: UpdateNodeShapeConfigDetails
+
         """
         self.swagger_types = {
             'name': 'str',
@@ -69,7 +73,8 @@ class UpdateNodePoolDetails(object):
             'node_metadata': 'dict(str, str)',
             'node_source_details': 'NodeSourceDetails',
             'ssh_public_key': 'str',
-            'node_shape': 'str'
+            'node_shape': 'str',
+            'node_shape_config': 'UpdateNodeShapeConfigDetails'
         }
 
         self.attribute_map = {
@@ -82,7 +87,8 @@ class UpdateNodePoolDetails(object):
             'node_metadata': 'nodeMetadata',
             'node_source_details': 'nodeSourceDetails',
             'ssh_public_key': 'sshPublicKey',
-            'node_shape': 'nodeShape'
+            'node_shape': 'nodeShape',
+            'node_shape_config': 'nodeShapeConfig'
         }
 
         self._name = None
@@ -95,6 +101,7 @@ class UpdateNodePoolDetails(object):
         self._node_source_details = None
         self._ssh_public_key = None
         self._node_shape = None
+        self._node_shape_config = None
 
     @property
     def name(self):
@@ -353,6 +360,30 @@ class UpdateNodePoolDetails(object):
         :type: str
         """
         self._node_shape = node_shape
+
+    @property
+    def node_shape_config(self):
+        """
+        Gets the node_shape_config of this UpdateNodePoolDetails.
+        Specify the configuration of the shape to launch nodes in the node pool.
+
+
+        :return: The node_shape_config of this UpdateNodePoolDetails.
+        :rtype: UpdateNodeShapeConfigDetails
+        """
+        return self._node_shape_config
+
+    @node_shape_config.setter
+    def node_shape_config(self, node_shape_config):
+        """
+        Sets the node_shape_config of this UpdateNodePoolDetails.
+        Specify the configuration of the shape to launch nodes in the node pool.
+
+
+        :param node_shape_config: The node_shape_config of this UpdateNodePoolDetails.
+        :type: UpdateNodeShapeConfigDetails
+        """
+        self._node_shape_config = node_shape_config
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/container_engine/models/update_node_shape_config_details.py
+++ b/src/oci/container_engine/models/update_node_shape_config_details.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateNodeShapeConfigDetails(object):
+    """
+    The shape configuration of the nodes.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateNodeShapeConfigDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param ocpus:
+            The value to assign to the ocpus property of this UpdateNodeShapeConfigDetails.
+        :type ocpus: float
+
+        """
+        self.swagger_types = {
+            'ocpus': 'float'
+        }
+
+        self.attribute_map = {
+            'ocpus': 'ocpus'
+        }
+
+        self._ocpus = None
+
+    @property
+    def ocpus(self):
+        """
+        Gets the ocpus of this UpdateNodeShapeConfigDetails.
+        The total number of OCPUs available to each node in the node pool.
+        See `here`__ for details.
+
+        __ https://docs.cloud.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Shape/
+
+
+        :return: The ocpus of this UpdateNodeShapeConfigDetails.
+        :rtype: float
+        """
+        return self._ocpus
+
+    @ocpus.setter
+    def ocpus(self, ocpus):
+        """
+        Sets the ocpus of this UpdateNodeShapeConfigDetails.
+        The total number of OCPUs available to each node in the node pool.
+        See `here`__ for details.
+
+        __ https://docs.cloud.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Shape/
+
+
+        :param ocpus: The ocpus of this UpdateNodeShapeConfigDetails.
+        :type: float
+        """
+        self._ocpus = ocpus
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/database_client.py
+++ b/src/oci/database/database_client.py
@@ -173,6 +173,103 @@ class DatabaseClient(object):
                 body=activate_exadata_infrastructure_details,
                 response_type="ExadataInfrastructure")
 
+    def autonomous_database_manual_refresh(self, autonomous_database_id, autonomous_database_manual_refresh_details, **kwargs):
+        """
+        Initiates a data refresh for an Autonomous Database refreshable clone. Data is refreshed from the source database to the point of a specified timestamp.
+
+
+        :param str autonomous_database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param AutonomousDatabaseManualRefreshDetails autonomous_database_manual_refresh_details: (required)
+            Request details for manually refreshing an Autonomous Database refreshable clone.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.AutonomousDatabase`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousDatabases/{autonomousDatabaseId}/actions/refresh"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "autonomous_database_manual_refresh got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "autonomousDatabaseId": autonomous_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=autonomous_database_manual_refresh_details,
+                response_type="AutonomousDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=autonomous_database_manual_refresh_details,
+                response_type="AutonomousDatabase")
+
     def change_autonomous_container_database_compartment(self, change_compartment_details, autonomous_container_database_id, **kwargs):
         """
         Move the Autonomous Container Database and its dependent resources to the specified compartment.
@@ -5688,11 +5785,11 @@ class DatabaseClient(object):
 
     def get_maintenance_run(self, maintenance_run_id, **kwargs):
         """
-        Gets information about the specified Maintenance Run.
+        Gets information about the specified maintenance run.
 
 
         :param str maintenance_run_id: (required)
-            The Maintenance Run OCID.
+            The maintenance run OCID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -6734,6 +6831,165 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="list[AutonomousDatabaseBackupSummary]")
 
+    def list_autonomous_database_clones(self, compartment_id, autonomous_database_id, **kwargs):
+        """
+        Gets a list of the Autonomous Database clones for the specified Autonomous Database.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str autonomous_database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the given lifecycle state exactly.
+
+            Allowed values are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING"
+
+        :param str sort_by: (optional)
+            The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+
+            **Note:** If you do not include the availability domain filter, the resources are grouped by availability domain, then sorted.
+
+            Allowed values are: "NONE", "TIMECREATED", "DISPLAYNAME"
+
+        :param str clone_type: (optional)
+            A filter to return only resources that match the given clone type exactly.
+
+            Allowed values are: "REFRESHABLE_CLONE"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.AutonomousDatabaseSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousDatabases/{autonomousDatabaseId}/clones"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "limit",
+            "page",
+            "sort_order",
+            "display_name",
+            "lifecycle_state",
+            "sort_by",
+            "clone_type"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_autonomous_database_clones got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "autonomousDatabaseId": autonomous_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["NONE", "TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'clone_type' in kwargs:
+            clone_type_allowed_values = ["REFRESHABLE_CLONE"]
+            if kwargs['clone_type'] not in clone_type_allowed_values:
+                raise ValueError(
+                    "Invalid value for `clone_type`, must be one of {0}".format(clone_type_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "displayName": kwargs.get("display_name", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "cloneType": kwargs.get("clone_type", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AutonomousDatabaseSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AutonomousDatabaseSummary]")
+
     def list_autonomous_databases(self, compartment_id, **kwargs):
         """
         Gets a list of Autonomous Databases.
@@ -6795,6 +7051,10 @@ class DatabaseClient(object):
         :param str opc_request_id: (optional)
             Unique identifier for the request.
 
+        :param bool is_refreshable_clone: (optional)
+            Filter on the value of the resource's 'isRefreshableClone' property. A value of `true` returns only refreshable clones.
+            A value of `false` excludes refreshable clones from the returned results. Omitting this parameter returns both refreshable clones and databases that are not refreshable clones.
+
         :param bool is_data_guard_enabled: (optional)
             A filter to return only resources that have Data Guard enabled.
 
@@ -6827,6 +7087,7 @@ class DatabaseClient(object):
             "is_free_tier",
             "display_name",
             "opc_request_id",
+            "is_refreshable_clone",
             "is_data_guard_enabled"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
@@ -6882,6 +7143,7 @@ class DatabaseClient(object):
             "dbVersion": kwargs.get("db_version", missing),
             "isFreeTier": kwargs.get("is_free_tier", missing),
             "displayName": kwargs.get("display_name", missing),
+            "isRefreshableClone": kwargs.get("is_refreshable_clone", missing),
             "isDataGuardEnabled": kwargs.get("is_data_guard_enabled", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
@@ -8641,7 +8903,7 @@ class DatabaseClient(object):
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the given lifecycle state exactly.
 
-            Allowed values are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"
+            Allowed values are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"
 
         :param str availability_domain: (optional)
             A filter to return only resources that match the given availability domain exactly.
@@ -8695,7 +8957,7 @@ class DatabaseClient(object):
                 )
 
         if 'lifecycle_state' in kwargs:
-            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
             if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
                 raise ValueError(
                     "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
@@ -9060,7 +9322,7 @@ class DatabaseClient(object):
 
     def list_maintenance_runs(self, compartment_id, **kwargs):
         """
-        Gets a list of the Maintenance Runs in the specified compartment.
+        Gets a list of the maintenance runs in the specified compartment.
 
 
         :param str compartment_id: (required)
@@ -11991,14 +12253,14 @@ class DatabaseClient(object):
 
     def update_maintenance_run(self, maintenance_run_id, update_maintenance_run_details, **kwargs):
         """
-        Updates the properties of a Maintenance Run, such as the state of a Maintenance Run.
+        Updates the properties of a maintenance run, such as the state of a maintenance run.
 
 
         :param str maintenance_run_id: (required)
-            The Maintenance Run OCID.
+            The maintenance run OCID.
 
         :param UpdateMaintenanceRunDetails update_maintenance_run_details: (required)
-            Request to update the properties of a Maintenance Run.
+            Request to update the properties of a maintenance run.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`

--- a/src/oci/database/database_client_composite_operations.py
+++ b/src/oci/database/database_client_composite_operations.py
@@ -110,6 +110,89 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def autonomous_database_manual_refresh_and_wait_for_work_request(self, autonomous_database_id, autonomous_database_manual_refresh_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.autonomous_database_manual_refresh` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str autonomous_database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param AutonomousDatabaseManualRefreshDetails autonomous_database_manual_refresh_details: (required)
+            Request details for manually refreshing an Autonomous Database refreshable clone.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.autonomous_database_manual_refresh`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.autonomous_database_manual_refresh(autonomous_database_id, autonomous_database_manual_refresh_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def autonomous_database_manual_refresh_and_wait_for_state(self, autonomous_database_id, autonomous_database_manual_refresh_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.autonomous_database_manual_refresh` and waits for the :py:class:`~oci.database.models.AutonomousDatabase` acted upon
+        to enter the given state(s).
+
+        :param str autonomous_database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param AutonomousDatabaseManualRefreshDetails autonomous_database_manual_refresh_details: (required)
+            Request details for manually refreshing an Autonomous Database refreshable clone.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.AutonomousDatabase.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.autonomous_database_manual_refresh`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.autonomous_database_manual_refresh(autonomous_database_id, autonomous_database_manual_refresh_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_autonomous_database(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def change_autonomous_container_database_compartment_and_wait_for_work_request(self, change_compartment_details, autonomous_container_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.change_autonomous_container_database_compartment` and waits for the oci.work_requests.models.WorkRequest
@@ -4247,10 +4330,10 @@ class DatabaseClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str maintenance_run_id: (required)
-            The Maintenance Run OCID.
+            The maintenance run OCID.
 
         :param UpdateMaintenanceRunDetails update_maintenance_run_details: (required)
-            Request to update the properties of a Maintenance Run.
+            Request to update the properties of a maintenance run.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.MaintenanceRun.lifecycle_state`

--- a/src/oci/database/models/__init__.py
+++ b/src/oci/database/models/__init__.py
@@ -22,6 +22,7 @@ from .autonomous_database_backup_summary import AutonomousDatabaseBackupSummary
 from .autonomous_database_connection_strings import AutonomousDatabaseConnectionStrings
 from .autonomous_database_connection_urls import AutonomousDatabaseConnectionUrls
 from .autonomous_database_console_token_details import AutonomousDatabaseConsoleTokenDetails
+from .autonomous_database_manual_refresh_details import AutonomousDatabaseManualRefreshDetails
 from .autonomous_database_standby_summary import AutonomousDatabaseStandbySummary
 from .autonomous_database_summary import AutonomousDatabaseSummary
 from .autonomous_database_wallet import AutonomousDatabaseWallet
@@ -66,10 +67,12 @@ from .create_database_details import CreateDatabaseDetails
 from .create_database_from_another_database_details import CreateDatabaseFromAnotherDatabaseDetails
 from .create_database_from_backup import CreateDatabaseFromBackup
 from .create_database_from_backup_details import CreateDatabaseFromBackupDetails
+from .create_database_from_db_system_details import CreateDatabaseFromDbSystemDetails
 from .create_db_home_base import CreateDbHomeBase
 from .create_db_home_details import CreateDbHomeDetails
 from .create_db_home_from_backup_details import CreateDbHomeFromBackupDetails
 from .create_db_home_from_database_details import CreateDbHomeFromDatabaseDetails
+from .create_db_home_from_db_system_details import CreateDbHomeFromDbSystemDetails
 from .create_db_home_with_db_system_id_details import CreateDbHomeWithDbSystemIdDetails
 from .create_db_home_with_db_system_id_from_backup_details import CreateDbHomeWithDbSystemIdFromBackupDetails
 from .create_db_home_with_db_system_id_from_database_details import CreateDbHomeWithDbSystemIdFromDatabaseDetails
@@ -79,6 +82,7 @@ from .create_external_backup_job_details import CreateExternalBackupJobDetails
 from .create_nfs_backup_destination_details import CreateNFSBackupDestinationDetails
 from .create_new_database_details import CreateNewDatabaseDetails
 from .create_recovery_appliance_backup_destination_details import CreateRecoveryApplianceBackupDestinationDetails
+from .create_refreshable_autonomous_database_clone_details import CreateRefreshableAutonomousDatabaseCloneDetails
 from .create_vm_cluster_details import CreateVmClusterDetails
 from .data_guard_association import DataGuardAssociation
 from .data_guard_association_summary import DataGuardAssociationSummary
@@ -115,6 +119,7 @@ from .launch_db_system_base import LaunchDbSystemBase
 from .launch_db_system_details import LaunchDbSystemDetails
 from .launch_db_system_from_backup_details import LaunchDbSystemFromBackupDetails
 from .launch_db_system_from_database_details import LaunchDbSystemFromDatabaseDetails
+from .launch_db_system_from_db_system_details import LaunchDbSystemFromDbSystemDetails
 from .maintenance_run import MaintenanceRun
 from .maintenance_run_summary import MaintenanceRunSummary
 from .maintenance_window import MaintenanceWindow
@@ -177,6 +182,7 @@ database_type_mapping = {
     "AutonomousDatabaseConnectionStrings": AutonomousDatabaseConnectionStrings,
     "AutonomousDatabaseConnectionUrls": AutonomousDatabaseConnectionUrls,
     "AutonomousDatabaseConsoleTokenDetails": AutonomousDatabaseConsoleTokenDetails,
+    "AutonomousDatabaseManualRefreshDetails": AutonomousDatabaseManualRefreshDetails,
     "AutonomousDatabaseStandbySummary": AutonomousDatabaseStandbySummary,
     "AutonomousDatabaseSummary": AutonomousDatabaseSummary,
     "AutonomousDatabaseWallet": AutonomousDatabaseWallet,
@@ -221,10 +227,12 @@ database_type_mapping = {
     "CreateDatabaseFromAnotherDatabaseDetails": CreateDatabaseFromAnotherDatabaseDetails,
     "CreateDatabaseFromBackup": CreateDatabaseFromBackup,
     "CreateDatabaseFromBackupDetails": CreateDatabaseFromBackupDetails,
+    "CreateDatabaseFromDbSystemDetails": CreateDatabaseFromDbSystemDetails,
     "CreateDbHomeBase": CreateDbHomeBase,
     "CreateDbHomeDetails": CreateDbHomeDetails,
     "CreateDbHomeFromBackupDetails": CreateDbHomeFromBackupDetails,
     "CreateDbHomeFromDatabaseDetails": CreateDbHomeFromDatabaseDetails,
+    "CreateDbHomeFromDbSystemDetails": CreateDbHomeFromDbSystemDetails,
     "CreateDbHomeWithDbSystemIdDetails": CreateDbHomeWithDbSystemIdDetails,
     "CreateDbHomeWithDbSystemIdFromBackupDetails": CreateDbHomeWithDbSystemIdFromBackupDetails,
     "CreateDbHomeWithDbSystemIdFromDatabaseDetails": CreateDbHomeWithDbSystemIdFromDatabaseDetails,
@@ -234,6 +242,7 @@ database_type_mapping = {
     "CreateNFSBackupDestinationDetails": CreateNFSBackupDestinationDetails,
     "CreateNewDatabaseDetails": CreateNewDatabaseDetails,
     "CreateRecoveryApplianceBackupDestinationDetails": CreateRecoveryApplianceBackupDestinationDetails,
+    "CreateRefreshableAutonomousDatabaseCloneDetails": CreateRefreshableAutonomousDatabaseCloneDetails,
     "CreateVmClusterDetails": CreateVmClusterDetails,
     "DataGuardAssociation": DataGuardAssociation,
     "DataGuardAssociationSummary": DataGuardAssociationSummary,
@@ -270,6 +279,7 @@ database_type_mapping = {
     "LaunchDbSystemDetails": LaunchDbSystemDetails,
     "LaunchDbSystemFromBackupDetails": LaunchDbSystemFromBackupDetails,
     "LaunchDbSystemFromDatabaseDetails": LaunchDbSystemFromDatabaseDetails,
+    "LaunchDbSystemFromDbSystemDetails": LaunchDbSystemFromDbSystemDetails,
     "MaintenanceRun": MaintenanceRun,
     "MaintenanceRunSummary": MaintenanceRunSummary,
     "MaintenanceWindow": MaintenanceWindow,

--- a/src/oci/database/models/autonomous_database.py
+++ b/src/oci/database/models/autonomous_database.py
@@ -137,6 +137,30 @@ class AutonomousDatabase(object):
     #: This constant has a value of "FAILED"
     DATA_SAFE_STATUS_FAILED = "FAILED"
 
+    #: A constant which can be used with the open_mode property of a AutonomousDatabase.
+    #: This constant has a value of "READ_ONLY"
+    OPEN_MODE_READ_ONLY = "READ_ONLY"
+
+    #: A constant which can be used with the open_mode property of a AutonomousDatabase.
+    #: This constant has a value of "READ_WRITE"
+    OPEN_MODE_READ_WRITE = "READ_WRITE"
+
+    #: A constant which can be used with the refreshable_status property of a AutonomousDatabase.
+    #: This constant has a value of "REFRESHING"
+    REFRESHABLE_STATUS_REFRESHING = "REFRESHING"
+
+    #: A constant which can be used with the refreshable_status property of a AutonomousDatabase.
+    #: This constant has a value of "NOT_REFRESHING"
+    REFRESHABLE_STATUS_NOT_REFRESHING = "NOT_REFRESHING"
+
+    #: A constant which can be used with the refreshable_mode property of a AutonomousDatabase.
+    #: This constant has a value of "AUTOMATIC"
+    REFRESHABLE_MODE_AUTOMATIC = "AUTOMATIC"
+
+    #: A constant which can be used with the refreshable_mode property of a AutonomousDatabase.
+    #: This constant has a value of "MANUAL"
+    REFRESHABLE_MODE_MANUAL = "MANUAL"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AutonomousDatabase object with values from keyword arguments.
@@ -296,6 +320,44 @@ class AutonomousDatabase(object):
             The value to assign to the time_maintenance_end property of this AutonomousDatabase.
         :type time_maintenance_end: datetime
 
+        :param is_refreshable_clone:
+            The value to assign to the is_refreshable_clone property of this AutonomousDatabase.
+        :type is_refreshable_clone: bool
+
+        :param time_of_last_refresh:
+            The value to assign to the time_of_last_refresh property of this AutonomousDatabase.
+        :type time_of_last_refresh: datetime
+
+        :param time_of_last_refresh_point:
+            The value to assign to the time_of_last_refresh_point property of this AutonomousDatabase.
+        :type time_of_last_refresh_point: datetime
+
+        :param time_of_next_refresh:
+            The value to assign to the time_of_next_refresh property of this AutonomousDatabase.
+        :type time_of_next_refresh: datetime
+
+        :param open_mode:
+            The value to assign to the open_mode property of this AutonomousDatabase.
+            Allowed values for this property are: "READ_ONLY", "READ_WRITE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type open_mode: str
+
+        :param refreshable_status:
+            The value to assign to the refreshable_status property of this AutonomousDatabase.
+            Allowed values for this property are: "REFRESHING", "NOT_REFRESHING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type refreshable_status: str
+
+        :param refreshable_mode:
+            The value to assign to the refreshable_mode property of this AutonomousDatabase.
+            Allowed values for this property are: "AUTOMATIC", "MANUAL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type refreshable_mode: str
+
+        :param source_id:
+            The value to assign to the source_id property of this AutonomousDatabase.
+        :type source_id: str
+
         :param time_of_last_switchover:
             The value to assign to the time_of_last_switchover property of this AutonomousDatabase.
         :type time_of_last_switchover: datetime
@@ -358,6 +420,14 @@ class AutonomousDatabase(object):
             'data_safe_status': 'str',
             'time_maintenance_begin': 'datetime',
             'time_maintenance_end': 'datetime',
+            'is_refreshable_clone': 'bool',
+            'time_of_last_refresh': 'datetime',
+            'time_of_last_refresh_point': 'datetime',
+            'time_of_next_refresh': 'datetime',
+            'open_mode': 'str',
+            'refreshable_status': 'str',
+            'refreshable_mode': 'str',
+            'source_id': 'str',
             'time_of_last_switchover': 'datetime',
             'time_of_last_failover': 'datetime',
             'is_data_guard_enabled': 'bool',
@@ -403,6 +473,14 @@ class AutonomousDatabase(object):
             'data_safe_status': 'dataSafeStatus',
             'time_maintenance_begin': 'timeMaintenanceBegin',
             'time_maintenance_end': 'timeMaintenanceEnd',
+            'is_refreshable_clone': 'isRefreshableClone',
+            'time_of_last_refresh': 'timeOfLastRefresh',
+            'time_of_last_refresh_point': 'timeOfLastRefreshPoint',
+            'time_of_next_refresh': 'timeOfNextRefresh',
+            'open_mode': 'openMode',
+            'refreshable_status': 'refreshableStatus',
+            'refreshable_mode': 'refreshableMode',
+            'source_id': 'sourceId',
             'time_of_last_switchover': 'timeOfLastSwitchover',
             'time_of_last_failover': 'timeOfLastFailover',
             'is_data_guard_enabled': 'isDataGuardEnabled',
@@ -447,6 +525,14 @@ class AutonomousDatabase(object):
         self._data_safe_status = None
         self._time_maintenance_begin = None
         self._time_maintenance_end = None
+        self._is_refreshable_clone = None
+        self._time_of_last_refresh = None
+        self._time_of_last_refresh_point = None
+        self._time_of_next_refresh = None
+        self._open_mode = None
+        self._refreshable_status = None
+        self._refreshable_mode = None
+        self._source_id = None
         self._time_of_last_switchover = None
         self._time_of_last_failover = None
         self._is_data_guard_enabled = None
@@ -1445,6 +1531,220 @@ class AutonomousDatabase(object):
         :type: datetime
         """
         self._time_maintenance_end = time_maintenance_end
+
+    @property
+    def is_refreshable_clone(self):
+        """
+        Gets the is_refreshable_clone of this AutonomousDatabase.
+        Indicates whether the Autonomous Database is a refreshable clone.
+
+
+        :return: The is_refreshable_clone of this AutonomousDatabase.
+        :rtype: bool
+        """
+        return self._is_refreshable_clone
+
+    @is_refreshable_clone.setter
+    def is_refreshable_clone(self, is_refreshable_clone):
+        """
+        Sets the is_refreshable_clone of this AutonomousDatabase.
+        Indicates whether the Autonomous Database is a refreshable clone.
+
+
+        :param is_refreshable_clone: The is_refreshable_clone of this AutonomousDatabase.
+        :type: bool
+        """
+        self._is_refreshable_clone = is_refreshable_clone
+
+    @property
+    def time_of_last_refresh(self):
+        """
+        Gets the time_of_last_refresh of this AutonomousDatabase.
+        The date and time when last refresh happened.
+
+
+        :return: The time_of_last_refresh of this AutonomousDatabase.
+        :rtype: datetime
+        """
+        return self._time_of_last_refresh
+
+    @time_of_last_refresh.setter
+    def time_of_last_refresh(self, time_of_last_refresh):
+        """
+        Sets the time_of_last_refresh of this AutonomousDatabase.
+        The date and time when last refresh happened.
+
+
+        :param time_of_last_refresh: The time_of_last_refresh of this AutonomousDatabase.
+        :type: datetime
+        """
+        self._time_of_last_refresh = time_of_last_refresh
+
+    @property
+    def time_of_last_refresh_point(self):
+        """
+        Gets the time_of_last_refresh_point of this AutonomousDatabase.
+        The refresh point timestamp (UTC). The refresh point is the time to which the database was most recently refreshed. Data created after the refresh point is not included in the refresh.
+
+
+        :return: The time_of_last_refresh_point of this AutonomousDatabase.
+        :rtype: datetime
+        """
+        return self._time_of_last_refresh_point
+
+    @time_of_last_refresh_point.setter
+    def time_of_last_refresh_point(self, time_of_last_refresh_point):
+        """
+        Sets the time_of_last_refresh_point of this AutonomousDatabase.
+        The refresh point timestamp (UTC). The refresh point is the time to which the database was most recently refreshed. Data created after the refresh point is not included in the refresh.
+
+
+        :param time_of_last_refresh_point: The time_of_last_refresh_point of this AutonomousDatabase.
+        :type: datetime
+        """
+        self._time_of_last_refresh_point = time_of_last_refresh_point
+
+    @property
+    def time_of_next_refresh(self):
+        """
+        Gets the time_of_next_refresh of this AutonomousDatabase.
+        The date and time of next refresh.
+
+
+        :return: The time_of_next_refresh of this AutonomousDatabase.
+        :rtype: datetime
+        """
+        return self._time_of_next_refresh
+
+    @time_of_next_refresh.setter
+    def time_of_next_refresh(self, time_of_next_refresh):
+        """
+        Sets the time_of_next_refresh of this AutonomousDatabase.
+        The date and time of next refresh.
+
+
+        :param time_of_next_refresh: The time_of_next_refresh of this AutonomousDatabase.
+        :type: datetime
+        """
+        self._time_of_next_refresh = time_of_next_refresh
+
+    @property
+    def open_mode(self):
+        """
+        Gets the open_mode of this AutonomousDatabase.
+        The `DATABASE OPEN` mode. You can open the database in `READ_ONLY` or `READ_WRITE` mode.
+
+        Allowed values for this property are: "READ_ONLY", "READ_WRITE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The open_mode of this AutonomousDatabase.
+        :rtype: str
+        """
+        return self._open_mode
+
+    @open_mode.setter
+    def open_mode(self, open_mode):
+        """
+        Sets the open_mode of this AutonomousDatabase.
+        The `DATABASE OPEN` mode. You can open the database in `READ_ONLY` or `READ_WRITE` mode.
+
+
+        :param open_mode: The open_mode of this AutonomousDatabase.
+        :type: str
+        """
+        allowed_values = ["READ_ONLY", "READ_WRITE"]
+        if not value_allowed_none_or_none_sentinel(open_mode, allowed_values):
+            open_mode = 'UNKNOWN_ENUM_VALUE'
+        self._open_mode = open_mode
+
+    @property
+    def refreshable_status(self):
+        """
+        Gets the refreshable_status of this AutonomousDatabase.
+        The refresh status of the clone. REFRESHING indicates that the clone is currently being refreshed with data from the source Autonomous Database.
+
+        Allowed values for this property are: "REFRESHING", "NOT_REFRESHING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The refreshable_status of this AutonomousDatabase.
+        :rtype: str
+        """
+        return self._refreshable_status
+
+    @refreshable_status.setter
+    def refreshable_status(self, refreshable_status):
+        """
+        Sets the refreshable_status of this AutonomousDatabase.
+        The refresh status of the clone. REFRESHING indicates that the clone is currently being refreshed with data from the source Autonomous Database.
+
+
+        :param refreshable_status: The refreshable_status of this AutonomousDatabase.
+        :type: str
+        """
+        allowed_values = ["REFRESHING", "NOT_REFRESHING"]
+        if not value_allowed_none_or_none_sentinel(refreshable_status, allowed_values):
+            refreshable_status = 'UNKNOWN_ENUM_VALUE'
+        self._refreshable_status = refreshable_status
+
+    @property
+    def refreshable_mode(self):
+        """
+        Gets the refreshable_mode of this AutonomousDatabase.
+        The refresh mode of the clone. AUTOMATIC indicates that the clone is automatically being refreshed with data from the source Autonomous Database.
+
+        Allowed values for this property are: "AUTOMATIC", "MANUAL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The refreshable_mode of this AutonomousDatabase.
+        :rtype: str
+        """
+        return self._refreshable_mode
+
+    @refreshable_mode.setter
+    def refreshable_mode(self, refreshable_mode):
+        """
+        Sets the refreshable_mode of this AutonomousDatabase.
+        The refresh mode of the clone. AUTOMATIC indicates that the clone is automatically being refreshed with data from the source Autonomous Database.
+
+
+        :param refreshable_mode: The refreshable_mode of this AutonomousDatabase.
+        :type: str
+        """
+        allowed_values = ["AUTOMATIC", "MANUAL"]
+        if not value_allowed_none_or_none_sentinel(refreshable_mode, allowed_values):
+            refreshable_mode = 'UNKNOWN_ENUM_VALUE'
+        self._refreshable_mode = refreshable_mode
+
+    @property
+    def source_id(self):
+        """
+        Gets the source_id of this AutonomousDatabase.
+        The `OCID`__ of the source Autonomous Database that was cloned to create the current Autonomous Database.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The source_id of this AutonomousDatabase.
+        :rtype: str
+        """
+        return self._source_id
+
+    @source_id.setter
+    def source_id(self, source_id):
+        """
+        Sets the source_id of this AutonomousDatabase.
+        The `OCID`__ of the source Autonomous Database that was cloned to create the current Autonomous Database.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param source_id: The source_id of this AutonomousDatabase.
+        :type: str
+        """
+        self._source_id = source_id
 
     @property
     def time_of_last_switchover(self):

--- a/src/oci/database/models/autonomous_database_manual_refresh_details.py
+++ b/src/oci/database/models/autonomous_database_manual_refresh_details.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AutonomousDatabaseManualRefreshDetails(object):
+    """
+    Details of manual refresh for an Autonomous Database refreshable clone.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AutonomousDatabaseManualRefreshDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param time_refresh_cutoff:
+            The value to assign to the time_refresh_cutoff property of this AutonomousDatabaseManualRefreshDetails.
+        :type time_refresh_cutoff: datetime
+
+        """
+        self.swagger_types = {
+            'time_refresh_cutoff': 'datetime'
+        }
+
+        self.attribute_map = {
+            'time_refresh_cutoff': 'timeRefreshCutoff'
+        }
+
+        self._time_refresh_cutoff = None
+
+    @property
+    def time_refresh_cutoff(self):
+        """
+        Gets the time_refresh_cutoff of this AutonomousDatabaseManualRefreshDetails.
+        The timestamp to which the Autonomous Database refreshable clone will be refreshed. Changes made in the primary database after this timestamp are not part of the data refresh.
+
+
+        :return: The time_refresh_cutoff of this AutonomousDatabaseManualRefreshDetails.
+        :rtype: datetime
+        """
+        return self._time_refresh_cutoff
+
+    @time_refresh_cutoff.setter
+    def time_refresh_cutoff(self, time_refresh_cutoff):
+        """
+        Sets the time_refresh_cutoff of this AutonomousDatabaseManualRefreshDetails.
+        The timestamp to which the Autonomous Database refreshable clone will be refreshed. Changes made in the primary database after this timestamp are not part of the data refresh.
+
+
+        :param time_refresh_cutoff: The time_refresh_cutoff of this AutonomousDatabaseManualRefreshDetails.
+        :type: datetime
+        """
+        self._time_refresh_cutoff = time_refresh_cutoff
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/autonomous_database_summary.py
+++ b/src/oci/database/models/autonomous_database_summary.py
@@ -139,6 +139,30 @@ class AutonomousDatabaseSummary(object):
     #: This constant has a value of "FAILED"
     DATA_SAFE_STATUS_FAILED = "FAILED"
 
+    #: A constant which can be used with the open_mode property of a AutonomousDatabaseSummary.
+    #: This constant has a value of "READ_ONLY"
+    OPEN_MODE_READ_ONLY = "READ_ONLY"
+
+    #: A constant which can be used with the open_mode property of a AutonomousDatabaseSummary.
+    #: This constant has a value of "READ_WRITE"
+    OPEN_MODE_READ_WRITE = "READ_WRITE"
+
+    #: A constant which can be used with the refreshable_status property of a AutonomousDatabaseSummary.
+    #: This constant has a value of "REFRESHING"
+    REFRESHABLE_STATUS_REFRESHING = "REFRESHING"
+
+    #: A constant which can be used with the refreshable_status property of a AutonomousDatabaseSummary.
+    #: This constant has a value of "NOT_REFRESHING"
+    REFRESHABLE_STATUS_NOT_REFRESHING = "NOT_REFRESHING"
+
+    #: A constant which can be used with the refreshable_mode property of a AutonomousDatabaseSummary.
+    #: This constant has a value of "AUTOMATIC"
+    REFRESHABLE_MODE_AUTOMATIC = "AUTOMATIC"
+
+    #: A constant which can be used with the refreshable_mode property of a AutonomousDatabaseSummary.
+    #: This constant has a value of "MANUAL"
+    REFRESHABLE_MODE_MANUAL = "MANUAL"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AutonomousDatabaseSummary object with values from keyword arguments.
@@ -298,6 +322,44 @@ class AutonomousDatabaseSummary(object):
             The value to assign to the time_maintenance_end property of this AutonomousDatabaseSummary.
         :type time_maintenance_end: datetime
 
+        :param is_refreshable_clone:
+            The value to assign to the is_refreshable_clone property of this AutonomousDatabaseSummary.
+        :type is_refreshable_clone: bool
+
+        :param time_of_last_refresh:
+            The value to assign to the time_of_last_refresh property of this AutonomousDatabaseSummary.
+        :type time_of_last_refresh: datetime
+
+        :param time_of_last_refresh_point:
+            The value to assign to the time_of_last_refresh_point property of this AutonomousDatabaseSummary.
+        :type time_of_last_refresh_point: datetime
+
+        :param time_of_next_refresh:
+            The value to assign to the time_of_next_refresh property of this AutonomousDatabaseSummary.
+        :type time_of_next_refresh: datetime
+
+        :param open_mode:
+            The value to assign to the open_mode property of this AutonomousDatabaseSummary.
+            Allowed values for this property are: "READ_ONLY", "READ_WRITE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type open_mode: str
+
+        :param refreshable_status:
+            The value to assign to the refreshable_status property of this AutonomousDatabaseSummary.
+            Allowed values for this property are: "REFRESHING", "NOT_REFRESHING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type refreshable_status: str
+
+        :param refreshable_mode:
+            The value to assign to the refreshable_mode property of this AutonomousDatabaseSummary.
+            Allowed values for this property are: "AUTOMATIC", "MANUAL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type refreshable_mode: str
+
+        :param source_id:
+            The value to assign to the source_id property of this AutonomousDatabaseSummary.
+        :type source_id: str
+
         :param time_of_last_switchover:
             The value to assign to the time_of_last_switchover property of this AutonomousDatabaseSummary.
         :type time_of_last_switchover: datetime
@@ -360,6 +422,14 @@ class AutonomousDatabaseSummary(object):
             'data_safe_status': 'str',
             'time_maintenance_begin': 'datetime',
             'time_maintenance_end': 'datetime',
+            'is_refreshable_clone': 'bool',
+            'time_of_last_refresh': 'datetime',
+            'time_of_last_refresh_point': 'datetime',
+            'time_of_next_refresh': 'datetime',
+            'open_mode': 'str',
+            'refreshable_status': 'str',
+            'refreshable_mode': 'str',
+            'source_id': 'str',
             'time_of_last_switchover': 'datetime',
             'time_of_last_failover': 'datetime',
             'is_data_guard_enabled': 'bool',
@@ -405,6 +475,14 @@ class AutonomousDatabaseSummary(object):
             'data_safe_status': 'dataSafeStatus',
             'time_maintenance_begin': 'timeMaintenanceBegin',
             'time_maintenance_end': 'timeMaintenanceEnd',
+            'is_refreshable_clone': 'isRefreshableClone',
+            'time_of_last_refresh': 'timeOfLastRefresh',
+            'time_of_last_refresh_point': 'timeOfLastRefreshPoint',
+            'time_of_next_refresh': 'timeOfNextRefresh',
+            'open_mode': 'openMode',
+            'refreshable_status': 'refreshableStatus',
+            'refreshable_mode': 'refreshableMode',
+            'source_id': 'sourceId',
             'time_of_last_switchover': 'timeOfLastSwitchover',
             'time_of_last_failover': 'timeOfLastFailover',
             'is_data_guard_enabled': 'isDataGuardEnabled',
@@ -449,6 +527,14 @@ class AutonomousDatabaseSummary(object):
         self._data_safe_status = None
         self._time_maintenance_begin = None
         self._time_maintenance_end = None
+        self._is_refreshable_clone = None
+        self._time_of_last_refresh = None
+        self._time_of_last_refresh_point = None
+        self._time_of_next_refresh = None
+        self._open_mode = None
+        self._refreshable_status = None
+        self._refreshable_mode = None
+        self._source_id = None
         self._time_of_last_switchover = None
         self._time_of_last_failover = None
         self._is_data_guard_enabled = None
@@ -1447,6 +1533,220 @@ class AutonomousDatabaseSummary(object):
         :type: datetime
         """
         self._time_maintenance_end = time_maintenance_end
+
+    @property
+    def is_refreshable_clone(self):
+        """
+        Gets the is_refreshable_clone of this AutonomousDatabaseSummary.
+        Indicates whether the Autonomous Database is a refreshable clone.
+
+
+        :return: The is_refreshable_clone of this AutonomousDatabaseSummary.
+        :rtype: bool
+        """
+        return self._is_refreshable_clone
+
+    @is_refreshable_clone.setter
+    def is_refreshable_clone(self, is_refreshable_clone):
+        """
+        Sets the is_refreshable_clone of this AutonomousDatabaseSummary.
+        Indicates whether the Autonomous Database is a refreshable clone.
+
+
+        :param is_refreshable_clone: The is_refreshable_clone of this AutonomousDatabaseSummary.
+        :type: bool
+        """
+        self._is_refreshable_clone = is_refreshable_clone
+
+    @property
+    def time_of_last_refresh(self):
+        """
+        Gets the time_of_last_refresh of this AutonomousDatabaseSummary.
+        The date and time when last refresh happened.
+
+
+        :return: The time_of_last_refresh of this AutonomousDatabaseSummary.
+        :rtype: datetime
+        """
+        return self._time_of_last_refresh
+
+    @time_of_last_refresh.setter
+    def time_of_last_refresh(self, time_of_last_refresh):
+        """
+        Sets the time_of_last_refresh of this AutonomousDatabaseSummary.
+        The date and time when last refresh happened.
+
+
+        :param time_of_last_refresh: The time_of_last_refresh of this AutonomousDatabaseSummary.
+        :type: datetime
+        """
+        self._time_of_last_refresh = time_of_last_refresh
+
+    @property
+    def time_of_last_refresh_point(self):
+        """
+        Gets the time_of_last_refresh_point of this AutonomousDatabaseSummary.
+        The refresh point timestamp (UTC). The refresh point is the time to which the database was most recently refreshed. Data created after the refresh point is not included in the refresh.
+
+
+        :return: The time_of_last_refresh_point of this AutonomousDatabaseSummary.
+        :rtype: datetime
+        """
+        return self._time_of_last_refresh_point
+
+    @time_of_last_refresh_point.setter
+    def time_of_last_refresh_point(self, time_of_last_refresh_point):
+        """
+        Sets the time_of_last_refresh_point of this AutonomousDatabaseSummary.
+        The refresh point timestamp (UTC). The refresh point is the time to which the database was most recently refreshed. Data created after the refresh point is not included in the refresh.
+
+
+        :param time_of_last_refresh_point: The time_of_last_refresh_point of this AutonomousDatabaseSummary.
+        :type: datetime
+        """
+        self._time_of_last_refresh_point = time_of_last_refresh_point
+
+    @property
+    def time_of_next_refresh(self):
+        """
+        Gets the time_of_next_refresh of this AutonomousDatabaseSummary.
+        The date and time of next refresh.
+
+
+        :return: The time_of_next_refresh of this AutonomousDatabaseSummary.
+        :rtype: datetime
+        """
+        return self._time_of_next_refresh
+
+    @time_of_next_refresh.setter
+    def time_of_next_refresh(self, time_of_next_refresh):
+        """
+        Sets the time_of_next_refresh of this AutonomousDatabaseSummary.
+        The date and time of next refresh.
+
+
+        :param time_of_next_refresh: The time_of_next_refresh of this AutonomousDatabaseSummary.
+        :type: datetime
+        """
+        self._time_of_next_refresh = time_of_next_refresh
+
+    @property
+    def open_mode(self):
+        """
+        Gets the open_mode of this AutonomousDatabaseSummary.
+        The `DATABASE OPEN` mode. You can open the database in `READ_ONLY` or `READ_WRITE` mode.
+
+        Allowed values for this property are: "READ_ONLY", "READ_WRITE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The open_mode of this AutonomousDatabaseSummary.
+        :rtype: str
+        """
+        return self._open_mode
+
+    @open_mode.setter
+    def open_mode(self, open_mode):
+        """
+        Sets the open_mode of this AutonomousDatabaseSummary.
+        The `DATABASE OPEN` mode. You can open the database in `READ_ONLY` or `READ_WRITE` mode.
+
+
+        :param open_mode: The open_mode of this AutonomousDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["READ_ONLY", "READ_WRITE"]
+        if not value_allowed_none_or_none_sentinel(open_mode, allowed_values):
+            open_mode = 'UNKNOWN_ENUM_VALUE'
+        self._open_mode = open_mode
+
+    @property
+    def refreshable_status(self):
+        """
+        Gets the refreshable_status of this AutonomousDatabaseSummary.
+        The refresh status of the clone. REFRESHING indicates that the clone is currently being refreshed with data from the source Autonomous Database.
+
+        Allowed values for this property are: "REFRESHING", "NOT_REFRESHING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The refreshable_status of this AutonomousDatabaseSummary.
+        :rtype: str
+        """
+        return self._refreshable_status
+
+    @refreshable_status.setter
+    def refreshable_status(self, refreshable_status):
+        """
+        Sets the refreshable_status of this AutonomousDatabaseSummary.
+        The refresh status of the clone. REFRESHING indicates that the clone is currently being refreshed with data from the source Autonomous Database.
+
+
+        :param refreshable_status: The refreshable_status of this AutonomousDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["REFRESHING", "NOT_REFRESHING"]
+        if not value_allowed_none_or_none_sentinel(refreshable_status, allowed_values):
+            refreshable_status = 'UNKNOWN_ENUM_VALUE'
+        self._refreshable_status = refreshable_status
+
+    @property
+    def refreshable_mode(self):
+        """
+        Gets the refreshable_mode of this AutonomousDatabaseSummary.
+        The refresh mode of the clone. AUTOMATIC indicates that the clone is automatically being refreshed with data from the source Autonomous Database.
+
+        Allowed values for this property are: "AUTOMATIC", "MANUAL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The refreshable_mode of this AutonomousDatabaseSummary.
+        :rtype: str
+        """
+        return self._refreshable_mode
+
+    @refreshable_mode.setter
+    def refreshable_mode(self, refreshable_mode):
+        """
+        Sets the refreshable_mode of this AutonomousDatabaseSummary.
+        The refresh mode of the clone. AUTOMATIC indicates that the clone is automatically being refreshed with data from the source Autonomous Database.
+
+
+        :param refreshable_mode: The refreshable_mode of this AutonomousDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["AUTOMATIC", "MANUAL"]
+        if not value_allowed_none_or_none_sentinel(refreshable_mode, allowed_values):
+            refreshable_mode = 'UNKNOWN_ENUM_VALUE'
+        self._refreshable_mode = refreshable_mode
+
+    @property
+    def source_id(self):
+        """
+        Gets the source_id of this AutonomousDatabaseSummary.
+        The `OCID`__ of the source Autonomous Database that was cloned to create the current Autonomous Database.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The source_id of this AutonomousDatabaseSummary.
+        :rtype: str
+        """
+        return self._source_id
+
+    @source_id.setter
+    def source_id(self, source_id):
+        """
+        Sets the source_id of this AutonomousDatabaseSummary.
+        The `OCID`__ of the source Autonomous Database that was cloned to create the current Autonomous Database.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param source_id: The source_id of this AutonomousDatabaseSummary.
+        :type: str
+        """
+        self._source_id = source_id
 
     @property
     def time_of_last_switchover(self):

--- a/src/oci/database/models/create_autonomous_database_base.py
+++ b/src/oci/database/models/create_autonomous_database_base.py
@@ -51,12 +51,17 @@ class CreateAutonomousDatabaseBase(object):
     #: This constant has a value of "BACKUP_FROM_TIMESTAMP"
     SOURCE_BACKUP_FROM_TIMESTAMP = "BACKUP_FROM_TIMESTAMP"
 
+    #: A constant which can be used with the source property of a CreateAutonomousDatabaseBase.
+    #: This constant has a value of "CLONE_TO_REFRESHABLE"
+    SOURCE_CLONE_TO_REFRESHABLE = "CLONE_TO_REFRESHABLE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new CreateAutonomousDatabaseBase object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
         * :class:`~oci.database.models.CreateAutonomousDatabaseCloneDetails`
+        * :class:`~oci.database.models.CreateRefreshableAutonomousDatabaseCloneDetails`
         * :class:`~oci.database.models.CreateAutonomousDatabaseFromBackupDetails`
         * :class:`~oci.database.models.CreateAutonomousDatabaseFromBackupTimestampDetails`
         * :class:`~oci.database.models.CreateAutonomousDatabaseDetails`
@@ -151,7 +156,7 @@ class CreateAutonomousDatabaseBase(object):
 
         :param source:
             The value to assign to the source property of this CreateAutonomousDatabaseBase.
-            Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP"
+            Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"
         :type source: str
 
         """
@@ -238,6 +243,9 @@ class CreateAutonomousDatabaseBase(object):
 
         if type == 'DATABASE':
             return 'CreateAutonomousDatabaseCloneDetails'
+
+        if type == 'CLONE_TO_REFRESHABLE':
+            return 'CreateRefreshableAutonomousDatabaseCloneDetails'
 
         if type == 'BACKUP_FROM_ID':
             return 'CreateAutonomousDatabaseFromBackupDetails'
@@ -417,7 +425,7 @@ class CreateAutonomousDatabaseBase(object):
     @property
     def admin_password(self):
         """
-        **[Required]** Gets the admin_password of this CreateAutonomousDatabaseBase.
+        Gets the admin_password of this CreateAutonomousDatabaseBase.
         The password must be between 12 and 30 characters long, and must contain at least 1 uppercase, 1 lowercase, and 1 numeric character. It cannot contain the double quote symbol (\") or the username \"admin\", regardless of casing.
 
 
@@ -875,7 +883,7 @@ class CreateAutonomousDatabaseBase(object):
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
         __ https://docs.cloud.oracle.com/Content/Database/Tasks/adbcloning.htm
 
-        Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP"
+        Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"
 
 
         :return: The source of this CreateAutonomousDatabaseBase.
@@ -898,7 +906,7 @@ class CreateAutonomousDatabaseBase(object):
         :param source: The source of this CreateAutonomousDatabaseBase.
         :type: str
         """
-        allowed_values = ["NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP"]
+        allowed_values = ["NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"]
         if not value_allowed_none_or_none_sentinel(source, allowed_values):
             raise ValueError(
                 "Invalid value for `source`, must be None or one of {0}"

--- a/src/oci/database/models/create_autonomous_database_clone_details.py
+++ b/src/oci/database/models/create_autonomous_database_clone_details.py
@@ -115,7 +115,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
 
         :param source:
             The value to assign to the source property of this CreateAutonomousDatabaseCloneDetails.
-            Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP"
+            Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"
         :type source: str
 
         :param source_id:

--- a/src/oci/database/models/create_autonomous_database_details.py
+++ b/src/oci/database/models/create_autonomous_database_details.py
@@ -107,7 +107,7 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
 
         :param source:
             The value to assign to the source property of this CreateAutonomousDatabaseDetails.
-            Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP"
+            Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"
         :type source: str
 
         """

--- a/src/oci/database/models/create_autonomous_database_from_backup_details.py
+++ b/src/oci/database/models/create_autonomous_database_from_backup_details.py
@@ -115,7 +115,7 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
 
         :param source:
             The value to assign to the source property of this CreateAutonomousDatabaseFromBackupDetails.
-            Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP"
+            Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"
         :type source: str
 
         :param autonomous_database_backup_id:

--- a/src/oci/database/models/create_autonomous_database_from_backup_timestamp_details.py
+++ b/src/oci/database/models/create_autonomous_database_from_backup_timestamp_details.py
@@ -115,7 +115,7 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
 
         :param source:
             The value to assign to the source property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
-            Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP"
+            Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"
         :type source: str
 
         :param autonomous_database_id:

--- a/src/oci/database/models/create_database_from_db_system_details.py
+++ b/src/oci/database/models/create_database_from_db_system_details.py
@@ -1,0 +1,270 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDatabaseFromDbSystemDetails(object):
+    """
+    Details for creating a database by restoring from a source database system.
+
+    **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDatabaseFromDbSystemDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param admin_password:
+            The value to assign to the admin_password property of this CreateDatabaseFromDbSystemDetails.
+        :type admin_password: str
+
+        :param db_name:
+            The value to assign to the db_name property of this CreateDatabaseFromDbSystemDetails.
+        :type db_name: str
+
+        :param db_domain:
+            The value to assign to the db_domain property of this CreateDatabaseFromDbSystemDetails.
+        :type db_domain: str
+
+        :param db_unique_name:
+            The value to assign to the db_unique_name property of this CreateDatabaseFromDbSystemDetails.
+        :type db_unique_name: str
+
+        :param db_backup_config:
+            The value to assign to the db_backup_config property of this CreateDatabaseFromDbSystemDetails.
+        :type db_backup_config: DbBackupConfig
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateDatabaseFromDbSystemDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateDatabaseFromDbSystemDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'admin_password': 'str',
+            'db_name': 'str',
+            'db_domain': 'str',
+            'db_unique_name': 'str',
+            'db_backup_config': 'DbBackupConfig',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'admin_password': 'adminPassword',
+            'db_name': 'dbName',
+            'db_domain': 'dbDomain',
+            'db_unique_name': 'dbUniqueName',
+            'db_backup_config': 'dbBackupConfig',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._admin_password = None
+        self._db_name = None
+        self._db_domain = None
+        self._db_unique_name = None
+        self._db_backup_config = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def admin_password(self):
+        """
+        **[Required]** Gets the admin_password of this CreateDatabaseFromDbSystemDetails.
+        A strong password for SYS, SYSTEM, PDB Admin and TDE Wallet. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numbers, and two special characters. The special characters must be _, \\#, or -.
+
+
+        :return: The admin_password of this CreateDatabaseFromDbSystemDetails.
+        :rtype: str
+        """
+        return self._admin_password
+
+    @admin_password.setter
+    def admin_password(self, admin_password):
+        """
+        Sets the admin_password of this CreateDatabaseFromDbSystemDetails.
+        A strong password for SYS, SYSTEM, PDB Admin and TDE Wallet. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numbers, and two special characters. The special characters must be _, \\#, or -.
+
+
+        :param admin_password: The admin_password of this CreateDatabaseFromDbSystemDetails.
+        :type: str
+        """
+        self._admin_password = admin_password
+
+    @property
+    def db_name(self):
+        """
+        Gets the db_name of this CreateDatabaseFromDbSystemDetails.
+        The display name of the database to be created from the backup. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted.
+
+
+        :return: The db_name of this CreateDatabaseFromDbSystemDetails.
+        :rtype: str
+        """
+        return self._db_name
+
+    @db_name.setter
+    def db_name(self, db_name):
+        """
+        Sets the db_name of this CreateDatabaseFromDbSystemDetails.
+        The display name of the database to be created from the backup. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted.
+
+
+        :param db_name: The db_name of this CreateDatabaseFromDbSystemDetails.
+        :type: str
+        """
+        self._db_name = db_name
+
+    @property
+    def db_domain(self):
+        """
+        Gets the db_domain of this CreateDatabaseFromDbSystemDetails.
+        The database domain. In a distributed database system, DB_DOMAIN specifies the logical location of the database within the network structure.
+
+
+        :return: The db_domain of this CreateDatabaseFromDbSystemDetails.
+        :rtype: str
+        """
+        return self._db_domain
+
+    @db_domain.setter
+    def db_domain(self, db_domain):
+        """
+        Sets the db_domain of this CreateDatabaseFromDbSystemDetails.
+        The database domain. In a distributed database system, DB_DOMAIN specifies the logical location of the database within the network structure.
+
+
+        :param db_domain: The db_domain of this CreateDatabaseFromDbSystemDetails.
+        :type: str
+        """
+        self._db_domain = db_domain
+
+    @property
+    def db_unique_name(self):
+        """
+        Gets the db_unique_name of this CreateDatabaseFromDbSystemDetails.
+        The `DB_UNIQUE_NAME` of the Oracle Database.
+
+
+        :return: The db_unique_name of this CreateDatabaseFromDbSystemDetails.
+        :rtype: str
+        """
+        return self._db_unique_name
+
+    @db_unique_name.setter
+    def db_unique_name(self, db_unique_name):
+        """
+        Sets the db_unique_name of this CreateDatabaseFromDbSystemDetails.
+        The `DB_UNIQUE_NAME` of the Oracle Database.
+
+
+        :param db_unique_name: The db_unique_name of this CreateDatabaseFromDbSystemDetails.
+        :type: str
+        """
+        self._db_unique_name = db_unique_name
+
+    @property
+    def db_backup_config(self):
+        """
+        Gets the db_backup_config of this CreateDatabaseFromDbSystemDetails.
+
+        :return: The db_backup_config of this CreateDatabaseFromDbSystemDetails.
+        :rtype: DbBackupConfig
+        """
+        return self._db_backup_config
+
+    @db_backup_config.setter
+    def db_backup_config(self, db_backup_config):
+        """
+        Sets the db_backup_config of this CreateDatabaseFromDbSystemDetails.
+
+        :param db_backup_config: The db_backup_config of this CreateDatabaseFromDbSystemDetails.
+        :type: DbBackupConfig
+        """
+        self._db_backup_config = db_backup_config
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateDatabaseFromDbSystemDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateDatabaseFromDbSystemDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateDatabaseFromDbSystemDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateDatabaseFromDbSystemDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateDatabaseFromDbSystemDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateDatabaseFromDbSystemDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateDatabaseFromDbSystemDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateDatabaseFromDbSystemDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_db_home_from_db_system_details.py
+++ b/src/oci/database/models/create_db_home_from_db_system_details.py
@@ -1,0 +1,177 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDbHomeFromDbSystemDetails(object):
+    """
+    Details for creating a Database Home if you are cloning a database from a another database system.
+
+    **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDbHomeFromDbSystemDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateDbHomeFromDbSystemDetails.
+        :type display_name: str
+
+        :param database:
+            The value to assign to the database property of this CreateDbHomeFromDbSystemDetails.
+        :type database: CreateDatabaseFromDbSystemDetails
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateDbHomeFromDbSystemDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateDbHomeFromDbSystemDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'database': 'CreateDatabaseFromDbSystemDetails',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'database': 'database',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._database = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateDbHomeFromDbSystemDetails.
+        The user-provided name of the Database Home.
+
+
+        :return: The display_name of this CreateDbHomeFromDbSystemDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateDbHomeFromDbSystemDetails.
+        The user-provided name of the Database Home.
+
+
+        :param display_name: The display_name of this CreateDbHomeFromDbSystemDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def database(self):
+        """
+        **[Required]** Gets the database of this CreateDbHomeFromDbSystemDetails.
+
+        :return: The database of this CreateDbHomeFromDbSystemDetails.
+        :rtype: CreateDatabaseFromDbSystemDetails
+        """
+        return self._database
+
+    @database.setter
+    def database(self, database):
+        """
+        Sets the database of this CreateDbHomeFromDbSystemDetails.
+
+        :param database: The database of this CreateDbHomeFromDbSystemDetails.
+        :type: CreateDatabaseFromDbSystemDetails
+        """
+        self._database = database
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateDbHomeFromDbSystemDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateDbHomeFromDbSystemDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateDbHomeFromDbSystemDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateDbHomeFromDbSystemDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateDbHomeFromDbSystemDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateDbHomeFromDbSystemDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateDbHomeFromDbSystemDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateDbHomeFromDbSystemDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_refreshable_autonomous_database_clone_details.py
+++ b/src/oci/database/models/create_refreshable_autonomous_database_clone_details.py
@@ -1,0 +1,281 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_autonomous_database_base import CreateAutonomousDatabaseBase
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateRefreshableAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
+    """
+    Details to create an Oracle Autonomous Database refreshable clone.
+    """
+
+    #: A constant which can be used with the refreshable_mode property of a CreateRefreshableAutonomousDatabaseCloneDetails.
+    #: This constant has a value of "AUTOMATIC"
+    REFRESHABLE_MODE_AUTOMATIC = "AUTOMATIC"
+
+    #: A constant which can be used with the refreshable_mode property of a CreateRefreshableAutonomousDatabaseCloneDetails.
+    #: This constant has a value of "MANUAL"
+    REFRESHABLE_MODE_MANUAL = "MANUAL"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateRefreshableAutonomousDatabaseCloneDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.CreateRefreshableAutonomousDatabaseCloneDetails.source` attribute
+        of this class is ``CLONE_TO_REFRESHABLE`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type compartment_id: str
+
+        :param db_name:
+            The value to assign to the db_name property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type db_name: str
+
+        :param cpu_core_count:
+            The value to assign to the cpu_core_count property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type cpu_core_count: int
+
+        :param db_workload:
+            The value to assign to the db_workload property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+            Allowed values for this property are: "OLTP", "DW", "AJD"
+        :type db_workload: str
+
+        :param data_storage_size_in_tbs:
+            The value to assign to the data_storage_size_in_tbs property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type data_storage_size_in_tbs: int
+
+        :param is_free_tier:
+            The value to assign to the is_free_tier property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type is_free_tier: bool
+
+        :param admin_password:
+            The value to assign to the admin_password property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type admin_password: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type display_name: str
+
+        :param license_model:
+            The value to assign to the license_model property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+        :type license_model: str
+
+        :param is_preview_version_with_service_terms_accepted:
+            The value to assign to the is_preview_version_with_service_terms_accepted property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type is_preview_version_with_service_terms_accepted: bool
+
+        :param is_auto_scaling_enabled:
+            The value to assign to the is_auto_scaling_enabled property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type is_auto_scaling_enabled: bool
+
+        :param is_dedicated:
+            The value to assign to the is_dedicated property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type is_dedicated: bool
+
+        :param autonomous_container_database_id:
+            The value to assign to the autonomous_container_database_id property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type autonomous_container_database_id: str
+
+        :param whitelisted_ips:
+            The value to assign to the whitelisted_ips property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type whitelisted_ips: list[str]
+
+        :param is_data_guard_enabled:
+            The value to assign to the is_data_guard_enabled property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type is_data_guard_enabled: bool
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type subnet_id: str
+
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type nsg_ids: list[str]
+
+        :param private_endpoint_label:
+            The value to assign to the private_endpoint_label property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type private_endpoint_label: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param db_version:
+            The value to assign to the db_version property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type db_version: str
+
+        :param source:
+            The value to assign to the source property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+            Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"
+        :type source: str
+
+        :param source_id:
+            The value to assign to the source_id property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type source_id: str
+
+        :param refreshable_mode:
+            The value to assign to the refreshable_mode property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+            Allowed values for this property are: "AUTOMATIC", "MANUAL"
+        :type refreshable_mode: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'db_name': 'str',
+            'cpu_core_count': 'int',
+            'db_workload': 'str',
+            'data_storage_size_in_tbs': 'int',
+            'is_free_tier': 'bool',
+            'admin_password': 'str',
+            'display_name': 'str',
+            'license_model': 'str',
+            'is_preview_version_with_service_terms_accepted': 'bool',
+            'is_auto_scaling_enabled': 'bool',
+            'is_dedicated': 'bool',
+            'autonomous_container_database_id': 'str',
+            'whitelisted_ips': 'list[str]',
+            'is_data_guard_enabled': 'bool',
+            'subnet_id': 'str',
+            'nsg_ids': 'list[str]',
+            'private_endpoint_label': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'db_version': 'str',
+            'source': 'str',
+            'source_id': 'str',
+            'refreshable_mode': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'db_name': 'dbName',
+            'cpu_core_count': 'cpuCoreCount',
+            'db_workload': 'dbWorkload',
+            'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
+            'is_free_tier': 'isFreeTier',
+            'admin_password': 'adminPassword',
+            'display_name': 'displayName',
+            'license_model': 'licenseModel',
+            'is_preview_version_with_service_terms_accepted': 'isPreviewVersionWithServiceTermsAccepted',
+            'is_auto_scaling_enabled': 'isAutoScalingEnabled',
+            'is_dedicated': 'isDedicated',
+            'autonomous_container_database_id': 'autonomousContainerDatabaseId',
+            'whitelisted_ips': 'whitelistedIps',
+            'is_data_guard_enabled': 'isDataGuardEnabled',
+            'subnet_id': 'subnetId',
+            'nsg_ids': 'nsgIds',
+            'private_endpoint_label': 'privateEndpointLabel',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'db_version': 'dbVersion',
+            'source': 'source',
+            'source_id': 'sourceId',
+            'refreshable_mode': 'refreshableMode'
+        }
+
+        self._compartment_id = None
+        self._db_name = None
+        self._cpu_core_count = None
+        self._db_workload = None
+        self._data_storage_size_in_tbs = None
+        self._is_free_tier = None
+        self._admin_password = None
+        self._display_name = None
+        self._license_model = None
+        self._is_preview_version_with_service_terms_accepted = None
+        self._is_auto_scaling_enabled = None
+        self._is_dedicated = None
+        self._autonomous_container_database_id = None
+        self._whitelisted_ips = None
+        self._is_data_guard_enabled = None
+        self._subnet_id = None
+        self._nsg_ids = None
+        self._private_endpoint_label = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._db_version = None
+        self._source = None
+        self._source_id = None
+        self._refreshable_mode = None
+        self._source = 'CLONE_TO_REFRESHABLE'
+
+    @property
+    def source_id(self):
+        """
+        **[Required]** Gets the source_id of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        The `OCID`__ of the source Autonomous Database that you will clone to create a new Autonomous Database.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The source_id of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :rtype: str
+        """
+        return self._source_id
+
+    @source_id.setter
+    def source_id(self, source_id):
+        """
+        Sets the source_id of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        The `OCID`__ of the source Autonomous Database that you will clone to create a new Autonomous Database.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param source_id: The source_id of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type: str
+        """
+        self._source_id = source_id
+
+    @property
+    def refreshable_mode(self):
+        """
+        Gets the refreshable_mode of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        The refresh mode of the clone. AUTOMATIC indicates that the clone is automatically being refreshed with data from the source Autonomous Database.
+
+        Allowed values for this property are: "AUTOMATIC", "MANUAL"
+
+
+        :return: The refreshable_mode of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :rtype: str
+        """
+        return self._refreshable_mode
+
+    @refreshable_mode.setter
+    def refreshable_mode(self, refreshable_mode):
+        """
+        Sets the refreshable_mode of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        The refresh mode of the clone. AUTOMATIC indicates that the clone is automatically being refreshed with data from the source Autonomous Database.
+
+
+        :param refreshable_mode: The refreshable_mode of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type: str
+        """
+        allowed_values = ["AUTOMATIC", "MANUAL"]
+        if not value_allowed_none_or_none_sentinel(refreshable_mode, allowed_values):
+            raise ValueError(
+                "Invalid value for `refreshable_mode`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._refreshable_mode = refreshable_mode
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/database.py
+++ b/src/oci/database/models/database.py
@@ -128,6 +128,10 @@ class Database(object):
             The value to assign to the connection_strings property of this Database.
         :type connection_strings: DatabaseConnectionStrings
 
+        :param source_database_point_in_time_recovery_timestamp:
+            The value to assign to the source_database_point_in_time_recovery_timestamp property of this Database.
+        :type source_database_point_in_time_recovery_timestamp: datetime
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -148,7 +152,8 @@ class Database(object):
             'db_backup_config': 'DbBackupConfig',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
-            'connection_strings': 'DatabaseConnectionStrings'
+            'connection_strings': 'DatabaseConnectionStrings',
+            'source_database_point_in_time_recovery_timestamp': 'datetime'
         }
 
         self.attribute_map = {
@@ -170,7 +175,8 @@ class Database(object):
             'db_backup_config': 'dbBackupConfig',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
-            'connection_strings': 'connectionStrings'
+            'connection_strings': 'connectionStrings',
+            'source_database_point_in_time_recovery_timestamp': 'sourceDatabasePointInTimeRecoveryTimestamp'
         }
 
         self._id = None
@@ -192,6 +198,7 @@ class Database(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._connection_strings = None
+        self._source_database_point_in_time_recovery_timestamp = None
 
     @property
     def id(self):
@@ -686,6 +693,34 @@ class Database(object):
         :type: DatabaseConnectionStrings
         """
         self._connection_strings = connection_strings
+
+    @property
+    def source_database_point_in_time_recovery_timestamp(self):
+        """
+        Gets the source_database_point_in_time_recovery_timestamp of this Database.
+        Point in time recovery timeStamp of the source database at which cloned database system is cloned from the source database system, as described in `RFC 3339`__
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The source_database_point_in_time_recovery_timestamp of this Database.
+        :rtype: datetime
+        """
+        return self._source_database_point_in_time_recovery_timestamp
+
+    @source_database_point_in_time_recovery_timestamp.setter
+    def source_database_point_in_time_recovery_timestamp(self, source_database_point_in_time_recovery_timestamp):
+        """
+        Sets the source_database_point_in_time_recovery_timestamp of this Database.
+        Point in time recovery timeStamp of the source database at which cloned database system is cloned from the source database system, as described in `RFC 3339`__
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param source_database_point_in_time_recovery_timestamp: The source_database_point_in_time_recovery_timestamp of this Database.
+        :type: datetime
+        """
+        self._source_database_point_in_time_recovery_timestamp = source_database_point_in_time_recovery_timestamp
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/database_summary.py
+++ b/src/oci/database/models/database_summary.py
@@ -135,6 +135,10 @@ class DatabaseSummary(object):
             The value to assign to the connection_strings property of this DatabaseSummary.
         :type connection_strings: DatabaseConnectionStrings
 
+        :param source_database_point_in_time_recovery_timestamp:
+            The value to assign to the source_database_point_in_time_recovery_timestamp property of this DatabaseSummary.
+        :type source_database_point_in_time_recovery_timestamp: datetime
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -155,7 +159,8 @@ class DatabaseSummary(object):
             'db_backup_config': 'DbBackupConfig',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
-            'connection_strings': 'DatabaseConnectionStrings'
+            'connection_strings': 'DatabaseConnectionStrings',
+            'source_database_point_in_time_recovery_timestamp': 'datetime'
         }
 
         self.attribute_map = {
@@ -177,7 +182,8 @@ class DatabaseSummary(object):
             'db_backup_config': 'dbBackupConfig',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
-            'connection_strings': 'connectionStrings'
+            'connection_strings': 'connectionStrings',
+            'source_database_point_in_time_recovery_timestamp': 'sourceDatabasePointInTimeRecoveryTimestamp'
         }
 
         self._id = None
@@ -199,6 +205,7 @@ class DatabaseSummary(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._connection_strings = None
+        self._source_database_point_in_time_recovery_timestamp = None
 
     @property
     def id(self):
@@ -693,6 +700,34 @@ class DatabaseSummary(object):
         :type: DatabaseConnectionStrings
         """
         self._connection_strings = connection_strings
+
+    @property
+    def source_database_point_in_time_recovery_timestamp(self):
+        """
+        Gets the source_database_point_in_time_recovery_timestamp of this DatabaseSummary.
+        Point in time recovery timeStamp of the source database at which cloned database system is cloned from the source database system, as described in `RFC 3339`__
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The source_database_point_in_time_recovery_timestamp of this DatabaseSummary.
+        :rtype: datetime
+        """
+        return self._source_database_point_in_time_recovery_timestamp
+
+    @source_database_point_in_time_recovery_timestamp.setter
+    def source_database_point_in_time_recovery_timestamp(self, source_database_point_in_time_recovery_timestamp):
+        """
+        Sets the source_database_point_in_time_recovery_timestamp of this DatabaseSummary.
+        Point in time recovery timeStamp of the source database at which cloned database system is cloned from the source database system, as described in `RFC 3339`__
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param source_database_point_in_time_recovery_timestamp: The source_database_point_in_time_recovery_timestamp of this DatabaseSummary.
+        :type: datetime
+        """
+        self._source_database_point_in_time_recovery_timestamp = source_database_point_in_time_recovery_timestamp
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/db_system.py
+++ b/src/oci/database/models/db_system.py
@@ -53,6 +53,10 @@ class DbSystem(object):
     #: This constant has a value of "FAILED"
     LIFECYCLE_STATE_FAILED = "FAILED"
 
+    #: A constant which can be used with the lifecycle_state property of a DbSystem.
+    #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
+    LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
+
     #: A constant which can be used with the disk_redundancy property of a DbSystem.
     #: This constant has a value of "HIGH"
     DISK_REDUNDANCY_HIGH = "HIGH"
@@ -170,7 +174,7 @@ class DbSystem(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this DbSystem.
-            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -242,6 +246,14 @@ class DbSystem(object):
             The value to assign to the defined_tags property of this DbSystem.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param source_db_system_id:
+            The value to assign to the source_db_system_id property of this DbSystem.
+        :type source_db_system_id: str
+
+        :param point_in_time_data_disk_clone_timestamp:
+            The value to assign to the point_in_time_data_disk_clone_timestamp property of this DbSystem.
+        :type point_in_time_data_disk_clone_timestamp: datetime
+
         """
         self.swagger_types = {
             'iorm_config_cache': 'ExadataIormConfig',
@@ -283,7 +295,9 @@ class DbSystem(object):
             'last_maintenance_run_id': 'str',
             'next_maintenance_run_id': 'str',
             'freeform_tags': 'dict(str, str)',
-            'defined_tags': 'dict(str, dict(str, object))'
+            'defined_tags': 'dict(str, dict(str, object))',
+            'source_db_system_id': 'str',
+            'point_in_time_data_disk_clone_timestamp': 'datetime'
         }
 
         self.attribute_map = {
@@ -326,7 +340,9 @@ class DbSystem(object):
             'last_maintenance_run_id': 'lastMaintenanceRunId',
             'next_maintenance_run_id': 'nextMaintenanceRunId',
             'freeform_tags': 'freeformTags',
-            'defined_tags': 'definedTags'
+            'defined_tags': 'definedTags',
+            'source_db_system_id': 'sourceDbSystemId',
+            'point_in_time_data_disk_clone_timestamp': 'pointInTimeDataDiskCloneTimestamp'
         }
 
         self._iorm_config_cache = None
@@ -369,6 +385,8 @@ class DbSystem(object):
         self._next_maintenance_run_id = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._source_db_system_id = None
+        self._point_in_time_data_disk_clone_timestamp = None
 
     @property
     def iorm_config_cache(self):
@@ -992,7 +1010,7 @@ class DbSystem(object):
         **[Required]** Gets the lifecycle_state of this DbSystem.
         The current state of the DB system.
 
-        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -1011,7 +1029,7 @@ class DbSystem(object):
         :param lifecycle_state: The lifecycle_state of this DbSystem.
         :type: str
         """
-        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
@@ -1463,6 +1481,62 @@ class DbSystem(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def source_db_system_id(self):
+        """
+        Gets the source_db_system_id of this DbSystem.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The source_db_system_id of this DbSystem.
+        :rtype: str
+        """
+        return self._source_db_system_id
+
+    @source_db_system_id.setter
+    def source_db_system_id(self, source_db_system_id):
+        """
+        Sets the source_db_system_id of this DbSystem.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param source_db_system_id: The source_db_system_id of this DbSystem.
+        :type: str
+        """
+        self._source_db_system_id = source_db_system_id
+
+    @property
+    def point_in_time_data_disk_clone_timestamp(self):
+        """
+        Gets the point_in_time_data_disk_clone_timestamp of this DbSystem.
+        The point in time for a cloned database system when the data disks were cloned from the source database system, as described in `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The point_in_time_data_disk_clone_timestamp of this DbSystem.
+        :rtype: datetime
+        """
+        return self._point_in_time_data_disk_clone_timestamp
+
+    @point_in_time_data_disk_clone_timestamp.setter
+    def point_in_time_data_disk_clone_timestamp(self, point_in_time_data_disk_clone_timestamp):
+        """
+        Sets the point_in_time_data_disk_clone_timestamp of this DbSystem.
+        The point in time for a cloned database system when the data disks were cloned from the source database system, as described in `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param point_in_time_data_disk_clone_timestamp: The point_in_time_data_disk_clone_timestamp of this DbSystem.
+        :type: datetime
+        """
+        self._point_in_time_data_disk_clone_timestamp = point_in_time_data_disk_clone_timestamp
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/db_system_summary.py
+++ b/src/oci/database/models/db_system_summary.py
@@ -75,6 +75,10 @@ class DbSystemSummary(object):
     #: This constant has a value of "FAILED"
     LIFECYCLE_STATE_FAILED = "FAILED"
 
+    #: A constant which can be used with the lifecycle_state property of a DbSystemSummary.
+    #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
+    LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
+
     #: A constant which can be used with the disk_redundancy property of a DbSystemSummary.
     #: This constant has a value of "HIGH"
     DISK_REDUNDANCY_HIGH = "HIGH"
@@ -188,7 +192,7 @@ class DbSystemSummary(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this DbSystemSummary.
-            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -260,6 +264,14 @@ class DbSystemSummary(object):
             The value to assign to the defined_tags property of this DbSystemSummary.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param source_db_system_id:
+            The value to assign to the source_db_system_id property of this DbSystemSummary.
+        :type source_db_system_id: str
+
+        :param point_in_time_data_disk_clone_timestamp:
+            The value to assign to the point_in_time_data_disk_clone_timestamp property of this DbSystemSummary.
+        :type point_in_time_data_disk_clone_timestamp: datetime
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -300,7 +312,9 @@ class DbSystemSummary(object):
             'last_maintenance_run_id': 'str',
             'next_maintenance_run_id': 'str',
             'freeform_tags': 'dict(str, str)',
-            'defined_tags': 'dict(str, dict(str, object))'
+            'defined_tags': 'dict(str, dict(str, object))',
+            'source_db_system_id': 'str',
+            'point_in_time_data_disk_clone_timestamp': 'datetime'
         }
 
         self.attribute_map = {
@@ -342,7 +356,9 @@ class DbSystemSummary(object):
             'last_maintenance_run_id': 'lastMaintenanceRunId',
             'next_maintenance_run_id': 'nextMaintenanceRunId',
             'freeform_tags': 'freeformTags',
-            'defined_tags': 'definedTags'
+            'defined_tags': 'definedTags',
+            'source_db_system_id': 'sourceDbSystemId',
+            'point_in_time_data_disk_clone_timestamp': 'pointInTimeDataDiskCloneTimestamp'
         }
 
         self._id = None
@@ -384,6 +400,8 @@ class DbSystemSummary(object):
         self._next_maintenance_run_id = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._source_db_system_id = None
+        self._point_in_time_data_disk_clone_timestamp = None
 
     @property
     def id(self):
@@ -987,7 +1005,7 @@ class DbSystemSummary(object):
         **[Required]** Gets the lifecycle_state of this DbSystemSummary.
         The current state of the DB system.
 
-        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -1006,7 +1024,7 @@ class DbSystemSummary(object):
         :param lifecycle_state: The lifecycle_state of this DbSystemSummary.
         :type: str
         """
-        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
@@ -1458,6 +1476,62 @@ class DbSystemSummary(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def source_db_system_id(self):
+        """
+        Gets the source_db_system_id of this DbSystemSummary.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The source_db_system_id of this DbSystemSummary.
+        :rtype: str
+        """
+        return self._source_db_system_id
+
+    @source_db_system_id.setter
+    def source_db_system_id(self, source_db_system_id):
+        """
+        Sets the source_db_system_id of this DbSystemSummary.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param source_db_system_id: The source_db_system_id of this DbSystemSummary.
+        :type: str
+        """
+        self._source_db_system_id = source_db_system_id
+
+    @property
+    def point_in_time_data_disk_clone_timestamp(self):
+        """
+        Gets the point_in_time_data_disk_clone_timestamp of this DbSystemSummary.
+        The point in time for a cloned database system when the data disks were cloned from the source database system, as described in `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The point_in_time_data_disk_clone_timestamp of this DbSystemSummary.
+        :rtype: datetime
+        """
+        return self._point_in_time_data_disk_clone_timestamp
+
+    @point_in_time_data_disk_clone_timestamp.setter
+    def point_in_time_data_disk_clone_timestamp(self, point_in_time_data_disk_clone_timestamp):
+        """
+        Sets the point_in_time_data_disk_clone_timestamp of this DbSystemSummary.
+        The point in time for a cloned database system when the data disks were cloned from the source database system, as described in `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param point_in_time_data_disk_clone_timestamp: The point_in_time_data_disk_clone_timestamp of this DbSystemSummary.
+        :type: datetime
+        """
+        self._point_in_time_data_disk_clone_timestamp = point_in_time_data_disk_clone_timestamp
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/launch_db_system_base.py
+++ b/src/oci/database/models/launch_db_system_base.py
@@ -27,12 +27,17 @@ class LaunchDbSystemBase(object):
     #: This constant has a value of "DATABASE"
     SOURCE_DATABASE = "DATABASE"
 
+    #: A constant which can be used with the source property of a LaunchDbSystemBase.
+    #: This constant has a value of "DB_SYSTEM"
+    SOURCE_DB_SYSTEM = "DB_SYSTEM"
+
     def __init__(self, **kwargs):
         """
         Initializes a new LaunchDbSystemBase object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
         * :class:`~oci.database.models.LaunchDbSystemDetails`
+        * :class:`~oci.database.models.LaunchDbSystemFromDbSystemDetails`
         * :class:`~oci.database.models.LaunchDbSystemFromDatabaseDetails`
         * :class:`~oci.database.models.LaunchDbSystemFromBackupDetails`
 
@@ -128,8 +133,12 @@ class LaunchDbSystemBase(object):
 
         :param source:
             The value to assign to the source property of this LaunchDbSystemBase.
-            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "DB_SYSTEM"
         :type source: str
+
+        :param private_ip:
+            The value to assign to the private_ip property of this LaunchDbSystemBase.
+        :type private_ip: str
 
         """
         self.swagger_types = {
@@ -155,7 +164,8 @@ class LaunchDbSystemBase(object):
             'node_count': 'int',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
-            'source': 'str'
+            'source': 'str',
+            'private_ip': 'str'
         }
 
         self.attribute_map = {
@@ -181,7 +191,8 @@ class LaunchDbSystemBase(object):
             'node_count': 'nodeCount',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
-            'source': 'source'
+            'source': 'source',
+            'private_ip': 'privateIp'
         }
 
         self._compartment_id = None
@@ -207,6 +218,7 @@ class LaunchDbSystemBase(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None
+        self._private_ip = None
 
     @staticmethod
     def get_subtype(object_dictionary):
@@ -218,6 +230,9 @@ class LaunchDbSystemBase(object):
 
         if type == 'NONE':
             return 'LaunchDbSystemDetails'
+
+        if type == 'DB_SYSTEM':
+            return 'LaunchDbSystemFromDbSystemDetails'
 
         if type == 'DATABASE':
             return 'LaunchDbSystemFromDatabaseDetails'
@@ -917,7 +932,7 @@ class LaunchDbSystemBase(object):
         Use `NONE` for creating a new database. Use `DB_BACKUP` for creating a new database by restoring from a backup. Use `DATABASE` for creating
         a new database from an existing database, including archive redo log data. The default is `NONE`.
 
-        Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE"
+        Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "DB_SYSTEM"
 
 
         :return: The source of this LaunchDbSystemBase.
@@ -937,13 +952,39 @@ class LaunchDbSystemBase(object):
         :param source: The source of this LaunchDbSystemBase.
         :type: str
         """
-        allowed_values = ["NONE", "DB_BACKUP", "DATABASE"]
+        allowed_values = ["NONE", "DB_BACKUP", "DATABASE", "DB_SYSTEM"]
         if not value_allowed_none_or_none_sentinel(source, allowed_values):
             raise ValueError(
                 "Invalid value for `source`, must be None or one of {0}"
                 .format(allowed_values)
             )
         self._source = source
+
+    @property
+    def private_ip(self):
+        """
+        Gets the private_ip of this LaunchDbSystemBase.
+        A private IP address of your choice. Must be an available IP address within the subnet's CIDR.
+        If you don't specify a value, Oracle automatically assigns a private IP address from the subnet.
+
+
+        :return: The private_ip of this LaunchDbSystemBase.
+        :rtype: str
+        """
+        return self._private_ip
+
+    @private_ip.setter
+    def private_ip(self, private_ip):
+        """
+        Sets the private_ip of this LaunchDbSystemBase.
+        A private IP address of your choice. Must be an available IP address within the subnet's CIDR.
+        If you don't specify a value, Oracle automatically assigns a private IP address from the subnet.
+
+
+        :param private_ip: The private_ip of this LaunchDbSystemBase.
+        :type: str
+        """
+        self._private_ip = private_ip
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/launch_db_system_details.py
+++ b/src/oci/database/models/launch_db_system_details.py
@@ -141,8 +141,12 @@ class LaunchDbSystemDetails(LaunchDbSystemBase):
 
         :param source:
             The value to assign to the source property of this LaunchDbSystemDetails.
-            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "DB_SYSTEM"
         :type source: str
+
+        :param private_ip:
+            The value to assign to the private_ip property of this LaunchDbSystemDetails.
+        :type private_ip: str
 
         :param db_home:
             The value to assign to the db_home property of this LaunchDbSystemDetails.
@@ -192,6 +196,7 @@ class LaunchDbSystemDetails(LaunchDbSystemBase):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str',
+            'private_ip': 'str',
             'db_home': 'CreateDbHomeDetails',
             'database_edition': 'str',
             'disk_redundancy': 'str',
@@ -223,6 +228,7 @@ class LaunchDbSystemDetails(LaunchDbSystemBase):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source',
+            'private_ip': 'privateIp',
             'db_home': 'dbHome',
             'database_edition': 'databaseEdition',
             'disk_redundancy': 'diskRedundancy',
@@ -253,6 +259,7 @@ class LaunchDbSystemDetails(LaunchDbSystemBase):
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None
+        self._private_ip = None
         self._db_home = None
         self._database_edition = None
         self._disk_redundancy = None

--- a/src/oci/database/models/launch_db_system_from_backup_details.py
+++ b/src/oci/database/models/launch_db_system_from_backup_details.py
@@ -141,8 +141,12 @@ class LaunchDbSystemFromBackupDetails(LaunchDbSystemBase):
 
         :param source:
             The value to assign to the source property of this LaunchDbSystemFromBackupDetails.
-            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "DB_SYSTEM"
         :type source: str
+
+        :param private_ip:
+            The value to assign to the private_ip property of this LaunchDbSystemFromBackupDetails.
+        :type private_ip: str
 
         :param db_home:
             The value to assign to the db_home property of this LaunchDbSystemFromBackupDetails.
@@ -188,6 +192,7 @@ class LaunchDbSystemFromBackupDetails(LaunchDbSystemBase):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str',
+            'private_ip': 'str',
             'db_home': 'CreateDbHomeFromBackupDetails',
             'database_edition': 'str',
             'disk_redundancy': 'str',
@@ -218,6 +223,7 @@ class LaunchDbSystemFromBackupDetails(LaunchDbSystemBase):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source',
+            'private_ip': 'privateIp',
             'db_home': 'dbHome',
             'database_edition': 'databaseEdition',
             'disk_redundancy': 'diskRedundancy',
@@ -247,6 +253,7 @@ class LaunchDbSystemFromBackupDetails(LaunchDbSystemBase):
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None
+        self._private_ip = None
         self._db_home = None
         self._database_edition = None
         self._disk_redundancy = None

--- a/src/oci/database/models/launch_db_system_from_database_details.py
+++ b/src/oci/database/models/launch_db_system_from_database_details.py
@@ -141,8 +141,12 @@ class LaunchDbSystemFromDatabaseDetails(LaunchDbSystemBase):
 
         :param source:
             The value to assign to the source property of this LaunchDbSystemFromDatabaseDetails.
-            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "DB_SYSTEM"
         :type source: str
+
+        :param private_ip:
+            The value to assign to the private_ip property of this LaunchDbSystemFromDatabaseDetails.
+        :type private_ip: str
 
         :param db_home:
             The value to assign to the db_home property of this LaunchDbSystemFromDatabaseDetails.
@@ -188,6 +192,7 @@ class LaunchDbSystemFromDatabaseDetails(LaunchDbSystemBase):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str',
+            'private_ip': 'str',
             'db_home': 'CreateDbHomeFromDatabaseDetails',
             'database_edition': 'str',
             'disk_redundancy': 'str',
@@ -218,6 +223,7 @@ class LaunchDbSystemFromDatabaseDetails(LaunchDbSystemBase):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source',
+            'private_ip': 'privateIp',
             'db_home': 'dbHome',
             'database_edition': 'databaseEdition',
             'disk_redundancy': 'diskRedundancy',
@@ -247,6 +253,7 @@ class LaunchDbSystemFromDatabaseDetails(LaunchDbSystemBase):
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None
+        self._private_ip = None
         self._db_home = None
         self._database_edition = None
         self._disk_redundancy = None

--- a/src/oci/database/models/launch_db_system_from_db_system_details.py
+++ b/src/oci/database/models/launch_db_system_from_db_system_details.py
@@ -1,0 +1,320 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .launch_db_system_base import LaunchDbSystemBase
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class LaunchDbSystemFromDbSystemDetails(LaunchDbSystemBase):
+    """
+    Used for creating a new database system by cloning an existing DB system.
+    """
+
+    #: A constant which can be used with the license_model property of a LaunchDbSystemFromDbSystemDetails.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a LaunchDbSystemFromDbSystemDetails.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new LaunchDbSystemFromDbSystemDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.LaunchDbSystemFromDbSystemDetails.source` attribute
+        of this class is ``DB_SYSTEM`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this LaunchDbSystemFromDbSystemDetails.
+        :type compartment_id: str
+
+        :param fault_domains:
+            The value to assign to the fault_domains property of this LaunchDbSystemFromDbSystemDetails.
+        :type fault_domains: list[str]
+
+        :param display_name:
+            The value to assign to the display_name property of this LaunchDbSystemFromDbSystemDetails.
+        :type display_name: str
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this LaunchDbSystemFromDbSystemDetails.
+        :type availability_domain: str
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this LaunchDbSystemFromDbSystemDetails.
+        :type subnet_id: str
+
+        :param backup_subnet_id:
+            The value to assign to the backup_subnet_id property of this LaunchDbSystemFromDbSystemDetails.
+        :type backup_subnet_id: str
+
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this LaunchDbSystemFromDbSystemDetails.
+        :type nsg_ids: list[str]
+
+        :param backup_network_nsg_ids:
+            The value to assign to the backup_network_nsg_ids property of this LaunchDbSystemFromDbSystemDetails.
+        :type backup_network_nsg_ids: list[str]
+
+        :param shape:
+            The value to assign to the shape property of this LaunchDbSystemFromDbSystemDetails.
+        :type shape: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this LaunchDbSystemFromDbSystemDetails.
+        :type time_zone: str
+
+        :param db_system_options:
+            The value to assign to the db_system_options property of this LaunchDbSystemFromDbSystemDetails.
+        :type db_system_options: DbSystemOptions
+
+        :param sparse_diskgroup:
+            The value to assign to the sparse_diskgroup property of this LaunchDbSystemFromDbSystemDetails.
+        :type sparse_diskgroup: bool
+
+        :param ssh_public_keys:
+            The value to assign to the ssh_public_keys property of this LaunchDbSystemFromDbSystemDetails.
+        :type ssh_public_keys: list[str]
+
+        :param hostname:
+            The value to assign to the hostname property of this LaunchDbSystemFromDbSystemDetails.
+        :type hostname: str
+
+        :param domain:
+            The value to assign to the domain property of this LaunchDbSystemFromDbSystemDetails.
+        :type domain: str
+
+        :param cpu_core_count:
+            The value to assign to the cpu_core_count property of this LaunchDbSystemFromDbSystemDetails.
+        :type cpu_core_count: int
+
+        :param cluster_name:
+            The value to assign to the cluster_name property of this LaunchDbSystemFromDbSystemDetails.
+        :type cluster_name: str
+
+        :param data_storage_percentage:
+            The value to assign to the data_storage_percentage property of this LaunchDbSystemFromDbSystemDetails.
+        :type data_storage_percentage: int
+
+        :param initial_data_storage_size_in_gb:
+            The value to assign to the initial_data_storage_size_in_gb property of this LaunchDbSystemFromDbSystemDetails.
+        :type initial_data_storage_size_in_gb: int
+
+        :param node_count:
+            The value to assign to the node_count property of this LaunchDbSystemFromDbSystemDetails.
+        :type node_count: int
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this LaunchDbSystemFromDbSystemDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this LaunchDbSystemFromDbSystemDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param source:
+            The value to assign to the source property of this LaunchDbSystemFromDbSystemDetails.
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "DB_SYSTEM"
+        :type source: str
+
+        :param private_ip:
+            The value to assign to the private_ip property of this LaunchDbSystemFromDbSystemDetails.
+        :type private_ip: str
+
+        :param source_db_system_id:
+            The value to assign to the source_db_system_id property of this LaunchDbSystemFromDbSystemDetails.
+        :type source_db_system_id: str
+
+        :param db_home:
+            The value to assign to the db_home property of this LaunchDbSystemFromDbSystemDetails.
+        :type db_home: CreateDbHomeFromDbSystemDetails
+
+        :param license_model:
+            The value to assign to the license_model property of this LaunchDbSystemFromDbSystemDetails.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+        :type license_model: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'fault_domains': 'list[str]',
+            'display_name': 'str',
+            'availability_domain': 'str',
+            'subnet_id': 'str',
+            'backup_subnet_id': 'str',
+            'nsg_ids': 'list[str]',
+            'backup_network_nsg_ids': 'list[str]',
+            'shape': 'str',
+            'time_zone': 'str',
+            'db_system_options': 'DbSystemOptions',
+            'sparse_diskgroup': 'bool',
+            'ssh_public_keys': 'list[str]',
+            'hostname': 'str',
+            'domain': 'str',
+            'cpu_core_count': 'int',
+            'cluster_name': 'str',
+            'data_storage_percentage': 'int',
+            'initial_data_storage_size_in_gb': 'int',
+            'node_count': 'int',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'source': 'str',
+            'private_ip': 'str',
+            'source_db_system_id': 'str',
+            'db_home': 'CreateDbHomeFromDbSystemDetails',
+            'license_model': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'fault_domains': 'faultDomains',
+            'display_name': 'displayName',
+            'availability_domain': 'availabilityDomain',
+            'subnet_id': 'subnetId',
+            'backup_subnet_id': 'backupSubnetId',
+            'nsg_ids': 'nsgIds',
+            'backup_network_nsg_ids': 'backupNetworkNsgIds',
+            'shape': 'shape',
+            'time_zone': 'timeZone',
+            'db_system_options': 'dbSystemOptions',
+            'sparse_diskgroup': 'sparseDiskgroup',
+            'ssh_public_keys': 'sshPublicKeys',
+            'hostname': 'hostname',
+            'domain': 'domain',
+            'cpu_core_count': 'cpuCoreCount',
+            'cluster_name': 'clusterName',
+            'data_storage_percentage': 'dataStoragePercentage',
+            'initial_data_storage_size_in_gb': 'initialDataStorageSizeInGB',
+            'node_count': 'nodeCount',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'source': 'source',
+            'private_ip': 'privateIp',
+            'source_db_system_id': 'sourceDbSystemId',
+            'db_home': 'dbHome',
+            'license_model': 'licenseModel'
+        }
+
+        self._compartment_id = None
+        self._fault_domains = None
+        self._display_name = None
+        self._availability_domain = None
+        self._subnet_id = None
+        self._backup_subnet_id = None
+        self._nsg_ids = None
+        self._backup_network_nsg_ids = None
+        self._shape = None
+        self._time_zone = None
+        self._db_system_options = None
+        self._sparse_diskgroup = None
+        self._ssh_public_keys = None
+        self._hostname = None
+        self._domain = None
+        self._cpu_core_count = None
+        self._cluster_name = None
+        self._data_storage_percentage = None
+        self._initial_data_storage_size_in_gb = None
+        self._node_count = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._source = None
+        self._private_ip = None
+        self._source_db_system_id = None
+        self._db_home = None
+        self._license_model = None
+        self._source = 'DB_SYSTEM'
+
+    @property
+    def source_db_system_id(self):
+        """
+        **[Required]** Gets the source_db_system_id of this LaunchDbSystemFromDbSystemDetails.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The source_db_system_id of this LaunchDbSystemFromDbSystemDetails.
+        :rtype: str
+        """
+        return self._source_db_system_id
+
+    @source_db_system_id.setter
+    def source_db_system_id(self, source_db_system_id):
+        """
+        Sets the source_db_system_id of this LaunchDbSystemFromDbSystemDetails.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param source_db_system_id: The source_db_system_id of this LaunchDbSystemFromDbSystemDetails.
+        :type: str
+        """
+        self._source_db_system_id = source_db_system_id
+
+    @property
+    def db_home(self):
+        """
+        **[Required]** Gets the db_home of this LaunchDbSystemFromDbSystemDetails.
+
+        :return: The db_home of this LaunchDbSystemFromDbSystemDetails.
+        :rtype: CreateDbHomeFromDbSystemDetails
+        """
+        return self._db_home
+
+    @db_home.setter
+    def db_home(self, db_home):
+        """
+        Sets the db_home of this LaunchDbSystemFromDbSystemDetails.
+
+        :param db_home: The db_home of this LaunchDbSystemFromDbSystemDetails.
+        :type: CreateDbHomeFromDbSystemDetails
+        """
+        self._db_home = db_home
+
+    @property
+    def license_model(self):
+        """
+        Gets the license_model of this LaunchDbSystemFromDbSystemDetails.
+        The Oracle license model that applies to all the databases on the DB system. The default is LICENSE_INCLUDED.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+
+
+        :return: The license_model of this LaunchDbSystemFromDbSystemDetails.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this LaunchDbSystemFromDbSystemDetails.
+        The Oracle license model that applies to all the databases on the DB system. The default is LICENSE_INCLUDED.
+
+
+        :param license_model: The license_model of this LaunchDbSystemFromDbSystemDetails.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            raise ValueError(
+                "Invalid value for `license_model`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._license_model = license_model
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/maintenance_run.py
+++ b/src/oci/database/models/maintenance_run.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class MaintenanceRun(object):
     """
-    Details of a Maintenance Run.
+    Details of a maintenance run.
     """
 
     #: A constant which can be used with the lifecycle_state property of a MaintenanceRun.
@@ -193,7 +193,7 @@ class MaintenanceRun(object):
     def id(self):
         """
         **[Required]** Gets the id of this MaintenanceRun.
-        The OCID of the Maintenance Run.
+        The OCID of the maintenance run.
 
 
         :return: The id of this MaintenanceRun.
@@ -205,7 +205,7 @@ class MaintenanceRun(object):
     def id(self, id):
         """
         Sets the id of this MaintenanceRun.
-        The OCID of the Maintenance Run.
+        The OCID of the maintenance run.
 
 
         :param id: The id of this MaintenanceRun.
@@ -241,7 +241,7 @@ class MaintenanceRun(object):
     def display_name(self):
         """
         **[Required]** Gets the display_name of this MaintenanceRun.
-        The user-friendly name for the Maintenance Run.
+        The user-friendly name for the maintenance run.
 
 
         :return: The display_name of this MaintenanceRun.
@@ -253,7 +253,7 @@ class MaintenanceRun(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this MaintenanceRun.
-        The user-friendly name for the Maintenance Run.
+        The user-friendly name for the maintenance run.
 
 
         :param display_name: The display_name of this MaintenanceRun.
@@ -265,7 +265,7 @@ class MaintenanceRun(object):
     def description(self):
         """
         Gets the description of this MaintenanceRun.
-        The text describing this Maintenance Run.
+        Description of the maintenance run.
 
 
         :return: The description of this MaintenanceRun.
@@ -277,7 +277,7 @@ class MaintenanceRun(object):
     def description(self, description):
         """
         Sets the description of this MaintenanceRun.
-        The text describing this Maintenance Run.
+        Description of the maintenance run.
 
 
         :param description: The description of this MaintenanceRun.
@@ -289,7 +289,7 @@ class MaintenanceRun(object):
     def lifecycle_state(self):
         """
         **[Required]** Gets the lifecycle_state of this MaintenanceRun.
-        The current state of the Maintenance Run.
+        The current state of the maintenance run.
 
         Allowed values for this property are: "SCHEDULED", "IN_PROGRESS", "SUCCEEDED", "SKIPPED", "FAILED", "UPDATING", "DELETING", "DELETED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -304,7 +304,7 @@ class MaintenanceRun(object):
     def lifecycle_state(self, lifecycle_state):
         """
         Sets the lifecycle_state of this MaintenanceRun.
-        The current state of the Maintenance Run.
+        The current state of the maintenance run.
 
 
         :param lifecycle_state: The lifecycle_state of this MaintenanceRun.
@@ -343,7 +343,7 @@ class MaintenanceRun(object):
     def time_scheduled(self):
         """
         **[Required]** Gets the time_scheduled of this MaintenanceRun.
-        The date and time the Maintenance Run is scheduled for.
+        The date and time the maintenance run is scheduled to occur.
 
 
         :return: The time_scheduled of this MaintenanceRun.
@@ -355,7 +355,7 @@ class MaintenanceRun(object):
     def time_scheduled(self, time_scheduled):
         """
         Sets the time_scheduled of this MaintenanceRun.
-        The date and time the Maintenance Run is scheduled for.
+        The date and time the maintenance run is scheduled to occur.
 
 
         :param time_scheduled: The time_scheduled of this MaintenanceRun.
@@ -367,7 +367,7 @@ class MaintenanceRun(object):
     def time_started(self):
         """
         Gets the time_started of this MaintenanceRun.
-        The date and time the Maintenance Run starts.
+        The date and time the maintenance run starts.
 
 
         :return: The time_started of this MaintenanceRun.
@@ -379,7 +379,7 @@ class MaintenanceRun(object):
     def time_started(self, time_started):
         """
         Sets the time_started of this MaintenanceRun.
-        The date and time the Maintenance Run starts.
+        The date and time the maintenance run starts.
 
 
         :param time_started: The time_started of this MaintenanceRun.
@@ -391,7 +391,7 @@ class MaintenanceRun(object):
     def time_ended(self):
         """
         Gets the time_ended of this MaintenanceRun.
-        The date and time the Maintenance Run was completed.
+        The date and time the maintenance run was completed.
 
 
         :return: The time_ended of this MaintenanceRun.
@@ -403,7 +403,7 @@ class MaintenanceRun(object):
     def time_ended(self, time_ended):
         """
         Sets the time_ended of this MaintenanceRun.
-        The date and time the Maintenance Run was completed.
+        The date and time the maintenance run was completed.
 
 
         :param time_ended: The time_ended of this MaintenanceRun.
@@ -415,7 +415,7 @@ class MaintenanceRun(object):
     def target_resource_type(self):
         """
         Gets the target_resource_type of this MaintenanceRun.
-        The type of the target resource on which the Maintenance Run occurs.
+        The type of the target resource on which the maintenance run occurs.
 
         Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -430,7 +430,7 @@ class MaintenanceRun(object):
     def target_resource_type(self, target_resource_type):
         """
         Sets the target_resource_type of this MaintenanceRun.
-        The type of the target resource on which the Maintenance Run occurs.
+        The type of the target resource on which the maintenance run occurs.
 
 
         :param target_resource_type: The target_resource_type of this MaintenanceRun.
@@ -445,7 +445,7 @@ class MaintenanceRun(object):
     def target_resource_id(self):
         """
         Gets the target_resource_id of this MaintenanceRun.
-        The ID of the target resource on which the Maintenance Run occurs.
+        The ID of the target resource on which the maintenance run occurs.
 
 
         :return: The target_resource_id of this MaintenanceRun.
@@ -457,7 +457,7 @@ class MaintenanceRun(object):
     def target_resource_id(self, target_resource_id):
         """
         Sets the target_resource_id of this MaintenanceRun.
-        The ID of the target resource on which the Maintenance Run occurs.
+        The ID of the target resource on which the maintenance run occurs.
 
 
         :param target_resource_id: The target_resource_id of this MaintenanceRun.

--- a/src/oci/database/models/maintenance_run_summary.py
+++ b/src/oci/database/models/maintenance_run_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class MaintenanceRunSummary(object):
     """
-    Details of a Maintenance Run.
+    Details of a maintenance run.
     """
 
     #: A constant which can be used with the lifecycle_state property of a MaintenanceRunSummary.
@@ -193,7 +193,7 @@ class MaintenanceRunSummary(object):
     def id(self):
         """
         **[Required]** Gets the id of this MaintenanceRunSummary.
-        The OCID of the Maintenance Run.
+        The OCID of the maintenance run.
 
 
         :return: The id of this MaintenanceRunSummary.
@@ -205,7 +205,7 @@ class MaintenanceRunSummary(object):
     def id(self, id):
         """
         Sets the id of this MaintenanceRunSummary.
-        The OCID of the Maintenance Run.
+        The OCID of the maintenance run.
 
 
         :param id: The id of this MaintenanceRunSummary.
@@ -241,7 +241,7 @@ class MaintenanceRunSummary(object):
     def display_name(self):
         """
         **[Required]** Gets the display_name of this MaintenanceRunSummary.
-        The user-friendly name for the Maintenance Run.
+        The user-friendly name for the maintenance run.
 
 
         :return: The display_name of this MaintenanceRunSummary.
@@ -253,7 +253,7 @@ class MaintenanceRunSummary(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this MaintenanceRunSummary.
-        The user-friendly name for the Maintenance Run.
+        The user-friendly name for the maintenance run.
 
 
         :param display_name: The display_name of this MaintenanceRunSummary.
@@ -265,7 +265,7 @@ class MaintenanceRunSummary(object):
     def description(self):
         """
         Gets the description of this MaintenanceRunSummary.
-        The text describing this Maintenance Run.
+        Description of the maintenance run.
 
 
         :return: The description of this MaintenanceRunSummary.
@@ -277,7 +277,7 @@ class MaintenanceRunSummary(object):
     def description(self, description):
         """
         Sets the description of this MaintenanceRunSummary.
-        The text describing this Maintenance Run.
+        Description of the maintenance run.
 
 
         :param description: The description of this MaintenanceRunSummary.
@@ -289,7 +289,7 @@ class MaintenanceRunSummary(object):
     def lifecycle_state(self):
         """
         **[Required]** Gets the lifecycle_state of this MaintenanceRunSummary.
-        The current state of the Maintenance Run.
+        The current state of the maintenance run.
 
         Allowed values for this property are: "SCHEDULED", "IN_PROGRESS", "SUCCEEDED", "SKIPPED", "FAILED", "UPDATING", "DELETING", "DELETED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -304,7 +304,7 @@ class MaintenanceRunSummary(object):
     def lifecycle_state(self, lifecycle_state):
         """
         Sets the lifecycle_state of this MaintenanceRunSummary.
-        The current state of the Maintenance Run.
+        The current state of the maintenance run.
 
 
         :param lifecycle_state: The lifecycle_state of this MaintenanceRunSummary.
@@ -343,7 +343,7 @@ class MaintenanceRunSummary(object):
     def time_scheduled(self):
         """
         **[Required]** Gets the time_scheduled of this MaintenanceRunSummary.
-        The date and time the Maintenance Run is scheduled for.
+        The date and time the maintenance run is scheduled to occur.
 
 
         :return: The time_scheduled of this MaintenanceRunSummary.
@@ -355,7 +355,7 @@ class MaintenanceRunSummary(object):
     def time_scheduled(self, time_scheduled):
         """
         Sets the time_scheduled of this MaintenanceRunSummary.
-        The date and time the Maintenance Run is scheduled for.
+        The date and time the maintenance run is scheduled to occur.
 
 
         :param time_scheduled: The time_scheduled of this MaintenanceRunSummary.
@@ -367,7 +367,7 @@ class MaintenanceRunSummary(object):
     def time_started(self):
         """
         Gets the time_started of this MaintenanceRunSummary.
-        The date and time the Maintenance Run starts.
+        The date and time the maintenance run starts.
 
 
         :return: The time_started of this MaintenanceRunSummary.
@@ -379,7 +379,7 @@ class MaintenanceRunSummary(object):
     def time_started(self, time_started):
         """
         Sets the time_started of this MaintenanceRunSummary.
-        The date and time the Maintenance Run starts.
+        The date and time the maintenance run starts.
 
 
         :param time_started: The time_started of this MaintenanceRunSummary.
@@ -391,7 +391,7 @@ class MaintenanceRunSummary(object):
     def time_ended(self):
         """
         Gets the time_ended of this MaintenanceRunSummary.
-        The date and time the Maintenance Run was completed.
+        The date and time the maintenance run was completed.
 
 
         :return: The time_ended of this MaintenanceRunSummary.
@@ -403,7 +403,7 @@ class MaintenanceRunSummary(object):
     def time_ended(self, time_ended):
         """
         Sets the time_ended of this MaintenanceRunSummary.
-        The date and time the Maintenance Run was completed.
+        The date and time the maintenance run was completed.
 
 
         :param time_ended: The time_ended of this MaintenanceRunSummary.
@@ -415,7 +415,7 @@ class MaintenanceRunSummary(object):
     def target_resource_type(self):
         """
         Gets the target_resource_type of this MaintenanceRunSummary.
-        The type of the target resource on which the Maintenance Run occurs.
+        The type of the target resource on which the maintenance run occurs.
 
         Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -430,7 +430,7 @@ class MaintenanceRunSummary(object):
     def target_resource_type(self, target_resource_type):
         """
         Sets the target_resource_type of this MaintenanceRunSummary.
-        The type of the target resource on which the Maintenance Run occurs.
+        The type of the target resource on which the maintenance run occurs.
 
 
         :param target_resource_type: The target_resource_type of this MaintenanceRunSummary.
@@ -445,7 +445,7 @@ class MaintenanceRunSummary(object):
     def target_resource_id(self):
         """
         Gets the target_resource_id of this MaintenanceRunSummary.
-        The ID of the target resource on which the Maintenance Run occurs.
+        The ID of the target resource on which the maintenance run occurs.
 
 
         :return: The target_resource_id of this MaintenanceRunSummary.
@@ -457,7 +457,7 @@ class MaintenanceRunSummary(object):
     def target_resource_id(self, target_resource_id):
         """
         Sets the target_resource_id of this MaintenanceRunSummary.
-        The ID of the target resource on which the Maintenance Run occurs.
+        The ID of the target resource on which the maintenance run occurs.
 
 
         :param target_resource_id: The target_resource_id of this MaintenanceRunSummary.

--- a/src/oci/database/models/update_autonomous_database_details.py
+++ b/src/oci/database/models/update_autonomous_database_details.py
@@ -35,6 +35,14 @@ class UpdateAutonomousDatabaseDetails(object):
     #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
     LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
 
+    #: A constant which can be used with the refreshable_mode property of a UpdateAutonomousDatabaseDetails.
+    #: This constant has a value of "AUTOMATIC"
+    REFRESHABLE_MODE_AUTOMATIC = "AUTOMATIC"
+
+    #: A constant which can be used with the refreshable_mode property of a UpdateAutonomousDatabaseDetails.
+    #: This constant has a value of "MANUAL"
+    REFRESHABLE_MODE_MANUAL = "MANUAL"
+
     def __init__(self, **kwargs):
         """
         Initializes a new UpdateAutonomousDatabaseDetails object with values from keyword arguments.
@@ -90,6 +98,15 @@ class UpdateAutonomousDatabaseDetails(object):
             The value to assign to the is_auto_scaling_enabled property of this UpdateAutonomousDatabaseDetails.
         :type is_auto_scaling_enabled: bool
 
+        :param is_refreshable_clone:
+            The value to assign to the is_refreshable_clone property of this UpdateAutonomousDatabaseDetails.
+        :type is_refreshable_clone: bool
+
+        :param refreshable_mode:
+            The value to assign to the refreshable_mode property of this UpdateAutonomousDatabaseDetails.
+            Allowed values for this property are: "AUTOMATIC", "MANUAL"
+        :type refreshable_mode: str
+
         :param is_data_guard_enabled:
             The value to assign to the is_data_guard_enabled property of this UpdateAutonomousDatabaseDetails.
         :type is_data_guard_enabled: bool
@@ -124,6 +141,8 @@ class UpdateAutonomousDatabaseDetails(object):
             'license_model': 'str',
             'whitelisted_ips': 'list[str]',
             'is_auto_scaling_enabled': 'bool',
+            'is_refreshable_clone': 'bool',
+            'refreshable_mode': 'str',
             'is_data_guard_enabled': 'bool',
             'db_version': 'str',
             'subnet_id': 'str',
@@ -144,6 +163,8 @@ class UpdateAutonomousDatabaseDetails(object):
             'license_model': 'licenseModel',
             'whitelisted_ips': 'whitelistedIps',
             'is_auto_scaling_enabled': 'isAutoScalingEnabled',
+            'is_refreshable_clone': 'isRefreshableClone',
+            'refreshable_mode': 'refreshableMode',
             'is_data_guard_enabled': 'isDataGuardEnabled',
             'db_version': 'dbVersion',
             'subnet_id': 'subnetId',
@@ -163,6 +184,8 @@ class UpdateAutonomousDatabaseDetails(object):
         self._license_model = None
         self._whitelisted_ips = None
         self._is_auto_scaling_enabled = None
+        self._is_refreshable_clone = None
+        self._refreshable_mode = None
         self._is_data_guard_enabled = None
         self._db_version = None
         self._subnet_id = None
@@ -524,6 +547,62 @@ class UpdateAutonomousDatabaseDetails(object):
         :type: bool
         """
         self._is_auto_scaling_enabled = is_auto_scaling_enabled
+
+    @property
+    def is_refreshable_clone(self):
+        """
+        Gets the is_refreshable_clone of this UpdateAutonomousDatabaseDetails.
+        Indicates whether the Autonomous Database is a refreshable clone.
+
+
+        :return: The is_refreshable_clone of this UpdateAutonomousDatabaseDetails.
+        :rtype: bool
+        """
+        return self._is_refreshable_clone
+
+    @is_refreshable_clone.setter
+    def is_refreshable_clone(self, is_refreshable_clone):
+        """
+        Sets the is_refreshable_clone of this UpdateAutonomousDatabaseDetails.
+        Indicates whether the Autonomous Database is a refreshable clone.
+
+
+        :param is_refreshable_clone: The is_refreshable_clone of this UpdateAutonomousDatabaseDetails.
+        :type: bool
+        """
+        self._is_refreshable_clone = is_refreshable_clone
+
+    @property
+    def refreshable_mode(self):
+        """
+        Gets the refreshable_mode of this UpdateAutonomousDatabaseDetails.
+        The refresh mode of the clone. AUTOMATIC indicates that the clone is automatically being refreshed with data from the source Autonomous Database.
+
+        Allowed values for this property are: "AUTOMATIC", "MANUAL"
+
+
+        :return: The refreshable_mode of this UpdateAutonomousDatabaseDetails.
+        :rtype: str
+        """
+        return self._refreshable_mode
+
+    @refreshable_mode.setter
+    def refreshable_mode(self, refreshable_mode):
+        """
+        Sets the refreshable_mode of this UpdateAutonomousDatabaseDetails.
+        The refresh mode of the clone. AUTOMATIC indicates that the clone is automatically being refreshed with data from the source Autonomous Database.
+
+
+        :param refreshable_mode: The refreshable_mode of this UpdateAutonomousDatabaseDetails.
+        :type: str
+        """
+        allowed_values = ["AUTOMATIC", "MANUAL"]
+        if not value_allowed_none_or_none_sentinel(refreshable_mode, allowed_values):
+            raise ValueError(
+                "Invalid value for `refreshable_mode`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._refreshable_mode = refreshable_mode
 
     @property
     def is_data_guard_enabled(self):

--- a/src/oci/database/models/update_maintenance_run_details.py
+++ b/src/oci/database/models/update_maintenance_run_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateMaintenanceRunDetails(object):
     """
-    Describes the modification parameters for the Maintenance Run.
+    Describes the modification parameters for the maintenance run.
     """
 
     def __init__(self, **kwargs):
@@ -51,7 +51,7 @@ class UpdateMaintenanceRunDetails(object):
     def is_enabled(self):
         """
         Gets the is_enabled of this UpdateMaintenanceRunDetails.
-        If set to false, skips the Maintenance Run.
+        If `FALSE`, skips the maintenance run.
 
 
         :return: The is_enabled of this UpdateMaintenanceRunDetails.
@@ -63,7 +63,7 @@ class UpdateMaintenanceRunDetails(object):
     def is_enabled(self, is_enabled):
         """
         Sets the is_enabled of this UpdateMaintenanceRunDetails.
-        If set to false, skips the Maintenance Run.
+        If `FALSE`, skips the maintenance run.
 
 
         :param is_enabled: The is_enabled of this UpdateMaintenanceRunDetails.
@@ -75,7 +75,7 @@ class UpdateMaintenanceRunDetails(object):
     def time_scheduled(self):
         """
         Gets the time_scheduled of this UpdateMaintenanceRunDetails.
-        The scheduled date and time of the Maintenance Run to update.
+        The scheduled date and time of the maintenance run to update.
 
 
         :return: The time_scheduled of this UpdateMaintenanceRunDetails.
@@ -87,7 +87,7 @@ class UpdateMaintenanceRunDetails(object):
     def time_scheduled(self, time_scheduled):
         """
         Sets the time_scheduled of this UpdateMaintenanceRunDetails.
-        The scheduled date and time of the Maintenance Run to update.
+        The scheduled date and time of the maintenance run to update.
 
 
         :param time_scheduled: The time_scheduled of this UpdateMaintenanceRunDetails.

--- a/src/oci/identity/models/__init__.py
+++ b/src/oci/identity/models/__init__.py
@@ -52,6 +52,7 @@ from .mfa_totp_device import MfaTotpDevice
 from .mfa_totp_device_summary import MfaTotpDeviceSummary
 from .mfa_totp_token import MfaTotpToken
 from .move_compartment_details import MoveCompartmentDetails
+from .network_policy import NetworkPolicy
 from .network_sources import NetworkSources
 from .network_sources_summary import NetworkSourcesSummary
 from .network_sources_virtual_source_list import NetworkSourcesVirtualSourceList
@@ -158,6 +159,7 @@ identity_type_mapping = {
     "MfaTotpDeviceSummary": MfaTotpDeviceSummary,
     "MfaTotpToken": MfaTotpToken,
     "MoveCompartmentDetails": MoveCompartmentDetails,
+    "NetworkPolicy": NetworkPolicy,
     "NetworkSources": NetworkSources,
     "NetworkSourcesSummary": NetworkSourcesSummary,
     "NetworkSourcesVirtualSourceList": NetworkSourcesVirtualSourceList,

--- a/src/oci/identity/models/authentication_policy.py
+++ b/src/oci/identity/models/authentication_policy.py
@@ -26,26 +26,31 @@ class AuthenticationPolicy(object):
             The value to assign to the compartment_id property of this AuthenticationPolicy.
         :type compartment_id: str
 
+        :param network_policy:
+            The value to assign to the network_policy property of this AuthenticationPolicy.
+        :type network_policy: NetworkPolicy
+
         """
         self.swagger_types = {
             'password_policy': 'PasswordPolicy',
-            'compartment_id': 'str'
+            'compartment_id': 'str',
+            'network_policy': 'NetworkPolicy'
         }
 
         self.attribute_map = {
             'password_policy': 'passwordPolicy',
-            'compartment_id': 'compartmentId'
+            'compartment_id': 'compartmentId',
+            'network_policy': 'networkPolicy'
         }
 
         self._password_policy = None
         self._compartment_id = None
+        self._network_policy = None
 
     @property
     def password_policy(self):
         """
         Gets the password_policy of this AuthenticationPolicy.
-        Password policy.
-
 
         :return: The password_policy of this AuthenticationPolicy.
         :rtype: PasswordPolicy
@@ -56,8 +61,6 @@ class AuthenticationPolicy(object):
     def password_policy(self, password_policy):
         """
         Sets the password_policy of this AuthenticationPolicy.
-        Password policy.
-
 
         :param password_policy: The password_policy of this AuthenticationPolicy.
         :type: PasswordPolicy
@@ -87,6 +90,26 @@ class AuthenticationPolicy(object):
         :type: str
         """
         self._compartment_id = compartment_id
+
+    @property
+    def network_policy(self):
+        """
+        Gets the network_policy of this AuthenticationPolicy.
+
+        :return: The network_policy of this AuthenticationPolicy.
+        :rtype: NetworkPolicy
+        """
+        return self._network_policy
+
+    @network_policy.setter
+    def network_policy(self, network_policy):
+        """
+        Sets the network_policy of this AuthenticationPolicy.
+
+        :param network_policy: The network_policy of this AuthenticationPolicy.
+        :type: NetworkPolicy
+        """
+        self._network_policy = network_policy
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/identity/models/create_tag_details.py
+++ b/src/oci/identity/models/create_tag_details.py
@@ -214,19 +214,6 @@ class CreateTagDetails(object):
     def validator(self):
         """
         Gets the validator of this CreateTagDetails.
-        The tag must have a value type, which is specified with a validator. Tags can use either a
-        static value or a list of possible values. Static values are entered by a user applying the tag
-        to a resource. Lists are created by you and the user must apply a value from the list. Lists
-        are validiated.
-
-        If you use the default validiator (or don't define a validator), the user applying the tag
-        enters a value. No additional validation is performed.
-
-        To clear the validator, call UpdateTag with
-        `DefaultTagDefinitionValidator`__.
-
-        __ https://docs.cloud.oracle.com/api/#/en/identity/latest/datatypes/DefaultTagDefinitionValidator
-
 
         :return: The validator of this CreateTagDetails.
         :rtype: BaseTagDefinitionValidator
@@ -237,19 +224,6 @@ class CreateTagDetails(object):
     def validator(self, validator):
         """
         Sets the validator of this CreateTagDetails.
-        The tag must have a value type, which is specified with a validator. Tags can use either a
-        static value or a list of possible values. Static values are entered by a user applying the tag
-        to a resource. Lists are created by you and the user must apply a value from the list. Lists
-        are validiated.
-
-        If you use the default validiator (or don't define a validator), the user applying the tag
-        enters a value. No additional validation is performed.
-
-        To clear the validator, call UpdateTag with
-        `DefaultTagDefinitionValidator`__.
-
-        __ https://docs.cloud.oracle.com/api/#/en/identity/latest/datatypes/DefaultTagDefinitionValidator
-
 
         :param validator: The validator of this CreateTagDetails.
         :type: BaseTagDefinitionValidator

--- a/src/oci/identity/models/network_policy.py
+++ b/src/oci/identity/models/network_policy.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class NetworkPolicy(object):
+    """
+    Network policy, Consists of a list of Network Source ids.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new NetworkPolicy object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param network_source_ids:
+            The value to assign to the network_source_ids property of this NetworkPolicy.
+        :type network_source_ids: list[str]
+
+        """
+        self.swagger_types = {
+            'network_source_ids': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'network_source_ids': 'networkSourceIds'
+        }
+
+        self._network_source_ids = None
+
+    @property
+    def network_source_ids(self):
+        """
+        Gets the network_source_ids of this NetworkPolicy.
+        Network Source ids
+
+
+        :return: The network_source_ids of this NetworkPolicy.
+        :rtype: list[str]
+        """
+        return self._network_source_ids
+
+    @network_source_ids.setter
+    def network_source_ids(self, network_source_ids):
+        """
+        Sets the network_source_ids of this NetworkPolicy.
+        Network Source ids
+
+
+        :param network_source_ids: The network_source_ids of this NetworkPolicy.
+        :type: list[str]
+        """
+        self._network_source_ids = network_source_ids
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/identity/models/network_sources_summary.py
+++ b/src/oci/identity/models/network_sources_summary.py
@@ -54,6 +54,14 @@ class NetworkSourcesSummary(object):
             The value to assign to the time_created property of this NetworkSourcesSummary.
         :type time_created: datetime
 
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this NetworkSourcesSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this NetworkSourcesSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -63,7 +71,9 @@ class NetworkSourcesSummary(object):
             'public_source_list': 'list[str]',
             'virtual_source_list': 'list[NetworkSourcesVirtualSourceList]',
             'services': 'list[str]',
-            'time_created': 'datetime'
+            'time_created': 'datetime',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
         }
 
         self.attribute_map = {
@@ -74,7 +84,9 @@ class NetworkSourcesSummary(object):
             'public_source_list': 'publicSourceList',
             'virtual_source_list': 'virtualSourceList',
             'services': 'services',
-            'time_created': 'timeCreated'
+            'time_created': 'timeCreated',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
         }
 
         self._id = None
@@ -85,6 +97,8 @@ class NetworkSourcesSummary(object):
         self._virtual_source_list = None
         self._services = None
         self._time_created = None
+        self._freeform_tags = None
+        self._defined_tags = None
 
     @property
     def id(self):
@@ -287,6 +301,70 @@ class NetworkSourcesSummary(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this NetworkSourcesSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this NetworkSourcesSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this NetworkSourcesSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this NetworkSourcesSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this NetworkSourcesSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this NetworkSourcesSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this NetworkSourcesSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this NetworkSourcesSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/identity/models/tag.py
+++ b/src/oci/identity/models/tag.py
@@ -472,19 +472,6 @@ class Tag(object):
     def validator(self):
         """
         Gets the validator of this Tag.
-        The tag must have a value type, which is specified with a validator. Tags can use either a
-        static value or a list of possible values. Static values are entered by a user applying the tag
-        to a resource. Lists are created by you and the user must apply a value from the list. Lists
-        are validiated.
-
-        If you use the default validiator (or don't define a validator), the user applying the tag
-        enters a value. No additional validation is performed.
-
-        To clear the validator, call UpdateTag with
-        `DefaultTagDefinitionValidator`__.
-
-        __ https://docs.cloud.oracle.com/api/#/en/identity/latest/datatypes/DefaultTagDefinitionValidator
-
 
         :return: The validator of this Tag.
         :rtype: BaseTagDefinitionValidator
@@ -495,19 +482,6 @@ class Tag(object):
     def validator(self, validator):
         """
         Sets the validator of this Tag.
-        The tag must have a value type, which is specified with a validator. Tags can use either a
-        static value or a list of possible values. Static values are entered by a user applying the tag
-        to a resource. Lists are created by you and the user must apply a value from the list. Lists
-        are validiated.
-
-        If you use the default validiator (or don't define a validator), the user applying the tag
-        enters a value. No additional validation is performed.
-
-        To clear the validator, call UpdateTag with
-        `DefaultTagDefinitionValidator`__.
-
-        __ https://docs.cloud.oracle.com/api/#/en/identity/latest/datatypes/DefaultTagDefinitionValidator
-
 
         :param validator: The validator of this Tag.
         :type: BaseTagDefinitionValidator

--- a/src/oci/identity/models/update_authentication_policy_details.py
+++ b/src/oci/identity/models/update_authentication_policy_details.py
@@ -22,23 +22,28 @@ class UpdateAuthenticationPolicyDetails(object):
             The value to assign to the password_policy property of this UpdateAuthenticationPolicyDetails.
         :type password_policy: PasswordPolicy
 
+        :param network_policy:
+            The value to assign to the network_policy property of this UpdateAuthenticationPolicyDetails.
+        :type network_policy: NetworkPolicy
+
         """
         self.swagger_types = {
-            'password_policy': 'PasswordPolicy'
+            'password_policy': 'PasswordPolicy',
+            'network_policy': 'NetworkPolicy'
         }
 
         self.attribute_map = {
-            'password_policy': 'passwordPolicy'
+            'password_policy': 'passwordPolicy',
+            'network_policy': 'networkPolicy'
         }
 
         self._password_policy = None
+        self._network_policy = None
 
     @property
     def password_policy(self):
         """
         Gets the password_policy of this UpdateAuthenticationPolicyDetails.
-        Password policy.
-
 
         :return: The password_policy of this UpdateAuthenticationPolicyDetails.
         :rtype: PasswordPolicy
@@ -49,13 +54,31 @@ class UpdateAuthenticationPolicyDetails(object):
     def password_policy(self, password_policy):
         """
         Sets the password_policy of this UpdateAuthenticationPolicyDetails.
-        Password policy.
-
 
         :param password_policy: The password_policy of this UpdateAuthenticationPolicyDetails.
         :type: PasswordPolicy
         """
         self._password_policy = password_policy
+
+    @property
+    def network_policy(self):
+        """
+        Gets the network_policy of this UpdateAuthenticationPolicyDetails.
+
+        :return: The network_policy of this UpdateAuthenticationPolicyDetails.
+        :rtype: NetworkPolicy
+        """
+        return self._network_policy
+
+    @network_policy.setter
+    def network_policy(self, network_policy):
+        """
+        Sets the network_policy of this UpdateAuthenticationPolicyDetails.
+
+        :param network_policy: The network_policy of this UpdateAuthenticationPolicyDetails.
+        :type: NetworkPolicy
+        """
+        self._network_policy = network_policy
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/identity/models/update_tag_details.py
+++ b/src/oci/identity/models/update_tag_details.py
@@ -218,19 +218,6 @@ class UpdateTagDetails(object):
     def validator(self):
         """
         Gets the validator of this UpdateTagDetails.
-        The tag must have a value type, which is specified with a validator. Tags can use either a
-        static value or a list of possible values. Static values are entered by a user applying the tag
-        to a resource. Lists are created by you and the user must apply a value from the list. Lists
-        are validiated.
-
-        If you use the default validiator (or don't define a validator), the user applying the tag
-        enters a value. No additional validation is performed.
-
-        To clear the validator, call UpdateTag with
-        `DefaultTagDefinitionValidator`__.
-
-        __ https://docs.cloud.oracle.com/api/#/en/identity/latest/datatypes/DefaultTagDefinitionValidator
-
 
         :return: The validator of this UpdateTagDetails.
         :rtype: BaseTagDefinitionValidator
@@ -241,19 +228,6 @@ class UpdateTagDetails(object):
     def validator(self, validator):
         """
         Sets the validator of this UpdateTagDetails.
-        The tag must have a value type, which is specified with a validator. Tags can use either a
-        static value or a list of possible values. Static values are entered by a user applying the tag
-        to a resource. Lists are created by you and the user must apply a value from the list. Lists
-        are validiated.
-
-        If you use the default validiator (or don't define a validator), the user applying the tag
-        enters a value. No additional validation is performed.
-
-        To clear the validator, call UpdateTag with
-        `DefaultTagDefinitionValidator`__.
-
-        __ https://docs.cloud.oracle.com/api/#/en/identity/latest/datatypes/DefaultTagDefinitionValidator
-
 
         :param validator: The validator of this UpdateTagDetails.
         :type: BaseTagDefinitionValidator

--- a/src/oci/identity/models/user.py
+++ b/src/oci/identity/models/user.py
@@ -537,8 +537,6 @@ class User(object):
     def capabilities(self):
         """
         Gets the capabilities of this User.
-        Properties indicating how the user is allowed to authenticate.
-
 
         :return: The capabilities of this User.
         :rtype: UserCapabilities
@@ -549,8 +547,6 @@ class User(object):
     def capabilities(self, capabilities):
         """
         Sets the capabilities of this User.
-        Properties indicating how the user is allowed to authenticate.
-
 
         :param capabilities: The capabilities of this User.
         :type: UserCapabilities

--- a/src/oci/load_balancer/load_balancer_client.py
+++ b/src/oci/load_balancer/load_balancer_client.py
@@ -913,6 +913,95 @@ class LoadBalancerClient(object):
                 header_params=header_params,
                 body=create_rule_set_details)
 
+    def create_ssl_cipher_suite(self, create_ssl_cipher_suite_details, load_balancer_id, **kwargs):
+        """
+        Creates a custom SSL cipher suite.
+
+
+        :param CreateSSLCipherSuiteDetails create_ssl_cipher_suite_details: (required)
+            The details of the SSL cipher suite to add.
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the associated load balancer.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+            a particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/loadBalancers/{loadBalancerId}/sslCipherSuites"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_ssl_cipher_suite got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "loadBalancerId": load_balancer_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_ssl_cipher_suite_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_ssl_cipher_suite_details)
+
     def delete_backend(self, load_balancer_id, backend_set_name, backend_name, **kwargs):
         """
         Removes a backend server from a given load balancer and backend set.
@@ -1521,6 +1610,85 @@ class LoadBalancerClient(object):
         path_params = {
             "loadBalancerId": load_balancer_id,
             "ruleSetName": rule_set_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_ssl_cipher_suite(self, load_balancer_id, name, **kwargs):
+        """
+        Deletes an SSL cipher suite from a load balancer.
+
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the associated load balancer.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str name: (required)
+            The name of the SSL cipher suite to delete.
+
+            example: `example_cipher_suite`
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+            a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/loadBalancers/{loadBalancerId}/sslCipherSuites/{name}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_ssl_cipher_suite got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "loadBalancerId": load_balancer_id,
+            "name": name
         }
 
         path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
@@ -2363,6 +2531,87 @@ class LoadBalancerClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 response_type="RuleSet")
+
+    def get_ssl_cipher_suite(self, load_balancer_id, name, **kwargs):
+        """
+        Gets the specified SSL cipher suite's configuration information.
+
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the associated load balancer.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str name: (required)
+            The name of the SSL cipher suite to retrieve.
+
+            example: `example_cipher_suite`
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+            a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.load_balancer.models.SSLCipherSuite`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/loadBalancers/{loadBalancerId}/sslCipherSuites/{name}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_ssl_cipher_suite got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "loadBalancerId": load_balancer_id,
+            "name": name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="SSLCipherSuite")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="SSLCipherSuite")
 
     def get_work_request(self, work_request_id, **kwargs):
         """
@@ -3492,6 +3741,81 @@ class LoadBalancerClient(object):
                 header_params=header_params,
                 response_type="list[LoadBalancerShape]")
 
+    def list_ssl_cipher_suites(self, load_balancer_id, **kwargs):
+        """
+        Lists all SSL cipher suites associated with the specified load balancer.
+
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the associated load balancer.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+            a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.load_balancer.models.SSLCipherSuite`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/loadBalancers/{loadBalancerId}/sslCipherSuites"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_ssl_cipher_suites got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "loadBalancerId": load_balancer_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="list[SSLCipherSuite]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="list[SSLCipherSuite]")
+
     def list_work_requests(self, load_balancer_id, **kwargs):
         """
         Lists the work requests for a given load balancer.
@@ -4429,3 +4753,98 @@ class LoadBalancerClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 body=update_rule_set_details)
+
+    def update_ssl_cipher_suite(self, update_ssl_cipher_suite_details, load_balancer_id, name, **kwargs):
+        """
+        Updates an existing SSL cipher suite for the specified load balancer.
+
+
+        :param UpdateSSLCipherSuiteDetails update_ssl_cipher_suite_details: (required)
+            The configuration details to update an SSL cipher suite.
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the associated load balancer.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str name: (required)
+            The name of the SSL cipher suite to update.
+
+            example: `example_cipher_suite`
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+            a particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/loadBalancers/{loadBalancerId}/sslCipherSuites/{name}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_ssl_cipher_suite got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "loadBalancerId": load_balancer_id,
+            "name": name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_ssl_cipher_suite_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_ssl_cipher_suite_details)

--- a/src/oci/load_balancer/load_balancer_client_composite_operations.py
+++ b/src/oci/load_balancer/load_balancer_client_composite_operations.py
@@ -410,6 +410,49 @@ class LoadBalancerClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def create_ssl_cipher_suite_and_wait_for_state(self, create_ssl_cipher_suite_details, load_balancer_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.load_balancer.LoadBalancerClient.create_ssl_cipher_suite` and waits for the :py:class:`~oci.load_balancer.models.WorkRequest`
+        to enter the given state(s).
+
+        :param CreateSSLCipherSuiteDetails create_ssl_cipher_suite_details: (required)
+            The details of the SSL cipher suite to add.
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the associated load balancer.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.load_balancer.models.WorkRequest.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.load_balancer.LoadBalancerClient.create_ssl_cipher_suite`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_ssl_cipher_suite(create_ssl_cipher_suite_details, load_balancer_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def delete_backend_and_wait_for_state(self, load_balancer_id, backend_set_name, backend_name, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.load_balancer.LoadBalancerClient.delete_backend` and waits for the :py:class:`~oci.load_balancer.models.WorkRequest`
@@ -810,6 +853,59 @@ class LoadBalancerClientCompositeOperations(object):
         operation_result = None
         try:
             operation_result = self.client.delete_rule_set(load_balancer_id, rule_set_name, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_ssl_cipher_suite_and_wait_for_state(self, load_balancer_id, name, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.load_balancer.LoadBalancerClient.delete_ssl_cipher_suite` and waits for the :py:class:`~oci.load_balancer.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the associated load balancer.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str name: (required)
+            The name of the SSL cipher suite to delete.
+
+            example: `example_cipher_suite`
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.load_balancer.models.WorkRequest.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.load_balancer.LoadBalancerClient.delete_ssl_cipher_suite`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = None
+        try:
+            operation_result = self.client.delete_ssl_cipher_suite(load_balancer_id, name, **operation_kwargs)
         except oci.exceptions.ServiceError as e:
             if e.status == 404:
                 return WAIT_RESOURCE_NOT_FOUND
@@ -1244,6 +1340,54 @@ class LoadBalancerClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         operation_result = self.client.update_rule_set(load_balancer_id, rule_set_name, update_rule_set_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_ssl_cipher_suite_and_wait_for_state(self, update_ssl_cipher_suite_details, load_balancer_id, name, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.load_balancer.LoadBalancerClient.update_ssl_cipher_suite` and waits for the :py:class:`~oci.load_balancer.models.WorkRequest`
+        to enter the given state(s).
+
+        :param UpdateSSLCipherSuiteDetails update_ssl_cipher_suite_details: (required)
+            The configuration details to update an SSL cipher suite.
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the associated load balancer.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str name: (required)
+            The name of the SSL cipher suite to update.
+
+            example: `example_cipher_suite`
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.load_balancer.models.WorkRequest.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.load_balancer.LoadBalancerClient.update_ssl_cipher_suite`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_ssl_cipher_suite(update_ssl_cipher_suite_details, load_balancer_id, name, **operation_kwargs)
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/load_balancer/models/__init__.py
+++ b/src/oci/load_balancer/models/__init__.py
@@ -26,6 +26,7 @@ from .create_listener_details import CreateListenerDetails
 from .create_load_balancer_details import CreateLoadBalancerDetails
 from .create_path_route_set_details import CreatePathRouteSetDetails
 from .create_rule_set_details import CreateRuleSetDetails
+from .create_ssl_cipher_suite_details import CreateSSLCipherSuiteDetails
 from .extend_http_request_header_value_rule import ExtendHttpRequestHeaderValueRule
 from .extend_http_response_header_value_rule import ExtendHttpResponseHeaderValueRule
 from .health_check_result import HealthCheckResult
@@ -58,6 +59,8 @@ from .rule import Rule
 from .rule_condition import RuleCondition
 from .rule_set import RuleSet
 from .rule_set_details import RuleSetDetails
+from .ssl_cipher_suite import SSLCipherSuite
+from .ssl_cipher_suite_details import SSLCipherSuiteDetails
 from .ssl_configuration import SSLConfiguration
 from .ssl_configuration_details import SSLConfigurationDetails
 from .session_persistence_configuration_details import SessionPersistenceConfigurationDetails
@@ -73,6 +76,7 @@ from .update_load_balancer_details import UpdateLoadBalancerDetails
 from .update_network_security_groups_details import UpdateNetworkSecurityGroupsDetails
 from .update_path_route_set_details import UpdatePathRouteSetDetails
 from .update_rule_set_details import UpdateRuleSetDetails
+from .update_ssl_cipher_suite_details import UpdateSSLCipherSuiteDetails
 from .work_request import WorkRequest
 from .work_request_error import WorkRequestError
 
@@ -100,6 +104,7 @@ load_balancer_type_mapping = {
     "CreateLoadBalancerDetails": CreateLoadBalancerDetails,
     "CreatePathRouteSetDetails": CreatePathRouteSetDetails,
     "CreateRuleSetDetails": CreateRuleSetDetails,
+    "CreateSSLCipherSuiteDetails": CreateSSLCipherSuiteDetails,
     "ExtendHttpRequestHeaderValueRule": ExtendHttpRequestHeaderValueRule,
     "ExtendHttpResponseHeaderValueRule": ExtendHttpResponseHeaderValueRule,
     "HealthCheckResult": HealthCheckResult,
@@ -132,6 +137,8 @@ load_balancer_type_mapping = {
     "RuleCondition": RuleCondition,
     "RuleSet": RuleSet,
     "RuleSetDetails": RuleSetDetails,
+    "SSLCipherSuite": SSLCipherSuite,
+    "SSLCipherSuiteDetails": SSLCipherSuiteDetails,
     "SSLConfiguration": SSLConfiguration,
     "SSLConfigurationDetails": SSLConfigurationDetails,
     "SessionPersistenceConfigurationDetails": SessionPersistenceConfigurationDetails,
@@ -147,6 +154,7 @@ load_balancer_type_mapping = {
     "UpdateNetworkSecurityGroupsDetails": UpdateNetworkSecurityGroupsDetails,
     "UpdatePathRouteSetDetails": UpdatePathRouteSetDetails,
     "UpdateRuleSetDetails": UpdateRuleSetDetails,
+    "UpdateSSLCipherSuiteDetails": UpdateSSLCipherSuiteDetails,
     "WorkRequest": WorkRequest,
     "WorkRequestError": WorkRequestError
 }

--- a/src/oci/load_balancer/models/create_load_balancer_details.py
+++ b/src/oci/load_balancer/models/create_load_balancer_details.py
@@ -73,6 +73,10 @@ class CreateLoadBalancerDetails(object):
             The value to assign to the certificates property of this CreateLoadBalancerDetails.
         :type certificates: dict(str, CertificateDetails)
 
+        :param ssl_cipher_suites:
+            The value to assign to the ssl_cipher_suites property of this CreateLoadBalancerDetails.
+        :type ssl_cipher_suites: dict(str, SSLCipherSuiteDetails)
+
         :param path_route_sets:
             The value to assign to the path_route_sets property of this CreateLoadBalancerDetails.
         :type path_route_sets: dict(str, PathRouteSetDetails)
@@ -102,6 +106,7 @@ class CreateLoadBalancerDetails(object):
             'network_security_group_ids': 'list[str]',
             'subnet_ids': 'list[str]',
             'certificates': 'dict(str, CertificateDetails)',
+            'ssl_cipher_suites': 'dict(str, SSLCipherSuiteDetails)',
             'path_route_sets': 'dict(str, PathRouteSetDetails)',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
@@ -120,6 +125,7 @@ class CreateLoadBalancerDetails(object):
             'network_security_group_ids': 'networkSecurityGroupIds',
             'subnet_ids': 'subnetIds',
             'certificates': 'certificates',
+            'ssl_cipher_suites': 'sslCipherSuites',
             'path_route_sets': 'pathRouteSets',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
@@ -137,6 +143,7 @@ class CreateLoadBalancerDetails(object):
         self._network_security_group_ids = None
         self._subnet_ids = None
         self._certificates = None
+        self._ssl_cipher_suites = None
         self._path_route_sets = None
         self._freeform_tags = None
         self._defined_tags = None
@@ -483,6 +490,26 @@ class CreateLoadBalancerDetails(object):
         :type: dict(str, CertificateDetails)
         """
         self._certificates = certificates
+
+    @property
+    def ssl_cipher_suites(self):
+        """
+        Gets the ssl_cipher_suites of this CreateLoadBalancerDetails.
+
+        :return: The ssl_cipher_suites of this CreateLoadBalancerDetails.
+        :rtype: dict(str, SSLCipherSuiteDetails)
+        """
+        return self._ssl_cipher_suites
+
+    @ssl_cipher_suites.setter
+    def ssl_cipher_suites(self, ssl_cipher_suites):
+        """
+        Sets the ssl_cipher_suites of this CreateLoadBalancerDetails.
+
+        :param ssl_cipher_suites: The ssl_cipher_suites of this CreateLoadBalancerDetails.
+        :type: dict(str, SSLCipherSuiteDetails)
+        """
+        self._ssl_cipher_suites = ssl_cipher_suites
 
     @property
     def path_route_sets(self):

--- a/src/oci/load_balancer/models/create_ssl_cipher_suite_details.py
+++ b/src/oci/load_balancer/models/create_ssl_cipher_suite_details.py
@@ -1,0 +1,502 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateSSLCipherSuiteDetails(object):
+    """
+    The configuration details of an SSL cipher suite.
+
+    The algorithms that compose a cipher suite help you secure Transport Layer Security (TLS) or Secure Socket Layer
+    (SSL) network connections. A cipher suite defines the list of security algorithms your load balancer uses to
+    negotiate with peers while sending and receiving information. The cipher suites you use affect the security
+    level, performance, and compatibility of your data traffic.
+
+    **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+
+    Oracle created the following predefined cipher suites that you can specify when you define a resource's
+    `SSL configuration`__. You can `create custom
+    cipher suites`__ if the predefined cipher
+    suites do not meet your requirements.
+
+
+    *  __oci-default-ssl-cipher-suite-v1__
+
+    \"DHE-RSA-AES128-GCM-SHA256\"
+    \"DHE-RSA-AES128-SHA256\"
+    \"DHE-RSA-AES256-GCM-SHA384\"
+    \"DHE-RSA-AES256-SHA256\"
+    \"ECDHE-RSA-AES128-GCM-SHA256\"
+    \"ECDHE-RSA-AES128-SHA256\"
+    \"ECDHE-RSA-AES256-GCM-SHA384\"
+    \"ECDHE-RSA-AES256-SHA384\"
+
+    *  __oci-modern-ssl-cipher-suite-v1__
+
+    \"AES128-GCM-SHA256\"
+    \"AES128-SHA256\"
+    \"AES256-GCM-SHA384\"
+    \"AES256-SHA256\"
+    \"DHE-RSA-AES128-GCM-SHA256\"
+    \"DHE-RSA-AES128-SHA256\"
+    \"DHE-RSA-AES256-GCM-SHA384\"
+    \"DHE-RSA-AES256-SHA256\"
+    \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+    \"ECDHE-ECDSA-AES128-SHA256\"
+    \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+    \"ECDHE-ECDSA-AES256-SHA384\"
+    \"ECDHE-RSA-AES128-GCM-SHA256\"
+    \"ECDHE-RSA-AES128-SHA256\"
+    \"ECDHE-RSA-AES256-GCM-SHA384\"
+    \"ECDHE-RSA-AES256-SHA384\"
+
+    *  __oci-compatible-ssl-cipher-suite-v1__
+
+    \"AES128-GCM-SHA256\"
+    \"AES128-SHA\"
+    \"AES128-SHA256\"
+    \"AES256-GCM-SHA384\"
+    \"AES256-SHA\"
+    \"AES256-SHA256\"
+    \"DHE-RSA-AES128-GCM-SHA256\"
+    \"DHE-RSA-AES128-SHA256\"
+    \"DHE-RSA-AES256-GCM-SHA384\"
+    \"DHE-RSA-AES256-SHA256\"
+    \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+    \"ECDHE-ECDSA-AES128-SHA\"
+    \"ECDHE-ECDSA-AES128-SHA256\"
+    \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+    \"ECDHE-ECDSA-AES256-SHA\"
+    \"ECDHE-ECDSA-AES256-SHA384\"
+    \"ECDHE-RSA-AES128-GCM-SHA256\"
+    \"ECDHE-RSA-AES128-SHA\"
+    \"ECDHE-RSA-AES128-SHA256\"
+    \"ECDHE-RSA-AES256-GCM-SHA384\"
+    \"ECDHE-RSA-AES256-SHA\"
+    \"ECDHE-RSA-AES256-SHA384\"
+
+    *  __oci-wider-compatible-ssl-cipher-suite-v1__
+
+    \"AES128-GCM-SHA256\"
+    \"AES128-SHA\"
+    \"AES128-SHA256\"
+    \"AES256-GCM-SHA384\"
+    \"AES256-SHA\"
+    \"AES256-SHA256\"
+    \"CAMELLIA128-SHA\"
+    \"CAMELLIA256-SHA\"
+    \"DES-CBC3-SHA\"
+    \"DH-DSS-AES128-GCM-SHA256\"
+    \"DH-DSS-AES128-SHA\"
+    \"DH-DSS-AES128-SHA256\"
+    \"DH-DSS-AES256-GCM-SHA384\"
+    \"DH-DSS-AES256-SHA\"
+    \"DH-DSS-AES256-SHA256\"
+    \"DH-DSS-CAMELLIA128-SHA\"
+    \"DH-DSS-CAMELLIA256-SHA\"
+    \"DH-DSS-DES-CBC3-SHAv\"
+    \"DH-DSS-SEED-SHA\"
+    \"DH-RSA-AES128-GCM-SHA256\"
+    \"DH-RSA-AES128-SHA\"
+    \"DH-RSA-AES128-SHA256\"
+    \"DH-RSA-AES256-GCM-SHA384\"
+    \"DH-RSA-AES256-SHA\"
+    \"DH-RSA-AES256-SHA256\"
+    \"DH-RSA-CAMELLIA128-SHA\"
+    \"DH-RSA-CAMELLIA256-SHA\"
+    \"DH-RSA-DES-CBC3-SHA\"
+    \"DH-RSA-SEED-SHA\"
+    \"DHE-DSS-AES128-GCM-SHA256\"
+    \"DHE-DSS-AES128-SHA\"
+    \"DHE-DSS-AES128-SHA256\"
+    \"DHE-DSS-AES256-GCM-SHA384\"
+    \"DHE-DSS-AES256-SHA\"
+    \"DHE-DSS-AES256-SHA256\"
+    \"DHE-DSS-CAMELLIA128-SHA\"
+    \"DHE-DSS-CAMELLIA256-SHA\"
+    \"DHE-DSS-DES-CBC3-SHA\"
+    \"DHE-DSS-SEED-SHA\"
+    \"DHE-RSA-AES128-GCM-SHA256\"
+    \"DHE-RSA-AES128-SHA\"
+    \"DHE-RSA-AES128-SHA256\"
+    \"DHE-RSA-AES256-GCM-SHA384\"
+    \"DHE-RSA-AES256-SHA\"
+    \"DHE-RSA-AES256-SHA256\"
+    \"DHE-RSA-CAMELLIA128-SHA\"
+    \"DHE-RSA-CAMELLIA256-SHA\"
+    \"DHE-RSA-DES-CBC3-SHA\"
+    \"DHE-RSA-SEED-SHA\"
+    \"ECDH-ECDSA-AES128-GCM-SHA256\"
+    \"ECDH-ECDSA-AES128-SHA\"
+    \"ECDH-ECDSA-AES128-SHA256\"
+    \"ECDH-ECDSA-AES256-GCM-SHA384\"
+    \"ECDH-ECDSA-AES256-SHA\"
+    \"ECDH-ECDSA-AES256-SHA384\"
+    \"ECDH-ECDSA-DES-CBC3-SHA\"
+    \"ECDH-ECDSA-RC4-SHA\"
+    \"ECDH-RSA-AES128-GCM-SHA256\"
+    \"ECDH-RSA-AES128-SHA\"
+    \"ECDH-RSA-AES128-SHA256\"
+    \"ECDH-RSA-AES256-GCM-SHA384\"
+    \"ECDH-RSA-AES256-SHA\"
+    \"ECDH-RSA-AES256-SHA384\"
+    \"ECDH-RSA-DES-CBC3-SHA\"
+    \"ECDH-RSA-RC4-SHA\"
+    \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+    \"ECDHE-ECDSA-AES128-SHA\"
+    \"ECDHE-ECDSA-AES128-SHA256\"
+    \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+    \"ECDHE-ECDSA-AES256-SHA\"
+    \"ECDHE-ECDSA-AES256-SHA384\"
+    \"ECDHE-ECDSA-DES-CBC3-SHA\"
+    \"ECDHE-ECDSA-RC4-SHA\"
+    \"ECDHE-RSA-AES128-GCM-SHA256\"
+    \"ECDHE-RSA-AES128-SHA\"
+    \"ECDHE-RSA-AES128-SHA256\"
+    \"ECDHE-RSA-AES256-GCM-SHA384\"
+    \"ECDHE-RSA-AES256-SHA\"
+    \"ECDHE-RSA-AES256-SHA384\"
+    \"ECDHE-RSA-DES-CBC3-SHA\"
+    \"ECDHE-RSA-RC4-SHA\"
+    \"IDEA-CBC-SHA\"
+    \"KRB5-DES-CBC3-MD5\"
+    \"KRB5-DES-CBC3-SHA\"
+    \"KRB5-IDEA-CBC-MD5\"
+    \"KRB5-IDEA-CBC-SHA\"
+    \"KRB5-RC4-MD5\"
+    \"KRB5-RC4-SHA\"
+    \"PSK-3DES-EDE-CBC-SHA\"
+    \"PSK-AES128-CBC-SHA\"
+    \"PSK-AES256-CBC-SHA\"
+    \"PSK-RC4-SHA\"
+    \"RC4-MD5\"
+    \"RC4-SHA\"
+    \"SEED-SHA\"
+
+    __ https://docs.cloud.oracle.com/api/#/en/loadbalancer/20170115/datatypes/SSLConfigurationDetails
+    __ https://docs.cloud.oracle.com/api/#/en/loadbalancer/20170115/SSLCipherSuite/CreateSSLCipherSuite
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateSSLCipherSuiteDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this CreateSSLCipherSuiteDetails.
+        :type name: str
+
+        :param ciphers:
+            The value to assign to the ciphers property of this CreateSSLCipherSuiteDetails.
+        :type ciphers: list[str]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'ciphers': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'ciphers': 'ciphers'
+        }
+
+        self._name = None
+        self._ciphers = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this CreateSSLCipherSuiteDetails.
+        A friendly name for the SSL cipher suite. It must be unique and it cannot be changed.
+
+        **Note:** The name of your user-defined cipher suite must not be the same as any of Oracle's predefined or
+                  reserved SSL cipher suite names:
+
+        * oci-default-ssl-cipher-suite-v1
+        * oci-modern-ssl-cipher-suite-v1
+        * oci-compatible-ssl-cipher-suite-v1
+        * oci-wider-compatible-ssl-cipher-suite-v1
+        * oci-customized-ssl-cipher-suite
+
+        example: `example_cipher_suite`
+
+
+        :return: The name of this CreateSSLCipherSuiteDetails.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this CreateSSLCipherSuiteDetails.
+        A friendly name for the SSL cipher suite. It must be unique and it cannot be changed.
+
+        **Note:** The name of your user-defined cipher suite must not be the same as any of Oracle's predefined or
+                  reserved SSL cipher suite names:
+
+        * oci-default-ssl-cipher-suite-v1
+        * oci-modern-ssl-cipher-suite-v1
+        * oci-compatible-ssl-cipher-suite-v1
+        * oci-wider-compatible-ssl-cipher-suite-v1
+        * oci-customized-ssl-cipher-suite
+
+        example: `example_cipher_suite`
+
+
+        :param name: The name of this CreateSSLCipherSuiteDetails.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def ciphers(self):
+        """
+        **[Required]** Gets the ciphers of this CreateSSLCipherSuiteDetails.
+        A list of SSL ciphers the load balancer must support for HTTPS or SSL connections.
+
+        The following ciphers are valid values for this property:
+
+        *  __TLSv1.2 ciphers__
+
+                \"AES128-GCM-SHA256\"
+                \"AES128-SHA256\"
+                \"AES256-GCM-SHA384\"
+                \"AES256-SHA256\"
+                \"DH-DSS-AES128-GCM-SHA256\"
+                \"DH-DSS-AES128-SHA256\"
+                \"DH-DSS-AES256-GCM-SHA384\"
+                \"DH-DSS-AES256-SHA256\"
+                \"DH-RSA-AES128-GCM-SHA256\"
+                \"DH-RSA-AES128-SHA256\"
+                \"DH-RSA-AES256-GCM-SHA384\"
+                \"DH-RSA-AES256-SHA256\"
+                \"DHE-DSS-AES128-GCM-SHA256\"
+                \"DHE-DSS-AES128-SHA256\"
+                \"DHE-DSS-AES256-GCM-SHA384\"
+                \"DHE-DSS-AES256-SHA256\"
+                \"DHE-RSA-AES128-GCM-SHA256\"
+                \"DHE-RSA-AES128-SHA256\"
+                \"DHE-RSA-AES256-GCM-SHA384\"
+                \"DHE-RSA-AES256-SHA256\"
+                \"ECDH-ECDSA-AES128-GCM-SHA256\"
+                \"ECDH-ECDSA-AES128-SHA256\"
+                \"ECDH-ECDSA-AES256-GCM-SHA384\"
+                \"ECDH-ECDSA-AES256-SHA384\"
+                \"ECDH-RSA-AES128-GCM-SHA256\"
+                \"ECDH-RSA-AES128-SHA256\"
+                \"ECDH-RSA-AES256-GCM-SHA384\"
+                \"ECDH-RSA-AES256-SHA384\"
+                \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+                \"ECDHE-ECDSA-AES128-SHA256\"
+                \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+                \"ECDHE-ECDSA-AES256-SHA384\"
+                \"ECDHE-RSA-AES128-GCM-SHA256\"
+                \"ECDHE-RSA-AES128-SHA256\"
+                \"ECDHE-RSA-AES256-GCM-SHA384\"
+                \"ECDHE-RSA-AES256-SHA384\"
+
+        *  __TLSv1 ciphers also supported by TLSv1.2__
+
+                \"AES128-SHA\"
+                \"AES256-SHA\"
+                \"CAMELLIA128-SHA\"
+                \"CAMELLIA256-SHA\"
+                \"DES-CBC3-SHA\"
+                \"DH-DSS-AES128-SHA\"
+                \"DH-DSS-AES256-SHA\"
+                \"DH-DSS-CAMELLIA128-SHA\"
+                \"DH-DSS-CAMELLIA256-SHA\"
+                \"DH-DSS-DES-CBC3-SHAv\"
+                \"DH-DSS-SEED-SHA\"
+                \"DH-RSA-AES128-SHA\"
+                \"DH-RSA-AES256-SHA\"
+                \"DH-RSA-CAMELLIA128-SHA\"
+                \"DH-RSA-CAMELLIA256-SHA\"
+                \"DH-RSA-DES-CBC3-SHA\"
+                \"DH-RSA-SEED-SHA\"
+                \"DHE-DSS-AES128-SHA\"
+                \"DHE-DSS-AES256-SHA\"
+                \"DHE-DSS-CAMELLIA128-SHA\"
+                \"DHE-DSS-CAMELLIA256-SHA\"
+                \"DHE-DSS-DES-CBC3-SHA\"
+                \"DHE-DSS-SEED-SHA\"
+                \"DHE-RSA-AES128-SHA\"
+                \"DHE-RSA-AES256-SHA\"
+                \"DHE-RSA-CAMELLIA128-SHA\"
+                \"DHE-RSA-CAMELLIA256-SHA\"
+                \"DHE-RSA-DES-CBC3-SHA\"
+                \"DHE-RSA-SEED-SHA\"
+                \"ECDH-ECDSA-AES128-SHA\"
+                \"ECDH-ECDSA-AES256-SHA\"
+                \"ECDH-ECDSA-DES-CBC3-SHA\"
+                \"ECDH-ECDSA-RC4-SHA\"
+                \"ECDH-RSA-AES128-SHA\"
+                \"ECDH-RSA-AES256-SHA\"
+                \"ECDH-RSA-DES-CBC3-SHA\"
+                \"ECDH-RSA-RC4-SHA\"
+                \"ECDHE-ECDSA-AES128-SHA\"
+                \"ECDHE-ECDSA-AES256-SHA\"
+                \"ECDHE-ECDSA-DES-CBC3-SHA\"
+                \"ECDHE-ECDSA-RC4-SHA\"
+                \"ECDHE-RSA-AES128-SHA\"
+                \"ECDHE-RSA-AES256-SHA\"
+                \"ECDHE-RSA-DES-CBC3-SHA\"
+                \"ECDHE-RSA-RC4-SHA\"
+                \"IDEA-CBC-SHA\"
+                \"KRB5-DES-CBC3-MD5\"
+                \"KRB5-DES-CBC3-SHA\"
+                \"KRB5-IDEA-CBC-MD5\"
+                \"KRB5-IDEA-CBC-SHA\"
+                \"KRB5-RC4-MD5\"
+                \"KRB5-RC4-SHA\"
+                \"PSK-3DES-EDE-CBC-SHA\"
+                \"PSK-AES128-CBC-SHA\"
+                \"PSK-AES256-CBC-SHA\"
+                \"PSK-RC4-SHA\"
+                \"RC4-MD5\"
+                \"RC4-SHA\"
+                \"SEED-SHA\"
+
+        example: `[\"ECDHE-RSA-AES256-GCM-SHA384\",\"ECDHE-ECDSA-AES256-GCM-SHA384\",\"ECDHE-RSA-AES128-GCM-SHA256\"]`
+
+
+        :return: The ciphers of this CreateSSLCipherSuiteDetails.
+        :rtype: list[str]
+        """
+        return self._ciphers
+
+    @ciphers.setter
+    def ciphers(self, ciphers):
+        """
+        Sets the ciphers of this CreateSSLCipherSuiteDetails.
+        A list of SSL ciphers the load balancer must support for HTTPS or SSL connections.
+
+        The following ciphers are valid values for this property:
+
+        *  __TLSv1.2 ciphers__
+
+                \"AES128-GCM-SHA256\"
+                \"AES128-SHA256\"
+                \"AES256-GCM-SHA384\"
+                \"AES256-SHA256\"
+                \"DH-DSS-AES128-GCM-SHA256\"
+                \"DH-DSS-AES128-SHA256\"
+                \"DH-DSS-AES256-GCM-SHA384\"
+                \"DH-DSS-AES256-SHA256\"
+                \"DH-RSA-AES128-GCM-SHA256\"
+                \"DH-RSA-AES128-SHA256\"
+                \"DH-RSA-AES256-GCM-SHA384\"
+                \"DH-RSA-AES256-SHA256\"
+                \"DHE-DSS-AES128-GCM-SHA256\"
+                \"DHE-DSS-AES128-SHA256\"
+                \"DHE-DSS-AES256-GCM-SHA384\"
+                \"DHE-DSS-AES256-SHA256\"
+                \"DHE-RSA-AES128-GCM-SHA256\"
+                \"DHE-RSA-AES128-SHA256\"
+                \"DHE-RSA-AES256-GCM-SHA384\"
+                \"DHE-RSA-AES256-SHA256\"
+                \"ECDH-ECDSA-AES128-GCM-SHA256\"
+                \"ECDH-ECDSA-AES128-SHA256\"
+                \"ECDH-ECDSA-AES256-GCM-SHA384\"
+                \"ECDH-ECDSA-AES256-SHA384\"
+                \"ECDH-RSA-AES128-GCM-SHA256\"
+                \"ECDH-RSA-AES128-SHA256\"
+                \"ECDH-RSA-AES256-GCM-SHA384\"
+                \"ECDH-RSA-AES256-SHA384\"
+                \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+                \"ECDHE-ECDSA-AES128-SHA256\"
+                \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+                \"ECDHE-ECDSA-AES256-SHA384\"
+                \"ECDHE-RSA-AES128-GCM-SHA256\"
+                \"ECDHE-RSA-AES128-SHA256\"
+                \"ECDHE-RSA-AES256-GCM-SHA384\"
+                \"ECDHE-RSA-AES256-SHA384\"
+
+        *  __TLSv1 ciphers also supported by TLSv1.2__
+
+                \"AES128-SHA\"
+                \"AES256-SHA\"
+                \"CAMELLIA128-SHA\"
+                \"CAMELLIA256-SHA\"
+                \"DES-CBC3-SHA\"
+                \"DH-DSS-AES128-SHA\"
+                \"DH-DSS-AES256-SHA\"
+                \"DH-DSS-CAMELLIA128-SHA\"
+                \"DH-DSS-CAMELLIA256-SHA\"
+                \"DH-DSS-DES-CBC3-SHAv\"
+                \"DH-DSS-SEED-SHA\"
+                \"DH-RSA-AES128-SHA\"
+                \"DH-RSA-AES256-SHA\"
+                \"DH-RSA-CAMELLIA128-SHA\"
+                \"DH-RSA-CAMELLIA256-SHA\"
+                \"DH-RSA-DES-CBC3-SHA\"
+                \"DH-RSA-SEED-SHA\"
+                \"DHE-DSS-AES128-SHA\"
+                \"DHE-DSS-AES256-SHA\"
+                \"DHE-DSS-CAMELLIA128-SHA\"
+                \"DHE-DSS-CAMELLIA256-SHA\"
+                \"DHE-DSS-DES-CBC3-SHA\"
+                \"DHE-DSS-SEED-SHA\"
+                \"DHE-RSA-AES128-SHA\"
+                \"DHE-RSA-AES256-SHA\"
+                \"DHE-RSA-CAMELLIA128-SHA\"
+                \"DHE-RSA-CAMELLIA256-SHA\"
+                \"DHE-RSA-DES-CBC3-SHA\"
+                \"DHE-RSA-SEED-SHA\"
+                \"ECDH-ECDSA-AES128-SHA\"
+                \"ECDH-ECDSA-AES256-SHA\"
+                \"ECDH-ECDSA-DES-CBC3-SHA\"
+                \"ECDH-ECDSA-RC4-SHA\"
+                \"ECDH-RSA-AES128-SHA\"
+                \"ECDH-RSA-AES256-SHA\"
+                \"ECDH-RSA-DES-CBC3-SHA\"
+                \"ECDH-RSA-RC4-SHA\"
+                \"ECDHE-ECDSA-AES128-SHA\"
+                \"ECDHE-ECDSA-AES256-SHA\"
+                \"ECDHE-ECDSA-DES-CBC3-SHA\"
+                \"ECDHE-ECDSA-RC4-SHA\"
+                \"ECDHE-RSA-AES128-SHA\"
+                \"ECDHE-RSA-AES256-SHA\"
+                \"ECDHE-RSA-DES-CBC3-SHA\"
+                \"ECDHE-RSA-RC4-SHA\"
+                \"IDEA-CBC-SHA\"
+                \"KRB5-DES-CBC3-MD5\"
+                \"KRB5-DES-CBC3-SHA\"
+                \"KRB5-IDEA-CBC-MD5\"
+                \"KRB5-IDEA-CBC-SHA\"
+                \"KRB5-RC4-MD5\"
+                \"KRB5-RC4-SHA\"
+                \"PSK-3DES-EDE-CBC-SHA\"
+                \"PSK-AES128-CBC-SHA\"
+                \"PSK-AES256-CBC-SHA\"
+                \"PSK-RC4-SHA\"
+                \"RC4-MD5\"
+                \"RC4-SHA\"
+                \"SEED-SHA\"
+
+        example: `[\"ECDHE-RSA-AES256-GCM-SHA384\",\"ECDHE-ECDSA-AES256-GCM-SHA384\",\"ECDHE-RSA-AES128-GCM-SHA256\"]`
+
+
+        :param ciphers: The ciphers of this CreateSSLCipherSuiteDetails.
+        :type: list[str]
+        """
+        self._ciphers = ciphers
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/load_balancer/models/load_balancer.py
+++ b/src/oci/load_balancer/models/load_balancer.py
@@ -102,6 +102,10 @@ class LoadBalancer(object):
             The value to assign to the hostnames property of this LoadBalancer.
         :type hostnames: dict(str, Hostname)
 
+        :param ssl_cipher_suites:
+            The value to assign to the ssl_cipher_suites property of this LoadBalancer.
+        :type ssl_cipher_suites: dict(str, SSLCipherSuite)
+
         :param certificates:
             The value to assign to the certificates property of this LoadBalancer.
         :type certificates: dict(str, Certificate)
@@ -144,6 +148,7 @@ class LoadBalancer(object):
             'network_security_group_ids': 'list[str]',
             'listeners': 'dict(str, Listener)',
             'hostnames': 'dict(str, Hostname)',
+            'ssl_cipher_suites': 'dict(str, SSLCipherSuite)',
             'certificates': 'dict(str, Certificate)',
             'backend_sets': 'dict(str, BackendSet)',
             'path_route_sets': 'dict(str, PathRouteSet)',
@@ -166,6 +171,7 @@ class LoadBalancer(object):
             'network_security_group_ids': 'networkSecurityGroupIds',
             'listeners': 'listeners',
             'hostnames': 'hostnames',
+            'ssl_cipher_suites': 'sslCipherSuites',
             'certificates': 'certificates',
             'backend_sets': 'backendSets',
             'path_route_sets': 'pathRouteSets',
@@ -187,6 +193,7 @@ class LoadBalancer(object):
         self._network_security_group_ids = None
         self._listeners = None
         self._hostnames = None
+        self._ssl_cipher_suites = None
         self._certificates = None
         self._backend_sets = None
         self._path_route_sets = None
@@ -562,6 +569,26 @@ class LoadBalancer(object):
         :type: dict(str, Hostname)
         """
         self._hostnames = hostnames
+
+    @property
+    def ssl_cipher_suites(self):
+        """
+        Gets the ssl_cipher_suites of this LoadBalancer.
+
+        :return: The ssl_cipher_suites of this LoadBalancer.
+        :rtype: dict(str, SSLCipherSuite)
+        """
+        return self._ssl_cipher_suites
+
+    @ssl_cipher_suites.setter
+    def ssl_cipher_suites(self, ssl_cipher_suites):
+        """
+        Sets the ssl_cipher_suites of this LoadBalancer.
+
+        :param ssl_cipher_suites: The ssl_cipher_suites of this LoadBalancer.
+        :type: dict(str, SSLCipherSuite)
+        """
+        self._ssl_cipher_suites = ssl_cipher_suites
 
     @property
     def certificates(self):

--- a/src/oci/load_balancer/models/ssl_cipher_suite.py
+++ b/src/oci/load_balancer/models/ssl_cipher_suite.py
@@ -1,0 +1,502 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SSLCipherSuite(object):
+    """
+    The configuration details of an SSL cipher suite.
+
+    The algorithms that compose a cipher suite help you secure Transport Layer Security (TLS) or Secure Socket Layer
+    (SSL) network connections. A cipher suite defines the list of security algorithms your load balancer uses to
+    negotiate with peers while sending and receiving information. The cipher suites you use affect the security
+    level, performance, and compatibility of your data traffic.
+
+    **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+
+    Oracle created the following predefined cipher suites that you can specify when you define a resource's
+    `SSL configuration`__. You can `create custom
+    cipher suites`__ if the predefined cipher
+    suites do not meet your requirements.
+
+
+    *  __oci-default-ssl-cipher-suite-v1__
+
+    \"DHE-RSA-AES128-GCM-SHA256\"
+    \"DHE-RSA-AES128-SHA256\"
+    \"DHE-RSA-AES256-GCM-SHA384\"
+    \"DHE-RSA-AES256-SHA256\"
+    \"ECDHE-RSA-AES128-GCM-SHA256\"
+    \"ECDHE-RSA-AES128-SHA256\"
+    \"ECDHE-RSA-AES256-GCM-SHA384\"
+    \"ECDHE-RSA-AES256-SHA384\"
+
+    *  __oci-modern-ssl-cipher-suite-v1__
+
+    \"AES128-GCM-SHA256\"
+    \"AES128-SHA256\"
+    \"AES256-GCM-SHA384\"
+    \"AES256-SHA256\"
+    \"DHE-RSA-AES128-GCM-SHA256\"
+    \"DHE-RSA-AES128-SHA256\"
+    \"DHE-RSA-AES256-GCM-SHA384\"
+    \"DHE-RSA-AES256-SHA256\"
+    \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+    \"ECDHE-ECDSA-AES128-SHA256\"
+    \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+    \"ECDHE-ECDSA-AES256-SHA384\"
+    \"ECDHE-RSA-AES128-GCM-SHA256\"
+    \"ECDHE-RSA-AES128-SHA256\"
+    \"ECDHE-RSA-AES256-GCM-SHA384\"
+    \"ECDHE-RSA-AES256-SHA384\"
+
+    *  __oci-compatible-ssl-cipher-suite-v1__
+
+    \"AES128-GCM-SHA256\"
+    \"AES128-SHA\"
+    \"AES128-SHA256\"
+    \"AES256-GCM-SHA384\"
+    \"AES256-SHA\"
+    \"AES256-SHA256\"
+    \"DHE-RSA-AES128-GCM-SHA256\"
+    \"DHE-RSA-AES128-SHA256\"
+    \"DHE-RSA-AES256-GCM-SHA384\"
+    \"DHE-RSA-AES256-SHA256\"
+    \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+    \"ECDHE-ECDSA-AES128-SHA\"
+    \"ECDHE-ECDSA-AES128-SHA256\"
+    \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+    \"ECDHE-ECDSA-AES256-SHA\"
+    \"ECDHE-ECDSA-AES256-SHA384\"
+    \"ECDHE-RSA-AES128-GCM-SHA256\"
+    \"ECDHE-RSA-AES128-SHA\"
+    \"ECDHE-RSA-AES128-SHA256\"
+    \"ECDHE-RSA-AES256-GCM-SHA384\"
+    \"ECDHE-RSA-AES256-SHA\"
+    \"ECDHE-RSA-AES256-SHA384\"
+
+    *  __oci-wider-compatible-ssl-cipher-suite-v1__
+
+    \"AES128-GCM-SHA256\"
+    \"AES128-SHA\"
+    \"AES128-SHA256\"
+    \"AES256-GCM-SHA384\"
+    \"AES256-SHA\"
+    \"AES256-SHA256\"
+    \"CAMELLIA128-SHA\"
+    \"CAMELLIA256-SHA\"
+    \"DES-CBC3-SHA\"
+    \"DH-DSS-AES128-GCM-SHA256\"
+    \"DH-DSS-AES128-SHA\"
+    \"DH-DSS-AES128-SHA256\"
+    \"DH-DSS-AES256-GCM-SHA384\"
+    \"DH-DSS-AES256-SHA\"
+    \"DH-DSS-AES256-SHA256\"
+    \"DH-DSS-CAMELLIA128-SHA\"
+    \"DH-DSS-CAMELLIA256-SHA\"
+    \"DH-DSS-DES-CBC3-SHAv\"
+    \"DH-DSS-SEED-SHA\"
+    \"DH-RSA-AES128-GCM-SHA256\"
+    \"DH-RSA-AES128-SHA\"
+    \"DH-RSA-AES128-SHA256\"
+    \"DH-RSA-AES256-GCM-SHA384\"
+    \"DH-RSA-AES256-SHA\"
+    \"DH-RSA-AES256-SHA256\"
+    \"DH-RSA-CAMELLIA128-SHA\"
+    \"DH-RSA-CAMELLIA256-SHA\"
+    \"DH-RSA-DES-CBC3-SHA\"
+    \"DH-RSA-SEED-SHA\"
+    \"DHE-DSS-AES128-GCM-SHA256\"
+    \"DHE-DSS-AES128-SHA\"
+    \"DHE-DSS-AES128-SHA256\"
+    \"DHE-DSS-AES256-GCM-SHA384\"
+    \"DHE-DSS-AES256-SHA\"
+    \"DHE-DSS-AES256-SHA256\"
+    \"DHE-DSS-CAMELLIA128-SHA\"
+    \"DHE-DSS-CAMELLIA256-SHA\"
+    \"DHE-DSS-DES-CBC3-SHA\"
+    \"DHE-DSS-SEED-SHA\"
+    \"DHE-RSA-AES128-GCM-SHA256\"
+    \"DHE-RSA-AES128-SHA\"
+    \"DHE-RSA-AES128-SHA256\"
+    \"DHE-RSA-AES256-GCM-SHA384\"
+    \"DHE-RSA-AES256-SHA\"
+    \"DHE-RSA-AES256-SHA256\"
+    \"DHE-RSA-CAMELLIA128-SHA\"
+    \"DHE-RSA-CAMELLIA256-SHA\"
+    \"DHE-RSA-DES-CBC3-SHA\"
+    \"DHE-RSA-SEED-SHA\"
+    \"ECDH-ECDSA-AES128-GCM-SHA256\"
+    \"ECDH-ECDSA-AES128-SHA\"
+    \"ECDH-ECDSA-AES128-SHA256\"
+    \"ECDH-ECDSA-AES256-GCM-SHA384\"
+    \"ECDH-ECDSA-AES256-SHA\"
+    \"ECDH-ECDSA-AES256-SHA384\"
+    \"ECDH-ECDSA-DES-CBC3-SHA\"
+    \"ECDH-ECDSA-RC4-SHA\"
+    \"ECDH-RSA-AES128-GCM-SHA256\"
+    \"ECDH-RSA-AES128-SHA\"
+    \"ECDH-RSA-AES128-SHA256\"
+    \"ECDH-RSA-AES256-GCM-SHA384\"
+    \"ECDH-RSA-AES256-SHA\"
+    \"ECDH-RSA-AES256-SHA384\"
+    \"ECDH-RSA-DES-CBC3-SHA\"
+    \"ECDH-RSA-RC4-SHA\"
+    \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+    \"ECDHE-ECDSA-AES128-SHA\"
+    \"ECDHE-ECDSA-AES128-SHA256\"
+    \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+    \"ECDHE-ECDSA-AES256-SHA\"
+    \"ECDHE-ECDSA-AES256-SHA384\"
+    \"ECDHE-ECDSA-DES-CBC3-SHA\"
+    \"ECDHE-ECDSA-RC4-SHA\"
+    \"ECDHE-RSA-AES128-GCM-SHA256\"
+    \"ECDHE-RSA-AES128-SHA\"
+    \"ECDHE-RSA-AES128-SHA256\"
+    \"ECDHE-RSA-AES256-GCM-SHA384\"
+    \"ECDHE-RSA-AES256-SHA\"
+    \"ECDHE-RSA-AES256-SHA384\"
+    \"ECDHE-RSA-DES-CBC3-SHA\"
+    \"ECDHE-RSA-RC4-SHA\"
+    \"IDEA-CBC-SHA\"
+    \"KRB5-DES-CBC3-MD5\"
+    \"KRB5-DES-CBC3-SHA\"
+    \"KRB5-IDEA-CBC-MD5\"
+    \"KRB5-IDEA-CBC-SHA\"
+    \"KRB5-RC4-MD5\"
+    \"KRB5-RC4-SHA\"
+    \"PSK-3DES-EDE-CBC-SHA\"
+    \"PSK-AES128-CBC-SHA\"
+    \"PSK-AES256-CBC-SHA\"
+    \"PSK-RC4-SHA\"
+    \"RC4-MD5\"
+    \"RC4-SHA\"
+    \"SEED-SHA\"
+
+    __ https://docs.cloud.oracle.com/api/#/en/loadbalancer/20170115/datatypes/SSLConfigurationDetails
+    __ https://docs.cloud.oracle.com/api/#/en/loadbalancer/20170115/SSLCipherSuite/CreateSSLCipherSuite
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SSLCipherSuite object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this SSLCipherSuite.
+        :type name: str
+
+        :param ciphers:
+            The value to assign to the ciphers property of this SSLCipherSuite.
+        :type ciphers: list[str]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'ciphers': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'ciphers': 'ciphers'
+        }
+
+        self._name = None
+        self._ciphers = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this SSLCipherSuite.
+        A friendly name for the SSL cipher suite. It must be unique and it cannot be changed.
+
+        **Note:** The name of your user-defined cipher suite must not be the same as any of Oracle's predefined or
+                  reserved SSL cipher suite names:
+
+        * oci-default-ssl-cipher-suite-v1
+        * oci-modern-ssl-cipher-suite-v1
+        * oci-compatible-ssl-cipher-suite-v1
+        * oci-wider-compatible-ssl-cipher-suite-v1
+        * oci-customized-ssl-cipher-suite
+
+        example: `example_cipher_suite`
+
+
+        :return: The name of this SSLCipherSuite.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this SSLCipherSuite.
+        A friendly name for the SSL cipher suite. It must be unique and it cannot be changed.
+
+        **Note:** The name of your user-defined cipher suite must not be the same as any of Oracle's predefined or
+                  reserved SSL cipher suite names:
+
+        * oci-default-ssl-cipher-suite-v1
+        * oci-modern-ssl-cipher-suite-v1
+        * oci-compatible-ssl-cipher-suite-v1
+        * oci-wider-compatible-ssl-cipher-suite-v1
+        * oci-customized-ssl-cipher-suite
+
+        example: `example_cipher_suite`
+
+
+        :param name: The name of this SSLCipherSuite.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def ciphers(self):
+        """
+        **[Required]** Gets the ciphers of this SSLCipherSuite.
+        A list of SSL ciphers the load balancer must support for HTTPS or SSL connections.
+
+        The following ciphers are valid values for this property:
+
+        *  __TLSv1.2 ciphers__
+
+                \"AES128-GCM-SHA256\"
+                \"AES128-SHA256\"
+                \"AES256-GCM-SHA384\"
+                \"AES256-SHA256\"
+                \"DH-DSS-AES128-GCM-SHA256\"
+                \"DH-DSS-AES128-SHA256\"
+                \"DH-DSS-AES256-GCM-SHA384\"
+                \"DH-DSS-AES256-SHA256\"
+                \"DH-RSA-AES128-GCM-SHA256\"
+                \"DH-RSA-AES128-SHA256\"
+                \"DH-RSA-AES256-GCM-SHA384\"
+                \"DH-RSA-AES256-SHA256\"
+                \"DHE-DSS-AES128-GCM-SHA256\"
+                \"DHE-DSS-AES128-SHA256\"
+                \"DHE-DSS-AES256-GCM-SHA384\"
+                \"DHE-DSS-AES256-SHA256\"
+                \"DHE-RSA-AES128-GCM-SHA256\"
+                \"DHE-RSA-AES128-SHA256\"
+                \"DHE-RSA-AES256-GCM-SHA384\"
+                \"DHE-RSA-AES256-SHA256\"
+                \"ECDH-ECDSA-AES128-GCM-SHA256\"
+                \"ECDH-ECDSA-AES128-SHA256\"
+                \"ECDH-ECDSA-AES256-GCM-SHA384\"
+                \"ECDH-ECDSA-AES256-SHA384\"
+                \"ECDH-RSA-AES128-GCM-SHA256\"
+                \"ECDH-RSA-AES128-SHA256\"
+                \"ECDH-RSA-AES256-GCM-SHA384\"
+                \"ECDH-RSA-AES256-SHA384\"
+                \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+                \"ECDHE-ECDSA-AES128-SHA256\"
+                \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+                \"ECDHE-ECDSA-AES256-SHA384\"
+                \"ECDHE-RSA-AES128-GCM-SHA256\"
+                \"ECDHE-RSA-AES128-SHA256\"
+                \"ECDHE-RSA-AES256-GCM-SHA384\"
+                \"ECDHE-RSA-AES256-SHA384\"
+
+        *  __TLSv1 ciphers also supported by TLSv1.2__
+
+                \"AES128-SHA\"
+                \"AES256-SHA\"
+                \"CAMELLIA128-SHA\"
+                \"CAMELLIA256-SHA\"
+                \"DES-CBC3-SHA\"
+                \"DH-DSS-AES128-SHA\"
+                \"DH-DSS-AES256-SHA\"
+                \"DH-DSS-CAMELLIA128-SHA\"
+                \"DH-DSS-CAMELLIA256-SHA\"
+                \"DH-DSS-DES-CBC3-SHAv\"
+                \"DH-DSS-SEED-SHA\"
+                \"DH-RSA-AES128-SHA\"
+                \"DH-RSA-AES256-SHA\"
+                \"DH-RSA-CAMELLIA128-SHA\"
+                \"DH-RSA-CAMELLIA256-SHA\"
+                \"DH-RSA-DES-CBC3-SHA\"
+                \"DH-RSA-SEED-SHA\"
+                \"DHE-DSS-AES128-SHA\"
+                \"DHE-DSS-AES256-SHA\"
+                \"DHE-DSS-CAMELLIA128-SHA\"
+                \"DHE-DSS-CAMELLIA256-SHA\"
+                \"DHE-DSS-DES-CBC3-SHA\"
+                \"DHE-DSS-SEED-SHA\"
+                \"DHE-RSA-AES128-SHA\"
+                \"DHE-RSA-AES256-SHA\"
+                \"DHE-RSA-CAMELLIA128-SHA\"
+                \"DHE-RSA-CAMELLIA256-SHA\"
+                \"DHE-RSA-DES-CBC3-SHA\"
+                \"DHE-RSA-SEED-SHA\"
+                \"ECDH-ECDSA-AES128-SHA\"
+                \"ECDH-ECDSA-AES256-SHA\"
+                \"ECDH-ECDSA-DES-CBC3-SHA\"
+                \"ECDH-ECDSA-RC4-SHA\"
+                \"ECDH-RSA-AES128-SHA\"
+                \"ECDH-RSA-AES256-SHA\"
+                \"ECDH-RSA-DES-CBC3-SHA\"
+                \"ECDH-RSA-RC4-SHA\"
+                \"ECDHE-ECDSA-AES128-SHA\"
+                \"ECDHE-ECDSA-AES256-SHA\"
+                \"ECDHE-ECDSA-DES-CBC3-SHA\"
+                \"ECDHE-ECDSA-RC4-SHA\"
+                \"ECDHE-RSA-AES128-SHA\"
+                \"ECDHE-RSA-AES256-SHA\"
+                \"ECDHE-RSA-DES-CBC3-SHA\"
+                \"ECDHE-RSA-RC4-SHA\"
+                \"IDEA-CBC-SHA\"
+                \"KRB5-DES-CBC3-MD5\"
+                \"KRB5-DES-CBC3-SHA\"
+                \"KRB5-IDEA-CBC-MD5\"
+                \"KRB5-IDEA-CBC-SHA\"
+                \"KRB5-RC4-MD5\"
+                \"KRB5-RC4-SHA\"
+                \"PSK-3DES-EDE-CBC-SHA\"
+                \"PSK-AES128-CBC-SHA\"
+                \"PSK-AES256-CBC-SHA\"
+                \"PSK-RC4-SHA\"
+                \"RC4-MD5\"
+                \"RC4-SHA\"
+                \"SEED-SHA\"
+
+        example: `[\"ECDHE-RSA-AES256-GCM-SHA384\",\"ECDHE-ECDSA-AES256-GCM-SHA384\",\"ECDHE-RSA-AES128-GCM-SHA256\"]`
+
+
+        :return: The ciphers of this SSLCipherSuite.
+        :rtype: list[str]
+        """
+        return self._ciphers
+
+    @ciphers.setter
+    def ciphers(self, ciphers):
+        """
+        Sets the ciphers of this SSLCipherSuite.
+        A list of SSL ciphers the load balancer must support for HTTPS or SSL connections.
+
+        The following ciphers are valid values for this property:
+
+        *  __TLSv1.2 ciphers__
+
+                \"AES128-GCM-SHA256\"
+                \"AES128-SHA256\"
+                \"AES256-GCM-SHA384\"
+                \"AES256-SHA256\"
+                \"DH-DSS-AES128-GCM-SHA256\"
+                \"DH-DSS-AES128-SHA256\"
+                \"DH-DSS-AES256-GCM-SHA384\"
+                \"DH-DSS-AES256-SHA256\"
+                \"DH-RSA-AES128-GCM-SHA256\"
+                \"DH-RSA-AES128-SHA256\"
+                \"DH-RSA-AES256-GCM-SHA384\"
+                \"DH-RSA-AES256-SHA256\"
+                \"DHE-DSS-AES128-GCM-SHA256\"
+                \"DHE-DSS-AES128-SHA256\"
+                \"DHE-DSS-AES256-GCM-SHA384\"
+                \"DHE-DSS-AES256-SHA256\"
+                \"DHE-RSA-AES128-GCM-SHA256\"
+                \"DHE-RSA-AES128-SHA256\"
+                \"DHE-RSA-AES256-GCM-SHA384\"
+                \"DHE-RSA-AES256-SHA256\"
+                \"ECDH-ECDSA-AES128-GCM-SHA256\"
+                \"ECDH-ECDSA-AES128-SHA256\"
+                \"ECDH-ECDSA-AES256-GCM-SHA384\"
+                \"ECDH-ECDSA-AES256-SHA384\"
+                \"ECDH-RSA-AES128-GCM-SHA256\"
+                \"ECDH-RSA-AES128-SHA256\"
+                \"ECDH-RSA-AES256-GCM-SHA384\"
+                \"ECDH-RSA-AES256-SHA384\"
+                \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+                \"ECDHE-ECDSA-AES128-SHA256\"
+                \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+                \"ECDHE-ECDSA-AES256-SHA384\"
+                \"ECDHE-RSA-AES128-GCM-SHA256\"
+                \"ECDHE-RSA-AES128-SHA256\"
+                \"ECDHE-RSA-AES256-GCM-SHA384\"
+                \"ECDHE-RSA-AES256-SHA384\"
+
+        *  __TLSv1 ciphers also supported by TLSv1.2__
+
+                \"AES128-SHA\"
+                \"AES256-SHA\"
+                \"CAMELLIA128-SHA\"
+                \"CAMELLIA256-SHA\"
+                \"DES-CBC3-SHA\"
+                \"DH-DSS-AES128-SHA\"
+                \"DH-DSS-AES256-SHA\"
+                \"DH-DSS-CAMELLIA128-SHA\"
+                \"DH-DSS-CAMELLIA256-SHA\"
+                \"DH-DSS-DES-CBC3-SHAv\"
+                \"DH-DSS-SEED-SHA\"
+                \"DH-RSA-AES128-SHA\"
+                \"DH-RSA-AES256-SHA\"
+                \"DH-RSA-CAMELLIA128-SHA\"
+                \"DH-RSA-CAMELLIA256-SHA\"
+                \"DH-RSA-DES-CBC3-SHA\"
+                \"DH-RSA-SEED-SHA\"
+                \"DHE-DSS-AES128-SHA\"
+                \"DHE-DSS-AES256-SHA\"
+                \"DHE-DSS-CAMELLIA128-SHA\"
+                \"DHE-DSS-CAMELLIA256-SHA\"
+                \"DHE-DSS-DES-CBC3-SHA\"
+                \"DHE-DSS-SEED-SHA\"
+                \"DHE-RSA-AES128-SHA\"
+                \"DHE-RSA-AES256-SHA\"
+                \"DHE-RSA-CAMELLIA128-SHA\"
+                \"DHE-RSA-CAMELLIA256-SHA\"
+                \"DHE-RSA-DES-CBC3-SHA\"
+                \"DHE-RSA-SEED-SHA\"
+                \"ECDH-ECDSA-AES128-SHA\"
+                \"ECDH-ECDSA-AES256-SHA\"
+                \"ECDH-ECDSA-DES-CBC3-SHA\"
+                \"ECDH-ECDSA-RC4-SHA\"
+                \"ECDH-RSA-AES128-SHA\"
+                \"ECDH-RSA-AES256-SHA\"
+                \"ECDH-RSA-DES-CBC3-SHA\"
+                \"ECDH-RSA-RC4-SHA\"
+                \"ECDHE-ECDSA-AES128-SHA\"
+                \"ECDHE-ECDSA-AES256-SHA\"
+                \"ECDHE-ECDSA-DES-CBC3-SHA\"
+                \"ECDHE-ECDSA-RC4-SHA\"
+                \"ECDHE-RSA-AES128-SHA\"
+                \"ECDHE-RSA-AES256-SHA\"
+                \"ECDHE-RSA-DES-CBC3-SHA\"
+                \"ECDHE-RSA-RC4-SHA\"
+                \"IDEA-CBC-SHA\"
+                \"KRB5-DES-CBC3-MD5\"
+                \"KRB5-DES-CBC3-SHA\"
+                \"KRB5-IDEA-CBC-MD5\"
+                \"KRB5-IDEA-CBC-SHA\"
+                \"KRB5-RC4-MD5\"
+                \"KRB5-RC4-SHA\"
+                \"PSK-3DES-EDE-CBC-SHA\"
+                \"PSK-AES128-CBC-SHA\"
+                \"PSK-AES256-CBC-SHA\"
+                \"PSK-RC4-SHA\"
+                \"RC4-MD5\"
+                \"RC4-SHA\"
+                \"SEED-SHA\"
+
+        example: `[\"ECDHE-RSA-AES256-GCM-SHA384\",\"ECDHE-ECDSA-AES256-GCM-SHA384\",\"ECDHE-RSA-AES128-GCM-SHA256\"]`
+
+
+        :param ciphers: The ciphers of this SSLCipherSuite.
+        :type: list[str]
+        """
+        self._ciphers = ciphers
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/load_balancer/models/ssl_cipher_suite_details.py
+++ b/src/oci/load_balancer/models/ssl_cipher_suite_details.py
@@ -1,0 +1,502 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SSLCipherSuiteDetails(object):
+    """
+    The configuration details of an SSL cipher suite.
+
+    The algorithms that compose a cipher suite help you secure Transport Layer Security (TLS) or Secure Socket Layer
+    (SSL) network connections. A cipher suite defines the list of security algorithms your load balancer uses to
+    negotiate with peers while sending and receiving information. The cipher suites you use affect the security
+    level, performance, and compatibility of your data traffic.
+
+    **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+
+    Oracle created the following predefined cipher suites that you can specify when you define a resource's
+    `SSL configuration`__. You can `create custom
+    cipher suites`__ if the predefined cipher
+    suites do not meet your requirements.
+
+
+    *  __oci-default-ssl-cipher-suite-v1__
+
+    \"DHE-RSA-AES128-GCM-SHA256\"
+    \"DHE-RSA-AES128-SHA256\"
+    \"DHE-RSA-AES256-GCM-SHA384\"
+    \"DHE-RSA-AES256-SHA256\"
+    \"ECDHE-RSA-AES128-GCM-SHA256\"
+    \"ECDHE-RSA-AES128-SHA256\"
+    \"ECDHE-RSA-AES256-GCM-SHA384\"
+    \"ECDHE-RSA-AES256-SHA384\"
+
+    *  __oci-modern-ssl-cipher-suite-v1__
+
+    \"AES128-GCM-SHA256\"
+    \"AES128-SHA256\"
+    \"AES256-GCM-SHA384\"
+    \"AES256-SHA256\"
+    \"DHE-RSA-AES128-GCM-SHA256\"
+    \"DHE-RSA-AES128-SHA256\"
+    \"DHE-RSA-AES256-GCM-SHA384\"
+    \"DHE-RSA-AES256-SHA256\"
+    \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+    \"ECDHE-ECDSA-AES128-SHA256\"
+    \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+    \"ECDHE-ECDSA-AES256-SHA384\"
+    \"ECDHE-RSA-AES128-GCM-SHA256\"
+    \"ECDHE-RSA-AES128-SHA256\"
+    \"ECDHE-RSA-AES256-GCM-SHA384\"
+    \"ECDHE-RSA-AES256-SHA384\"
+
+    *  __oci-compatible-ssl-cipher-suite-v1__
+
+    \"AES128-GCM-SHA256\"
+    \"AES128-SHA\"
+    \"AES128-SHA256\"
+    \"AES256-GCM-SHA384\"
+    \"AES256-SHA\"
+    \"AES256-SHA256\"
+    \"DHE-RSA-AES128-GCM-SHA256\"
+    \"DHE-RSA-AES128-SHA256\"
+    \"DHE-RSA-AES256-GCM-SHA384\"
+    \"DHE-RSA-AES256-SHA256\"
+    \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+    \"ECDHE-ECDSA-AES128-SHA\"
+    \"ECDHE-ECDSA-AES128-SHA256\"
+    \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+    \"ECDHE-ECDSA-AES256-SHA\"
+    \"ECDHE-ECDSA-AES256-SHA384\"
+    \"ECDHE-RSA-AES128-GCM-SHA256\"
+    \"ECDHE-RSA-AES128-SHA\"
+    \"ECDHE-RSA-AES128-SHA256\"
+    \"ECDHE-RSA-AES256-GCM-SHA384\"
+    \"ECDHE-RSA-AES256-SHA\"
+    \"ECDHE-RSA-AES256-SHA384\"
+
+    *  __oci-wider-compatible-ssl-cipher-suite-v1__
+
+    \"AES128-GCM-SHA256\"
+    \"AES128-SHA\"
+    \"AES128-SHA256\"
+    \"AES256-GCM-SHA384\"
+    \"AES256-SHA\"
+    \"AES256-SHA256\"
+    \"CAMELLIA128-SHA\"
+    \"CAMELLIA256-SHA\"
+    \"DES-CBC3-SHA\"
+    \"DH-DSS-AES128-GCM-SHA256\"
+    \"DH-DSS-AES128-SHA\"
+    \"DH-DSS-AES128-SHA256\"
+    \"DH-DSS-AES256-GCM-SHA384\"
+    \"DH-DSS-AES256-SHA\"
+    \"DH-DSS-AES256-SHA256\"
+    \"DH-DSS-CAMELLIA128-SHA\"
+    \"DH-DSS-CAMELLIA256-SHA\"
+    \"DH-DSS-DES-CBC3-SHAv\"
+    \"DH-DSS-SEED-SHA\"
+    \"DH-RSA-AES128-GCM-SHA256\"
+    \"DH-RSA-AES128-SHA\"
+    \"DH-RSA-AES128-SHA256\"
+    \"DH-RSA-AES256-GCM-SHA384\"
+    \"DH-RSA-AES256-SHA\"
+    \"DH-RSA-AES256-SHA256\"
+    \"DH-RSA-CAMELLIA128-SHA\"
+    \"DH-RSA-CAMELLIA256-SHA\"
+    \"DH-RSA-DES-CBC3-SHA\"
+    \"DH-RSA-SEED-SHA\"
+    \"DHE-DSS-AES128-GCM-SHA256\"
+    \"DHE-DSS-AES128-SHA\"
+    \"DHE-DSS-AES128-SHA256\"
+    \"DHE-DSS-AES256-GCM-SHA384\"
+    \"DHE-DSS-AES256-SHA\"
+    \"DHE-DSS-AES256-SHA256\"
+    \"DHE-DSS-CAMELLIA128-SHA\"
+    \"DHE-DSS-CAMELLIA256-SHA\"
+    \"DHE-DSS-DES-CBC3-SHA\"
+    \"DHE-DSS-SEED-SHA\"
+    \"DHE-RSA-AES128-GCM-SHA256\"
+    \"DHE-RSA-AES128-SHA\"
+    \"DHE-RSA-AES128-SHA256\"
+    \"DHE-RSA-AES256-GCM-SHA384\"
+    \"DHE-RSA-AES256-SHA\"
+    \"DHE-RSA-AES256-SHA256\"
+    \"DHE-RSA-CAMELLIA128-SHA\"
+    \"DHE-RSA-CAMELLIA256-SHA\"
+    \"DHE-RSA-DES-CBC3-SHA\"
+    \"DHE-RSA-SEED-SHA\"
+    \"ECDH-ECDSA-AES128-GCM-SHA256\"
+    \"ECDH-ECDSA-AES128-SHA\"
+    \"ECDH-ECDSA-AES128-SHA256\"
+    \"ECDH-ECDSA-AES256-GCM-SHA384\"
+    \"ECDH-ECDSA-AES256-SHA\"
+    \"ECDH-ECDSA-AES256-SHA384\"
+    \"ECDH-ECDSA-DES-CBC3-SHA\"
+    \"ECDH-ECDSA-RC4-SHA\"
+    \"ECDH-RSA-AES128-GCM-SHA256\"
+    \"ECDH-RSA-AES128-SHA\"
+    \"ECDH-RSA-AES128-SHA256\"
+    \"ECDH-RSA-AES256-GCM-SHA384\"
+    \"ECDH-RSA-AES256-SHA\"
+    \"ECDH-RSA-AES256-SHA384\"
+    \"ECDH-RSA-DES-CBC3-SHA\"
+    \"ECDH-RSA-RC4-SHA\"
+    \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+    \"ECDHE-ECDSA-AES128-SHA\"
+    \"ECDHE-ECDSA-AES128-SHA256\"
+    \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+    \"ECDHE-ECDSA-AES256-SHA\"
+    \"ECDHE-ECDSA-AES256-SHA384\"
+    \"ECDHE-ECDSA-DES-CBC3-SHA\"
+    \"ECDHE-ECDSA-RC4-SHA\"
+    \"ECDHE-RSA-AES128-GCM-SHA256\"
+    \"ECDHE-RSA-AES128-SHA\"
+    \"ECDHE-RSA-AES128-SHA256\"
+    \"ECDHE-RSA-AES256-GCM-SHA384\"
+    \"ECDHE-RSA-AES256-SHA\"
+    \"ECDHE-RSA-AES256-SHA384\"
+    \"ECDHE-RSA-DES-CBC3-SHA\"
+    \"ECDHE-RSA-RC4-SHA\"
+    \"IDEA-CBC-SHA\"
+    \"KRB5-DES-CBC3-MD5\"
+    \"KRB5-DES-CBC3-SHA\"
+    \"KRB5-IDEA-CBC-MD5\"
+    \"KRB5-IDEA-CBC-SHA\"
+    \"KRB5-RC4-MD5\"
+    \"KRB5-RC4-SHA\"
+    \"PSK-3DES-EDE-CBC-SHA\"
+    \"PSK-AES128-CBC-SHA\"
+    \"PSK-AES256-CBC-SHA\"
+    \"PSK-RC4-SHA\"
+    \"RC4-MD5\"
+    \"RC4-SHA\"
+    \"SEED-SHA\"
+
+    __ https://docs.cloud.oracle.com/api/#/en/loadbalancer/20170115/datatypes/SSLConfigurationDetails
+    __ https://docs.cloud.oracle.com/api/#/en/loadbalancer/20170115/SSLCipherSuite/CreateSSLCipherSuite
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SSLCipherSuiteDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this SSLCipherSuiteDetails.
+        :type name: str
+
+        :param ciphers:
+            The value to assign to the ciphers property of this SSLCipherSuiteDetails.
+        :type ciphers: list[str]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'ciphers': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'ciphers': 'ciphers'
+        }
+
+        self._name = None
+        self._ciphers = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this SSLCipherSuiteDetails.
+        A friendly name for the SSL cipher suite. It must be unique and it cannot be changed.
+
+        **Note:** The name of your user-defined cipher suite must not be the same as any of Oracle's predefined or
+                  reserved SSL cipher suite names:
+
+        * oci-default-ssl-cipher-suite-v1
+        * oci-modern-ssl-cipher-suite-v1
+        * oci-compatible-ssl-cipher-suite-v1
+        * oci-wider-compatible-ssl-cipher-suite-v1
+        * oci-customized-ssl-cipher-suite
+
+        example: `example_cipher_suite`
+
+
+        :return: The name of this SSLCipherSuiteDetails.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this SSLCipherSuiteDetails.
+        A friendly name for the SSL cipher suite. It must be unique and it cannot be changed.
+
+        **Note:** The name of your user-defined cipher suite must not be the same as any of Oracle's predefined or
+                  reserved SSL cipher suite names:
+
+        * oci-default-ssl-cipher-suite-v1
+        * oci-modern-ssl-cipher-suite-v1
+        * oci-compatible-ssl-cipher-suite-v1
+        * oci-wider-compatible-ssl-cipher-suite-v1
+        * oci-customized-ssl-cipher-suite
+
+        example: `example_cipher_suite`
+
+
+        :param name: The name of this SSLCipherSuiteDetails.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def ciphers(self):
+        """
+        **[Required]** Gets the ciphers of this SSLCipherSuiteDetails.
+        A list of SSL ciphers the load balancer must support for HTTPS or SSL connections.
+
+        The following ciphers are valid values for this property:
+
+        *  __TLSv1.2 ciphers__
+
+                \"AES128-GCM-SHA256\"
+                \"AES128-SHA256\"
+                \"AES256-GCM-SHA384\"
+                \"AES256-SHA256\"
+                \"DH-DSS-AES128-GCM-SHA256\"
+                \"DH-DSS-AES128-SHA256\"
+                \"DH-DSS-AES256-GCM-SHA384\"
+                \"DH-DSS-AES256-SHA256\"
+                \"DH-RSA-AES128-GCM-SHA256\"
+                \"DH-RSA-AES128-SHA256\"
+                \"DH-RSA-AES256-GCM-SHA384\"
+                \"DH-RSA-AES256-SHA256\"
+                \"DHE-DSS-AES128-GCM-SHA256\"
+                \"DHE-DSS-AES128-SHA256\"
+                \"DHE-DSS-AES256-GCM-SHA384\"
+                \"DHE-DSS-AES256-SHA256\"
+                \"DHE-RSA-AES128-GCM-SHA256\"
+                \"DHE-RSA-AES128-SHA256\"
+                \"DHE-RSA-AES256-GCM-SHA384\"
+                \"DHE-RSA-AES256-SHA256\"
+                \"ECDH-ECDSA-AES128-GCM-SHA256\"
+                \"ECDH-ECDSA-AES128-SHA256\"
+                \"ECDH-ECDSA-AES256-GCM-SHA384\"
+                \"ECDH-ECDSA-AES256-SHA384\"
+                \"ECDH-RSA-AES128-GCM-SHA256\"
+                \"ECDH-RSA-AES128-SHA256\"
+                \"ECDH-RSA-AES256-GCM-SHA384\"
+                \"ECDH-RSA-AES256-SHA384\"
+                \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+                \"ECDHE-ECDSA-AES128-SHA256\"
+                \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+                \"ECDHE-ECDSA-AES256-SHA384\"
+                \"ECDHE-RSA-AES128-GCM-SHA256\"
+                \"ECDHE-RSA-AES128-SHA256\"
+                \"ECDHE-RSA-AES256-GCM-SHA384\"
+                \"ECDHE-RSA-AES256-SHA384\"
+
+        *  __TLSv1 ciphers also supported by TLSv1.2__
+
+                \"AES128-SHA\"
+                \"AES256-SHA\"
+                \"CAMELLIA128-SHA\"
+                \"CAMELLIA256-SHA\"
+                \"DES-CBC3-SHA\"
+                \"DH-DSS-AES128-SHA\"
+                \"DH-DSS-AES256-SHA\"
+                \"DH-DSS-CAMELLIA128-SHA\"
+                \"DH-DSS-CAMELLIA256-SHA\"
+                \"DH-DSS-DES-CBC3-SHAv\"
+                \"DH-DSS-SEED-SHA\"
+                \"DH-RSA-AES128-SHA\"
+                \"DH-RSA-AES256-SHA\"
+                \"DH-RSA-CAMELLIA128-SHA\"
+                \"DH-RSA-CAMELLIA256-SHA\"
+                \"DH-RSA-DES-CBC3-SHA\"
+                \"DH-RSA-SEED-SHA\"
+                \"DHE-DSS-AES128-SHA\"
+                \"DHE-DSS-AES256-SHA\"
+                \"DHE-DSS-CAMELLIA128-SHA\"
+                \"DHE-DSS-CAMELLIA256-SHA\"
+                \"DHE-DSS-DES-CBC3-SHA\"
+                \"DHE-DSS-SEED-SHA\"
+                \"DHE-RSA-AES128-SHA\"
+                \"DHE-RSA-AES256-SHA\"
+                \"DHE-RSA-CAMELLIA128-SHA\"
+                \"DHE-RSA-CAMELLIA256-SHA\"
+                \"DHE-RSA-DES-CBC3-SHA\"
+                \"DHE-RSA-SEED-SHA\"
+                \"ECDH-ECDSA-AES128-SHA\"
+                \"ECDH-ECDSA-AES256-SHA\"
+                \"ECDH-ECDSA-DES-CBC3-SHA\"
+                \"ECDH-ECDSA-RC4-SHA\"
+                \"ECDH-RSA-AES128-SHA\"
+                \"ECDH-RSA-AES256-SHA\"
+                \"ECDH-RSA-DES-CBC3-SHA\"
+                \"ECDH-RSA-RC4-SHA\"
+                \"ECDHE-ECDSA-AES128-SHA\"
+                \"ECDHE-ECDSA-AES256-SHA\"
+                \"ECDHE-ECDSA-DES-CBC3-SHA\"
+                \"ECDHE-ECDSA-RC4-SHA\"
+                \"ECDHE-RSA-AES128-SHA\"
+                \"ECDHE-RSA-AES256-SHA\"
+                \"ECDHE-RSA-DES-CBC3-SHA\"
+                \"ECDHE-RSA-RC4-SHA\"
+                \"IDEA-CBC-SHA\"
+                \"KRB5-DES-CBC3-MD5\"
+                \"KRB5-DES-CBC3-SHA\"
+                \"KRB5-IDEA-CBC-MD5\"
+                \"KRB5-IDEA-CBC-SHA\"
+                \"KRB5-RC4-MD5\"
+                \"KRB5-RC4-SHA\"
+                \"PSK-3DES-EDE-CBC-SHA\"
+                \"PSK-AES128-CBC-SHA\"
+                \"PSK-AES256-CBC-SHA\"
+                \"PSK-RC4-SHA\"
+                \"RC4-MD5\"
+                \"RC4-SHA\"
+                \"SEED-SHA\"
+
+        example: `[\"ECDHE-RSA-AES256-GCM-SHA384\",\"ECDHE-ECDSA-AES256-GCM-SHA384\",\"ECDHE-RSA-AES128-GCM-SHA256\"]`
+
+
+        :return: The ciphers of this SSLCipherSuiteDetails.
+        :rtype: list[str]
+        """
+        return self._ciphers
+
+    @ciphers.setter
+    def ciphers(self, ciphers):
+        """
+        Sets the ciphers of this SSLCipherSuiteDetails.
+        A list of SSL ciphers the load balancer must support for HTTPS or SSL connections.
+
+        The following ciphers are valid values for this property:
+
+        *  __TLSv1.2 ciphers__
+
+                \"AES128-GCM-SHA256\"
+                \"AES128-SHA256\"
+                \"AES256-GCM-SHA384\"
+                \"AES256-SHA256\"
+                \"DH-DSS-AES128-GCM-SHA256\"
+                \"DH-DSS-AES128-SHA256\"
+                \"DH-DSS-AES256-GCM-SHA384\"
+                \"DH-DSS-AES256-SHA256\"
+                \"DH-RSA-AES128-GCM-SHA256\"
+                \"DH-RSA-AES128-SHA256\"
+                \"DH-RSA-AES256-GCM-SHA384\"
+                \"DH-RSA-AES256-SHA256\"
+                \"DHE-DSS-AES128-GCM-SHA256\"
+                \"DHE-DSS-AES128-SHA256\"
+                \"DHE-DSS-AES256-GCM-SHA384\"
+                \"DHE-DSS-AES256-SHA256\"
+                \"DHE-RSA-AES128-GCM-SHA256\"
+                \"DHE-RSA-AES128-SHA256\"
+                \"DHE-RSA-AES256-GCM-SHA384\"
+                \"DHE-RSA-AES256-SHA256\"
+                \"ECDH-ECDSA-AES128-GCM-SHA256\"
+                \"ECDH-ECDSA-AES128-SHA256\"
+                \"ECDH-ECDSA-AES256-GCM-SHA384\"
+                \"ECDH-ECDSA-AES256-SHA384\"
+                \"ECDH-RSA-AES128-GCM-SHA256\"
+                \"ECDH-RSA-AES128-SHA256\"
+                \"ECDH-RSA-AES256-GCM-SHA384\"
+                \"ECDH-RSA-AES256-SHA384\"
+                \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+                \"ECDHE-ECDSA-AES128-SHA256\"
+                \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+                \"ECDHE-ECDSA-AES256-SHA384\"
+                \"ECDHE-RSA-AES128-GCM-SHA256\"
+                \"ECDHE-RSA-AES128-SHA256\"
+                \"ECDHE-RSA-AES256-GCM-SHA384\"
+                \"ECDHE-RSA-AES256-SHA384\"
+
+        *  __TLSv1 ciphers also supported by TLSv1.2__
+
+                \"AES128-SHA\"
+                \"AES256-SHA\"
+                \"CAMELLIA128-SHA\"
+                \"CAMELLIA256-SHA\"
+                \"DES-CBC3-SHA\"
+                \"DH-DSS-AES128-SHA\"
+                \"DH-DSS-AES256-SHA\"
+                \"DH-DSS-CAMELLIA128-SHA\"
+                \"DH-DSS-CAMELLIA256-SHA\"
+                \"DH-DSS-DES-CBC3-SHAv\"
+                \"DH-DSS-SEED-SHA\"
+                \"DH-RSA-AES128-SHA\"
+                \"DH-RSA-AES256-SHA\"
+                \"DH-RSA-CAMELLIA128-SHA\"
+                \"DH-RSA-CAMELLIA256-SHA\"
+                \"DH-RSA-DES-CBC3-SHA\"
+                \"DH-RSA-SEED-SHA\"
+                \"DHE-DSS-AES128-SHA\"
+                \"DHE-DSS-AES256-SHA\"
+                \"DHE-DSS-CAMELLIA128-SHA\"
+                \"DHE-DSS-CAMELLIA256-SHA\"
+                \"DHE-DSS-DES-CBC3-SHA\"
+                \"DHE-DSS-SEED-SHA\"
+                \"DHE-RSA-AES128-SHA\"
+                \"DHE-RSA-AES256-SHA\"
+                \"DHE-RSA-CAMELLIA128-SHA\"
+                \"DHE-RSA-CAMELLIA256-SHA\"
+                \"DHE-RSA-DES-CBC3-SHA\"
+                \"DHE-RSA-SEED-SHA\"
+                \"ECDH-ECDSA-AES128-SHA\"
+                \"ECDH-ECDSA-AES256-SHA\"
+                \"ECDH-ECDSA-DES-CBC3-SHA\"
+                \"ECDH-ECDSA-RC4-SHA\"
+                \"ECDH-RSA-AES128-SHA\"
+                \"ECDH-RSA-AES256-SHA\"
+                \"ECDH-RSA-DES-CBC3-SHA\"
+                \"ECDH-RSA-RC4-SHA\"
+                \"ECDHE-ECDSA-AES128-SHA\"
+                \"ECDHE-ECDSA-AES256-SHA\"
+                \"ECDHE-ECDSA-DES-CBC3-SHA\"
+                \"ECDHE-ECDSA-RC4-SHA\"
+                \"ECDHE-RSA-AES128-SHA\"
+                \"ECDHE-RSA-AES256-SHA\"
+                \"ECDHE-RSA-DES-CBC3-SHA\"
+                \"ECDHE-RSA-RC4-SHA\"
+                \"IDEA-CBC-SHA\"
+                \"KRB5-DES-CBC3-MD5\"
+                \"KRB5-DES-CBC3-SHA\"
+                \"KRB5-IDEA-CBC-MD5\"
+                \"KRB5-IDEA-CBC-SHA\"
+                \"KRB5-RC4-MD5\"
+                \"KRB5-RC4-SHA\"
+                \"PSK-3DES-EDE-CBC-SHA\"
+                \"PSK-AES128-CBC-SHA\"
+                \"PSK-AES256-CBC-SHA\"
+                \"PSK-RC4-SHA\"
+                \"RC4-MD5\"
+                \"RC4-SHA\"
+                \"SEED-SHA\"
+
+        example: `[\"ECDHE-RSA-AES256-GCM-SHA384\",\"ECDHE-ECDSA-AES256-GCM-SHA384\",\"ECDHE-RSA-AES128-GCM-SHA256\"]`
+
+
+        :param ciphers: The ciphers of this SSLCipherSuiteDetails.
+        :type: list[str]
+        """
+        self._ciphers = ciphers
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/load_balancer/models/ssl_configuration.py
+++ b/src/oci/load_balancer/models/ssl_configuration.py
@@ -17,39 +17,126 @@ class SSLConfiguration(object):
     **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
     """
 
+    #: A constant which can be used with the server_order_preference property of a SSLConfiguration.
+    #: This constant has a value of "ENABLED"
+    SERVER_ORDER_PREFERENCE_ENABLED = "ENABLED"
+
+    #: A constant which can be used with the server_order_preference property of a SSLConfiguration.
+    #: This constant has a value of "DISABLED"
+    SERVER_ORDER_PREFERENCE_DISABLED = "DISABLED"
+
     def __init__(self, **kwargs):
         """
         Initializes a new SSLConfiguration object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
-        :param certificate_name:
-            The value to assign to the certificate_name property of this SSLConfiguration.
-        :type certificate_name: str
+        :param verify_depth:
+            The value to assign to the verify_depth property of this SSLConfiguration.
+        :type verify_depth: int
 
         :param verify_peer_certificate:
             The value to assign to the verify_peer_certificate property of this SSLConfiguration.
         :type verify_peer_certificate: bool
 
-        :param verify_depth:
-            The value to assign to the verify_depth property of this SSLConfiguration.
-        :type verify_depth: int
+        :param certificate_name:
+            The value to assign to the certificate_name property of this SSLConfiguration.
+        :type certificate_name: str
+
+        :param server_order_preference:
+            The value to assign to the server_order_preference property of this SSLConfiguration.
+            Allowed values for this property are: "ENABLED", "DISABLED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type server_order_preference: str
+
+        :param cipher_suite_name:
+            The value to assign to the cipher_suite_name property of this SSLConfiguration.
+        :type cipher_suite_name: str
+
+        :param protocols:
+            The value to assign to the protocols property of this SSLConfiguration.
+        :type protocols: list[str]
 
         """
         self.swagger_types = {
-            'certificate_name': 'str',
+            'verify_depth': 'int',
             'verify_peer_certificate': 'bool',
-            'verify_depth': 'int'
+            'certificate_name': 'str',
+            'server_order_preference': 'str',
+            'cipher_suite_name': 'str',
+            'protocols': 'list[str]'
         }
 
         self.attribute_map = {
-            'certificate_name': 'certificateName',
+            'verify_depth': 'verifyDepth',
             'verify_peer_certificate': 'verifyPeerCertificate',
-            'verify_depth': 'verifyDepth'
+            'certificate_name': 'certificateName',
+            'server_order_preference': 'serverOrderPreference',
+            'cipher_suite_name': 'cipherSuiteName',
+            'protocols': 'protocols'
         }
 
-        self._certificate_name = None
-        self._verify_peer_certificate = None
         self._verify_depth = None
+        self._verify_peer_certificate = None
+        self._certificate_name = None
+        self._server_order_preference = None
+        self._cipher_suite_name = None
+        self._protocols = None
+
+    @property
+    def verify_depth(self):
+        """
+        **[Required]** Gets the verify_depth of this SSLConfiguration.
+        The maximum depth for peer certificate chain verification.
+
+        Example: `3`
+
+
+        :return: The verify_depth of this SSLConfiguration.
+        :rtype: int
+        """
+        return self._verify_depth
+
+    @verify_depth.setter
+    def verify_depth(self, verify_depth):
+        """
+        Sets the verify_depth of this SSLConfiguration.
+        The maximum depth for peer certificate chain verification.
+
+        Example: `3`
+
+
+        :param verify_depth: The verify_depth of this SSLConfiguration.
+        :type: int
+        """
+        self._verify_depth = verify_depth
+
+    @property
+    def verify_peer_certificate(self):
+        """
+        **[Required]** Gets the verify_peer_certificate of this SSLConfiguration.
+        Whether the load balancer listener should verify peer certificates.
+
+        Example: `true`
+
+
+        :return: The verify_peer_certificate of this SSLConfiguration.
+        :rtype: bool
+        """
+        return self._verify_peer_certificate
+
+    @verify_peer_certificate.setter
+    def verify_peer_certificate(self, verify_peer_certificate):
+        """
+        Sets the verify_peer_certificate of this SSLConfiguration.
+        Whether the load balancer listener should verify peer certificates.
+
+        Example: `true`
+
+
+        :param verify_peer_certificate: The verify_peer_certificate of this SSLConfiguration.
+        :type: bool
+        """
+        self._verify_peer_certificate = verify_peer_certificate
 
     @property
     def certificate_name(self):
@@ -84,60 +171,184 @@ class SSLConfiguration(object):
         self._certificate_name = certificate_name
 
     @property
-    def verify_peer_certificate(self):
+    def server_order_preference(self):
         """
-        **[Required]** Gets the verify_peer_certificate of this SSLConfiguration.
-        Whether the load balancer listener should verify peer certificates.
+        Gets the server_order_preference of this SSLConfiguration.
+        When this attribute is set to ENABLED, the system gives preference to the server ciphers over the client
+        ciphers.
 
-        Example: `true`
+        **Note:** This configuration is applicable only when the load balancer is acting as an SSL/HTTPS server. This
+                  field is ignored when the `SSLConfiguration` object is associated with a backend set.
+
+        Allowed values for this property are: "ENABLED", "DISABLED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
-        :return: The verify_peer_certificate of this SSLConfiguration.
-        :rtype: bool
+        :return: The server_order_preference of this SSLConfiguration.
+        :rtype: str
         """
-        return self._verify_peer_certificate
+        return self._server_order_preference
 
-    @verify_peer_certificate.setter
-    def verify_peer_certificate(self, verify_peer_certificate):
+    @server_order_preference.setter
+    def server_order_preference(self, server_order_preference):
         """
-        Sets the verify_peer_certificate of this SSLConfiguration.
-        Whether the load balancer listener should verify peer certificates.
+        Sets the server_order_preference of this SSLConfiguration.
+        When this attribute is set to ENABLED, the system gives preference to the server ciphers over the client
+        ciphers.
 
-        Example: `true`
+        **Note:** This configuration is applicable only when the load balancer is acting as an SSL/HTTPS server. This
+                  field is ignored when the `SSLConfiguration` object is associated with a backend set.
 
 
-        :param verify_peer_certificate: The verify_peer_certificate of this SSLConfiguration.
-        :type: bool
+        :param server_order_preference: The server_order_preference of this SSLConfiguration.
+        :type: str
         """
-        self._verify_peer_certificate = verify_peer_certificate
+        allowed_values = ["ENABLED", "DISABLED"]
+        if not value_allowed_none_or_none_sentinel(server_order_preference, allowed_values):
+            server_order_preference = 'UNKNOWN_ENUM_VALUE'
+        self._server_order_preference = server_order_preference
 
     @property
-    def verify_depth(self):
+    def cipher_suite_name(self):
         """
-        **[Required]** Gets the verify_depth of this SSLConfiguration.
-        The maximum depth for peer certificate chain verification.
+        Gets the cipher_suite_name of this SSLConfiguration.
+        The name of the cipher suite to use for HTTPS or SSL connections.
 
-        Example: `3`
+        If this field is not specified, the default is `oci-default-ssl-cipher-suite-v1`.
+
+        **Notes:**
+
+        *  You must ensure compatibility between the specified SSL protocols and the ciphers configured in the cipher
+           suite. Clients cannot perform an SSL handshake if there is an incompatible configuration.
+        *  You must ensure compatibility between the ciphers configured in the cipher suite and the configured
+           certificates. For example, RSA-based ciphers require RSA certificates and ECDSA-based ciphers require ECDSA
+           certificates.
+        *  If the cipher configuration is not modified after load balancer creation, the `GET` operation returns
+           `oci-default-ssl-cipher-suite-v1` as the value of this field in the SSL configuration for existing listeners
+           that predate this feature.
+        *  If the cipher configuration was modified using Oracle operations after load balancer creation, the `GET`
+           operation returns `oci-customized-ssl-cipher-suite` as the value of this field in the SSL configuration for
+           existing listeners that predate this feature.
+        *  The `GET` operation returns `oci-wider-compatible-ssl-cipher-suite-v1` as the value of this field in the SSL
+           configuration for existing backend sets that predate this feature.
+        *  If the `GET` operation on a listener returns `oci-customized-ssl-cipher-suite` as the value of this field,
+           you must specify an appropriate predefined or custom cipher suite name when updating the resource.
+        *  The `oci-customized-ssl-cipher-suite` Oracle reserved cipher suite name is not accepted as valid input for
+           this field.
+
+        example: `example_cipher_suite`
 
 
-        :return: The verify_depth of this SSLConfiguration.
-        :rtype: int
+        :return: The cipher_suite_name of this SSLConfiguration.
+        :rtype: str
         """
-        return self._verify_depth
+        return self._cipher_suite_name
 
-    @verify_depth.setter
-    def verify_depth(self, verify_depth):
+    @cipher_suite_name.setter
+    def cipher_suite_name(self, cipher_suite_name):
         """
-        Sets the verify_depth of this SSLConfiguration.
-        The maximum depth for peer certificate chain verification.
+        Sets the cipher_suite_name of this SSLConfiguration.
+        The name of the cipher suite to use for HTTPS or SSL connections.
 
-        Example: `3`
+        If this field is not specified, the default is `oci-default-ssl-cipher-suite-v1`.
+
+        **Notes:**
+
+        *  You must ensure compatibility between the specified SSL protocols and the ciphers configured in the cipher
+           suite. Clients cannot perform an SSL handshake if there is an incompatible configuration.
+        *  You must ensure compatibility between the ciphers configured in the cipher suite and the configured
+           certificates. For example, RSA-based ciphers require RSA certificates and ECDSA-based ciphers require ECDSA
+           certificates.
+        *  If the cipher configuration is not modified after load balancer creation, the `GET` operation returns
+           `oci-default-ssl-cipher-suite-v1` as the value of this field in the SSL configuration for existing listeners
+           that predate this feature.
+        *  If the cipher configuration was modified using Oracle operations after load balancer creation, the `GET`
+           operation returns `oci-customized-ssl-cipher-suite` as the value of this field in the SSL configuration for
+           existing listeners that predate this feature.
+        *  The `GET` operation returns `oci-wider-compatible-ssl-cipher-suite-v1` as the value of this field in the SSL
+           configuration for existing backend sets that predate this feature.
+        *  If the `GET` operation on a listener returns `oci-customized-ssl-cipher-suite` as the value of this field,
+           you must specify an appropriate predefined or custom cipher suite name when updating the resource.
+        *  The `oci-customized-ssl-cipher-suite` Oracle reserved cipher suite name is not accepted as valid input for
+           this field.
+
+        example: `example_cipher_suite`
 
 
-        :param verify_depth: The verify_depth of this SSLConfiguration.
-        :type: int
+        :param cipher_suite_name: The cipher_suite_name of this SSLConfiguration.
+        :type: str
         """
-        self._verify_depth = verify_depth
+        self._cipher_suite_name = cipher_suite_name
+
+    @property
+    def protocols(self):
+        """
+        Gets the protocols of this SSLConfiguration.
+        A list of SSL protocols the load balancer must support for HTTPS or SSL connections.
+
+        The load balancer uses SSL protocols to establish a secure connection between a client and a server. A secure
+        connection ensures that all data passed between the client and the server is private.
+
+        The Load Balancing service supports the following protocols:
+
+        *  TLSv1
+        *  TLSv1.1
+        *  TLSv1.2
+
+        If this field is not specified, TLSv1.2 is the default.
+
+        **Warning:** All SSL listeners created on a given port must use the same set of SSL protocols.
+
+        **Notes:**
+
+        *  The handshake to establish an SSL connection fails if the client supports none of the specified protocols.
+        *  You must ensure compatibility between the specified SSL protocols and the ciphers configured in the cipher
+           suite.
+        *  For all existing load balancer listeners and backend sets that predate this feature, the `GET` operation
+           displays a list of SSL protocols currently used by those resources.
+
+        example: `[\"TLSv1.1\", \"TLSv1.2\"]`
+
+
+        :return: The protocols of this SSLConfiguration.
+        :rtype: list[str]
+        """
+        return self._protocols
+
+    @protocols.setter
+    def protocols(self, protocols):
+        """
+        Sets the protocols of this SSLConfiguration.
+        A list of SSL protocols the load balancer must support for HTTPS or SSL connections.
+
+        The load balancer uses SSL protocols to establish a secure connection between a client and a server. A secure
+        connection ensures that all data passed between the client and the server is private.
+
+        The Load Balancing service supports the following protocols:
+
+        *  TLSv1
+        *  TLSv1.1
+        *  TLSv1.2
+
+        If this field is not specified, TLSv1.2 is the default.
+
+        **Warning:** All SSL listeners created on a given port must use the same set of SSL protocols.
+
+        **Notes:**
+
+        *  The handshake to establish an SSL connection fails if the client supports none of the specified protocols.
+        *  You must ensure compatibility between the specified SSL protocols and the ciphers configured in the cipher
+           suite.
+        *  For all existing load balancer listeners and backend sets that predate this feature, the `GET` operation
+           displays a list of SSL protocols currently used by those resources.
+
+        example: `[\"TLSv1.1\", \"TLSv1.2\"]`
+
+
+        :param protocols: The protocols of this SSLConfiguration.
+        :type: list[str]
+        """
+        self._protocols = protocols
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/load_balancer/models/ssl_configuration_details.py
+++ b/src/oci/load_balancer/models/ssl_configuration_details.py
@@ -15,39 +15,125 @@ class SSLConfigurationDetails(object):
     **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
     """
 
+    #: A constant which can be used with the server_order_preference property of a SSLConfigurationDetails.
+    #: This constant has a value of "ENABLED"
+    SERVER_ORDER_PREFERENCE_ENABLED = "ENABLED"
+
+    #: A constant which can be used with the server_order_preference property of a SSLConfigurationDetails.
+    #: This constant has a value of "DISABLED"
+    SERVER_ORDER_PREFERENCE_DISABLED = "DISABLED"
+
     def __init__(self, **kwargs):
         """
         Initializes a new SSLConfigurationDetails object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
-        :param certificate_name:
-            The value to assign to the certificate_name property of this SSLConfigurationDetails.
-        :type certificate_name: str
+        :param verify_depth:
+            The value to assign to the verify_depth property of this SSLConfigurationDetails.
+        :type verify_depth: int
 
         :param verify_peer_certificate:
             The value to assign to the verify_peer_certificate property of this SSLConfigurationDetails.
         :type verify_peer_certificate: bool
 
-        :param verify_depth:
-            The value to assign to the verify_depth property of this SSLConfigurationDetails.
-        :type verify_depth: int
+        :param certificate_name:
+            The value to assign to the certificate_name property of this SSLConfigurationDetails.
+        :type certificate_name: str
+
+        :param protocols:
+            The value to assign to the protocols property of this SSLConfigurationDetails.
+        :type protocols: list[str]
+
+        :param cipher_suite_name:
+            The value to assign to the cipher_suite_name property of this SSLConfigurationDetails.
+        :type cipher_suite_name: str
+
+        :param server_order_preference:
+            The value to assign to the server_order_preference property of this SSLConfigurationDetails.
+            Allowed values for this property are: "ENABLED", "DISABLED"
+        :type server_order_preference: str
 
         """
         self.swagger_types = {
-            'certificate_name': 'str',
+            'verify_depth': 'int',
             'verify_peer_certificate': 'bool',
-            'verify_depth': 'int'
+            'certificate_name': 'str',
+            'protocols': 'list[str]',
+            'cipher_suite_name': 'str',
+            'server_order_preference': 'str'
         }
 
         self.attribute_map = {
-            'certificate_name': 'certificateName',
+            'verify_depth': 'verifyDepth',
             'verify_peer_certificate': 'verifyPeerCertificate',
-            'verify_depth': 'verifyDepth'
+            'certificate_name': 'certificateName',
+            'protocols': 'protocols',
+            'cipher_suite_name': 'cipherSuiteName',
+            'server_order_preference': 'serverOrderPreference'
         }
 
-        self._certificate_name = None
-        self._verify_peer_certificate = None
         self._verify_depth = None
+        self._verify_peer_certificate = None
+        self._certificate_name = None
+        self._protocols = None
+        self._cipher_suite_name = None
+        self._server_order_preference = None
+
+    @property
+    def verify_depth(self):
+        """
+        Gets the verify_depth of this SSLConfigurationDetails.
+        The maximum depth for peer certificate chain verification.
+
+        Example: `3`
+
+
+        :return: The verify_depth of this SSLConfigurationDetails.
+        :rtype: int
+        """
+        return self._verify_depth
+
+    @verify_depth.setter
+    def verify_depth(self, verify_depth):
+        """
+        Sets the verify_depth of this SSLConfigurationDetails.
+        The maximum depth for peer certificate chain verification.
+
+        Example: `3`
+
+
+        :param verify_depth: The verify_depth of this SSLConfigurationDetails.
+        :type: int
+        """
+        self._verify_depth = verify_depth
+
+    @property
+    def verify_peer_certificate(self):
+        """
+        Gets the verify_peer_certificate of this SSLConfigurationDetails.
+        Whether the load balancer listener should verify peer certificates.
+
+        Example: `true`
+
+
+        :return: The verify_peer_certificate of this SSLConfigurationDetails.
+        :rtype: bool
+        """
+        return self._verify_peer_certificate
+
+    @verify_peer_certificate.setter
+    def verify_peer_certificate(self, verify_peer_certificate):
+        """
+        Sets the verify_peer_certificate of this SSLConfigurationDetails.
+        Whether the load balancer listener should verify peer certificates.
+
+        Example: `true`
+
+
+        :param verify_peer_certificate: The verify_peer_certificate of this SSLConfigurationDetails.
+        :type: bool
+        """
+        self._verify_peer_certificate = verify_peer_certificate
 
     @property
     def certificate_name(self):
@@ -82,60 +168,186 @@ class SSLConfigurationDetails(object):
         self._certificate_name = certificate_name
 
     @property
-    def verify_peer_certificate(self):
+    def protocols(self):
         """
-        Gets the verify_peer_certificate of this SSLConfigurationDetails.
-        Whether the load balancer listener should verify peer certificates.
+        Gets the protocols of this SSLConfigurationDetails.
+        A list of SSL protocols the load balancer must support for HTTPS or SSL connections.
 
-        Example: `true`
+        The load balancer uses SSL protocols to establish a secure connection between a client and a server. A secure
+        connection ensures that all data passed between the client and the server is private.
+
+        The Load Balancing service supports the following protocols:
+
+        *  TLSv1
+        *  TLSv1.1
+        *  TLSv1.2
+
+        If this field is not specified, TLSv1.2 is the default.
+
+        **Warning:** All SSL listeners created on a given port must use the same set of SSL protocols.
+
+        **Notes:**
+
+        *  The handshake to establish an SSL connection fails if the client supports none of the specified protocols.
+        *  You must ensure compatibility between the specified SSL protocols and the ciphers configured in the cipher
+           suite.
+        *  For all existing load balancer listeners and backend sets that predate this feature, the `GET` operation
+           displays a list of SSL protocols currently used by those resources.
+
+        example: `[\"TLSv1.1\", \"TLSv1.2\"]`
 
 
-        :return: The verify_peer_certificate of this SSLConfigurationDetails.
-        :rtype: bool
+        :return: The protocols of this SSLConfigurationDetails.
+        :rtype: list[str]
         """
-        return self._verify_peer_certificate
+        return self._protocols
 
-    @verify_peer_certificate.setter
-    def verify_peer_certificate(self, verify_peer_certificate):
+    @protocols.setter
+    def protocols(self, protocols):
         """
-        Sets the verify_peer_certificate of this SSLConfigurationDetails.
-        Whether the load balancer listener should verify peer certificates.
+        Sets the protocols of this SSLConfigurationDetails.
+        A list of SSL protocols the load balancer must support for HTTPS or SSL connections.
 
-        Example: `true`
+        The load balancer uses SSL protocols to establish a secure connection between a client and a server. A secure
+        connection ensures that all data passed between the client and the server is private.
+
+        The Load Balancing service supports the following protocols:
+
+        *  TLSv1
+        *  TLSv1.1
+        *  TLSv1.2
+
+        If this field is not specified, TLSv1.2 is the default.
+
+        **Warning:** All SSL listeners created on a given port must use the same set of SSL protocols.
+
+        **Notes:**
+
+        *  The handshake to establish an SSL connection fails if the client supports none of the specified protocols.
+        *  You must ensure compatibility between the specified SSL protocols and the ciphers configured in the cipher
+           suite.
+        *  For all existing load balancer listeners and backend sets that predate this feature, the `GET` operation
+           displays a list of SSL protocols currently used by those resources.
+
+        example: `[\"TLSv1.1\", \"TLSv1.2\"]`
 
 
-        :param verify_peer_certificate: The verify_peer_certificate of this SSLConfigurationDetails.
-        :type: bool
+        :param protocols: The protocols of this SSLConfigurationDetails.
+        :type: list[str]
         """
-        self._verify_peer_certificate = verify_peer_certificate
+        self._protocols = protocols
 
     @property
-    def verify_depth(self):
+    def cipher_suite_name(self):
         """
-        Gets the verify_depth of this SSLConfigurationDetails.
-        The maximum depth for peer certificate chain verification.
+        Gets the cipher_suite_name of this SSLConfigurationDetails.
+        The name of the cipher suite to use for HTTPS or SSL connections.
 
-        Example: `3`
+        If this field is not specified, the default is `oci-default-ssl-cipher-suite-v1`.
+
+        **Notes:**
+
+        *  You must ensure compatibility between the specified SSL protocols and the ciphers configured in the cipher
+           suite. Clients cannot perform an SSL handshake if there is an incompatible configuration.
+        *  You must ensure compatibility between the ciphers configured in the cipher suite and the configured
+           certificates. For example, RSA-based ciphers require RSA certificates and ECDSA-based ciphers require ECDSA
+           certificates.
+        *  If the cipher configuration is not modified after load balancer creation, the `GET` operation returns
+           `oci-default-ssl-cipher-suite-v1` as the value of this field in the SSL configuration for existing listeners
+           that predate this feature.
+        *  If the cipher configuration was modified using Oracle operations after load balancer creation, the `GET`
+           operation returns `oci-customized-ssl-cipher-suite` as the value of this field in the SSL configuration for
+           existing listeners that predate this feature.
+        *  The `GET` operation returns `oci-wider-compatible-ssl-cipher-suite-v1` as the value of this field in the SSL
+           configuration for existing backend sets that predate this feature.
+        *  If the `GET` operation on a listener returns `oci-customized-ssl-cipher-suite` as the value of this field,
+           you must specify an appropriate predefined or custom cipher suite name when updating the resource.
+        *  The `oci-customized-ssl-cipher-suite` Oracle reserved cipher suite name is not accepted as valid input for
+           this field.
+
+        example: `example_cipher_suite`
 
 
-        :return: The verify_depth of this SSLConfigurationDetails.
-        :rtype: int
+        :return: The cipher_suite_name of this SSLConfigurationDetails.
+        :rtype: str
         """
-        return self._verify_depth
+        return self._cipher_suite_name
 
-    @verify_depth.setter
-    def verify_depth(self, verify_depth):
+    @cipher_suite_name.setter
+    def cipher_suite_name(self, cipher_suite_name):
         """
-        Sets the verify_depth of this SSLConfigurationDetails.
-        The maximum depth for peer certificate chain verification.
+        Sets the cipher_suite_name of this SSLConfigurationDetails.
+        The name of the cipher suite to use for HTTPS or SSL connections.
 
-        Example: `3`
+        If this field is not specified, the default is `oci-default-ssl-cipher-suite-v1`.
+
+        **Notes:**
+
+        *  You must ensure compatibility between the specified SSL protocols and the ciphers configured in the cipher
+           suite. Clients cannot perform an SSL handshake if there is an incompatible configuration.
+        *  You must ensure compatibility between the ciphers configured in the cipher suite and the configured
+           certificates. For example, RSA-based ciphers require RSA certificates and ECDSA-based ciphers require ECDSA
+           certificates.
+        *  If the cipher configuration is not modified after load balancer creation, the `GET` operation returns
+           `oci-default-ssl-cipher-suite-v1` as the value of this field in the SSL configuration for existing listeners
+           that predate this feature.
+        *  If the cipher configuration was modified using Oracle operations after load balancer creation, the `GET`
+           operation returns `oci-customized-ssl-cipher-suite` as the value of this field in the SSL configuration for
+           existing listeners that predate this feature.
+        *  The `GET` operation returns `oci-wider-compatible-ssl-cipher-suite-v1` as the value of this field in the SSL
+           configuration for existing backend sets that predate this feature.
+        *  If the `GET` operation on a listener returns `oci-customized-ssl-cipher-suite` as the value of this field,
+           you must specify an appropriate predefined or custom cipher suite name when updating the resource.
+        *  The `oci-customized-ssl-cipher-suite` Oracle reserved cipher suite name is not accepted as valid input for
+           this field.
+
+        example: `example_cipher_suite`
 
 
-        :param verify_depth: The verify_depth of this SSLConfigurationDetails.
-        :type: int
+        :param cipher_suite_name: The cipher_suite_name of this SSLConfigurationDetails.
+        :type: str
         """
-        self._verify_depth = verify_depth
+        self._cipher_suite_name = cipher_suite_name
+
+    @property
+    def server_order_preference(self):
+        """
+        Gets the server_order_preference of this SSLConfigurationDetails.
+        When this attribute is set to ENABLED, the system gives preference to the server ciphers over the client
+        ciphers.
+
+        **Note:** This configuration is applicable only when the load balancer is acting as an SSL/HTTPS server. This
+                  field is ignored when the `SSLConfiguration` object is associated with a backend set.
+
+        Allowed values for this property are: "ENABLED", "DISABLED"
+
+
+        :return: The server_order_preference of this SSLConfigurationDetails.
+        :rtype: str
+        """
+        return self._server_order_preference
+
+    @server_order_preference.setter
+    def server_order_preference(self, server_order_preference):
+        """
+        Sets the server_order_preference of this SSLConfigurationDetails.
+        When this attribute is set to ENABLED, the system gives preference to the server ciphers over the client
+        ciphers.
+
+        **Note:** This configuration is applicable only when the load balancer is acting as an SSL/HTTPS server. This
+                  field is ignored when the `SSLConfiguration` object is associated with a backend set.
+
+
+        :param server_order_preference: The server_order_preference of this SSLConfigurationDetails.
+        :type: str
+        """
+        allowed_values = ["ENABLED", "DISABLED"]
+        if not value_allowed_none_or_none_sentinel(server_order_preference, allowed_values):
+            raise ValueError(
+                "Invalid value for `server_order_preference`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._server_order_preference = server_order_preference
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/load_balancer/models/update_ssl_cipher_suite_details.py
+++ b/src/oci/load_balancer/models/update_ssl_cipher_suite_details.py
@@ -1,0 +1,282 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateSSLCipherSuiteDetails(object):
+    """
+    The configuration details for updating an SSL cipher suite.
+
+    **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateSSLCipherSuiteDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param ciphers:
+            The value to assign to the ciphers property of this UpdateSSLCipherSuiteDetails.
+        :type ciphers: list[str]
+
+        """
+        self.swagger_types = {
+            'ciphers': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'ciphers': 'ciphers'
+        }
+
+        self._ciphers = None
+
+    @property
+    def ciphers(self):
+        """
+        **[Required]** Gets the ciphers of this UpdateSSLCipherSuiteDetails.
+        A list of SSL ciphers the load balancer must support for HTTPS or SSL connections.
+
+        The following ciphers are valid values for this property:
+
+        *  __TLSv1.2 ciphers__
+
+                \"AES128-GCM-SHA256\"
+                \"AES128-SHA256\"
+                \"AES256-GCM-SHA384\"
+                \"AES256-SHA256\"
+                \"DH-DSS-AES128-GCM-SHA256\"
+                \"DH-DSS-AES128-SHA256\"
+                \"DH-DSS-AES256-GCM-SHA384\"
+                \"DH-DSS-AES256-SHA256\"
+                \"DH-RSA-AES128-GCM-SHA256\"
+                \"DH-RSA-AES128-SHA256\"
+                \"DH-RSA-AES256-GCM-SHA384\"
+                \"DH-RSA-AES256-SHA256\"
+                \"DHE-DSS-AES128-GCM-SHA256\"
+                \"DHE-DSS-AES128-SHA256\"
+                \"DHE-DSS-AES256-GCM-SHA384\"
+                \"DHE-DSS-AES256-SHA256\"
+                \"DHE-RSA-AES128-GCM-SHA256\"
+                \"DHE-RSA-AES128-SHA256\"
+                \"DHE-RSA-AES256-GCM-SHA384\"
+                \"DHE-RSA-AES256-SHA256\"
+                \"ECDH-ECDSA-AES128-GCM-SHA256\"
+                \"ECDH-ECDSA-AES128-SHA256\"
+                \"ECDH-ECDSA-AES256-GCM-SHA384\"
+                \"ECDH-ECDSA-AES256-SHA384\"
+                \"ECDH-RSA-AES128-GCM-SHA256\"
+                \"ECDH-RSA-AES128-SHA256\"
+                \"ECDH-RSA-AES256-GCM-SHA384\"
+                \"ECDH-RSA-AES256-SHA384\"
+                \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+                \"ECDHE-ECDSA-AES128-SHA256\"
+                \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+                \"ECDHE-ECDSA-AES256-SHA384\"
+                \"ECDHE-RSA-AES128-GCM-SHA256\"
+                \"ECDHE-RSA-AES128-SHA256\"
+                \"ECDHE-RSA-AES256-GCM-SHA384\"
+                \"ECDHE-RSA-AES256-SHA384\"
+
+        *  __TLSv1 ciphers also supported by TLSv1.2__
+
+                \"AES128-SHA\"
+                \"AES256-SHA\"
+                \"CAMELLIA128-SHA\"
+                \"CAMELLIA256-SHA\"
+                \"DES-CBC3-SHA\"
+                \"DH-DSS-AES128-SHA\"
+                \"DH-DSS-AES256-SHA\"
+                \"DH-DSS-CAMELLIA128-SHA\"
+                \"DH-DSS-CAMELLIA256-SHA\"
+                \"DH-DSS-DES-CBC3-SHAv\"
+                \"DH-DSS-SEED-SHA\"
+                \"DH-RSA-AES128-SHA\"
+                \"DH-RSA-AES256-SHA\"
+                \"DH-RSA-CAMELLIA128-SHA\"
+                \"DH-RSA-CAMELLIA256-SHA\"
+                \"DH-RSA-DES-CBC3-SHA\"
+                \"DH-RSA-SEED-SHA\"
+                \"DHE-DSS-AES128-SHA\"
+                \"DHE-DSS-AES256-SHA\"
+                \"DHE-DSS-CAMELLIA128-SHA\"
+                \"DHE-DSS-CAMELLIA256-SHA\"
+                \"DHE-DSS-DES-CBC3-SHA\"
+                \"DHE-DSS-SEED-SHA\"
+                \"DHE-RSA-AES128-SHA\"
+                \"DHE-RSA-AES256-SHA\"
+                \"DHE-RSA-CAMELLIA128-SHA\"
+                \"DHE-RSA-CAMELLIA256-SHA\"
+                \"DHE-RSA-DES-CBC3-SHA\"
+                \"DHE-RSA-SEED-SHA\"
+                \"ECDH-ECDSA-AES128-SHA\"
+                \"ECDH-ECDSA-AES256-SHA\"
+                \"ECDH-ECDSA-DES-CBC3-SHA\"
+                \"ECDH-ECDSA-RC4-SHA\"
+                \"ECDH-RSA-AES128-SHA\"
+                \"ECDH-RSA-AES256-SHA\"
+                \"ECDH-RSA-DES-CBC3-SHA\"
+                \"ECDH-RSA-RC4-SHA\"
+                \"ECDHE-ECDSA-AES128-SHA\"
+                \"ECDHE-ECDSA-AES256-SHA\"
+                \"ECDHE-ECDSA-DES-CBC3-SHA\"
+                \"ECDHE-ECDSA-RC4-SHA\"
+                \"ECDHE-RSA-AES128-SHA\"
+                \"ECDHE-RSA-AES256-SHA\"
+                \"ECDHE-RSA-DES-CBC3-SHA\"
+                \"ECDHE-RSA-RC4-SHA\"
+                \"IDEA-CBC-SHA\"
+                \"KRB5-DES-CBC3-MD5\"
+                \"KRB5-DES-CBC3-SHA\"
+                \"KRB5-IDEA-CBC-MD5\"
+                \"KRB5-IDEA-CBC-SHA\"
+                \"KRB5-RC4-MD5\"
+                \"KRB5-RC4-SHA\"
+                \"PSK-3DES-EDE-CBC-SHA\"
+                \"PSK-AES128-CBC-SHA\"
+                \"PSK-AES256-CBC-SHA\"
+                \"PSK-RC4-SHA\"
+                \"RC4-MD5\"
+                \"RC4-SHA\"
+                \"SEED-SHA\"
+
+        example: `[\"ECDHE-RSA-AES256-GCM-SHA384\",\"ECDHE-ECDSA-AES256-GCM-SHA384\",\"ECDHE-RSA-AES128-GCM-SHA256\"]`
+
+
+        :return: The ciphers of this UpdateSSLCipherSuiteDetails.
+        :rtype: list[str]
+        """
+        return self._ciphers
+
+    @ciphers.setter
+    def ciphers(self, ciphers):
+        """
+        Sets the ciphers of this UpdateSSLCipherSuiteDetails.
+        A list of SSL ciphers the load balancer must support for HTTPS or SSL connections.
+
+        The following ciphers are valid values for this property:
+
+        *  __TLSv1.2 ciphers__
+
+                \"AES128-GCM-SHA256\"
+                \"AES128-SHA256\"
+                \"AES256-GCM-SHA384\"
+                \"AES256-SHA256\"
+                \"DH-DSS-AES128-GCM-SHA256\"
+                \"DH-DSS-AES128-SHA256\"
+                \"DH-DSS-AES256-GCM-SHA384\"
+                \"DH-DSS-AES256-SHA256\"
+                \"DH-RSA-AES128-GCM-SHA256\"
+                \"DH-RSA-AES128-SHA256\"
+                \"DH-RSA-AES256-GCM-SHA384\"
+                \"DH-RSA-AES256-SHA256\"
+                \"DHE-DSS-AES128-GCM-SHA256\"
+                \"DHE-DSS-AES128-SHA256\"
+                \"DHE-DSS-AES256-GCM-SHA384\"
+                \"DHE-DSS-AES256-SHA256\"
+                \"DHE-RSA-AES128-GCM-SHA256\"
+                \"DHE-RSA-AES128-SHA256\"
+                \"DHE-RSA-AES256-GCM-SHA384\"
+                \"DHE-RSA-AES256-SHA256\"
+                \"ECDH-ECDSA-AES128-GCM-SHA256\"
+                \"ECDH-ECDSA-AES128-SHA256\"
+                \"ECDH-ECDSA-AES256-GCM-SHA384\"
+                \"ECDH-ECDSA-AES256-SHA384\"
+                \"ECDH-RSA-AES128-GCM-SHA256\"
+                \"ECDH-RSA-AES128-SHA256\"
+                \"ECDH-RSA-AES256-GCM-SHA384\"
+                \"ECDH-RSA-AES256-SHA384\"
+                \"ECDHE-ECDSA-AES128-GCM-SHA256\"
+                \"ECDHE-ECDSA-AES128-SHA256\"
+                \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+                \"ECDHE-ECDSA-AES256-SHA384\"
+                \"ECDHE-RSA-AES128-GCM-SHA256\"
+                \"ECDHE-RSA-AES128-SHA256\"
+                \"ECDHE-RSA-AES256-GCM-SHA384\"
+                \"ECDHE-RSA-AES256-SHA384\"
+
+        *  __TLSv1 ciphers also supported by TLSv1.2__
+
+                \"AES128-SHA\"
+                \"AES256-SHA\"
+                \"CAMELLIA128-SHA\"
+                \"CAMELLIA256-SHA\"
+                \"DES-CBC3-SHA\"
+                \"DH-DSS-AES128-SHA\"
+                \"DH-DSS-AES256-SHA\"
+                \"DH-DSS-CAMELLIA128-SHA\"
+                \"DH-DSS-CAMELLIA256-SHA\"
+                \"DH-DSS-DES-CBC3-SHAv\"
+                \"DH-DSS-SEED-SHA\"
+                \"DH-RSA-AES128-SHA\"
+                \"DH-RSA-AES256-SHA\"
+                \"DH-RSA-CAMELLIA128-SHA\"
+                \"DH-RSA-CAMELLIA256-SHA\"
+                \"DH-RSA-DES-CBC3-SHA\"
+                \"DH-RSA-SEED-SHA\"
+                \"DHE-DSS-AES128-SHA\"
+                \"DHE-DSS-AES256-SHA\"
+                \"DHE-DSS-CAMELLIA128-SHA\"
+                \"DHE-DSS-CAMELLIA256-SHA\"
+                \"DHE-DSS-DES-CBC3-SHA\"
+                \"DHE-DSS-SEED-SHA\"
+                \"DHE-RSA-AES128-SHA\"
+                \"DHE-RSA-AES256-SHA\"
+                \"DHE-RSA-CAMELLIA128-SHA\"
+                \"DHE-RSA-CAMELLIA256-SHA\"
+                \"DHE-RSA-DES-CBC3-SHA\"
+                \"DHE-RSA-SEED-SHA\"
+                \"ECDH-ECDSA-AES128-SHA\"
+                \"ECDH-ECDSA-AES256-SHA\"
+                \"ECDH-ECDSA-DES-CBC3-SHA\"
+                \"ECDH-ECDSA-RC4-SHA\"
+                \"ECDH-RSA-AES128-SHA\"
+                \"ECDH-RSA-AES256-SHA\"
+                \"ECDH-RSA-DES-CBC3-SHA\"
+                \"ECDH-RSA-RC4-SHA\"
+                \"ECDHE-ECDSA-AES128-SHA\"
+                \"ECDHE-ECDSA-AES256-SHA\"
+                \"ECDHE-ECDSA-DES-CBC3-SHA\"
+                \"ECDHE-ECDSA-RC4-SHA\"
+                \"ECDHE-RSA-AES128-SHA\"
+                \"ECDHE-RSA-AES256-SHA\"
+                \"ECDHE-RSA-DES-CBC3-SHA\"
+                \"ECDHE-RSA-RC4-SHA\"
+                \"IDEA-CBC-SHA\"
+                \"KRB5-DES-CBC3-MD5\"
+                \"KRB5-DES-CBC3-SHA\"
+                \"KRB5-IDEA-CBC-MD5\"
+                \"KRB5-IDEA-CBC-SHA\"
+                \"KRB5-RC4-MD5\"
+                \"KRB5-RC4-SHA\"
+                \"PSK-3DES-EDE-CBC-SHA\"
+                \"PSK-AES128-CBC-SHA\"
+                \"PSK-AES256-CBC-SHA\"
+                \"PSK-RC4-SHA\"
+                \"RC4-MD5\"
+                \"RC4-SHA\"
+                \"SEED-SHA\"
+
+        example: `[\"ECDHE-RSA-AES256-GCM-SHA384\",\"ECDHE-ECDSA-AES256-GCM-SHA384\",\"ECDHE-RSA-AES128-GCM-SHA256\"]`
+
+
+        :param ciphers: The ciphers of this UpdateSSLCipherSuiteDetails.
+        :type: list[str]
+        """
+        self._ciphers = ciphers
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/regions.py
+++ b/src/oci/regions.py
@@ -36,7 +36,8 @@ REGIONS_SHORT_NAMES = {
     'yul': 'ca-montreal-1',
     'hyd': 'ap-hyderabad-1',
     'yny': 'ap-chuncheon-1',
-    'brs': 'uk-gov-cardiff-1'
+    'brs': 'uk-gov-cardiff-1',
+    'nja': 'ap-chiyoda-1'
 }
 REGION_REALMS = {
     'ap-melbourne-1': 'oc1',
@@ -67,13 +68,16 @@ REGION_REALMS = {
     'us-gov-phoenix-1': 'oc3',
 
     'uk-gov-london-1': 'oc4',
-    'uk-gov-cardiff-1': 'oc4'
+    'uk-gov-cardiff-1': 'oc4',
+
+    'ap-chiyoda-1': 'oc8'
 }
 REALMS = {
     'oc1': 'oraclecloud.com',
     'oc2': 'oraclegovcloud.com',
     'oc3': 'oraclegovcloud.com',
-    'oc4': 'oraclegovcloud.uk'
+    'oc4': 'oraclegovcloud.uk',
+    'oc8': 'oraclecloud8.com'
 }
 REGIONS = [
     "ap-melbourne-1",
@@ -84,6 +88,7 @@ REGIONS = [
     "ap-sydney-1",
     "ap-tokyo-1",
     "ap-chuncheon-1",
+    "ap-chiyoda-1",
     "us-phoenix-1",
     "us-ashburn-1",
     "us-sanjose-1",

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.21.1"
+__version__ = "2.21.2"

--- a/tests/util.py
+++ b/tests/util.py
@@ -222,4 +222,5 @@ def test_config_to_python_config(test_config):
     converted_config['user'] = converted_config.pop('user_id')
     converted_config['key_content'] = converted_config.pop('key_file_content')
     converted_config['service_endpoint'] = converted_config.pop('endpoint')
+    converted_config['endpoint'] = converted_config['service_endpoint']
     return converted_config


### PR DESCRIPTION
## Added

* Support for calling Oracle Cloud Infrastructure services in the ap-chiyoda-1 region

* Support for VM database cloning in the Database service

* Support for the MAINTENANCE_IN_PROGRESS lifecycle state on database systems, VM clusters, and Cloud Exadata in the Database service

* Support for provisioning refreshable clones in the Database service

* Support for new options on listeners and backend sets for specifying SSL protocols, SSL cipher suites, and server ordering preferences in the Load Balancing service

* Support for AMD flexible shapes with configurable CPU in the Container Engine for Kubernetes service

* Support for network sources in authentication policies in the Identity service



## Fixed

* Fixed a bug where integer, float and bool type headers were not converted to a type which the requests library accepts. These types will be typecast to strings.