### PR TITLE
Updates to tag composite functionality, bug found

### DIFF
--- a/src/oci/identity/identity_client_composite_operations.py
+++ b/src/oci/identity/identity_client_composite_operations.py
@@ -514,12 +514,13 @@ class IdentityClientCompositeOperations(object):
             return operation_result
 
         lowered_wait_for_states = [w.lower() for w in wait_for_states]
-        wait_for_resource_id = operation_result.data.id
+        wait_for_namespace_id = operation_result.data.tag_namespace_id
+        wait_for_tag_name = operation_result.data.name
 
         try:
             waiter_result = oci.wait_until(
                 self.client,
-                self.client.get_tag(wait_for_resource_id),
+                self.client.get_tag(wait_for_namespace_id, wait_for_tag_name),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )
@@ -1465,12 +1466,13 @@ class IdentityClientCompositeOperations(object):
             return operation_result
 
         lowered_wait_for_states = [w.lower() for w in wait_for_states]
-        wait_for_resource_id = operation_result.data.id
+        wait_for_namespace_id = operation_result.data.tag_namespace_id
+        wait_for_tag_name = operation_result.data.name
 
         try:
             waiter_result = oci.wait_until(
                 self.client,
-                self.client.get_tag(wait_for_resource_id),
+                self.client.get_tag(wait_for_namespace_id, wait_for_tag_name),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )


### PR DESCRIPTION
After a tag has been created with the required tag_namespace_id and tag_name parameter, the code attempts to get the tag with an ID but this is not possible, get_tag requires a composite key for instead of an ID. see docs https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/api/identity/client/oci.identity.IdentityClient.html#oci.identity.IdentityClient.get_tag. Changes made in the fork fix this.  

Race condition still exists on occasion the get_tag inside the wait block gets called before the create or update has completed. I'll log a bug internally for this.