### PR TITLE
Releasing version 2.22.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.22.0 - 2020-10-06
+====================
+
+Added
+-----
+* Support for calling Oracle Cloud Infrastructure services in the me-dubai-1 region
+* Support for rotating keys on autonomous container databases and autonomous databases in the Database service
+* Support for cloud Exadata infrastructure and cloud VM clusters in the Database service
+* Support for controlling the display of tax banners in the Marketplace service
+* Support for application references, patch changes, generic JDBC and MySQL data asset types, and publishing tasks to OCI Dataflow in the Data Integration service
+* Support for disabling the legacy Instance Metadata endpoints v1 in the Compute service
+* Support for instance configurations specifying instance options in the Compute Management service
+
+Breaking
+--------
+* The attribute `model_type` in `TypedObject` model now raises `ValueError` when provided with an invalid value. Please see the `documentation <https://docs.cloud.oracle.com/en-us/iaas/tools/python/2.21.6/api/data_integration/models/oci.data_integration.models.TypedObject.html#oci.data_integration.models.TypedObject.model_type>`_ for a list of allowed values.
+
+====================
 2.21.6 - 2020-09-29
 ====================
 

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -225,6 +225,7 @@ Core Services
     oci.core.models.InstanceConfigurationCreateVnicDetails
     oci.core.models.InstanceConfigurationCreateVolumeDetails
     oci.core.models.InstanceConfigurationInstanceDetails
+    oci.core.models.InstanceConfigurationInstanceOptions
     oci.core.models.InstanceConfigurationInstanceSourceDetails
     oci.core.models.InstanceConfigurationInstanceSourceViaBootVolumeDetails
     oci.core.models.InstanceConfigurationInstanceSourceViaImageDetails
@@ -240,6 +241,7 @@ Core Services
     oci.core.models.InstanceConfigurationVolumeSourceFromVolumeDetails
     oci.core.models.InstanceConsoleConnection
     oci.core.models.InstanceCredentials
+    oci.core.models.InstanceOptions
     oci.core.models.InstancePool
     oci.core.models.InstancePoolInstanceLoadBalancerBackend
     oci.core.models.InstancePoolLoadBalancerAttachment

--- a/docs/api/core/models/oci.core.models.InstanceConfigurationInstanceOptions.rst
+++ b/docs/api/core/models/oci.core.models.InstanceConfigurationInstanceOptions.rst
@@ -1,0 +1,11 @@
+InstanceConfigurationInstanceOptions
+====================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: InstanceConfigurationInstanceOptions
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.InstanceOptions.rst
+++ b/docs/api/core/models/oci.core.models.InstanceOptions.rst
@@ -1,0 +1,11 @@
+InstanceOptions
+===============
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: InstanceOptions
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration.rst
+++ b/docs/api/data_integration.rst
@@ -28,8 +28,11 @@ Data Integration
     oci.data_integration.models.ApplicationDetails
     oci.data_integration.models.ApplicationSummary
     oci.data_integration.models.ApplicationSummaryCollection
+    oci.data_integration.models.AvroFormatAttribute
     oci.data_integration.models.BaseType
     oci.data_integration.models.ChangeCompartmentDetails
+    oci.data_integration.models.ChildReference
+    oci.data_integration.models.ChildReferenceDetail
     oci.data_integration.models.CompositeFieldMap
     oci.data_integration.models.CompositeType
     oci.data_integration.models.ConditionalInputLink
@@ -38,6 +41,7 @@ Data Integration
     oci.data_integration.models.ConfigParameterValue
     oci.data_integration.models.ConfigProvider
     oci.data_integration.models.ConfigValues
+    oci.data_integration.models.ConfigurationDetails
     oci.data_integration.models.ConfiguredType
     oci.data_integration.models.Connection
     oci.data_integration.models.ConnectionDetails
@@ -45,6 +49,10 @@ Data Integration
     oci.data_integration.models.ConnectionFromAdwcDetails
     oci.data_integration.models.ConnectionFromAtp
     oci.data_integration.models.ConnectionFromAtpDetails
+    oci.data_integration.models.ConnectionFromJdbc
+    oci.data_integration.models.ConnectionFromJdbcDetails
+    oci.data_integration.models.ConnectionFromMySQL
+    oci.data_integration.models.ConnectionFromMySQLDetails
     oci.data_integration.models.ConnectionFromObjectStorage
     oci.data_integration.models.ConnectionFromObjectStorageDetails
     oci.data_integration.models.ConnectionFromOracle
@@ -54,6 +62,8 @@ Data Integration
     oci.data_integration.models.ConnectionSummaryCollection
     oci.data_integration.models.ConnectionSummaryFromAdwc
     oci.data_integration.models.ConnectionSummaryFromAtp
+    oci.data_integration.models.ConnectionSummaryFromJdbc
+    oci.data_integration.models.ConnectionSummaryFromMySQL
     oci.data_integration.models.ConnectionSummaryFromObjectStorage
     oci.data_integration.models.ConnectionSummaryFromOracle
     oci.data_integration.models.ConnectionValidation
@@ -66,21 +76,28 @@ Data Integration
     oci.data_integration.models.CreateConnectionDetails
     oci.data_integration.models.CreateConnectionFromAdwc
     oci.data_integration.models.CreateConnectionFromAtp
+    oci.data_integration.models.CreateConnectionFromJdbc
+    oci.data_integration.models.CreateConnectionFromMySQL
     oci.data_integration.models.CreateConnectionFromObjectStorage
     oci.data_integration.models.CreateConnectionFromOracle
     oci.data_integration.models.CreateConnectionValidationDetails
     oci.data_integration.models.CreateDataAssetDetails
     oci.data_integration.models.CreateDataAssetFromAdwc
     oci.data_integration.models.CreateDataAssetFromAtp
+    oci.data_integration.models.CreateDataAssetFromJdbc
+    oci.data_integration.models.CreateDataAssetFromMySQL
     oci.data_integration.models.CreateDataAssetFromObjectStorage
     oci.data_integration.models.CreateDataAssetFromOracle
     oci.data_integration.models.CreateDataFlowDetails
     oci.data_integration.models.CreateDataFlowValidationDetails
     oci.data_integration.models.CreateEntityShapeDetails
     oci.data_integration.models.CreateEntityShapeFromFile
+    oci.data_integration.models.CreateExternalPublicationDetails
+    oci.data_integration.models.CreateExternalPublicationValidationDetails
     oci.data_integration.models.CreateFolderDetails
     oci.data_integration.models.CreatePatchDetails
     oci.data_integration.models.CreateProjectDetails
+    oci.data_integration.models.CreateSourceApplicationInfo
     oci.data_integration.models.CreateTaskDetails
     oci.data_integration.models.CreateTaskFromDataLoaderTask
     oci.data_integration.models.CreateTaskFromIntegrationTask
@@ -93,12 +110,16 @@ Data Integration
     oci.data_integration.models.DataAsset
     oci.data_integration.models.DataAssetFromAdwcDetails
     oci.data_integration.models.DataAssetFromAtpDetails
+    oci.data_integration.models.DataAssetFromJdbc
+    oci.data_integration.models.DataAssetFromMySQL
     oci.data_integration.models.DataAssetFromObjectStorageDetails
     oci.data_integration.models.DataAssetFromOracleDetails
     oci.data_integration.models.DataAssetSummary
     oci.data_integration.models.DataAssetSummaryCollection
     oci.data_integration.models.DataAssetSummaryFromAdwc
     oci.data_integration.models.DataAssetSummaryFromAtp
+    oci.data_integration.models.DataAssetSummaryFromJdbc
+    oci.data_integration.models.DataAssetSummaryFromMySQL
     oci.data_integration.models.DataAssetSummaryFromObjectStorage
     oci.data_integration.models.DataAssetSummaryFromOracle
     oci.data_integration.models.DataEntity
@@ -130,14 +151,22 @@ Data Integration
     oci.data_integration.models.DerivedType
     oci.data_integration.models.DirectFieldMap
     oci.data_integration.models.DirectNamedFieldMap
+    oci.data_integration.models.Distinct
     oci.data_integration.models.DynamicInputField
     oci.data_integration.models.DynamicProxyField
     oci.data_integration.models.DynamicType
     oci.data_integration.models.DynamicTypeHandler
+    oci.data_integration.models.EnrichedEntity
     oci.data_integration.models.EntityShape
     oci.data_integration.models.EntityShapeFromFile
     oci.data_integration.models.ErrorDetails
     oci.data_integration.models.Expression
+    oci.data_integration.models.ExternalPublication
+    oci.data_integration.models.ExternalPublicationSummary
+    oci.data_integration.models.ExternalPublicationSummaryCollection
+    oci.data_integration.models.ExternalPublicationValidation
+    oci.data_integration.models.ExternalPublicationValidationSummary
+    oci.data_integration.models.ExternalPublicationValidationSummaryCollection
     oci.data_integration.models.FieldMap
     oci.data_integration.models.Filter
     oci.data_integration.models.FilterPush
@@ -160,6 +189,7 @@ Data Integration
     oci.data_integration.models.KeyAttribute
     oci.data_integration.models.KeyRange
     oci.data_integration.models.KeyRangePartitionConfig
+    oci.data_integration.models.MacroField
     oci.data_integration.models.Message
     oci.data_integration.models.NameListRule
     oci.data_integration.models.NamePatternRule
@@ -167,9 +197,13 @@ Data Integration
     oci.data_integration.models.ObjectMetadata
     oci.data_integration.models.Operator
     oci.data_integration.models.OracleAdwcWriteAttribute
+    oci.data_integration.models.OracleAdwcWriteAttributes
     oci.data_integration.models.OracleAtpWriteAttribute
+    oci.data_integration.models.OracleAtpWriteAttributes
     oci.data_integration.models.OracleReadAttribute
+    oci.data_integration.models.OracleReadAttributes
     oci.data_integration.models.OracleWriteAttribute
+    oci.data_integration.models.OracleWriteAttributes
     oci.data_integration.models.OutputField
     oci.data_integration.models.OutputLink
     oci.data_integration.models.OutputPort
@@ -178,6 +212,8 @@ Data Integration
     oci.data_integration.models.ParentReference
     oci.data_integration.models.PartitionConfig
     oci.data_integration.models.Patch
+    oci.data_integration.models.PatchChangeSummary
+    oci.data_integration.models.PatchChangeSummaryCollection
     oci.data_integration.models.PatchObjectMetadata
     oci.data_integration.models.PatchSummary
     oci.data_integration.models.PatchSummaryCollection
@@ -199,8 +235,13 @@ Data Integration
     oci.data_integration.models.PushDownOperation
     oci.data_integration.models.Query
     oci.data_integration.models.ReadOperationConfig
+    oci.data_integration.models.Reference
+    oci.data_integration.models.ReferenceSummary
+    oci.data_integration.models.ReferenceSummaryCollection
+    oci.data_integration.models.ReferenceUsedBy
     oci.data_integration.models.RegistryMetadata
     oci.data_integration.models.RenameRule
+    oci.data_integration.models.ResourceConfiguration
     oci.data_integration.models.RootObject
     oci.data_integration.models.RuleBasedFieldMap
     oci.data_integration.models.RuleTypeConfig
@@ -212,7 +253,11 @@ Data Integration
     oci.data_integration.models.ShapeField
     oci.data_integration.models.Sort
     oci.data_integration.models.SortClause
+    oci.data_integration.models.SortKey
+    oci.data_integration.models.SortKeyRule
+    oci.data_integration.models.SortOper
     oci.data_integration.models.Source
+    oci.data_integration.models.SourceApplicationInfo
     oci.data_integration.models.StructuredType
     oci.data_integration.models.Target
     oci.data_integration.models.Task
@@ -241,16 +286,22 @@ Data Integration
     oci.data_integration.models.UpdateConnectionDetails
     oci.data_integration.models.UpdateConnectionFromAdwc
     oci.data_integration.models.UpdateConnectionFromAtp
+    oci.data_integration.models.UpdateConnectionFromJdbc
+    oci.data_integration.models.UpdateConnectionFromMySQL
     oci.data_integration.models.UpdateConnectionFromObjectStorage
     oci.data_integration.models.UpdateConnectionFromOracle
     oci.data_integration.models.UpdateDataAssetDetails
     oci.data_integration.models.UpdateDataAssetFromAdwc
     oci.data_integration.models.UpdateDataAssetFromAtp
+    oci.data_integration.models.UpdateDataAssetFromJdbc
+    oci.data_integration.models.UpdateDataAssetFromMySQL
     oci.data_integration.models.UpdateDataAssetFromObjectStorage
     oci.data_integration.models.UpdateDataAssetFromOracle
     oci.data_integration.models.UpdateDataFlowDetails
+    oci.data_integration.models.UpdateExternalPublicationDetails
     oci.data_integration.models.UpdateFolderDetails
     oci.data_integration.models.UpdateProjectDetails
+    oci.data_integration.models.UpdateReferenceDetails
     oci.data_integration.models.UpdateTaskDetails
     oci.data_integration.models.UpdateTaskFromDataLoaderTask
     oci.data_integration.models.UpdateTaskFromIntegrationTask

--- a/docs/api/data_integration/models/oci.data_integration.models.AvroFormatAttribute.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.AvroFormatAttribute.rst
@@ -1,0 +1,11 @@
+AvroFormatAttribute
+===================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: AvroFormatAttribute
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ChildReference.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ChildReference.rst
@@ -1,0 +1,11 @@
+ChildReference
+==============
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ChildReference
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ChildReferenceDetail.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ChildReferenceDetail.rst
@@ -1,0 +1,11 @@
+ChildReferenceDetail
+====================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ChildReferenceDetail
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ConfigurationDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ConfigurationDetails.rst
@@ -1,0 +1,11 @@
+ConfigurationDetails
+====================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ConfigurationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ConnectionFromJdbc.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ConnectionFromJdbc.rst
@@ -1,0 +1,11 @@
+ConnectionFromJdbc
+==================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ConnectionFromJdbc
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ConnectionFromJdbcDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ConnectionFromJdbcDetails.rst
@@ -1,0 +1,11 @@
+ConnectionFromJdbcDetails
+=========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ConnectionFromJdbcDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ConnectionFromMySQL.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ConnectionFromMySQL.rst
@@ -1,0 +1,11 @@
+ConnectionFromMySQL
+===================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ConnectionFromMySQL
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ConnectionFromMySQLDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ConnectionFromMySQLDetails.rst
@@ -1,0 +1,11 @@
+ConnectionFromMySQLDetails
+==========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ConnectionFromMySQLDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ConnectionSummaryFromJdbc.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ConnectionSummaryFromJdbc.rst
@@ -1,0 +1,11 @@
+ConnectionSummaryFromJdbc
+=========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ConnectionSummaryFromJdbc
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ConnectionSummaryFromMySQL.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ConnectionSummaryFromMySQL.rst
@@ -1,0 +1,11 @@
+ConnectionSummaryFromMySQL
+==========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ConnectionSummaryFromMySQL
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.CreateConnectionFromJdbc.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.CreateConnectionFromJdbc.rst
@@ -1,0 +1,11 @@
+CreateConnectionFromJdbc
+========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: CreateConnectionFromJdbc
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.CreateConnectionFromMySQL.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.CreateConnectionFromMySQL.rst
@@ -1,0 +1,11 @@
+CreateConnectionFromMySQL
+=========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: CreateConnectionFromMySQL
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.CreateDataAssetFromJdbc.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.CreateDataAssetFromJdbc.rst
@@ -1,0 +1,11 @@
+CreateDataAssetFromJdbc
+=======================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: CreateDataAssetFromJdbc
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.CreateDataAssetFromMySQL.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.CreateDataAssetFromMySQL.rst
@@ -1,0 +1,11 @@
+CreateDataAssetFromMySQL
+========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: CreateDataAssetFromMySQL
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.CreateExternalPublicationDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.CreateExternalPublicationDetails.rst
@@ -1,0 +1,11 @@
+CreateExternalPublicationDetails
+================================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: CreateExternalPublicationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.CreateExternalPublicationValidationDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.CreateExternalPublicationValidationDetails.rst
@@ -1,0 +1,11 @@
+CreateExternalPublicationValidationDetails
+==========================================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: CreateExternalPublicationValidationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.CreateSourceApplicationInfo.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.CreateSourceApplicationInfo.rst
@@ -1,0 +1,11 @@
+CreateSourceApplicationInfo
+===========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: CreateSourceApplicationInfo
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.DataAssetFromJdbc.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.DataAssetFromJdbc.rst
@@ -1,0 +1,11 @@
+DataAssetFromJdbc
+=================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: DataAssetFromJdbc
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.DataAssetFromMySQL.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.DataAssetFromMySQL.rst
@@ -1,0 +1,11 @@
+DataAssetFromMySQL
+==================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: DataAssetFromMySQL
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.DataAssetSummaryFromJdbc.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.DataAssetSummaryFromJdbc.rst
@@ -1,0 +1,11 @@
+DataAssetSummaryFromJdbc
+========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: DataAssetSummaryFromJdbc
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.DataAssetSummaryFromMySQL.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.DataAssetSummaryFromMySQL.rst
@@ -1,0 +1,11 @@
+DataAssetSummaryFromMySQL
+=========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: DataAssetSummaryFromMySQL
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.Distinct.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.Distinct.rst
@@ -1,0 +1,11 @@
+Distinct
+========
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: Distinct
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.EnrichedEntity.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.EnrichedEntity.rst
@@ -1,0 +1,11 @@
+EnrichedEntity
+==============
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: EnrichedEntity
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ExternalPublication.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ExternalPublication.rst
@@ -1,0 +1,11 @@
+ExternalPublication
+===================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ExternalPublication
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ExternalPublicationSummary.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ExternalPublicationSummary.rst
@@ -1,0 +1,11 @@
+ExternalPublicationSummary
+==========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ExternalPublicationSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ExternalPublicationSummaryCollection.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ExternalPublicationSummaryCollection.rst
@@ -1,0 +1,11 @@
+ExternalPublicationSummaryCollection
+====================================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ExternalPublicationSummaryCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ExternalPublicationValidation.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ExternalPublicationValidation.rst
@@ -1,0 +1,11 @@
+ExternalPublicationValidation
+=============================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ExternalPublicationValidation
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ExternalPublicationValidationSummary.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ExternalPublicationValidationSummary.rst
@@ -1,0 +1,11 @@
+ExternalPublicationValidationSummary
+====================================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ExternalPublicationValidationSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ExternalPublicationValidationSummaryCollection.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ExternalPublicationValidationSummaryCollection.rst
@@ -1,0 +1,11 @@
+ExternalPublicationValidationSummaryCollection
+==============================================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ExternalPublicationValidationSummaryCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.MacroField.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.MacroField.rst
@@ -1,0 +1,11 @@
+MacroField
+==========
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: MacroField
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.OracleAdwcWriteAttributes.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.OracleAdwcWriteAttributes.rst
@@ -1,0 +1,11 @@
+OracleAdwcWriteAttributes
+=========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: OracleAdwcWriteAttributes
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.OracleAtpWriteAttributes.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.OracleAtpWriteAttributes.rst
@@ -1,0 +1,11 @@
+OracleAtpWriteAttributes
+========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: OracleAtpWriteAttributes
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.OracleReadAttributes.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.OracleReadAttributes.rst
@@ -1,0 +1,11 @@
+OracleReadAttributes
+====================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: OracleReadAttributes
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.OracleWriteAttributes.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.OracleWriteAttributes.rst
@@ -1,0 +1,11 @@
+OracleWriteAttributes
+=====================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: OracleWriteAttributes
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.PatchChangeSummary.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.PatchChangeSummary.rst
@@ -1,0 +1,11 @@
+PatchChangeSummary
+==================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: PatchChangeSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.PatchChangeSummaryCollection.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.PatchChangeSummaryCollection.rst
@@ -1,0 +1,11 @@
+PatchChangeSummaryCollection
+============================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: PatchChangeSummaryCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.Reference.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.Reference.rst
@@ -1,0 +1,11 @@
+Reference
+=========
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: Reference
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ReferenceSummary.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ReferenceSummary.rst
@@ -1,0 +1,11 @@
+ReferenceSummary
+================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ReferenceSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ReferenceSummaryCollection.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ReferenceSummaryCollection.rst
@@ -1,0 +1,11 @@
+ReferenceSummaryCollection
+==========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ReferenceSummaryCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ReferenceUsedBy.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ReferenceUsedBy.rst
@@ -1,0 +1,11 @@
+ReferenceUsedBy
+===============
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ReferenceUsedBy
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.ResourceConfiguration.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.ResourceConfiguration.rst
@@ -1,0 +1,11 @@
+ResourceConfiguration
+=====================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: ResourceConfiguration
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.SortKey.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.SortKey.rst
@@ -1,0 +1,11 @@
+SortKey
+=======
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: SortKey
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.SortKeyRule.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.SortKeyRule.rst
@@ -1,0 +1,11 @@
+SortKeyRule
+===========
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: SortKeyRule
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.SortOper.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.SortOper.rst
@@ -1,0 +1,11 @@
+SortOper
+========
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: SortOper
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.SourceApplicationInfo.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.SourceApplicationInfo.rst
@@ -1,0 +1,11 @@
+SourceApplicationInfo
+=====================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: SourceApplicationInfo
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.UpdateConnectionFromJdbc.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.UpdateConnectionFromJdbc.rst
@@ -1,0 +1,11 @@
+UpdateConnectionFromJdbc
+========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: UpdateConnectionFromJdbc
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.UpdateConnectionFromMySQL.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.UpdateConnectionFromMySQL.rst
@@ -1,0 +1,11 @@
+UpdateConnectionFromMySQL
+=========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: UpdateConnectionFromMySQL
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.UpdateDataAssetFromJdbc.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.UpdateDataAssetFromJdbc.rst
@@ -1,0 +1,11 @@
+UpdateDataAssetFromJdbc
+=======================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: UpdateDataAssetFromJdbc
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.UpdateDataAssetFromMySQL.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.UpdateDataAssetFromMySQL.rst
@@ -1,0 +1,11 @@
+UpdateDataAssetFromMySQL
+========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: UpdateDataAssetFromMySQL
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.UpdateExternalPublicationDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.UpdateExternalPublicationDetails.rst
@@ -1,0 +1,11 @@
+UpdateExternalPublicationDetails
+================================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: UpdateExternalPublicationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.UpdateReferenceDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.UpdateReferenceDetails.rst
@@ -1,0 +1,11 @@
+UpdateReferenceDetails
+======================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: UpdateReferenceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -55,9 +55,15 @@ Database
     oci.database.models.BackupDestinationSummary
     oci.database.models.BackupSummary
     oci.database.models.ChangeAutonomousVmClusterCompartmentDetails
+    oci.database.models.ChangeCloudExadataInfrastructureCompartmentDetails
+    oci.database.models.ChangeCloudVmClusterCompartmentDetails
     oci.database.models.ChangeCompartmentDetails
     oci.database.models.ChangeExadataInfrastructureCompartmentDetails
     oci.database.models.ChangeVmClusterCompartmentDetails
+    oci.database.models.CloudExadataInfrastructure
+    oci.database.models.CloudExadataInfrastructureSummary
+    oci.database.models.CloudVmCluster
+    oci.database.models.CloudVmClusterSummary
     oci.database.models.CompleteExternalBackupJobDetails
     oci.database.models.ConsoleConnection
     oci.database.models.ConsoleConnectionSummary
@@ -73,6 +79,8 @@ Database
     oci.database.models.CreateAutonomousVmClusterDetails
     oci.database.models.CreateBackupDestinationDetails
     oci.database.models.CreateBackupDetails
+    oci.database.models.CreateCloudExadataInfrastructureDetails
+    oci.database.models.CreateCloudVmClusterDetails
     oci.database.models.CreateConsoleConnectionDetails
     oci.database.models.CreateDataGuardAssociationDetails
     oci.database.models.CreateDataGuardAssociationToExistingDbSystemDetails
@@ -94,6 +102,7 @@ Database
     oci.database.models.CreateDbHomeWithDbSystemIdFromBackupDetails
     oci.database.models.CreateDbHomeWithDbSystemIdFromDatabaseDetails
     oci.database.models.CreateDbHomeWithVmClusterIdDetails
+    oci.database.models.CreateDbHomeWithVmClusterIdFromBackupDetails
     oci.database.models.CreateExadataInfrastructureDetails
     oci.database.models.CreateExternalBackupJobDetails
     oci.database.models.CreateNFSBackupDestinationDetails
@@ -122,6 +131,8 @@ Database
     oci.database.models.DbSystemSummary
     oci.database.models.DbVersionSummary
     oci.database.models.DeregisterAutonomousDatabaseDataSafeDetails
+    oci.database.models.ExadataDbSystemMigration
+    oci.database.models.ExadataDbSystemMigrationSummary
     oci.database.models.ExadataInfrastructure
     oci.database.models.ExadataInfrastructureContact
     oci.database.models.ExadataInfrastructureSummary
@@ -160,6 +171,7 @@ Database
     oci.database.models.ScanDetails
     oci.database.models.SelfMountDetails
     oci.database.models.SwitchoverDataGuardAssociationDetails
+    oci.database.models.Update
     oci.database.models.UpdateAutonomousContainerDatabaseDetails
     oci.database.models.UpdateAutonomousDataWarehouseDetails
     oci.database.models.UpdateAutonomousDatabaseDetails
@@ -167,12 +179,18 @@ Database
     oci.database.models.UpdateAutonomousExadataInfrastructureDetails
     oci.database.models.UpdateAutonomousVmClusterDetails
     oci.database.models.UpdateBackupDestinationDetails
+    oci.database.models.UpdateCloudExadataInfrastructureDetails
+    oci.database.models.UpdateCloudVmClusterDetails
     oci.database.models.UpdateDatabaseDetails
     oci.database.models.UpdateDatabaseSoftwareImageDetails
     oci.database.models.UpdateDbHomeDetails
     oci.database.models.UpdateDbSystemDetails
+    oci.database.models.UpdateDetails
     oci.database.models.UpdateExadataInfrastructureDetails
+    oci.database.models.UpdateHistoryEntry
+    oci.database.models.UpdateHistoryEntrySummary
     oci.database.models.UpdateMaintenanceRunDetails
+    oci.database.models.UpdateSummary
     oci.database.models.UpdateVmClusterDetails
     oci.database.models.UpdateVmClusterNetworkDetails
     oci.database.models.VmCluster

--- a/docs/api/database/models/oci.database.models.ChangeCloudExadataInfrastructureCompartmentDetails.rst
+++ b/docs/api/database/models/oci.database.models.ChangeCloudExadataInfrastructureCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeCloudExadataInfrastructureCompartmentDetails
+==================================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ChangeCloudExadataInfrastructureCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ChangeCloudVmClusterCompartmentDetails.rst
+++ b/docs/api/database/models/oci.database.models.ChangeCloudVmClusterCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeCloudVmClusterCompartmentDetails
+======================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ChangeCloudVmClusterCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CloudExadataInfrastructure.rst
+++ b/docs/api/database/models/oci.database.models.CloudExadataInfrastructure.rst
@@ -1,0 +1,11 @@
+CloudExadataInfrastructure
+==========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CloudExadataInfrastructure
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CloudExadataInfrastructureSummary.rst
+++ b/docs/api/database/models/oci.database.models.CloudExadataInfrastructureSummary.rst
@@ -1,0 +1,11 @@
+CloudExadataInfrastructureSummary
+=================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CloudExadataInfrastructureSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CloudVmCluster.rst
+++ b/docs/api/database/models/oci.database.models.CloudVmCluster.rst
@@ -1,0 +1,11 @@
+CloudVmCluster
+==============
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CloudVmCluster
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CloudVmClusterSummary.rst
+++ b/docs/api/database/models/oci.database.models.CloudVmClusterSummary.rst
@@ -1,0 +1,11 @@
+CloudVmClusterSummary
+=====================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CloudVmClusterSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateCloudExadataInfrastructureDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateCloudExadataInfrastructureDetails.rst
@@ -1,0 +1,11 @@
+CreateCloudExadataInfrastructureDetails
+=======================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateCloudExadataInfrastructureDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateCloudVmClusterDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateCloudVmClusterDetails.rst
@@ -1,0 +1,11 @@
+CreateCloudVmClusterDetails
+===========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateCloudVmClusterDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateDbHomeWithVmClusterIdFromBackupDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateDbHomeWithVmClusterIdFromBackupDetails.rst
@@ -1,0 +1,11 @@
+CreateDbHomeWithVmClusterIdFromBackupDetails
+============================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateDbHomeWithVmClusterIdFromBackupDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExadataDbSystemMigration.rst
+++ b/docs/api/database/models/oci.database.models.ExadataDbSystemMigration.rst
@@ -1,0 +1,11 @@
+ExadataDbSystemMigration
+========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExadataDbSystemMigration
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExadataDbSystemMigrationSummary.rst
+++ b/docs/api/database/models/oci.database.models.ExadataDbSystemMigrationSummary.rst
@@ -1,0 +1,11 @@
+ExadataDbSystemMigrationSummary
+===============================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExadataDbSystemMigrationSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.Update.rst
+++ b/docs/api/database/models/oci.database.models.Update.rst
@@ -1,0 +1,11 @@
+Update
+======
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: Update
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateCloudExadataInfrastructureDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateCloudExadataInfrastructureDetails.rst
@@ -1,0 +1,11 @@
+UpdateCloudExadataInfrastructureDetails
+=======================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateCloudExadataInfrastructureDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateCloudVmClusterDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateCloudVmClusterDetails.rst
@@ -1,0 +1,11 @@
+UpdateCloudVmClusterDetails
+===========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateCloudVmClusterDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateDetails.rst
@@ -1,0 +1,11 @@
+UpdateDetails
+=============
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateHistoryEntry.rst
+++ b/docs/api/database/models/oci.database.models.UpdateHistoryEntry.rst
@@ -1,0 +1,11 @@
+UpdateHistoryEntry
+==================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateHistoryEntry
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateHistoryEntrySummary.rst
+++ b/docs/api/database/models/oci.database.models.UpdateHistoryEntrySummary.rst
@@ -1,0 +1,11 @@
+UpdateHistoryEntrySummary
+=========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateHistoryEntrySummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateSummary.rst
+++ b/docs/api/database/models/oci.database.models.UpdateSummary.rst
@@ -1,0 +1,11 @@
+UpdateSummary
+=============
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/marketplace.rst
+++ b/docs/api/marketplace.rst
@@ -46,5 +46,6 @@ Marketplace
     oci.marketplace.models.ReportTypeSummary
     oci.marketplace.models.Screenshot
     oci.marketplace.models.SupportContact
+    oci.marketplace.models.TaxSummary
     oci.marketplace.models.UpdateAcceptedAgreementDetails
     oci.marketplace.models.UploadData

--- a/docs/api/marketplace/models/oci.marketplace.models.TaxSummary.rst
+++ b/docs/api/marketplace/models/oci.marketplace.models.TaxSummary.rst
@@ -1,0 +1,11 @@
+TaxSummary
+==========
+
+.. currentmodule:: oci.marketplace.models
+
+.. autoclass:: TaxSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/src/oci/core/models/__init__.py
+++ b/src/oci/core/models/__init__.py
@@ -205,6 +205,7 @@ from .instance_configuration_block_volume_details import InstanceConfigurationBl
 from .instance_configuration_create_vnic_details import InstanceConfigurationCreateVnicDetails
 from .instance_configuration_create_volume_details import InstanceConfigurationCreateVolumeDetails
 from .instance_configuration_instance_details import InstanceConfigurationInstanceDetails
+from .instance_configuration_instance_options import InstanceConfigurationInstanceOptions
 from .instance_configuration_instance_source_details import InstanceConfigurationInstanceSourceDetails
 from .instance_configuration_instance_source_via_boot_volume_details import InstanceConfigurationInstanceSourceViaBootVolumeDetails
 from .instance_configuration_instance_source_via_image_details import InstanceConfigurationInstanceSourceViaImageDetails
@@ -220,6 +221,7 @@ from .instance_configuration_volume_source_from_volume_backup_details import Ins
 from .instance_configuration_volume_source_from_volume_details import InstanceConfigurationVolumeSourceFromVolumeDetails
 from .instance_console_connection import InstanceConsoleConnection
 from .instance_credentials import InstanceCredentials
+from .instance_options import InstanceOptions
 from .instance_pool import InstancePool
 from .instance_pool_instance_load_balancer_backend import InstancePoolInstanceLoadBalancerBackend
 from .instance_pool_load_balancer_attachment import InstancePoolLoadBalancerAttachment
@@ -555,6 +557,7 @@ core_type_mapping = {
     "InstanceConfigurationCreateVnicDetails": InstanceConfigurationCreateVnicDetails,
     "InstanceConfigurationCreateVolumeDetails": InstanceConfigurationCreateVolumeDetails,
     "InstanceConfigurationInstanceDetails": InstanceConfigurationInstanceDetails,
+    "InstanceConfigurationInstanceOptions": InstanceConfigurationInstanceOptions,
     "InstanceConfigurationInstanceSourceDetails": InstanceConfigurationInstanceSourceDetails,
     "InstanceConfigurationInstanceSourceViaBootVolumeDetails": InstanceConfigurationInstanceSourceViaBootVolumeDetails,
     "InstanceConfigurationInstanceSourceViaImageDetails": InstanceConfigurationInstanceSourceViaImageDetails,
@@ -570,6 +573,7 @@ core_type_mapping = {
     "InstanceConfigurationVolumeSourceFromVolumeDetails": InstanceConfigurationVolumeSourceFromVolumeDetails,
     "InstanceConsoleConnection": InstanceConsoleConnection,
     "InstanceCredentials": InstanceCredentials,
+    "InstanceOptions": InstanceOptions,
     "InstancePool": InstancePool,
     "InstancePoolInstanceLoadBalancerBackend": InstancePoolInstanceLoadBalancerBackend,
     "InstancePoolLoadBalancerAttachment": InstancePoolLoadBalancerAttachment,

--- a/src/oci/core/models/instance.py
+++ b/src/oci/core/models/instance.py
@@ -137,6 +137,10 @@ class Instance(object):
             The value to assign to the launch_options property of this Instance.
         :type launch_options: LaunchOptions
 
+        :param instance_options:
+            The value to assign to the instance_options property of this Instance.
+        :type instance_options: InstanceOptions
+
         :param availability_config:
             The value to assign to the availability_config property of this Instance.
         :type availability_config: InstanceAvailabilityConfig
@@ -198,6 +202,7 @@ class Instance(object):
             'ipxe_script': 'str',
             'launch_mode': 'str',
             'launch_options': 'LaunchOptions',
+            'instance_options': 'InstanceOptions',
             'availability_config': 'InstanceAvailabilityConfig',
             'lifecycle_state': 'str',
             'metadata': 'dict(str, str)',
@@ -225,6 +230,7 @@ class Instance(object):
             'ipxe_script': 'ipxeScript',
             'launch_mode': 'launchMode',
             'launch_options': 'launchOptions',
+            'instance_options': 'instanceOptions',
             'availability_config': 'availabilityConfig',
             'lifecycle_state': 'lifecycleState',
             'metadata': 'metadata',
@@ -251,6 +257,7 @@ class Instance(object):
         self._ipxe_script = None
         self._launch_mode = None
         self._launch_options = None
+        self._instance_options = None
         self._availability_config = None
         self._lifecycle_state = None
         self._metadata = None
@@ -692,6 +699,26 @@ class Instance(object):
         :type: LaunchOptions
         """
         self._launch_options = launch_options
+
+    @property
+    def instance_options(self):
+        """
+        Gets the instance_options of this Instance.
+
+        :return: The instance_options of this Instance.
+        :rtype: InstanceOptions
+        """
+        return self._instance_options
+
+    @instance_options.setter
+    def instance_options(self, instance_options):
+        """
+        Sets the instance_options of this Instance.
+
+        :param instance_options: The instance_options of this Instance.
+        :type: InstanceOptions
+        """
+        self._instance_options = instance_options
 
     @property
     def availability_config(self):

--- a/src/oci/core/models/instance_configuration_instance_options.py
+++ b/src/oci/core/models/instance_configuration_instance_options.py
@@ -1,0 +1,74 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class InstanceConfigurationInstanceOptions(object):
+    """
+    Optional mutable instance options. As a part of Instance Metadata Service Security Header, This allows user to disable the legacy imds endpoints.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new InstanceConfigurationInstanceOptions object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param are_legacy_imds_endpoints_disabled:
+            The value to assign to the are_legacy_imds_endpoints_disabled property of this InstanceConfigurationInstanceOptions.
+        :type are_legacy_imds_endpoints_disabled: bool
+
+        """
+        self.swagger_types = {
+            'are_legacy_imds_endpoints_disabled': 'bool'
+        }
+
+        self.attribute_map = {
+            'are_legacy_imds_endpoints_disabled': 'areLegacyImdsEndpointsDisabled'
+        }
+
+        self._are_legacy_imds_endpoints_disabled = None
+
+    @property
+    def are_legacy_imds_endpoints_disabled(self):
+        """
+        Gets the are_legacy_imds_endpoints_disabled of this InstanceConfigurationInstanceOptions.
+        Whether to disable the legacy (/v1) instance metadata service endpoints.
+        Customers who have migrated to /v2 should set this to true for added security.
+        Default is false.
+
+
+        :return: The are_legacy_imds_endpoints_disabled of this InstanceConfigurationInstanceOptions.
+        :rtype: bool
+        """
+        return self._are_legacy_imds_endpoints_disabled
+
+    @are_legacy_imds_endpoints_disabled.setter
+    def are_legacy_imds_endpoints_disabled(self, are_legacy_imds_endpoints_disabled):
+        """
+        Sets the are_legacy_imds_endpoints_disabled of this InstanceConfigurationInstanceOptions.
+        Whether to disable the legacy (/v1) instance metadata service endpoints.
+        Customers who have migrated to /v2 should set this to true for added security.
+        Default is false.
+
+
+        :param are_legacy_imds_endpoints_disabled: The are_legacy_imds_endpoints_disabled of this InstanceConfigurationInstanceOptions.
+        :type: bool
+        """
+        self._are_legacy_imds_endpoints_disabled = are_legacy_imds_endpoints_disabled
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/instance_configuration_launch_instance_details.py
+++ b/src/oci/core/models/instance_configuration_launch_instance_details.py
@@ -125,6 +125,10 @@ class InstanceConfigurationLaunchInstanceDetails(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type preferred_maintenance_action: str
 
+        :param instance_options:
+            The value to assign to the instance_options property of this InstanceConfigurationLaunchInstanceDetails.
+        :type instance_options: InstanceConfigurationInstanceOptions
+
         :param availability_config:
             The value to assign to the availability_config property of this InstanceConfigurationLaunchInstanceDetails.
         :type availability_config: InstanceConfigurationAvailabilityConfig
@@ -150,6 +154,7 @@ class InstanceConfigurationLaunchInstanceDetails(object):
             'agent_config': 'InstanceConfigurationLaunchInstanceAgentConfigDetails',
             'is_pv_encryption_in_transit_enabled': 'bool',
             'preferred_maintenance_action': 'str',
+            'instance_options': 'InstanceConfigurationInstanceOptions',
             'availability_config': 'InstanceConfigurationAvailabilityConfig'
         }
 
@@ -173,6 +178,7 @@ class InstanceConfigurationLaunchInstanceDetails(object):
             'agent_config': 'agentConfig',
             'is_pv_encryption_in_transit_enabled': 'isPvEncryptionInTransitEnabled',
             'preferred_maintenance_action': 'preferredMaintenanceAction',
+            'instance_options': 'instanceOptions',
             'availability_config': 'availabilityConfig'
         }
 
@@ -195,6 +201,7 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         self._agent_config = None
         self._is_pv_encryption_in_transit_enabled = None
         self._preferred_maintenance_action = None
+        self._instance_options = None
         self._availability_config = None
 
     @property
@@ -904,6 +911,26 @@ class InstanceConfigurationLaunchInstanceDetails(object):
         if not value_allowed_none_or_none_sentinel(preferred_maintenance_action, allowed_values):
             preferred_maintenance_action = 'UNKNOWN_ENUM_VALUE'
         self._preferred_maintenance_action = preferred_maintenance_action
+
+    @property
+    def instance_options(self):
+        """
+        Gets the instance_options of this InstanceConfigurationLaunchInstanceDetails.
+
+        :return: The instance_options of this InstanceConfigurationLaunchInstanceDetails.
+        :rtype: InstanceConfigurationInstanceOptions
+        """
+        return self._instance_options
+
+    @instance_options.setter
+    def instance_options(self, instance_options):
+        """
+        Sets the instance_options of this InstanceConfigurationLaunchInstanceDetails.
+
+        :param instance_options: The instance_options of this InstanceConfigurationLaunchInstanceDetails.
+        :type: InstanceConfigurationInstanceOptions
+        """
+        self._instance_options = instance_options
 
     @property
     def availability_config(self):

--- a/src/oci/core/models/instance_options.py
+++ b/src/oci/core/models/instance_options.py
@@ -1,0 +1,74 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class InstanceOptions(object):
+    """
+    Optional mutable instance options
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new InstanceOptions object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param are_legacy_imds_endpoints_disabled:
+            The value to assign to the are_legacy_imds_endpoints_disabled property of this InstanceOptions.
+        :type are_legacy_imds_endpoints_disabled: bool
+
+        """
+        self.swagger_types = {
+            'are_legacy_imds_endpoints_disabled': 'bool'
+        }
+
+        self.attribute_map = {
+            'are_legacy_imds_endpoints_disabled': 'areLegacyImdsEndpointsDisabled'
+        }
+
+        self._are_legacy_imds_endpoints_disabled = None
+
+    @property
+    def are_legacy_imds_endpoints_disabled(self):
+        """
+        Gets the are_legacy_imds_endpoints_disabled of this InstanceOptions.
+        Whether to disable the legacy (/v1) instance metadata service endpoints.
+        Customers who have migrated to /v2 should set this to true for added security.
+        Default is false.
+
+
+        :return: The are_legacy_imds_endpoints_disabled of this InstanceOptions.
+        :rtype: bool
+        """
+        return self._are_legacy_imds_endpoints_disabled
+
+    @are_legacy_imds_endpoints_disabled.setter
+    def are_legacy_imds_endpoints_disabled(self, are_legacy_imds_endpoints_disabled):
+        """
+        Sets the are_legacy_imds_endpoints_disabled of this InstanceOptions.
+        Whether to disable the legacy (/v1) instance metadata service endpoints.
+        Customers who have migrated to /v2 should set this to true for added security.
+        Default is false.
+
+
+        :param are_legacy_imds_endpoints_disabled: The are_legacy_imds_endpoints_disabled of this InstanceOptions.
+        :type: bool
+        """
+        self._are_legacy_imds_endpoints_disabled = are_legacy_imds_endpoints_disabled
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/launch_instance_details.py
+++ b/src/oci/core/models/launch_instance_details.py
@@ -71,6 +71,10 @@ class LaunchInstanceDetails(object):
             The value to assign to the launch_options property of this LaunchInstanceDetails.
         :type launch_options: LaunchOptions
 
+        :param instance_options:
+            The value to assign to the instance_options property of this LaunchInstanceDetails.
+        :type instance_options: InstanceOptions
+
         :param availability_config:
             The value to assign to the availability_config property of this LaunchInstanceDetails.
         :type availability_config: LaunchInstanceAvailabilityConfigDetails
@@ -118,6 +122,7 @@ class LaunchInstanceDetails(object):
             'image_id': 'str',
             'ipxe_script': 'str',
             'launch_options': 'LaunchOptions',
+            'instance_options': 'InstanceOptions',
             'availability_config': 'LaunchInstanceAvailabilityConfigDetails',
             'metadata': 'dict(str, str)',
             'agent_config': 'LaunchInstanceAgentConfigDetails',
@@ -142,6 +147,7 @@ class LaunchInstanceDetails(object):
             'image_id': 'imageId',
             'ipxe_script': 'ipxeScript',
             'launch_options': 'launchOptions',
+            'instance_options': 'instanceOptions',
             'availability_config': 'availabilityConfig',
             'metadata': 'metadata',
             'agent_config': 'agentConfig',
@@ -165,6 +171,7 @@ class LaunchInstanceDetails(object):
         self._image_id = None
         self._ipxe_script = None
         self._launch_options = None
+        self._instance_options = None
         self._availability_config = None
         self._metadata = None
         self._agent_config = None
@@ -615,6 +622,26 @@ class LaunchInstanceDetails(object):
         :type: LaunchOptions
         """
         self._launch_options = launch_options
+
+    @property
+    def instance_options(self):
+        """
+        Gets the instance_options of this LaunchInstanceDetails.
+
+        :return: The instance_options of this LaunchInstanceDetails.
+        :rtype: InstanceOptions
+        """
+        return self._instance_options
+
+    @instance_options.setter
+    def instance_options(self, instance_options):
+        """
+        Sets the instance_options of this LaunchInstanceDetails.
+
+        :param instance_options: The instance_options of this LaunchInstanceDetails.
+        :type: InstanceOptions
+        """
+        self._instance_options = instance_options
 
     @property
     def availability_config(self):

--- a/src/oci/core/models/update_instance_details.py
+++ b/src/oci/core/models/update_instance_details.py
@@ -50,6 +50,10 @@ class UpdateInstanceDetails(object):
             The value to assign to the shape_config property of this UpdateInstanceDetails.
         :type shape_config: UpdateInstanceShapeConfigDetails
 
+        :param instance_options:
+            The value to assign to the instance_options property of this UpdateInstanceDetails.
+        :type instance_options: InstanceOptions
+
         :param fault_domain:
             The value to assign to the fault_domain property of this UpdateInstanceDetails.
         :type fault_domain: str
@@ -72,6 +76,7 @@ class UpdateInstanceDetails(object):
             'extended_metadata': 'dict(str, object)',
             'shape': 'str',
             'shape_config': 'UpdateInstanceShapeConfigDetails',
+            'instance_options': 'InstanceOptions',
             'fault_domain': 'str',
             'launch_options': 'UpdateLaunchOptions',
             'availability_config': 'UpdateInstanceAvailabilityConfigDetails'
@@ -86,6 +91,7 @@ class UpdateInstanceDetails(object):
             'extended_metadata': 'extendedMetadata',
             'shape': 'shape',
             'shape_config': 'shapeConfig',
+            'instance_options': 'instanceOptions',
             'fault_domain': 'faultDomain',
             'launch_options': 'launchOptions',
             'availability_config': 'availabilityConfig'
@@ -99,6 +105,7 @@ class UpdateInstanceDetails(object):
         self._extended_metadata = None
         self._shape = None
         self._shape_config = None
+        self._instance_options = None
         self._fault_domain = None
         self._launch_options = None
         self._availability_config = None
@@ -394,6 +401,26 @@ class UpdateInstanceDetails(object):
         :type: UpdateInstanceShapeConfigDetails
         """
         self._shape_config = shape_config
+
+    @property
+    def instance_options(self):
+        """
+        Gets the instance_options of this UpdateInstanceDetails.
+
+        :return: The instance_options of this UpdateInstanceDetails.
+        :rtype: InstanceOptions
+        """
+        return self._instance_options
+
+    @instance_options.setter
+    def instance_options(self, instance_options):
+        """
+        Sets the instance_options of this UpdateInstanceDetails.
+
+        :param instance_options: The instance_options of this UpdateInstanceDetails.
+        :type: InstanceOptions
+        """
+        self._instance_options = instance_options
 
     @property
     def fault_domain(self):

--- a/src/oci/data_integration/data_integration_client.py
+++ b/src/oci/data_integration/data_integration_client.py
@@ -87,20 +87,19 @@ class DataIntegrationClient(object):
 
     def change_compartment(self, workspace_id, change_compartment_details, **kwargs):
         """
-        The workspace will be moved to the desired compartment.
+        Moves a workspace to a specified compartment.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param ChangeCompartmentDetails change_compartment_details: (required)
-            The details of change compartment action.
+            The information needed to move a workspace to a specified compartment.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -108,7 +107,7 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -183,7 +182,7 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param CreateApplicationDetails create_application_details: (required)
             The details needed to create an application.
@@ -194,7 +193,7 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -269,10 +268,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param CreateConnectionDetails create_connection_details: (required)
-            Request body parameter for connection details
+            The information needed to create a connection.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -280,7 +279,7 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -355,10 +354,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param CreateConnectionValidationDetails create_connection_validation_details: (required)
-            Connection info
+            The information needed to validate a connection.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -366,7 +365,7 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -441,10 +440,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param CreateDataAssetDetails create_data_asset_details: (required)
-            Request body parameter for data asset details
+            The information needed to create a data asset.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -452,7 +451,7 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -527,13 +526,13 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param CreateDataFlowDetails create_data_flow_details: (required)
             The details needed to create a new data flow.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -609,14 +608,14 @@ class DataIntegrationClient(object):
 
     def create_data_flow_validation(self, workspace_id, create_data_flow_validation_details, **kwargs):
         """
-        The endpoint accepts the DataFlow object definition in the request payload and creates a DataFlow object validation.
+        Accepts the data flow definition in the request payload and creates a data flow validation.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param CreateDataFlowValidationDetails create_data_flow_validation_details: (required)
-            Details for the new DataFlow object.
+            The information needed to create the data flow validation for the data flow object.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -624,7 +623,7 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -695,20 +694,20 @@ class DataIntegrationClient(object):
 
     def create_entity_shape(self, workspace_id, connection_key, schema_resource_name, create_entity_shape_details, **kwargs):
         """
-        Retrieves the data entity shape from the end data system. The input can specify the data entity to get the shape for. For databases, this can be retrieved from the database data dictionary. For files, some hints as to the file properties can also be supplied in the input.
+        Creates the data entity shape using the shape from the data asset.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str connection_key: (required)
-            The connection key
+            The connection key.
 
         :param str schema_resource_name: (required)
-            Schema resource name used for retrieving schemas
+            The schema resource name used for retrieving schemas.
 
         :param CreateEntityShapeDetails create_entity_shape_details: (required)
-            The details of the data entity to use to infer the data entity shape.
+            The details needed to create the data entity shape.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -716,13 +715,12 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -795,6 +793,186 @@ class DataIntegrationClient(object):
                 body=create_entity_shape_details,
                 response_type="EntityShape")
 
+    def create_external_publication(self, workspace_id, task_key, create_external_publication_details, **kwargs):
+        """
+        Publish a DataFlow in a OCI DataFlow application.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str task_key: (required)
+            The task key.
+
+        :param CreateExternalPublicationDetails create_external_publication_details: (required)
+            Details needed to publish a task to OCI DataFlow application.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.ExternalPublication`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workspaces/{workspaceId}/tasks/{taskKey}/externalPublications"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_external_publication got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "taskKey": task_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_external_publication_details,
+                response_type="ExternalPublication")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_external_publication_details,
+                response_type="ExternalPublication")
+
+    def create_external_publication_validation(self, workspace_id, task_key, create_external_publication_validation_details, **kwargs):
+        """
+        Validates a specific task.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str task_key: (required)
+            The task key.
+
+        :param CreateExternalPublicationValidationDetails create_external_publication_validation_details: (required)
+            The information needed to create a task validation.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.ExternalPublicationValidation`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workspaces/{workspaceId}/tasks/{taskKey}/externalPublicationValidations"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_external_publication_validation got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "taskKey": task_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_external_publication_validation_details,
+                response_type="ExternalPublicationValidation")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_external_publication_validation_details,
+                response_type="ExternalPublicationValidation")
+
     def create_folder(self, workspace_id, create_folder_details, **kwargs):
         """
         Creates a folder in a project or in another folder, limited to two levels of folders. |
@@ -802,13 +980,13 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param CreateFolderDetails create_folder_details: (required)
             The details needed to create a folder.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -888,10 +1066,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param CreatePatchDetails create_patch_details: (required)
             Detailed needed to create a patch in an application.
@@ -902,7 +1080,7 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -978,13 +1156,13 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param CreateProjectDetails create_project_details: (required)
             The details needed to create a project in a workspace.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -1064,13 +1242,13 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param CreateTaskDetails create_task_details: (required)
             The details needed to create a new task.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -1146,20 +1324,20 @@ class DataIntegrationClient(object):
 
     def create_task_run(self, workspace_id, application_key, create_task_run_details, **kwargs):
         """
-        Creates a data integration task or task run. The task can be based on a dataflow design or a task.
+        Creates a data integration task run for the specified task.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param CreateTaskRunDetails create_task_run_details: (required)
             The details needed to create a task run.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -1240,10 +1418,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param CreateTaskValidationDetails create_task_validation_details: (required)
-            Task info
+            The information needed to create a task validation.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -1251,7 +1429,7 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1322,14 +1500,14 @@ class DataIntegrationClient(object):
 
     def create_workspace(self, create_workspace_details, **kwargs):
         """
-        Creates a new Data Integration Workspace ready for performing data integration.
+        Creates a new Data Integration workspace ready for performing data integration tasks.
 
 
         :param CreateWorkspaceDetails create_workspace_details: (required)
-            Details for the new Data Integration Workspace.
+            The information needed to create a new Data Integration workspace.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -1395,16 +1573,15 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -1479,16 +1656,15 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str connection_key: (required)
-            The connection key
+            The connection key.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -1559,20 +1735,19 @@ class DataIntegrationClient(object):
 
     def delete_connection_validation(self, workspace_id, connection_validation_key, **kwargs):
         """
-        Successfully accepted the delete request. The connection validation will be deleted.
+        Deletes a connection validation.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str connection_validation_key: (required)
-            key of the connection validation.
+            The key of the connection validation.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -1647,16 +1822,15 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str data_asset_key: (required)
-            Data asset key.
+            The data asset key.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -1731,16 +1905,15 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str data_flow_key: (required)
-            DIS DataFlow key
+            The data flow key.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -1815,16 +1988,15 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str data_flow_validation_key: (required)
-            key of the dataflow validation.
+            The key of the dataflow validation.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -1893,22 +2065,195 @@ class DataIntegrationClient(object):
                 path_params=path_params,
                 header_params=header_params)
 
+    def delete_external_publication(self, workspace_id, task_key, external_publications_key, **kwargs):
+        """
+        Removes a published object using the specified identifier.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str task_key: (required)
+            The task key.
+
+        :param str external_publications_key: (required)
+            The external published object key.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workspaces/{workspaceId}/tasks/{taskKey}/externalPublications/{externalPublicationsKey}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_external_publication got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "taskKey": task_key,
+            "externalPublicationsKey": external_publications_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_external_publication_validation(self, workspace_id, task_key, external_publication_validation_key, **kwargs):
+        """
+        Removes a task validation using the specified identifier.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str task_key: (required)
+            The task key.
+
+        :param str external_publication_validation_key: (required)
+            The external published object key.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workspaces/{workspaceId}/tasks/{taskKey}/externalPublicationValidations/{externalPublicationValidationKey}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_external_publication_validation got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "taskKey": task_key,
+            "externalPublicationValidationKey": external_publication_validation_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
     def delete_folder(self, workspace_id, folder_key, **kwargs):
         """
         Removes a folder from a project using the specified identifier.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str folder_key: (required)
-            DIS Folder key
+            The folder key.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -1983,19 +2328,18 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param str patch_key: (required)
-            DIS patch key
+            The patch key.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -2071,16 +2415,15 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str project_key: (required)
-            DIS Project key
+            The project key.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -2155,16 +2498,15 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str task_key: (required)
-            DIS Task key
+            The task key.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -2239,19 +2581,18 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param str task_run_key: (required)
-            DIS taskRun key
+            The task run key.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -2327,16 +2668,15 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str task_validation_key: (required)
-            key of the task validation.
+            The task validation key.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -2407,23 +2747,22 @@ class DataIntegrationClient(object):
 
     def delete_workspace(self, workspace_id, **kwargs):
         """
-        Deletes a Data Integration Workspace resource by identifier
+        Deletes a Data Integration workspace resource using the specified identifier.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param int quiesce_timeout: (optional)
-            This parameter allows users to set the timeout for DIS to gracefully close down any running jobs before stopping the workspace.
+            Used to set the timeout for Data Integration to gracefully close down any running jobs before stopping the workspace.
 
         :param bool is_force_operation: (optional)
-            This parameter allows users to force close down the workspace.
+            Used to force close down the workspace.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -2507,10 +2846,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -2585,10 +2924,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str connection_key: (required)
-            The connection key
+            The connection key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -2663,10 +3002,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str connection_validation_key: (required)
-            key of the connection validation.
+            The key of the connection validation.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -2742,7 +3081,7 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str count_statistic_key: (required)
             A unique key of the container object, such as workspace, project, and so on, to count statistics for. The statistics is fetched for the given key.
@@ -2820,10 +3159,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str data_asset_key: (required)
-            Data asset key.
+            The data asset key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -2898,16 +3237,16 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str connection_key: (required)
-            The connection key
+            The connection key.
 
         :param str schema_resource_name: (required)
-            Schema resource name used for retrieving schemas
+            The schema resource name used for retrieving schemas.
 
         :param str data_entity_key: (required)
-            Name of the data entity
+            The key of the data entity.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -2984,10 +3323,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str data_flow_key: (required)
-            DIS DataFlow key
+            The data flow key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -3062,10 +3401,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str data_flow_validation_key: (required)
-            key of the dataflow validation.
+            The key of the dataflow validation.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -3140,13 +3479,13 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param str dependent_object_key: (required)
-            DIS dependent object key
+            The dependent object key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -3216,16 +3555,180 @@ class DataIntegrationClient(object):
                 header_params=header_params,
                 response_type="DependentObject")
 
+    def get_external_publication(self, workspace_id, task_key, external_publications_key, **kwargs):
+        """
+        Retrieves a publshed object in an task using the specified identifier.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str task_key: (required)
+            The task key.
+
+        :param str external_publications_key: (required)
+            The external published object key.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.ExternalPublication`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workspaces/{workspaceId}/tasks/{taskKey}/externalPublications/{externalPublicationsKey}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_external_publication got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "taskKey": task_key,
+            "externalPublicationsKey": external_publications_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExternalPublication")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExternalPublication")
+
+    def get_external_publication_validation(self, workspace_id, task_key, external_publication_validation_key, **kwargs):
+        """
+        Retrieves an external publication validation using the specified identifier.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str task_key: (required)
+            The task key.
+
+        :param str external_publication_validation_key: (required)
+            The external published object key.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.ExternalPublicationValidation`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workspaces/{workspaceId}/tasks/{taskKey}/externalPublicationValidations/{externalPublicationValidationKey}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_external_publication_validation got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "taskKey": task_key,
+            "externalPublicationValidationKey": external_publication_validation_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExternalPublicationValidation")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExternalPublicationValidation")
+
     def get_folder(self, workspace_id, folder_key, **kwargs):
         """
         Retrieves a folder using the specified identifier.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str folder_key: (required)
-            DIS Folder key
+            The folder key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -3300,13 +3803,13 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param str patch_key: (required)
-            DIS patch key
+            The patch key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -3382,10 +3885,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str project_key: (required)
-            DIS Project key
+            The project key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -3460,13 +3963,13 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param str published_object_key: (required)
-            DIS published object key
+            The published object key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -3474,7 +3977,7 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str expand_references: (optional)
-            This is used to expand references of the object. If value is true, then all referenced objects will be expanded. If value is false, then shallow objects will be returned in place of references. Default is false. <br><br><B>Examples:-</B><br> <ul> <li><B>?expandReferences=true</B> returns all objects of type data loader task</li> </ul>
+            Used to expand references of the object. If value is true, then all referenced objects are expanded. If value is false, then shallow objects are returned in place of references. Default is false. <br><br><B>Example:</B><br> <ul> <li><B>?expandReferences=true</B> returns all objects of type data loader task</li> </ul>
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -3547,19 +4050,101 @@ class DataIntegrationClient(object):
                 header_params=header_params,
                 response_type="PublishedObject")
 
+    def get_reference(self, workspace_id, application_key, reference_key, **kwargs):
+        """
+        Retrieves a reference in an application.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str application_key: (required)
+            The application key.
+
+        :param str reference_key: (required)
+            The reference key.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.Reference`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workspaces/{workspaceId}/applications/{applicationKey}/references/{referenceKey}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_reference got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "applicationKey": application_key,
+            "referenceKey": reference_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Reference")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Reference")
+
     def get_schema(self, workspace_id, connection_key, schema_resource_name, **kwargs):
         """
         Retrieves a schema that can be accessed using the specified connection.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str connection_key: (required)
-            The connection key
+            The connection key.
 
         :param str schema_resource_name: (required)
-            Schema resource name used for retrieving schemas
+            The schema resource name used for retrieving schemas.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -3635,10 +4220,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str task_key: (required)
-            DIS Task key
+            The task key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -3713,13 +4298,13 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param str task_run_key: (required)
-            DIS taskRun key
+            The task run key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -3795,10 +4380,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str task_validation_key: (required)
-            key of the task validation.
+            The task validation key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -3869,11 +4454,11 @@ class DataIntegrationClient(object):
 
     def get_work_request(self, work_request_id, **kwargs):
         """
-        Gets the status of the work request with the given ID.
+        Retrieves the status of the work request with the given ID.
 
 
         :param str work_request_id: (required)
-            The ID of the asynchronous request.
+            The ID of the asynchronous work request to retrieve.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -3943,11 +4528,11 @@ class DataIntegrationClient(object):
 
     def get_workspace(self, workspace_id, **kwargs):
         """
-        Gets a Data Integration Workspace by identifier
+        Retrieves a Data Integration workspace using the specified identifier.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -4021,30 +4606,34 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param list[str] identifier: (optional)
-            This filter parameter can be used to filter by the identifier of the published object.
+            Used to filter by the identifier of the published object.
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -4154,33 +4743,37 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str key: (optional)
-            This filter parameter can be used to filter by the key of the object.
+            Used to filter by the key of the object.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param str identifier: (optional)
-            This filter parameter can be used to filter by the identifier of the object.
+            Used to filter by the identifier of the object.
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
@@ -4292,33 +4885,37 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str data_asset_key: (required)
-            This filter parameter can be used to filter by the data asset key of the object.
+            Used to filter by the data asset key of the object.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str type: (optional)
             Type of the object to filter the results with.
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
@@ -4425,36 +5022,40 @@ class DataIntegrationClient(object):
 
     def list_data_assets(self, workspace_id, **kwargs):
         """
-        This endpoint can be used to list all data asset summaries
+        Retrieves a list of all data asset summaries.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str type: (optional)
             Type of the object to filter the results with.
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -4558,41 +5159,44 @@ class DataIntegrationClient(object):
 
     def list_data_entities(self, workspace_id, connection_key, schema_resource_name, **kwargs):
         """
-        Retrieves a list of summaries of data entities present in the schema identified by schema name. |
-        A live query is run on the data asset identified via the connection specified.
+        Lists a summary of data entities from the data asset using the specified connection.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str connection_key: (required)
-            The connection key
+            The connection key.
 
         :param str schema_resource_name: (required)
-            Schema resource name used for retrieving schemas
+            The schema resource name used for retrieving schemas.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str type: (optional)
             Type of the object to filter the results with.
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
@@ -4700,37 +5304,41 @@ class DataIntegrationClient(object):
 
     def list_data_flow_validations(self, workspace_id, **kwargs):
         """
-        Retrieves a list of data flow validations within the specified workspace
+        Retrieves a list of data flow validations within the specified workspace.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str key: (optional)
-            This filter parameter can be used to filter by the key of the object.
+            Used to filter by the key of the object.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param str identifier: (optional)
-            This filter parameter can be used to filter by the identifier of the object.
+            Used to filter by the identifier of the object.
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
@@ -4842,7 +5450,7 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -4850,30 +5458,34 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str folder_id: (optional)
-            Unique key of the folder
+            Unique key of the folder.
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param list[str] identifier: (optional)
-            This filter parameter can be used to filter by the identifier of the object.
+            Used to filter by the identifier of the object.
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -4980,43 +5592,47 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param list[str] identifier: (optional)
-            This filter parameter can be used to filter by the identifier of the published object.
+            Used to filter by the identifier of the published object.
 
         :param list[str] type: (optional)
-            This filter parameter can be used to filter by the object type of the object.
-            This parameter can be suffixed with an optional filter operator InSubtree.
-            For DIS APIs we will filter based on type Task.
+            Used to filter by the object type of the object.
+            It can be suffixed with an optional filter operator InSubtree.
+            For Data Integration APIs, a filter based on type Task is used.
 
         :param str type_in_subtree: (optional)
-            This is used in association with type parameter. If value is true,
+            Used in association with type parameter. If value is true,
             then type all sub types of the given type parameter is considered.
             If value is false, then sub types are not considered. Default is false.
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -5125,13 +5741,290 @@ class DataIntegrationClient(object):
                 header_params=header_params,
                 response_type="DependentObjectSummaryCollection")
 
+    def list_external_publication_validations(self, workspace_id, task_key, **kwargs):
+        """
+        Retrieves a lists of external publication validations in a workspace and provides options to filter the list.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str task_key: (required)
+            The task key.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param list[str] fields: (optional)
+            Specifies the fields to get for an object.
+
+        :param str name: (optional)
+            Used to filter by the name of the object.
+
+        :param list[str] identifier: (optional)
+            Used to filter by the identifier of the object.
+
+        :param str page: (optional)
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param int limit: (optional)
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str sort_order: (optional)
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+
+            Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.ExternalPublicationValidationSummaryCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workspaces/{workspaceId}/tasks/{taskKey}/externalPublicationValidations"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "fields",
+            "name",
+            "identifier",
+            "page",
+            "limit",
+            "sort_order",
+            "sort_by"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_external_publication_validations got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "taskKey": task_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIME_CREATED", "DISPLAY_NAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "fields": self.base_client.generate_collection_format_param(kwargs.get("fields", missing), 'multi'),
+            "name": kwargs.get("name", missing),
+            "identifier": self.base_client.generate_collection_format_param(kwargs.get("identifier", missing), 'multi'),
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ExternalPublicationValidationSummaryCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ExternalPublicationValidationSummaryCollection")
+
+    def list_external_publications(self, workspace_id, task_key, **kwargs):
+        """
+        Retrieves a list of external publications in an application and provides options to filter the list.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str task_key: (required)
+            The task key.
+
+        :param list[str] fields: (optional)
+            Specifies the fields to get for an object.
+
+        :param str name: (optional)
+            Used to filter by the name of the object.
+
+        :param int limit: (optional)
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str sort_order: (optional)
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+
+            Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.ExternalPublicationSummaryCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workspaces/{workspaceId}/tasks/{taskKey}/externalPublications"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "fields",
+            "name",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_external_publications got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "taskKey": task_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIME_CREATED", "DISPLAY_NAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "fields": self.base_client.generate_collection_format_param(kwargs.get("fields", missing), 'multi'),
+            "name": kwargs.get("name", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ExternalPublicationSummaryCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ExternalPublicationSummaryCollection")
+
     def list_folders(self, workspace_id, **kwargs):
         """
         Retrieves a list of folders in a project and provides options to filter the list.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -5139,30 +6032,34 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str aggregator_key: (optional)
-            This filter parameter can be used to filter by the project or the folder object.
+            Used to filter by the project or the folder object.
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param list[str] identifier: (optional)
-            This filter parameter can be used to filter by the identifier of the object.
+            Used to filter by the identifier of the object.
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -5263,39 +6160,184 @@ class DataIntegrationClient(object):
                 header_params=header_params,
                 response_type="FolderSummaryCollection")
 
-    def list_patches(self, workspace_id, application_key, **kwargs):
+    def list_patch_changes(self, workspace_id, application_key, **kwargs):
         """
         Retrieves a list of patches in an application and provides options to filter the list.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
-        :param list[str] identifier: (optional)
-            This filter parameter can be used to filter by the identifier of the published object.
+        :param str since_patch: (optional)
+            Specifies the patch key to query from.
 
-        :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+        :param str to_patch: (optional)
+            Specifies the patch key to query to.
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+
+            Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.PatchChangeSummaryCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workspaces/{workspaceId}/applications/{applicationKey}/patchChanges"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "name",
+            "since_patch",
+            "to_patch",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_patch_changes got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "applicationKey": application_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIME_CREATED", "DISPLAY_NAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "name": kwargs.get("name", missing),
+            "sincePatch": kwargs.get("since_patch", missing),
+            "toPatch": kwargs.get("to_patch", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="PatchChangeSummaryCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="PatchChangeSummaryCollection")
+
+    def list_patches(self, workspace_id, application_key, **kwargs):
+        """
+        Retrieves a list of patches in an application and provides options to filter the list. For listing changes based on a period and logical objects changed, see ListPatchChanges API.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str application_key: (required)
+            The application key.
+
+        :param str name: (optional)
+            Used to filter by the name of the object.
+
+        :param list[str] identifier: (optional)
+            Used to filter by the identifier of the published object.
+
+        :param list[str] fields: (optional)
+            Specifies the fields to get for an object.
+
+        :param int limit: (optional)
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str sort_order: (optional)
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -5406,7 +6448,7 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -5414,27 +6456,31 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param list[str] identifier: (optional)
-            This filter parameter can be used to filter by the identifier of the object.
+            Used to filter by the identifier of the object.
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -5539,43 +6585,47 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param list[str] identifier: (optional)
-            This filter parameter can be used to filter by the identifier of the published object.
+            Used to filter by the identifier of the published object.
 
         :param list[str] type: (optional)
-            This filter parameter can be used to filter by the object type of the object.
-            This parameter can be suffixed with an optional filter operator InSubtree.
-            For DIS APIs we will filter based on type Task.
+            Used to filter by the object type of the object.
+            It can be suffixed with an optional filter operator InSubtree.
+            For Data Integration APIs, a filter based on type Task is used.
 
         :param str type_in_subtree: (optional)
-            This is used in association with type parameter. If value is true,
+            Used in association with type parameter. If value is true,
             then type all sub types of the given type parameter is considered.
             If value is false, then sub types are not considered. Default is false.
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -5684,41 +6734,176 @@ class DataIntegrationClient(object):
                 header_params=header_params,
                 response_type="PublishedObjectSummaryCollection")
 
+    def list_references(self, workspace_id, application_key, **kwargs):
+        """
+        Retrieves a list of references in an application. Reference objects are created when dataflows and tasks use objects, such as data assets and connections.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str application_key: (required)
+            The application key.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param int limit: (optional)
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str name: (optional)
+            Used to filter by the name of the object.
+
+        :param str sort_order: (optional)
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+
+            Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.ReferenceSummaryCollection`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workspaces/{workspaceId}/applications/{applicationKey}/references"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "limit",
+            "page",
+            "name",
+            "sort_order",
+            "sort_by"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_references got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "applicationKey": application_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIME_CREATED", "DISPLAY_NAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "name": kwargs.get("name", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ReferenceSummaryCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ReferenceSummaryCollection")
+
     def list_schemas(self, workspace_id, connection_key, schema_resource_name, **kwargs):
         """
         Retrieves a list of all the schemas that can be accessed using the specified connection.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str connection_key: (required)
-            The connection key
+            The connection key.
 
         :param str schema_resource_name: (required)
-            Schema resource name used for retrieving schemas
+            Schema resource name used for retrieving schemas.
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -5822,17 +7007,17 @@ class DataIntegrationClient(object):
 
     def list_task_run_logs(self, workspace_id, application_key, task_run_key, **kwargs):
         """
-        Get log entries for task runs using its key
+        Gets log entries for task runs using its key.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param str task_run_key: (required)
-            DIS taskRun key
+            The task run key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -5840,18 +7025,22 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -5952,10 +7141,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -5963,27 +7152,31 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param list[str] identifier: (optional)
-            This filter parameter can be used to filter by the identifier of the object.
+            Used to filter by the identifier of the object.
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -6089,33 +7282,37 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str key: (optional)
-            This filter parameter can be used to filter by the key of the object.
+            Used to filter by the key of the object.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param str identifier: (optional)
-            This filter parameter can be used to filter by the identifier of the object.
+            Used to filter by the identifier of the object.
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
@@ -6227,7 +7424,7 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -6235,36 +7432,40 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str folder_id: (optional)
-            Unique key of the folder
+            Unique key of the folder.
 
         :param list[str] fields: (optional)
-            This parameter allows users to specify which fields to get for an object.
+            Specifies the fields to get for an object.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param list[str] key: (optional)
-            This filter parameter can be used to filter by the key of the object.
+            Used to filter by the key of the object.
 
         :param list[str] identifier: (optional)
-            This filter parameter can be used to filter by the identifier of the object.
+            Used to filter by the identifier of the object.
 
         :param list[str] type: (optional)
-            This filter parameter can be used to filter by the object type of the object. This parameter can be suffixed with an optional filter operator InSubtree. If this operator is not specified, then exact match is considered. <br><br><B>Examples:-</B><br> <ul> <li><B>?type=DATA_LOADER_TASK&typeInSubtree=false</B> returns all objects of type data loader task</li> <li><B>?type=DATA_LOADER_TASK</B> returns all objects of type data loader task</li> <li><B>?type=DATA_LOADER_TASK&typeInSubtree=true</B> returns all objects of type data loader task</li> </ul>
+            Used to filter by the object type of the object. It can be suffixed with an optional filter operator InSubtree. If this operator is not specified, then exact match is considered. <br><br><B>Examples:</B><br> <ul> <li><B>?type=DATA_LOADER_TASK&typeInSubtree=false</B> returns all objects of type data loader task</li> <li><B>?type=DATA_LOADER_TASK</B> returns all objects of type data loader task</li> <li><B>?type=DATA_LOADER_TASK&typeInSubtree=true</B> returns all objects of type data loader task</li> </ul>
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -6371,11 +7572,11 @@ class DataIntegrationClient(object):
 
     def list_work_request_errors(self, work_request_id, **kwargs):
         """
-        Return a (paginated) list of errors for a given work request.
+        Retrieves a paginated list of errors for a given work request.
 
 
         :param str work_request_id: (required)
-            The ID of the asynchronous request.
+            The ID of the asynchronous work request to retrieve.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -6383,18 +7584,22 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -6489,11 +7694,11 @@ class DataIntegrationClient(object):
 
     def list_work_request_logs(self, work_request_id, **kwargs):
         """
-        Return a (paginated) list of logs for a given work request.
+        Retrieves a paginated list of logs for a given work request.
 
 
         :param str work_request_id: (required)
-            The ID of the asynchronous request.
+            The ID of the asynchronous work request to retrieve.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -6501,18 +7706,22 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -6611,7 +7820,7 @@ class DataIntegrationClient(object):
 
 
         :param str compartment_id: (required)
-            The ID of the compartment in which to list resources.
+            The OCID of the compartment containing the resources you want to list.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -6619,23 +7828,27 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str work_request_status: (optional)
-            Work Request status.
+            The work request status.
 
             Allowed values are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", "CANCELING", "CANCELED"
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -6728,33 +7941,37 @@ class DataIntegrationClient(object):
 
     def list_workspaces(self, compartment_id, **kwargs):
         """
-        Returns a list of Data Integration Workspaces.
+        Retrieves a list of Data Integration workspaces.
 
 
         :param str compartment_id: (required)
-            The ID of the compartment in which to list resources.
+            The OCID of the compartment containing the resources you want to list.
 
         :param str name: (optional)
-            This filter parameter can be used to filter by the name of the object.
+            Used to filter by the name of the object.
 
         :param int limit: (optional)
-            This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str lifecycle_state: (optional)
-            Lifecycle state of the resource.
+            The lifecycle state of a resource. When specified, the operation only returns resources that match the given lifecycle state. When not specified, all lifecycle states are processed as a match.
 
             Allowed values are: "CREATING", "ACTIVE", "INACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED", "STARTING", "STOPPING", "STOPPED"
 
         :param str sort_order: (optional)
-            This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
 
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
 
             Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
 
@@ -6854,17 +8071,16 @@ class DataIntegrationClient(object):
 
     def start_workspace(self, workspace_id, **kwargs):
         """
-        The workspace will be started.
+        Starts a workspace.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -6872,7 +8088,7 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -6941,23 +8157,22 @@ class DataIntegrationClient(object):
 
     def stop_workspace(self, workspace_id, **kwargs):
         """
-        The workspace will be stopped.
+        Stops a workspace.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param int quiesce_timeout: (optional)
-            This parameter allows users to set the timeout for DIS to gracefully close down any running jobs before stopping the workspace.
+            Used to set the timeout for Data Integration to gracefully close down any running jobs before stopping the workspace.
 
         :param bool is_force_operation: (optional)
-            This parameter allows users to force close down the workspace.
+            Used to force close down the workspace.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -6965,7 +8180,7 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str opc_retry_token: (optional)
-            Caller may provide \"retry tokens\" allowing them to retry an operation
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -7048,19 +8263,18 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param UpdateApplicationDetails update_application_details: (required)
             The details needed to update an application.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -7139,13 +8353,13 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str connection_key: (required)
-            The connection key
+            The connection key.
 
         :param UpdateConnectionDetails update_connection_details: (required)
-            Request body parameter for connection details
+            The information needed to update a connection.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -7153,10 +8367,9 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -7230,13 +8443,13 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str data_asset_key: (required)
-            Data asset key.
+            The data asset key.
 
         :param UpdateDataAssetDetails update_data_asset_details: (required)
-            Request body parameter for data asset details
+            The information needed to update a data asset.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If
@@ -7244,10 +8457,9 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -7321,10 +8533,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str data_flow_key: (required)
-            DIS DataFlow key
+            The data flow key.
 
         :param UpdateDataFlowDetails update_data_flow_details: (required)
             The details needed to updated a data flow.
@@ -7335,10 +8547,9 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -7406,16 +8617,110 @@ class DataIntegrationClient(object):
                 body=update_data_flow_details,
                 response_type="DataFlow")
 
+    def update_external_publication(self, workspace_id, task_key, external_publications_key, update_external_publication_details, **kwargs):
+        """
+        Updates the external publication object.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str task_key: (required)
+            The task key.
+
+        :param str external_publications_key: (required)
+            The external published object key.
+
+        :param UpdateExternalPublicationDetails update_external_publication_details: (required)
+            The information to be updated.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.ExternalPublication`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workspaces/{workspaceId}/tasks/{taskKey}/externalPublications/{externalPublicationsKey}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_external_publication got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "taskKey": task_key,
+            "externalPublicationsKey": external_publications_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_external_publication_details,
+                response_type="ExternalPublication")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_external_publication_details,
+                response_type="ExternalPublication")
+
     def update_folder(self, workspace_id, folder_key, update_folder_details, **kwargs):
         """
         Updates a specific folder.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str folder_key: (required)
-            DIS Folder key
+            The folder key.
 
         :param UpdateFolderDetails update_folder_details: (required)
             The details needed to update a folder.
@@ -7426,10 +8731,9 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -7503,10 +8807,10 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str project_key: (required)
-            DIS Project key
+            The project key.
 
         :param UpdateProjectDetails update_project_details: (required)
             The details needed to update a project.
@@ -7517,10 +8821,9 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -7588,16 +8891,117 @@ class DataIntegrationClient(object):
                 body=update_project_details,
                 response_type="Project")
 
+    def update_reference(self, workspace_id, application_key, reference_key, update_reference_details, **kwargs):
+        """
+        Updates the application references. For example, to map a data asset to a different target object.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str application_key: (required)
+            The application key.
+
+        :param str reference_key: (required)
+            The reference key.
+
+        :param UpdateReferenceDetails update_reference_details: (required)
+            The details needed to update the references.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.Reference`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/workspaces/{workspaceId}/applications/{applicationKey}/references/{referenceKey}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_reference got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "applicationKey": application_key,
+            "referenceKey": reference_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_reference_details,
+                response_type="Reference")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_reference_details,
+                response_type="Reference")
+
     def update_task(self, workspace_id, task_key, update_task_details, **kwargs):
         """
         Updates a specific task. For example, you can update the task description or move the task to a different folder by changing the `aggregatorKey` to a different folder in the registry.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str task_key: (required)
-            DIS Task key
+            The task key.
 
         :param UpdateTaskDetails update_task_details: (required)
             The details needed to update a task.
@@ -7608,10 +9012,9 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -7685,13 +9088,13 @@ class DataIntegrationClient(object):
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param str application_key: (required)
-            DIS application key
+            The application key.
 
         :param str task_run_key: (required)
-            DIS taskRun key
+            The task run key.
 
         :param UpdateTaskRunDetails update_task_run_details: (required)
             The details needed to update the status of a task run.
@@ -7702,10 +9105,9 @@ class DataIntegrationClient(object):
             please provide the request ID.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -7776,20 +9178,19 @@ class DataIntegrationClient(object):
 
     def update_workspace(self, workspace_id, update_workspace_details, **kwargs):
         """
-        Updates the Data Integration Workspace
+        Updates the specified Data Integration workspace.
 
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param UpdateWorkspaceDetails update_workspace_details: (required)
-            The information to be updated.
+            The information needed to update the workspace.
 
         :param str if_match: (optional)
-            Update and Delete operations should accept an optional If-Match header,
-            in which clients can send a previously-received ETag. When If-Match is
-            provided and its value does not exactly match the ETag of the resource
-            on the server, the request should fail with HTTP response status code 412
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If

--- a/src/oci/data_integration/data_integration_client_composite_operations.py
+++ b/src/oci/data_integration/data_integration_client_composite_operations.py
@@ -29,10 +29,10 @@ class DataIntegrationClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param ChangeCompartmentDetails change_compartment_details: (required)
-            The details of change compartment action.
+            The information needed to move a workspace to a specified compartment.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_integration.models.WorkRequest.status`
@@ -70,7 +70,7 @@ class DataIntegrationClientCompositeOperations(object):
         to enter the given state(s).
 
         :param CreateWorkspaceDetails create_workspace_details: (required)
-            Details for the new Data Integration Workspace.
+            The information needed to create a new Data Integration workspace.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_integration.models.WorkRequest.status`
@@ -108,7 +108,7 @@ class DataIntegrationClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_integration.models.WorkRequest.status`
@@ -154,7 +154,7 @@ class DataIntegrationClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_integration.models.WorkRequest.status`
@@ -192,7 +192,7 @@ class DataIntegrationClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_integration.models.WorkRequest.status`
@@ -230,10 +230,10 @@ class DataIntegrationClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str workspace_id: (required)
-            DIS workspace id
+            The workspace ID.
 
         :param UpdateWorkspaceDetails update_workspace_details: (required)
-            The information to be updated.
+            The information needed to update the workspace.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_integration.models.WorkRequest.status`

--- a/src/oci/data_integration/models/__init__.py
+++ b/src/oci/data_integration/models/__init__.py
@@ -14,8 +14,11 @@ from .application import Application
 from .application_details import ApplicationDetails
 from .application_summary import ApplicationSummary
 from .application_summary_collection import ApplicationSummaryCollection
+from .avro_format_attribute import AvroFormatAttribute
 from .base_type import BaseType
 from .change_compartment_details import ChangeCompartmentDetails
+from .child_reference import ChildReference
+from .child_reference_detail import ChildReferenceDetail
 from .composite_field_map import CompositeFieldMap
 from .composite_type import CompositeType
 from .conditional_input_link import ConditionalInputLink
@@ -24,6 +27,7 @@ from .config_parameter_definition import ConfigParameterDefinition
 from .config_parameter_value import ConfigParameterValue
 from .config_provider import ConfigProvider
 from .config_values import ConfigValues
+from .configuration_details import ConfigurationDetails
 from .configured_type import ConfiguredType
 from .connection import Connection
 from .connection_details import ConnectionDetails
@@ -31,6 +35,10 @@ from .connection_from_adwc import ConnectionFromAdwc
 from .connection_from_adwc_details import ConnectionFromAdwcDetails
 from .connection_from_atp import ConnectionFromAtp
 from .connection_from_atp_details import ConnectionFromAtpDetails
+from .connection_from_jdbc import ConnectionFromJdbc
+from .connection_from_jdbc_details import ConnectionFromJdbcDetails
+from .connection_from_my_sql import ConnectionFromMySQL
+from .connection_from_my_sql_details import ConnectionFromMySQLDetails
 from .connection_from_object_storage import ConnectionFromObjectStorage
 from .connection_from_object_storage_details import ConnectionFromObjectStorageDetails
 from .connection_from_oracle import ConnectionFromOracle
@@ -40,6 +48,8 @@ from .connection_summary import ConnectionSummary
 from .connection_summary_collection import ConnectionSummaryCollection
 from .connection_summary_from_adwc import ConnectionSummaryFromAdwc
 from .connection_summary_from_atp import ConnectionSummaryFromAtp
+from .connection_summary_from_jdbc import ConnectionSummaryFromJdbc
+from .connection_summary_from_my_sql import ConnectionSummaryFromMySQL
 from .connection_summary_from_object_storage import ConnectionSummaryFromObjectStorage
 from .connection_summary_from_oracle import ConnectionSummaryFromOracle
 from .connection_validation import ConnectionValidation
@@ -52,21 +62,28 @@ from .create_config_provider import CreateConfigProvider
 from .create_connection_details import CreateConnectionDetails
 from .create_connection_from_adwc import CreateConnectionFromAdwc
 from .create_connection_from_atp import CreateConnectionFromAtp
+from .create_connection_from_jdbc import CreateConnectionFromJdbc
+from .create_connection_from_my_sql import CreateConnectionFromMySQL
 from .create_connection_from_object_storage import CreateConnectionFromObjectStorage
 from .create_connection_from_oracle import CreateConnectionFromOracle
 from .create_connection_validation_details import CreateConnectionValidationDetails
 from .create_data_asset_details import CreateDataAssetDetails
 from .create_data_asset_from_adwc import CreateDataAssetFromAdwc
 from .create_data_asset_from_atp import CreateDataAssetFromAtp
+from .create_data_asset_from_jdbc import CreateDataAssetFromJdbc
+from .create_data_asset_from_my_sql import CreateDataAssetFromMySQL
 from .create_data_asset_from_object_storage import CreateDataAssetFromObjectStorage
 from .create_data_asset_from_oracle import CreateDataAssetFromOracle
 from .create_data_flow_details import CreateDataFlowDetails
 from .create_data_flow_validation_details import CreateDataFlowValidationDetails
 from .create_entity_shape_details import CreateEntityShapeDetails
 from .create_entity_shape_from_file import CreateEntityShapeFromFile
+from .create_external_publication_details import CreateExternalPublicationDetails
+from .create_external_publication_validation_details import CreateExternalPublicationValidationDetails
 from .create_folder_details import CreateFolderDetails
 from .create_patch_details import CreatePatchDetails
 from .create_project_details import CreateProjectDetails
+from .create_source_application_info import CreateSourceApplicationInfo
 from .create_task_details import CreateTaskDetails
 from .create_task_from_data_loader_task import CreateTaskFromDataLoaderTask
 from .create_task_from_integration_task import CreateTaskFromIntegrationTask
@@ -79,12 +96,16 @@ from .csv_format_attribute import CsvFormatAttribute
 from .data_asset import DataAsset
 from .data_asset_from_adwc_details import DataAssetFromAdwcDetails
 from .data_asset_from_atp_details import DataAssetFromAtpDetails
+from .data_asset_from_jdbc import DataAssetFromJdbc
+from .data_asset_from_my_sql import DataAssetFromMySQL
 from .data_asset_from_object_storage_details import DataAssetFromObjectStorageDetails
 from .data_asset_from_oracle_details import DataAssetFromOracleDetails
 from .data_asset_summary import DataAssetSummary
 from .data_asset_summary_collection import DataAssetSummaryCollection
 from .data_asset_summary_from_adwc import DataAssetSummaryFromAdwc
 from .data_asset_summary_from_atp import DataAssetSummaryFromAtp
+from .data_asset_summary_from_jdbc import DataAssetSummaryFromJdbc
+from .data_asset_summary_from_my_sql import DataAssetSummaryFromMySQL
 from .data_asset_summary_from_object_storage import DataAssetSummaryFromObjectStorage
 from .data_asset_summary_from_oracle import DataAssetSummaryFromOracle
 from .data_entity import DataEntity
@@ -116,14 +137,22 @@ from .derived_field import DerivedField
 from .derived_type import DerivedType
 from .direct_field_map import DirectFieldMap
 from .direct_named_field_map import DirectNamedFieldMap
+from .distinct import Distinct
 from .dynamic_input_field import DynamicInputField
 from .dynamic_proxy_field import DynamicProxyField
 from .dynamic_type import DynamicType
 from .dynamic_type_handler import DynamicTypeHandler
+from .enriched_entity import EnrichedEntity
 from .entity_shape import EntityShape
 from .entity_shape_from_file import EntityShapeFromFile
 from .error_details import ErrorDetails
 from .expression import Expression
+from .external_publication import ExternalPublication
+from .external_publication_summary import ExternalPublicationSummary
+from .external_publication_summary_collection import ExternalPublicationSummaryCollection
+from .external_publication_validation import ExternalPublicationValidation
+from .external_publication_validation_summary import ExternalPublicationValidationSummary
+from .external_publication_validation_summary_collection import ExternalPublicationValidationSummaryCollection
 from .field_map import FieldMap
 from .filter import Filter
 from .filter_push import FilterPush
@@ -146,6 +175,7 @@ from .key import Key
 from .key_attribute import KeyAttribute
 from .key_range import KeyRange
 from .key_range_partition_config import KeyRangePartitionConfig
+from .macro_field import MacroField
 from .message import Message
 from .name_list_rule import NameListRule
 from .name_pattern_rule import NamePatternRule
@@ -153,9 +183,13 @@ from .native_shape_field import NativeShapeField
 from .object_metadata import ObjectMetadata
 from .operator import Operator
 from .oracle_adwc_write_attribute import OracleAdwcWriteAttribute
+from .oracle_adwc_write_attributes import OracleAdwcWriteAttributes
 from .oracle_atp_write_attribute import OracleAtpWriteAttribute
+from .oracle_atp_write_attributes import OracleAtpWriteAttributes
 from .oracle_read_attribute import OracleReadAttribute
+from .oracle_read_attributes import OracleReadAttributes
 from .oracle_write_attribute import OracleWriteAttribute
+from .oracle_write_attributes import OracleWriteAttributes
 from .output_field import OutputField
 from .output_link import OutputLink
 from .output_port import OutputPort
@@ -164,6 +198,8 @@ from .parameter_value import ParameterValue
 from .parent_reference import ParentReference
 from .partition_config import PartitionConfig
 from .patch import Patch
+from .patch_change_summary import PatchChangeSummary
+from .patch_change_summary_collection import PatchChangeSummaryCollection
 from .patch_object_metadata import PatchObjectMetadata
 from .patch_summary import PatchSummary
 from .patch_summary_collection import PatchSummaryCollection
@@ -185,8 +221,13 @@ from .published_object_summary_from_integration_task import PublishedObjectSumma
 from .push_down_operation import PushDownOperation
 from .query import Query
 from .read_operation_config import ReadOperationConfig
+from .reference import Reference
+from .reference_summary import ReferenceSummary
+from .reference_summary_collection import ReferenceSummaryCollection
+from .reference_used_by import ReferenceUsedBy
 from .registry_metadata import RegistryMetadata
 from .rename_rule import RenameRule
+from .resource_configuration import ResourceConfiguration
 from .root_object import RootObject
 from .rule_based_field_map import RuleBasedFieldMap
 from .rule_type_config import RuleTypeConfig
@@ -198,7 +239,11 @@ from .shape import Shape
 from .shape_field import ShapeField
 from .sort import Sort
 from .sort_clause import SortClause
+from .sort_key import SortKey
+from .sort_key_rule import SortKeyRule
+from .sort_oper import SortOper
 from .source import Source
+from .source_application_info import SourceApplicationInfo
 from .structured_type import StructuredType
 from .target import Target
 from .task import Task
@@ -227,16 +272,22 @@ from .update_application_details import UpdateApplicationDetails
 from .update_connection_details import UpdateConnectionDetails
 from .update_connection_from_adwc import UpdateConnectionFromAdwc
 from .update_connection_from_atp import UpdateConnectionFromAtp
+from .update_connection_from_jdbc import UpdateConnectionFromJdbc
+from .update_connection_from_my_sql import UpdateConnectionFromMySQL
 from .update_connection_from_object_storage import UpdateConnectionFromObjectStorage
 from .update_connection_from_oracle import UpdateConnectionFromOracle
 from .update_data_asset_details import UpdateDataAssetDetails
 from .update_data_asset_from_adwc import UpdateDataAssetFromAdwc
 from .update_data_asset_from_atp import UpdateDataAssetFromAtp
+from .update_data_asset_from_jdbc import UpdateDataAssetFromJdbc
+from .update_data_asset_from_my_sql import UpdateDataAssetFromMySQL
 from .update_data_asset_from_object_storage import UpdateDataAssetFromObjectStorage
 from .update_data_asset_from_oracle import UpdateDataAssetFromOracle
 from .update_data_flow_details import UpdateDataFlowDetails
+from .update_external_publication_details import UpdateExternalPublicationDetails
 from .update_folder_details import UpdateFolderDetails
 from .update_project_details import UpdateProjectDetails
+from .update_reference_details import UpdateReferenceDetails
 from .update_task_details import UpdateTaskDetails
 from .update_task_from_data_loader_task import UpdateTaskFromDataLoaderTask
 from .update_task_from_integration_task import UpdateTaskFromIntegrationTask
@@ -264,8 +315,11 @@ data_integration_type_mapping = {
     "ApplicationDetails": ApplicationDetails,
     "ApplicationSummary": ApplicationSummary,
     "ApplicationSummaryCollection": ApplicationSummaryCollection,
+    "AvroFormatAttribute": AvroFormatAttribute,
     "BaseType": BaseType,
     "ChangeCompartmentDetails": ChangeCompartmentDetails,
+    "ChildReference": ChildReference,
+    "ChildReferenceDetail": ChildReferenceDetail,
     "CompositeFieldMap": CompositeFieldMap,
     "CompositeType": CompositeType,
     "ConditionalInputLink": ConditionalInputLink,
@@ -274,6 +328,7 @@ data_integration_type_mapping = {
     "ConfigParameterValue": ConfigParameterValue,
     "ConfigProvider": ConfigProvider,
     "ConfigValues": ConfigValues,
+    "ConfigurationDetails": ConfigurationDetails,
     "ConfiguredType": ConfiguredType,
     "Connection": Connection,
     "ConnectionDetails": ConnectionDetails,
@@ -281,6 +336,10 @@ data_integration_type_mapping = {
     "ConnectionFromAdwcDetails": ConnectionFromAdwcDetails,
     "ConnectionFromAtp": ConnectionFromAtp,
     "ConnectionFromAtpDetails": ConnectionFromAtpDetails,
+    "ConnectionFromJdbc": ConnectionFromJdbc,
+    "ConnectionFromJdbcDetails": ConnectionFromJdbcDetails,
+    "ConnectionFromMySQL": ConnectionFromMySQL,
+    "ConnectionFromMySQLDetails": ConnectionFromMySQLDetails,
     "ConnectionFromObjectStorage": ConnectionFromObjectStorage,
     "ConnectionFromObjectStorageDetails": ConnectionFromObjectStorageDetails,
     "ConnectionFromOracle": ConnectionFromOracle,
@@ -290,6 +349,8 @@ data_integration_type_mapping = {
     "ConnectionSummaryCollection": ConnectionSummaryCollection,
     "ConnectionSummaryFromAdwc": ConnectionSummaryFromAdwc,
     "ConnectionSummaryFromAtp": ConnectionSummaryFromAtp,
+    "ConnectionSummaryFromJdbc": ConnectionSummaryFromJdbc,
+    "ConnectionSummaryFromMySQL": ConnectionSummaryFromMySQL,
     "ConnectionSummaryFromObjectStorage": ConnectionSummaryFromObjectStorage,
     "ConnectionSummaryFromOracle": ConnectionSummaryFromOracle,
     "ConnectionValidation": ConnectionValidation,
@@ -302,21 +363,28 @@ data_integration_type_mapping = {
     "CreateConnectionDetails": CreateConnectionDetails,
     "CreateConnectionFromAdwc": CreateConnectionFromAdwc,
     "CreateConnectionFromAtp": CreateConnectionFromAtp,
+    "CreateConnectionFromJdbc": CreateConnectionFromJdbc,
+    "CreateConnectionFromMySQL": CreateConnectionFromMySQL,
     "CreateConnectionFromObjectStorage": CreateConnectionFromObjectStorage,
     "CreateConnectionFromOracle": CreateConnectionFromOracle,
     "CreateConnectionValidationDetails": CreateConnectionValidationDetails,
     "CreateDataAssetDetails": CreateDataAssetDetails,
     "CreateDataAssetFromAdwc": CreateDataAssetFromAdwc,
     "CreateDataAssetFromAtp": CreateDataAssetFromAtp,
+    "CreateDataAssetFromJdbc": CreateDataAssetFromJdbc,
+    "CreateDataAssetFromMySQL": CreateDataAssetFromMySQL,
     "CreateDataAssetFromObjectStorage": CreateDataAssetFromObjectStorage,
     "CreateDataAssetFromOracle": CreateDataAssetFromOracle,
     "CreateDataFlowDetails": CreateDataFlowDetails,
     "CreateDataFlowValidationDetails": CreateDataFlowValidationDetails,
     "CreateEntityShapeDetails": CreateEntityShapeDetails,
     "CreateEntityShapeFromFile": CreateEntityShapeFromFile,
+    "CreateExternalPublicationDetails": CreateExternalPublicationDetails,
+    "CreateExternalPublicationValidationDetails": CreateExternalPublicationValidationDetails,
     "CreateFolderDetails": CreateFolderDetails,
     "CreatePatchDetails": CreatePatchDetails,
     "CreateProjectDetails": CreateProjectDetails,
+    "CreateSourceApplicationInfo": CreateSourceApplicationInfo,
     "CreateTaskDetails": CreateTaskDetails,
     "CreateTaskFromDataLoaderTask": CreateTaskFromDataLoaderTask,
     "CreateTaskFromIntegrationTask": CreateTaskFromIntegrationTask,
@@ -329,12 +397,16 @@ data_integration_type_mapping = {
     "DataAsset": DataAsset,
     "DataAssetFromAdwcDetails": DataAssetFromAdwcDetails,
     "DataAssetFromAtpDetails": DataAssetFromAtpDetails,
+    "DataAssetFromJdbc": DataAssetFromJdbc,
+    "DataAssetFromMySQL": DataAssetFromMySQL,
     "DataAssetFromObjectStorageDetails": DataAssetFromObjectStorageDetails,
     "DataAssetFromOracleDetails": DataAssetFromOracleDetails,
     "DataAssetSummary": DataAssetSummary,
     "DataAssetSummaryCollection": DataAssetSummaryCollection,
     "DataAssetSummaryFromAdwc": DataAssetSummaryFromAdwc,
     "DataAssetSummaryFromAtp": DataAssetSummaryFromAtp,
+    "DataAssetSummaryFromJdbc": DataAssetSummaryFromJdbc,
+    "DataAssetSummaryFromMySQL": DataAssetSummaryFromMySQL,
     "DataAssetSummaryFromObjectStorage": DataAssetSummaryFromObjectStorage,
     "DataAssetSummaryFromOracle": DataAssetSummaryFromOracle,
     "DataEntity": DataEntity,
@@ -366,14 +438,22 @@ data_integration_type_mapping = {
     "DerivedType": DerivedType,
     "DirectFieldMap": DirectFieldMap,
     "DirectNamedFieldMap": DirectNamedFieldMap,
+    "Distinct": Distinct,
     "DynamicInputField": DynamicInputField,
     "DynamicProxyField": DynamicProxyField,
     "DynamicType": DynamicType,
     "DynamicTypeHandler": DynamicTypeHandler,
+    "EnrichedEntity": EnrichedEntity,
     "EntityShape": EntityShape,
     "EntityShapeFromFile": EntityShapeFromFile,
     "ErrorDetails": ErrorDetails,
     "Expression": Expression,
+    "ExternalPublication": ExternalPublication,
+    "ExternalPublicationSummary": ExternalPublicationSummary,
+    "ExternalPublicationSummaryCollection": ExternalPublicationSummaryCollection,
+    "ExternalPublicationValidation": ExternalPublicationValidation,
+    "ExternalPublicationValidationSummary": ExternalPublicationValidationSummary,
+    "ExternalPublicationValidationSummaryCollection": ExternalPublicationValidationSummaryCollection,
     "FieldMap": FieldMap,
     "Filter": Filter,
     "FilterPush": FilterPush,
@@ -396,6 +476,7 @@ data_integration_type_mapping = {
     "KeyAttribute": KeyAttribute,
     "KeyRange": KeyRange,
     "KeyRangePartitionConfig": KeyRangePartitionConfig,
+    "MacroField": MacroField,
     "Message": Message,
     "NameListRule": NameListRule,
     "NamePatternRule": NamePatternRule,
@@ -403,9 +484,13 @@ data_integration_type_mapping = {
     "ObjectMetadata": ObjectMetadata,
     "Operator": Operator,
     "OracleAdwcWriteAttribute": OracleAdwcWriteAttribute,
+    "OracleAdwcWriteAttributes": OracleAdwcWriteAttributes,
     "OracleAtpWriteAttribute": OracleAtpWriteAttribute,
+    "OracleAtpWriteAttributes": OracleAtpWriteAttributes,
     "OracleReadAttribute": OracleReadAttribute,
+    "OracleReadAttributes": OracleReadAttributes,
     "OracleWriteAttribute": OracleWriteAttribute,
+    "OracleWriteAttributes": OracleWriteAttributes,
     "OutputField": OutputField,
     "OutputLink": OutputLink,
     "OutputPort": OutputPort,
@@ -414,6 +499,8 @@ data_integration_type_mapping = {
     "ParentReference": ParentReference,
     "PartitionConfig": PartitionConfig,
     "Patch": Patch,
+    "PatchChangeSummary": PatchChangeSummary,
+    "PatchChangeSummaryCollection": PatchChangeSummaryCollection,
     "PatchObjectMetadata": PatchObjectMetadata,
     "PatchSummary": PatchSummary,
     "PatchSummaryCollection": PatchSummaryCollection,
@@ -435,8 +522,13 @@ data_integration_type_mapping = {
     "PushDownOperation": PushDownOperation,
     "Query": Query,
     "ReadOperationConfig": ReadOperationConfig,
+    "Reference": Reference,
+    "ReferenceSummary": ReferenceSummary,
+    "ReferenceSummaryCollection": ReferenceSummaryCollection,
+    "ReferenceUsedBy": ReferenceUsedBy,
     "RegistryMetadata": RegistryMetadata,
     "RenameRule": RenameRule,
+    "ResourceConfiguration": ResourceConfiguration,
     "RootObject": RootObject,
     "RuleBasedFieldMap": RuleBasedFieldMap,
     "RuleTypeConfig": RuleTypeConfig,
@@ -448,7 +540,11 @@ data_integration_type_mapping = {
     "ShapeField": ShapeField,
     "Sort": Sort,
     "SortClause": SortClause,
+    "SortKey": SortKey,
+    "SortKeyRule": SortKeyRule,
+    "SortOper": SortOper,
     "Source": Source,
+    "SourceApplicationInfo": SourceApplicationInfo,
     "StructuredType": StructuredType,
     "Target": Target,
     "Task": Task,
@@ -477,16 +573,22 @@ data_integration_type_mapping = {
     "UpdateConnectionDetails": UpdateConnectionDetails,
     "UpdateConnectionFromAdwc": UpdateConnectionFromAdwc,
     "UpdateConnectionFromAtp": UpdateConnectionFromAtp,
+    "UpdateConnectionFromJdbc": UpdateConnectionFromJdbc,
+    "UpdateConnectionFromMySQL": UpdateConnectionFromMySQL,
     "UpdateConnectionFromObjectStorage": UpdateConnectionFromObjectStorage,
     "UpdateConnectionFromOracle": UpdateConnectionFromOracle,
     "UpdateDataAssetDetails": UpdateDataAssetDetails,
     "UpdateDataAssetFromAdwc": UpdateDataAssetFromAdwc,
     "UpdateDataAssetFromAtp": UpdateDataAssetFromAtp,
+    "UpdateDataAssetFromJdbc": UpdateDataAssetFromJdbc,
+    "UpdateDataAssetFromMySQL": UpdateDataAssetFromMySQL,
     "UpdateDataAssetFromObjectStorage": UpdateDataAssetFromObjectStorage,
     "UpdateDataAssetFromOracle": UpdateDataAssetFromOracle,
     "UpdateDataFlowDetails": UpdateDataFlowDetails,
+    "UpdateExternalPublicationDetails": UpdateExternalPublicationDetails,
     "UpdateFolderDetails": UpdateFolderDetails,
     "UpdateProjectDetails": UpdateProjectDetails,
+    "UpdateReferenceDetails": UpdateReferenceDetails,
     "UpdateTaskDetails": UpdateTaskDetails,
     "UpdateTaskFromDataLoaderTask": UpdateTaskFromDataLoaderTask,
     "UpdateTaskFromIntegrationTask": UpdateTaskFromIntegrationTask,

--- a/src/oci/data_integration/models/abstract_field.py
+++ b/src/oci/data_integration/models/abstract_field.py
@@ -21,7 +21,7 @@ class AbstractField(TypedObject):
 
         :param model_type:
             The value to assign to the model_type property of this AbstractField.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 

--- a/src/oci/data_integration/models/abstract_format_attribute.py
+++ b/src/oci/data_integration/models/abstract_format_attribute.py
@@ -21,11 +21,16 @@ class AbstractFormatAttribute(object):
     #: This constant has a value of "CSV_FORMAT"
     MODEL_TYPE_CSV_FORMAT = "CSV_FORMAT"
 
+    #: A constant which can be used with the model_type property of a AbstractFormatAttribute.
+    #: This constant has a value of "AVRO_FORMAT"
+    MODEL_TYPE_AVRO_FORMAT = "AVRO_FORMAT"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AbstractFormatAttribute object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.data_integration.models.AvroFormatAttribute`
         * :class:`~oci.data_integration.models.JsonFormatAttribute`
         * :class:`~oci.data_integration.models.CsvFormatAttribute`
 
@@ -33,7 +38,7 @@ class AbstractFormatAttribute(object):
 
         :param model_type:
             The value to assign to the model_type property of this AbstractFormatAttribute.
-            Allowed values for this property are: "JSON_FORMAT", "CSV_FORMAT", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "JSON_FORMAT", "CSV_FORMAT", "AVRO_FORMAT", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -56,6 +61,9 @@ class AbstractFormatAttribute(object):
         """
         type = object_dictionary['modelType']
 
+        if type == 'AVRO_FORMAT':
+            return 'AvroFormatAttribute'
+
         if type == 'JSON_FORMAT':
             return 'JsonFormatAttribute'
 
@@ -70,7 +78,7 @@ class AbstractFormatAttribute(object):
         **[Required]** Gets the model_type of this AbstractFormatAttribute.
         The type of the format attribute.
 
-        Allowed values for this property are: "JSON_FORMAT", "CSV_FORMAT", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "JSON_FORMAT", "CSV_FORMAT", "AVRO_FORMAT", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -89,7 +97,7 @@ class AbstractFormatAttribute(object):
         :param model_type: The model_type of this AbstractFormatAttribute.
         :type: str
         """
-        allowed_values = ["JSON_FORMAT", "CSV_FORMAT"]
+        allowed_values = ["JSON_FORMAT", "CSV_FORMAT", "AVRO_FORMAT"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type

--- a/src/oci/data_integration/models/abstract_read_attribute.py
+++ b/src/oci/data_integration/models/abstract_read_attribute.py
@@ -17,6 +17,10 @@ class AbstractReadAttribute(object):
     #: This constant has a value of "ORACLEREADATTRIBUTE"
     MODEL_TYPE_ORACLEREADATTRIBUTE = "ORACLEREADATTRIBUTE"
 
+    #: A constant which can be used with the model_type property of a AbstractReadAttribute.
+    #: This constant has a value of "ORACLE_READ_ATTRIBUTE"
+    MODEL_TYPE_ORACLE_READ_ATTRIBUTE = "ORACLE_READ_ATTRIBUTE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AbstractReadAttribute object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
@@ -28,7 +32,7 @@ class AbstractReadAttribute(object):
 
         :param model_type:
             The value to assign to the model_type property of this AbstractReadAttribute.
-            Allowed values for this property are: "ORACLEREADATTRIBUTE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ORACLEREADATTRIBUTE", "ORACLE_READ_ATTRIBUTE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -62,7 +66,7 @@ class AbstractReadAttribute(object):
         **[Required]** Gets the model_type of this AbstractReadAttribute.
         The type of the abstract read attribute.
 
-        Allowed values for this property are: "ORACLEREADATTRIBUTE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ORACLEREADATTRIBUTE", "ORACLE_READ_ATTRIBUTE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -81,7 +85,7 @@ class AbstractReadAttribute(object):
         :param model_type: The model_type of this AbstractReadAttribute.
         :type: str
         """
-        allowed_values = ["ORACLEREADATTRIBUTE"]
+        allowed_values = ["ORACLEREADATTRIBUTE", "ORACLE_READ_ATTRIBUTE"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type

--- a/src/oci/data_integration/models/abstract_write_attribute.py
+++ b/src/oci/data_integration/models/abstract_write_attribute.py
@@ -25,6 +25,18 @@ class AbstractWriteAttribute(object):
     #: This constant has a value of "ORACLEADWCWRITEATTRIBUTE"
     MODEL_TYPE_ORACLEADWCWRITEATTRIBUTE = "ORACLEADWCWRITEATTRIBUTE"
 
+    #: A constant which can be used with the model_type property of a AbstractWriteAttribute.
+    #: This constant has a value of "ORACLE_WRITE_ATTRIBUTE"
+    MODEL_TYPE_ORACLE_WRITE_ATTRIBUTE = "ORACLE_WRITE_ATTRIBUTE"
+
+    #: A constant which can be used with the model_type property of a AbstractWriteAttribute.
+    #: This constant has a value of "ORACLE_ATP_WRITE_ATTRIBUTE"
+    MODEL_TYPE_ORACLE_ATP_WRITE_ATTRIBUTE = "ORACLE_ATP_WRITE_ATTRIBUTE"
+
+    #: A constant which can be used with the model_type property of a AbstractWriteAttribute.
+    #: This constant has a value of "ORACLE_ADWC_WRITE_ATTRIBUTE"
+    MODEL_TYPE_ORACLE_ADWC_WRITE_ATTRIBUTE = "ORACLE_ADWC_WRITE_ATTRIBUTE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AbstractWriteAttribute object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
@@ -38,7 +50,7 @@ class AbstractWriteAttribute(object):
 
         :param model_type:
             The value to assign to the model_type property of this AbstractWriteAttribute.
-            Allowed values for this property are: "ORACLEWRITEATTRIBUTE", "ORACLEATPWRITEATTRIBUTE", "ORACLEADWCWRITEATTRIBUTE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ORACLEWRITEATTRIBUTE", "ORACLEATPWRITEATTRIBUTE", "ORACLEADWCWRITEATTRIBUTE", "ORACLE_WRITE_ATTRIBUTE", "ORACLE_ATP_WRITE_ATTRIBUTE", "ORACLE_ADWC_WRITE_ATTRIBUTE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -78,7 +90,7 @@ class AbstractWriteAttribute(object):
         **[Required]** Gets the model_type of this AbstractWriteAttribute.
         The type of the abstract write attribute.
 
-        Allowed values for this property are: "ORACLEWRITEATTRIBUTE", "ORACLEATPWRITEATTRIBUTE", "ORACLEADWCWRITEATTRIBUTE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ORACLEWRITEATTRIBUTE", "ORACLEATPWRITEATTRIBUTE", "ORACLEADWCWRITEATTRIBUTE", "ORACLE_WRITE_ATTRIBUTE", "ORACLE_ATP_WRITE_ATTRIBUTE", "ORACLE_ADWC_WRITE_ATTRIBUTE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -97,7 +109,7 @@ class AbstractWriteAttribute(object):
         :param model_type: The model_type of this AbstractWriteAttribute.
         :type: str
         """
-        allowed_values = ["ORACLEWRITEATTRIBUTE", "ORACLEATPWRITEATTRIBUTE", "ORACLEADWCWRITEATTRIBUTE"]
+        allowed_values = ["ORACLEWRITEATTRIBUTE", "ORACLEATPWRITEATTRIBUTE", "ORACLEADWCWRITEATTRIBUTE", "ORACLE_WRITE_ATTRIBUTE", "ORACLE_ATP_WRITE_ATTRIBUTE", "ORACLE_ADWC_WRITE_ATTRIBUTE"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type

--- a/src/oci/data_integration/models/aggregator.py
+++ b/src/oci/data_integration/models/aggregator.py
@@ -21,7 +21,7 @@ class Aggregator(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this Aggregator.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR"
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/application.py
+++ b/src/oci/data_integration/models/application.py
@@ -66,6 +66,14 @@ class Application(object):
             The value to assign to the published_object_metadata property of this Application.
         :type published_object_metadata: dict(str, PatchObjectMetadata)
 
+        :param source_application_info:
+            The value to assign to the source_application_info property of this Application.
+        :type source_application_info: SourceApplicationInfo
+
+        :param time_patched:
+            The value to assign to the time_patched property of this Application.
+        :type time_patched: datetime
+
         :param metadata:
             The value to assign to the metadata property of this Application.
         :type metadata: ObjectMetadata
@@ -88,6 +96,8 @@ class Application(object):
             'object_version': 'int',
             'dependent_object_metadata': 'list[PatchObjectMetadata]',
             'published_object_metadata': 'dict(str, PatchObjectMetadata)',
+            'source_application_info': 'SourceApplicationInfo',
+            'time_patched': 'datetime',
             'metadata': 'ObjectMetadata',
             'key_map': 'dict(str, str)'
         }
@@ -105,6 +115,8 @@ class Application(object):
             'object_version': 'objectVersion',
             'dependent_object_metadata': 'dependentObjectMetadata',
             'published_object_metadata': 'publishedObjectMetadata',
+            'source_application_info': 'sourceApplicationInfo',
+            'time_patched': 'timePatched',
             'metadata': 'metadata',
             'key_map': 'keyMap'
         }
@@ -121,6 +133,8 @@ class Application(object):
         self._object_version = None
         self._dependent_object_metadata = None
         self._published_object_metadata = None
+        self._source_application_info = None
+        self._time_patched = None
         self._metadata = None
         self._key_map = None
 
@@ -152,7 +166,7 @@ class Application(object):
     def model_type(self):
         """
         Gets the model_type of this Application.
-        The type of the object.
+        The object type.
 
 
         :return: The model_type of this Application.
@@ -164,7 +178,7 @@ class Application(object):
     def model_type(self, model_type):
         """
         Sets the model_type of this Application.
-        The type of the object.
+        The object type.
 
 
         :param model_type: The model_type of this Application.
@@ -176,7 +190,7 @@ class Application(object):
     def model_version(self):
         """
         Gets the model_version of this Application.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this Application.
@@ -188,7 +202,7 @@ class Application(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this Application.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this Application.
@@ -200,7 +214,7 @@ class Application(object):
     def name(self):
         """
         Gets the name of this Application.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this Application.
@@ -212,7 +226,7 @@ class Application(object):
     def name(self, name):
         """
         Sets the name of this Application.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this Application.
@@ -248,7 +262,7 @@ class Application(object):
     def application_version(self):
         """
         Gets the application_version of this Application.
-        version
+        The application's version.
 
 
         :return: The application_version of this Application.
@@ -260,7 +274,7 @@ class Application(object):
     def application_version(self, application_version):
         """
         Sets the application_version of this Application.
-        version
+        The application's version.
 
 
         :param application_version: The application_version of this Application.
@@ -296,7 +310,7 @@ class Application(object):
     def identifier(self):
         """
         Gets the identifier of this Application.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this Application.
@@ -308,7 +322,7 @@ class Application(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this Application.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this Application.
@@ -364,7 +378,7 @@ class Application(object):
     def dependent_object_metadata(self):
         """
         Gets the dependent_object_metadata of this Application.
-        List of dependent objects in this patch.
+        A list of dependent objects in this patch.
 
 
         :return: The dependent_object_metadata of this Application.
@@ -376,7 +390,7 @@ class Application(object):
     def dependent_object_metadata(self, dependent_object_metadata):
         """
         Sets the dependent_object_metadata of this Application.
-        List of dependent objects in this patch.
+        A list of dependent objects in this patch.
 
 
         :param dependent_object_metadata: The dependent_object_metadata of this Application.
@@ -388,7 +402,7 @@ class Application(object):
     def published_object_metadata(self):
         """
         Gets the published_object_metadata of this Application.
-        List of objects that are published / unpublished in this patch.
+        A list of objects that are published or unpublished in this patch.
 
 
         :return: The published_object_metadata of this Application.
@@ -400,13 +414,57 @@ class Application(object):
     def published_object_metadata(self, published_object_metadata):
         """
         Sets the published_object_metadata of this Application.
-        List of objects that are published / unpublished in this patch.
+        A list of objects that are published or unpublished in this patch.
 
 
         :param published_object_metadata: The published_object_metadata of this Application.
         :type: dict(str, PatchObjectMetadata)
         """
         self._published_object_metadata = published_object_metadata
+
+    @property
+    def source_application_info(self):
+        """
+        Gets the source_application_info of this Application.
+
+        :return: The source_application_info of this Application.
+        :rtype: SourceApplicationInfo
+        """
+        return self._source_application_info
+
+    @source_application_info.setter
+    def source_application_info(self, source_application_info):
+        """
+        Sets the source_application_info of this Application.
+
+        :param source_application_info: The source_application_info of this Application.
+        :type: SourceApplicationInfo
+        """
+        self._source_application_info = source_application_info
+
+    @property
+    def time_patched(self):
+        """
+        Gets the time_patched of this Application.
+        The date and time the application was patched, in the timestamp format defined by RFC3339.
+
+
+        :return: The time_patched of this Application.
+        :rtype: datetime
+        """
+        return self._time_patched
+
+    @time_patched.setter
+    def time_patched(self, time_patched):
+        """
+        Sets the time_patched of this Application.
+        The date and time the application was patched, in the timestamp format defined by RFC3339.
+
+
+        :param time_patched: The time_patched of this Application.
+        :type: datetime
+        """
+        self._time_patched = time_patched
 
     @property
     def metadata(self):
@@ -432,7 +490,7 @@ class Application(object):
     def key_map(self):
         """
         Gets the key_map of this Application.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this Application.
@@ -444,7 +502,7 @@ class Application(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this Application.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this Application.

--- a/src/oci/data_integration/models/application_details.py
+++ b/src/oci/data_integration/models/application_details.py
@@ -131,7 +131,7 @@ class ApplicationDetails(object):
     def model_type(self):
         """
         **[Required]** Gets the model_type of this ApplicationDetails.
-        The type of the object.
+        The object type.
 
 
         :return: The model_type of this ApplicationDetails.
@@ -143,7 +143,7 @@ class ApplicationDetails(object):
     def model_type(self, model_type):
         """
         Sets the model_type of this ApplicationDetails.
-        The type of the object.
+        The object type.
 
 
         :param model_type: The model_type of this ApplicationDetails.
@@ -155,7 +155,7 @@ class ApplicationDetails(object):
     def model_version(self):
         """
         Gets the model_version of this ApplicationDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this ApplicationDetails.
@@ -167,7 +167,7 @@ class ApplicationDetails(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this ApplicationDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this ApplicationDetails.
@@ -179,7 +179,7 @@ class ApplicationDetails(object):
     def name(self):
         """
         Gets the name of this ApplicationDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this ApplicationDetails.
@@ -191,7 +191,7 @@ class ApplicationDetails(object):
     def name(self, name):
         """
         Sets the name of this ApplicationDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this ApplicationDetails.
@@ -275,7 +275,7 @@ class ApplicationDetails(object):
     def identifier(self):
         """
         Gets the identifier of this ApplicationDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this ApplicationDetails.
@@ -287,7 +287,7 @@ class ApplicationDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this ApplicationDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this ApplicationDetails.

--- a/src/oci/data_integration/models/application_summary.py
+++ b/src/oci/data_integration/models/application_summary.py
@@ -66,6 +66,14 @@ class ApplicationSummary(object):
             The value to assign to the published_object_metadata property of this ApplicationSummary.
         :type published_object_metadata: dict(str, PatchObjectMetadata)
 
+        :param source_application_info:
+            The value to assign to the source_application_info property of this ApplicationSummary.
+        :type source_application_info: SourceApplicationInfo
+
+        :param time_patched:
+            The value to assign to the time_patched property of this ApplicationSummary.
+        :type time_patched: datetime
+
         :param metadata:
             The value to assign to the metadata property of this ApplicationSummary.
         :type metadata: ObjectMetadata
@@ -88,6 +96,8 @@ class ApplicationSummary(object):
             'object_version': 'int',
             'dependent_object_metadata': 'list[PatchObjectMetadata]',
             'published_object_metadata': 'dict(str, PatchObjectMetadata)',
+            'source_application_info': 'SourceApplicationInfo',
+            'time_patched': 'datetime',
             'metadata': 'ObjectMetadata',
             'key_map': 'dict(str, str)'
         }
@@ -105,6 +115,8 @@ class ApplicationSummary(object):
             'object_version': 'objectVersion',
             'dependent_object_metadata': 'dependentObjectMetadata',
             'published_object_metadata': 'publishedObjectMetadata',
+            'source_application_info': 'sourceApplicationInfo',
+            'time_patched': 'timePatched',
             'metadata': 'metadata',
             'key_map': 'keyMap'
         }
@@ -121,6 +133,8 @@ class ApplicationSummary(object):
         self._object_version = None
         self._dependent_object_metadata = None
         self._published_object_metadata = None
+        self._source_application_info = None
+        self._time_patched = None
         self._metadata = None
         self._key_map = None
 
@@ -152,7 +166,7 @@ class ApplicationSummary(object):
     def model_type(self):
         """
         Gets the model_type of this ApplicationSummary.
-        The type of the object.
+        The object type.
 
 
         :return: The model_type of this ApplicationSummary.
@@ -164,7 +178,7 @@ class ApplicationSummary(object):
     def model_type(self, model_type):
         """
         Sets the model_type of this ApplicationSummary.
-        The type of the object.
+        The object type.
 
 
         :param model_type: The model_type of this ApplicationSummary.
@@ -176,7 +190,7 @@ class ApplicationSummary(object):
     def model_version(self):
         """
         Gets the model_version of this ApplicationSummary.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this ApplicationSummary.
@@ -188,7 +202,7 @@ class ApplicationSummary(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this ApplicationSummary.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this ApplicationSummary.
@@ -200,7 +214,7 @@ class ApplicationSummary(object):
     def name(self):
         """
         Gets the name of this ApplicationSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this ApplicationSummary.
@@ -212,7 +226,7 @@ class ApplicationSummary(object):
     def name(self, name):
         """
         Sets the name of this ApplicationSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this ApplicationSummary.
@@ -248,7 +262,7 @@ class ApplicationSummary(object):
     def application_version(self):
         """
         Gets the application_version of this ApplicationSummary.
-        version
+        The application's version.
 
 
         :return: The application_version of this ApplicationSummary.
@@ -260,7 +274,7 @@ class ApplicationSummary(object):
     def application_version(self, application_version):
         """
         Sets the application_version of this ApplicationSummary.
-        version
+        The application's version.
 
 
         :param application_version: The application_version of this ApplicationSummary.
@@ -296,7 +310,7 @@ class ApplicationSummary(object):
     def identifier(self):
         """
         Gets the identifier of this ApplicationSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this ApplicationSummary.
@@ -308,7 +322,7 @@ class ApplicationSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this ApplicationSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this ApplicationSummary.
@@ -364,7 +378,7 @@ class ApplicationSummary(object):
     def dependent_object_metadata(self):
         """
         Gets the dependent_object_metadata of this ApplicationSummary.
-        List of dependent objects in this patch.
+        A list of dependent objects in this patch.
 
 
         :return: The dependent_object_metadata of this ApplicationSummary.
@@ -376,7 +390,7 @@ class ApplicationSummary(object):
     def dependent_object_metadata(self, dependent_object_metadata):
         """
         Sets the dependent_object_metadata of this ApplicationSummary.
-        List of dependent objects in this patch.
+        A list of dependent objects in this patch.
 
 
         :param dependent_object_metadata: The dependent_object_metadata of this ApplicationSummary.
@@ -388,7 +402,7 @@ class ApplicationSummary(object):
     def published_object_metadata(self):
         """
         Gets the published_object_metadata of this ApplicationSummary.
-        List of objects that are published / unpublished in this patch.
+        A list of objects that are published or unpublished in this patch.
 
 
         :return: The published_object_metadata of this ApplicationSummary.
@@ -400,13 +414,57 @@ class ApplicationSummary(object):
     def published_object_metadata(self, published_object_metadata):
         """
         Sets the published_object_metadata of this ApplicationSummary.
-        List of objects that are published / unpublished in this patch.
+        A list of objects that are published or unpublished in this patch.
 
 
         :param published_object_metadata: The published_object_metadata of this ApplicationSummary.
         :type: dict(str, PatchObjectMetadata)
         """
         self._published_object_metadata = published_object_metadata
+
+    @property
+    def source_application_info(self):
+        """
+        Gets the source_application_info of this ApplicationSummary.
+
+        :return: The source_application_info of this ApplicationSummary.
+        :rtype: SourceApplicationInfo
+        """
+        return self._source_application_info
+
+    @source_application_info.setter
+    def source_application_info(self, source_application_info):
+        """
+        Sets the source_application_info of this ApplicationSummary.
+
+        :param source_application_info: The source_application_info of this ApplicationSummary.
+        :type: SourceApplicationInfo
+        """
+        self._source_application_info = source_application_info
+
+    @property
+    def time_patched(self):
+        """
+        Gets the time_patched of this ApplicationSummary.
+        The date and time the application was patched, in the timestamp format defined by RFC3339.
+
+
+        :return: The time_patched of this ApplicationSummary.
+        :rtype: datetime
+        """
+        return self._time_patched
+
+    @time_patched.setter
+    def time_patched(self, time_patched):
+        """
+        Sets the time_patched of this ApplicationSummary.
+        The date and time the application was patched, in the timestamp format defined by RFC3339.
+
+
+        :param time_patched: The time_patched of this ApplicationSummary.
+        :type: datetime
+        """
+        self._time_patched = time_patched
 
     @property
     def metadata(self):
@@ -432,7 +490,7 @@ class ApplicationSummary(object):
     def key_map(self):
         """
         Gets the key_map of this ApplicationSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this ApplicationSummary.
@@ -444,7 +502,7 @@ class ApplicationSummary(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this ApplicationSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this ApplicationSummary.

--- a/src/oci/data_integration/models/application_summary_collection.py
+++ b/src/oci/data_integration/models/application_summary_collection.py
@@ -37,7 +37,7 @@ class ApplicationSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this ApplicationSummaryCollection.
-        The array of Application summaries
+        The array of application summaries.
 
 
         :return: The items of this ApplicationSummaryCollection.
@@ -49,7 +49,7 @@ class ApplicationSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this ApplicationSummaryCollection.
-        The array of Application summaries
+        The array of application summaries.
 
 
         :param items: The items of this ApplicationSummaryCollection.

--- a/src/oci/data_integration/models/avro_format_attribute.py
+++ b/src/oci/data_integration/models/avro_format_attribute.py
@@ -1,0 +1,80 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .abstract_format_attribute import AbstractFormatAttribute
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AvroFormatAttribute(AbstractFormatAttribute):
+    """
+    The AVRO format attribute.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AvroFormatAttribute object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.AvroFormatAttribute.model_type` attribute
+        of this class is ``AVRO_FORMAT`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this AvroFormatAttribute.
+            Allowed values for this property are: "JSON_FORMAT", "CSV_FORMAT", "AVRO_FORMAT"
+        :type model_type: str
+
+        :param compression:
+            The value to assign to the compression property of this AvroFormatAttribute.
+        :type compression: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'compression': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'compression': 'compression'
+        }
+
+        self._model_type = None
+        self._compression = None
+        self._model_type = 'AVRO_FORMAT'
+
+    @property
+    def compression(self):
+        """
+        Gets the compression of this AvroFormatAttribute.
+        The compression for the file.
+
+
+        :return: The compression of this AvroFormatAttribute.
+        :rtype: str
+        """
+        return self._compression
+
+    @compression.setter
+    def compression(self, compression):
+        """
+        Sets the compression of this AvroFormatAttribute.
+        The compression for the file.
+
+
+        :param compression: The compression of this AvroFormatAttribute.
+        :type: str
+        """
+        self._compression = compression
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/base_type.py
+++ b/src/oci/data_integration/models/base_type.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class BaseType(object):
     """
-    Base type for the type system
+    Base type for the type system.
     """
 
     #: A constant which can be used with the model_type property of a BaseType.
@@ -240,7 +240,7 @@ class BaseType(object):
     def name(self):
         """
         Gets the name of this BaseType.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this BaseType.
@@ -252,7 +252,7 @@ class BaseType(object):
     def name(self, name):
         """
         Sets the name of this BaseType.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this BaseType.
@@ -288,7 +288,7 @@ class BaseType(object):
     def description(self):
         """
         Gets the description of this BaseType.
-        Detailed description for the object.
+        A user defined description for the object.
 
 
         :return: The description of this BaseType.
@@ -300,7 +300,7 @@ class BaseType(object):
     def description(self, description):
         """
         Sets the description of this BaseType.
-        Detailed description for the object.
+        A user defined description for the object.
 
 
         :param description: The description of this BaseType.

--- a/src/oci/data_integration/models/change_compartment_details.py
+++ b/src/oci/data_integration/models/change_compartment_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ChangeCompartmentDetails(object):
     """
-    The information about change compartment action.
+    The information needed to change the workspace compartment.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/data_integration/models/child_reference.py
+++ b/src/oci/data_integration/models/child_reference.py
@@ -1,0 +1,350 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChildReference(object):
+    """
+    Child reference contains application configuration information.
+    """
+
+    #: A constant which can be used with the type property of a ChildReference.
+    #: This constant has a value of "ORACLEDB_CONNECTION"
+    TYPE_ORACLEDB_CONNECTION = "ORACLEDB_CONNECTION"
+
+    #: A constant which can be used with the type property of a ChildReference.
+    #: This constant has a value of "ORACLE_OBJECT_STORAGE_CONNECTION"
+    TYPE_ORACLE_OBJECT_STORAGE_CONNECTION = "ORACLE_OBJECT_STORAGE_CONNECTION"
+
+    #: A constant which can be used with the type property of a ChildReference.
+    #: This constant has a value of "ORACLE_ATP_CONNECTION"
+    TYPE_ORACLE_ATP_CONNECTION = "ORACLE_ATP_CONNECTION"
+
+    #: A constant which can be used with the type property of a ChildReference.
+    #: This constant has a value of "ORACLE_ADWC_CONNECTION"
+    TYPE_ORACLE_ADWC_CONNECTION = "ORACLE_ADWC_CONNECTION"
+
+    #: A constant which can be used with the type property of a ChildReference.
+    #: This constant has a value of "MYSQL_CONNECTION"
+    TYPE_MYSQL_CONNECTION = "MYSQL_CONNECTION"
+
+    #: A constant which can be used with the type property of a ChildReference.
+    #: This constant has a value of "GENERIC_JDBC_CONNECTION"
+    TYPE_GENERIC_JDBC_CONNECTION = "GENERIC_JDBC_CONNECTION"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChildReference object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this ChildReference.
+        :type key: str
+
+        :param name:
+            The value to assign to the name property of this ChildReference.
+        :type name: str
+
+        :param identifier:
+            The value to assign to the identifier property of this ChildReference.
+        :type identifier: str
+
+        :param identifier_path:
+            The value to assign to the identifier_path property of this ChildReference.
+        :type identifier_path: str
+
+        :param description:
+            The value to assign to the description property of this ChildReference.
+        :type description: str
+
+        :param type:
+            The value to assign to the type property of this ChildReference.
+            Allowed values for this property are: "ORACLEDB_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_ADWC_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type type: str
+
+        :param target_object:
+            The value to assign to the target_object property of this ChildReference.
+        :type target_object: object
+
+        :param aggregator_key:
+            The value to assign to the aggregator_key property of this ChildReference.
+        :type aggregator_key: str
+
+        :param used_by:
+            The value to assign to the used_by property of this ChildReference.
+        :type used_by: list[ReferenceUsedBy]
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'name': 'str',
+            'identifier': 'str',
+            'identifier_path': 'str',
+            'description': 'str',
+            'type': 'str',
+            'target_object': 'object',
+            'aggregator_key': 'str',
+            'used_by': 'list[ReferenceUsedBy]'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'name': 'name',
+            'identifier': 'identifier',
+            'identifier_path': 'identifierPath',
+            'description': 'description',
+            'type': 'type',
+            'target_object': 'targetObject',
+            'aggregator_key': 'aggregatorKey',
+            'used_by': 'usedBy'
+        }
+
+        self._key = None
+        self._name = None
+        self._identifier = None
+        self._identifier_path = None
+        self._description = None
+        self._type = None
+        self._target_object = None
+        self._aggregator_key = None
+        self._used_by = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this ChildReference.
+        The reference's key, key of the object that is being used by a published object or its dependents.
+
+
+        :return: The key of this ChildReference.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this ChildReference.
+        The reference's key, key of the object that is being used by a published object or its dependents.
+
+
+        :param key: The key of this ChildReference.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def name(self):
+        """
+        Gets the name of this ChildReference.
+        The name of reference object.
+
+
+        :return: The name of this ChildReference.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this ChildReference.
+        The name of reference object.
+
+
+        :param name: The name of this ChildReference.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this ChildReference.
+        The identifier of reference object.
+
+
+        :return: The identifier of this ChildReference.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this ChildReference.
+        The identifier of reference object.
+
+
+        :param identifier: The identifier of this ChildReference.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def identifier_path(self):
+        """
+        Gets the identifier_path of this ChildReference.
+        The identifier path of reference object.
+
+
+        :return: The identifier_path of this ChildReference.
+        :rtype: str
+        """
+        return self._identifier_path
+
+    @identifier_path.setter
+    def identifier_path(self, identifier_path):
+        """
+        Sets the identifier_path of this ChildReference.
+        The identifier path of reference object.
+
+
+        :param identifier_path: The identifier_path of this ChildReference.
+        :type: str
+        """
+        self._identifier_path = identifier_path
+
+    @property
+    def description(self):
+        """
+        Gets the description of this ChildReference.
+        The description of reference object.
+
+
+        :return: The description of this ChildReference.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this ChildReference.
+        The description of reference object.
+
+
+        :param description: The description of this ChildReference.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def type(self):
+        """
+        Gets the type of this ChildReference.
+        The type of the reference object.
+
+        Allowed values for this property are: "ORACLEDB_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_ADWC_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The type of this ChildReference.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this ChildReference.
+        The type of the reference object.
+
+
+        :param type: The type of this ChildReference.
+        :type: str
+        """
+        allowed_values = ["ORACLEDB_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_ADWC_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"]
+        if not value_allowed_none_or_none_sentinel(type, allowed_values):
+            type = 'UNKNOWN_ENUM_VALUE'
+        self._type = type
+
+    @property
+    def target_object(self):
+        """
+        Gets the target_object of this ChildReference.
+        The new reference object to use instead of the original reference. For example, this can be a data asset reference.
+
+
+        :return: The target_object of this ChildReference.
+        :rtype: object
+        """
+        return self._target_object
+
+    @target_object.setter
+    def target_object(self, target_object):
+        """
+        Sets the target_object of this ChildReference.
+        The new reference object to use instead of the original reference. For example, this can be a data asset reference.
+
+
+        :param target_object: The target_object of this ChildReference.
+        :type: object
+        """
+        self._target_object = target_object
+
+    @property
+    def aggregator_key(self):
+        """
+        Gets the aggregator_key of this ChildReference.
+        The aggregator key of the child reference object. For example, this can be a data asset key.
+
+
+        :return: The aggregator_key of this ChildReference.
+        :rtype: str
+        """
+        return self._aggregator_key
+
+    @aggregator_key.setter
+    def aggregator_key(self, aggregator_key):
+        """
+        Sets the aggregator_key of this ChildReference.
+        The aggregator key of the child reference object. For example, this can be a data asset key.
+
+
+        :param aggregator_key: The aggregator_key of this ChildReference.
+        :type: str
+        """
+        self._aggregator_key = aggregator_key
+
+    @property
+    def used_by(self):
+        """
+        Gets the used_by of this ChildReference.
+        List of published objects where this is used.
+
+
+        :return: The used_by of this ChildReference.
+        :rtype: list[ReferenceUsedBy]
+        """
+        return self._used_by
+
+    @used_by.setter
+    def used_by(self, used_by):
+        """
+        Sets the used_by of this ChildReference.
+        List of published objects where this is used.
+
+
+        :param used_by: The used_by of this ChildReference.
+        :type: list[ReferenceUsedBy]
+        """
+        self._used_by = used_by
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/child_reference_detail.py
+++ b/src/oci/data_integration/models/child_reference_detail.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChildReferenceDetail(object):
+    """
+    References used in an application.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChildReferenceDetail object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this ChildReferenceDetail.
+        :type key: str
+
+        :param target_object:
+            The value to assign to the target_object property of this ChildReferenceDetail.
+        :type target_object: object
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'target_object': 'object'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'target_object': 'targetObject'
+        }
+
+        self._key = None
+        self._target_object = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this ChildReferenceDetail.
+        The child reference key.
+
+
+        :return: The key of this ChildReferenceDetail.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this ChildReferenceDetail.
+        The child reference key.
+
+
+        :param key: The key of this ChildReferenceDetail.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def target_object(self):
+        """
+        Gets the target_object of this ChildReferenceDetail.
+        The new reference object to use instead of the original reference. For example, this can be a connection reference.
+
+
+        :return: The target_object of this ChildReferenceDetail.
+        :rtype: object
+        """
+        return self._target_object
+
+    @target_object.setter
+    def target_object(self, target_object):
+        """
+        Sets the target_object of this ChildReferenceDetail.
+        The new reference object to use instead of the original reference. For example, this can be a connection reference.
+
+
+        :param target_object: The target_object of this ChildReferenceDetail.
+        :type: object
+        """
+        self._target_object = target_object
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/composite_field_map.py
+++ b/src/oci/data_integration/models/composite_field_map.py
@@ -89,7 +89,7 @@ class CompositeFieldMap(FieldMap):
     def key(self):
         """
         Gets the key of this CompositeFieldMap.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this CompositeFieldMap.
@@ -101,7 +101,7 @@ class CompositeFieldMap(FieldMap):
     def key(self, key):
         """
         Sets the key of this CompositeFieldMap.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this CompositeFieldMap.
@@ -113,7 +113,7 @@ class CompositeFieldMap(FieldMap):
     def model_version(self):
         """
         Gets the model_version of this CompositeFieldMap.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this CompositeFieldMap.
@@ -125,7 +125,7 @@ class CompositeFieldMap(FieldMap):
     def model_version(self, model_version):
         """
         Sets the model_version of this CompositeFieldMap.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this CompositeFieldMap.

--- a/src/oci/data_integration/models/composite_type.py
+++ b/src/oci/data_integration/models/composite_type.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CompositeType(BaseType):
     """
-    A CompositeType represents a type that is composed of a list of sub-types, for example an \"Address\" type.   The sub-types can be simple DataType or other CompositeType objects. Thus in general a CompositeType may represent an arbitrarily deep hierarchy of types.
+    A `CompositeType` represents a type that is composed of a list of sub-types, for example an `Address` type.   The sub-types can be simple `DataType` or other `CompositeType` objects. Typically, a `CompositeType` may represent an arbitrarily deep hierarchy of types.
     """
 
     def __init__(self, **kwargs):
@@ -123,7 +123,7 @@ class CompositeType(BaseType):
     def elements(self):
         """
         Gets the elements of this CompositeType.
-        elements
+        An array of elements.
 
 
         :return: The elements of this CompositeType.
@@ -135,7 +135,7 @@ class CompositeType(BaseType):
     def elements(self, elements):
         """
         Sets the elements of this CompositeType.
-        elements
+        An array of elements.
 
 
         :param elements: The elements of this CompositeType.

--- a/src/oci/data_integration/models/config_definition.py
+++ b/src/oci/data_integration/models/config_definition.py
@@ -178,7 +178,7 @@ class ConfigDefinition(object):
     def name(self):
         """
         Gets the name of this ConfigDefinition.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this ConfigDefinition.
@@ -190,7 +190,7 @@ class ConfigDefinition(object):
     def name(self, name):
         """
         Sets the name of this ConfigDefinition.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this ConfigDefinition.
@@ -202,7 +202,7 @@ class ConfigDefinition(object):
     def is_contained(self):
         """
         Gets the is_contained of this ConfigDefinition.
-        Whether the configuration is contained or not.
+        Specifies whether the configuration is contained or not.
 
 
         :return: The is_contained of this ConfigDefinition.
@@ -214,7 +214,7 @@ class ConfigDefinition(object):
     def is_contained(self, is_contained):
         """
         Sets the is_contained of this ConfigDefinition.
-        Whether the configuration is contained or not.
+        Specifies whether the configuration is contained or not.
 
 
         :param is_contained: The is_contained of this ConfigDefinition.
@@ -250,7 +250,7 @@ class ConfigDefinition(object):
     def config_parameter_definitions(self):
         """
         Gets the config_parameter_definitions of this ConfigDefinition.
-        configParamDefs
+        The parameter configuration details.
 
 
         :return: The config_parameter_definitions of this ConfigDefinition.
@@ -262,7 +262,7 @@ class ConfigDefinition(object):
     def config_parameter_definitions(self, config_parameter_definitions):
         """
         Sets the config_parameter_definitions of this ConfigDefinition.
-        configParamDefs
+        The parameter configuration details.
 
 
         :param config_parameter_definitions: The config_parameter_definitions of this ConfigDefinition.

--- a/src/oci/data_integration/models/config_parameter_definition.py
+++ b/src/oci/data_integration/models/config_parameter_definition.py
@@ -123,7 +123,7 @@ class ConfigParameterDefinition(object):
     def description(self):
         """
         Gets the description of this ConfigParameterDefinition.
-        Detailed description for the object.
+        A user defined description for the object.
 
 
         :return: The description of this ConfigParameterDefinition.
@@ -135,7 +135,7 @@ class ConfigParameterDefinition(object):
     def description(self, description):
         """
         Sets the description of this ConfigParameterDefinition.
-        Detailed description for the object.
+        A user defined description for the object.
 
 
         :param description: The description of this ConfigParameterDefinition.
@@ -195,7 +195,7 @@ class ConfigParameterDefinition(object):
     def is_static(self):
         """
         Gets the is_static of this ConfigParameterDefinition.
-        Whether the parameter is static or not.
+        Specifies whether the parameter is static or not.
 
 
         :return: The is_static of this ConfigParameterDefinition.
@@ -207,7 +207,7 @@ class ConfigParameterDefinition(object):
     def is_static(self, is_static):
         """
         Sets the is_static of this ConfigParameterDefinition.
-        Whether the parameter is static or not.
+        Specifies whether the parameter is static or not.
 
 
         :param is_static: The is_static of this ConfigParameterDefinition.
@@ -219,7 +219,7 @@ class ConfigParameterDefinition(object):
     def is_class_field_value(self):
         """
         Gets the is_class_field_value of this ConfigParameterDefinition.
-        Whether the parameter is a class field or not.
+        Specifies whether the parameter is a class field or not.
 
 
         :return: The is_class_field_value of this ConfigParameterDefinition.
@@ -231,7 +231,7 @@ class ConfigParameterDefinition(object):
     def is_class_field_value(self, is_class_field_value):
         """
         Sets the is_class_field_value of this ConfigParameterDefinition.
-        Whether the parameter is a class field or not.
+        Specifies whether the parameter is a class field or not.
 
 
         :param is_class_field_value: The is_class_field_value of this ConfigParameterDefinition.

--- a/src/oci/data_integration/models/config_parameter_value.py
+++ b/src/oci/data_integration/models/config_parameter_value.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConfigParameterValue(object):
     """
-    This holds the values/objects.
+    Contains the parameter configuration values.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/data_integration/models/config_provider.py
+++ b/src/oci/data_integration/models/config_provider.py
@@ -44,7 +44,7 @@ class ConfigProvider(object):
     def bindings(self):
         """
         Gets the bindings of this ConfigProvider.
-        bindings
+        The configuration provider bindings.
 
 
         :return: The bindings of this ConfigProvider.
@@ -56,7 +56,7 @@ class ConfigProvider(object):
     def bindings(self, bindings):
         """
         Sets the bindings of this ConfigProvider.
-        bindings
+        The configuration provider bindings.
 
 
         :param bindings: The bindings of this ConfigProvider.
@@ -68,7 +68,7 @@ class ConfigProvider(object):
     def child_providers(self):
         """
         Gets the child_providers of this ConfigProvider.
-        childProviders
+        The child providers.
 
 
         :return: The child_providers of this ConfigProvider.
@@ -80,7 +80,7 @@ class ConfigProvider(object):
     def child_providers(self, child_providers):
         """
         Sets the child_providers of this ConfigProvider.
-        childProviders
+        The child providers.
 
 
         :param child_providers: The child_providers of this ConfigProvider.

--- a/src/oci/data_integration/models/config_values.py
+++ b/src/oci/data_integration/models/config_values.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConfigValues(object):
     """
-    Configuration values can be string, objects or parameters.
+    Configuration values can be string, objects, or parameters.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,7 @@ class ConfigValues(object):
     def config_param_values(self):
         """
         Gets the config_param_values of this ConfigValues.
-        configParamValues
+        The configuration parameter values.
 
 
         :return: The config_param_values of this ConfigValues.
@@ -56,7 +56,7 @@ class ConfigValues(object):
     def config_param_values(self, config_param_values):
         """
         Sets the config_param_values of this ConfigValues.
-        configParamValues
+        The configuration parameter values.
 
 
         :param config_param_values: The config_param_values of this ConfigValues.

--- a/src/oci/data_integration/models/configuration_details.py
+++ b/src/oci/data_integration/models/configuration_details.py
@@ -1,0 +1,151 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ConfigurationDetails(object):
+    """
+    A key map. If provided, key is replaced with generated key.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ConfigurationDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param data_asset:
+            The value to assign to the data_asset property of this ConfigurationDetails.
+        :type data_asset: DataAsset
+
+        :param connection:
+            The value to assign to the connection property of this ConfigurationDetails.
+        :type connection: Connection
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ConfigurationDetails.
+        :type compartment_id: str
+
+        :param schema:
+            The value to assign to the schema property of this ConfigurationDetails.
+        :type schema: Schema
+
+        """
+        self.swagger_types = {
+            'data_asset': 'DataAsset',
+            'connection': 'Connection',
+            'compartment_id': 'str',
+            'schema': 'Schema'
+        }
+
+        self.attribute_map = {
+            'data_asset': 'dataAsset',
+            'connection': 'connection',
+            'compartment_id': 'compartmentId',
+            'schema': 'schema'
+        }
+
+        self._data_asset = None
+        self._connection = None
+        self._compartment_id = None
+        self._schema = None
+
+    @property
+    def data_asset(self):
+        """
+        Gets the data_asset of this ConfigurationDetails.
+
+        :return: The data_asset of this ConfigurationDetails.
+        :rtype: DataAsset
+        """
+        return self._data_asset
+
+    @data_asset.setter
+    def data_asset(self, data_asset):
+        """
+        Sets the data_asset of this ConfigurationDetails.
+
+        :param data_asset: The data_asset of this ConfigurationDetails.
+        :type: DataAsset
+        """
+        self._data_asset = data_asset
+
+    @property
+    def connection(self):
+        """
+        Gets the connection of this ConfigurationDetails.
+
+        :return: The connection of this ConfigurationDetails.
+        :rtype: Connection
+        """
+        return self._connection
+
+    @connection.setter
+    def connection(self, connection):
+        """
+        Sets the connection of this ConfigurationDetails.
+
+        :param connection: The connection of this ConfigurationDetails.
+        :type: Connection
+        """
+        self._connection = connection
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this ConfigurationDetails.
+        The compartment ID of the object store.
+
+
+        :return: The compartment_id of this ConfigurationDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ConfigurationDetails.
+        The compartment ID of the object store.
+
+
+        :param compartment_id: The compartment_id of this ConfigurationDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def schema(self):
+        """
+        Gets the schema of this ConfigurationDetails.
+
+        :return: The schema of this ConfigurationDetails.
+        :rtype: Schema
+        """
+        return self._schema
+
+    @schema.setter
+    def schema(self, schema):
+        """
+        Sets the schema of this ConfigurationDetails.
+
+        :param schema: The schema of this ConfigurationDetails.
+        :type: Schema
+        """
+        self._schema = schema
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/configured_type.py
+++ b/src/oci/data_integration/models/configured_type.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConfiguredType(BaseType):
     """
-    A ConfiguraedType represents a type that has built-in configuration to the type itself. An example is a SSN type whose basic type is VARCHAR, but the type itself also has a built-in configuration like length=10
+    A `ConfiguredType` represents a type that has built-in configuration to the type itself. An example is a `SSN` type whose basic type is `VARCHAR`, but the type itself also has a built-in configuration like length=10.
     """
 
     def __init__(self, **kwargs):
@@ -50,7 +50,7 @@ class ConfiguredType(BaseType):
 
         :param wrapped_type:
             The value to assign to the wrapped_type property of this ConfiguredType.
-        :type wrapped_type: BaseType
+        :type wrapped_type: object
 
         :param config_values:
             The value to assign to the config_values property of this ConfiguredType.
@@ -69,7 +69,7 @@ class ConfiguredType(BaseType):
             'name': 'str',
             'object_status': 'int',
             'description': 'str',
-            'wrapped_type': 'BaseType',
+            'wrapped_type': 'object',
             'config_values': 'ConfigValues',
             'config_definition': 'ConfigDefinition'
         }
@@ -103,9 +103,11 @@ class ConfiguredType(BaseType):
     def wrapped_type(self):
         """
         Gets the wrapped_type of this ConfiguredType.
+        A wrapped type, may be a string or a BaseType.
+
 
         :return: The wrapped_type of this ConfiguredType.
-        :rtype: BaseType
+        :rtype: object
         """
         return self._wrapped_type
 
@@ -113,9 +115,11 @@ class ConfiguredType(BaseType):
     def wrapped_type(self, wrapped_type):
         """
         Sets the wrapped_type of this ConfiguredType.
+        A wrapped type, may be a string or a BaseType.
+
 
         :param wrapped_type: The wrapped_type of this ConfiguredType.
-        :type: BaseType
+        :type: object
         """
         self._wrapped_type = wrapped_type
 

--- a/src/oci/data_integration/models/connection.py
+++ b/src/oci/data_integration/models/connection.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Connection(object):
     """
-    The connection object.
+    The connection for a data asset.
     """
 
     #: A constant which can be used with the model_type property of a Connection.
@@ -29,6 +29,14 @@ class Connection(object):
     #: This constant has a value of "ORACLEDB_CONNECTION"
     MODEL_TYPE_ORACLEDB_CONNECTION = "ORACLEDB_CONNECTION"
 
+    #: A constant which can be used with the model_type property of a Connection.
+    #: This constant has a value of "MYSQL_CONNECTION"
+    MODEL_TYPE_MYSQL_CONNECTION = "MYSQL_CONNECTION"
+
+    #: A constant which can be used with the model_type property of a Connection.
+    #: This constant has a value of "GENERIC_JDBC_CONNECTION"
+    MODEL_TYPE_GENERIC_JDBC_CONNECTION = "GENERIC_JDBC_CONNECTION"
+
     def __init__(self, **kwargs):
         """
         Initializes a new Connection object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
@@ -38,12 +46,14 @@ class Connection(object):
         * :class:`~oci.data_integration.models.ConnectionFromAdwc`
         * :class:`~oci.data_integration.models.ConnectionFromAtp`
         * :class:`~oci.data_integration.models.ConnectionFromOracle`
+        * :class:`~oci.data_integration.models.ConnectionFromMySQL`
+        * :class:`~oci.data_integration.models.ConnectionFromJdbc`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param model_type:
             The value to assign to the model_type property of this Connection.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -168,6 +178,12 @@ class Connection(object):
 
         if type == 'ORACLEDB_CONNECTION':
             return 'ConnectionFromOracle'
+
+        if type == 'MYSQL_CONNECTION':
+            return 'ConnectionFromMySQL'
+
+        if type == 'GENERIC_JDBC_CONNECTION':
+            return 'ConnectionFromJdbc'
         else:
             return 'Connection'
 
@@ -177,7 +193,7 @@ class Connection(object):
         **[Required]** Gets the model_type of this Connection.
         The type of the connection.
 
-        Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -196,7 +212,7 @@ class Connection(object):
         :param model_type: The model_type of this Connection.
         :type: str
         """
-        allowed_values = ["ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"]
+        allowed_values = ["ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type
@@ -273,7 +289,7 @@ class Connection(object):
     def name(self):
         """
         Gets the name of this Connection.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this Connection.
@@ -285,7 +301,7 @@ class Connection(object):
     def name(self, name):
         """
         Sets the name of this Connection.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this Connection.
@@ -297,7 +313,7 @@ class Connection(object):
     def description(self):
         """
         Gets the description of this Connection.
-        Detailed description for the object.
+        User-defined description for the connection.
 
 
         :return: The description of this Connection.
@@ -309,7 +325,7 @@ class Connection(object):
     def description(self, description):
         """
         Sets the description of this Connection.
-        Detailed description for the object.
+        User-defined description for the connection.
 
 
         :param description: The description of this Connection.
@@ -369,7 +385,7 @@ class Connection(object):
     def identifier(self):
         """
         Gets the identifier of this Connection.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this Connection.
@@ -381,7 +397,7 @@ class Connection(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this Connection.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this Connection.
@@ -481,7 +497,7 @@ class Connection(object):
     def key_map(self):
         """
         Gets the key_map of this Connection.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this Connection.
@@ -493,7 +509,7 @@ class Connection(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this Connection.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this Connection.

--- a/src/oci/data_integration/models/connection_details.py
+++ b/src/oci/data_integration/models/connection_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionDetails(object):
     """
-    The connection details object.
+    The connection details for a data asset.
     """
 
     #: A constant which can be used with the model_type property of a ConnectionDetails.
@@ -29,12 +29,22 @@ class ConnectionDetails(object):
     #: This constant has a value of "ORACLEDB_CONNECTION"
     MODEL_TYPE_ORACLEDB_CONNECTION = "ORACLEDB_CONNECTION"
 
+    #: A constant which can be used with the model_type property of a ConnectionDetails.
+    #: This constant has a value of "MYSQL_CONNECTION"
+    MODEL_TYPE_MYSQL_CONNECTION = "MYSQL_CONNECTION"
+
+    #: A constant which can be used with the model_type property of a ConnectionDetails.
+    #: This constant has a value of "GENERIC_JDBC_CONNECTION"
+    MODEL_TYPE_GENERIC_JDBC_CONNECTION = "GENERIC_JDBC_CONNECTION"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ConnectionDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.data_integration.models.ConnectionFromJdbcDetails`
         * :class:`~oci.data_integration.models.ConnectionFromObjectStorageDetails`
+        * :class:`~oci.data_integration.models.ConnectionFromMySQLDetails`
         * :class:`~oci.data_integration.models.ConnectionFromAdwcDetails`
         * :class:`~oci.data_integration.models.ConnectionFromAtpDetails`
         * :class:`~oci.data_integration.models.ConnectionFromOracleDetails`
@@ -43,7 +53,7 @@ class ConnectionDetails(object):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionDetails.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:
@@ -149,8 +159,14 @@ class ConnectionDetails(object):
         """
         type = object_dictionary['modelType']
 
+        if type == 'GENERIC_JDBC_CONNECTION':
+            return 'ConnectionFromJdbcDetails'
+
         if type == 'ORACLE_OBJECT_STORAGE_CONNECTION':
             return 'ConnectionFromObjectStorageDetails'
+
+        if type == 'MYSQL_CONNECTION':
+            return 'ConnectionFromMySQLDetails'
 
         if type == 'ORACLE_ADWC_CONNECTION':
             return 'ConnectionFromAdwcDetails'
@@ -169,7 +185,7 @@ class ConnectionDetails(object):
         **[Required]** Gets the model_type of this ConnectionDetails.
         The type of the connection.
 
-        Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+        Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
 
 
         :return: The model_type of this ConnectionDetails.
@@ -187,7 +203,7 @@ class ConnectionDetails(object):
         :param model_type: The model_type of this ConnectionDetails.
         :type: str
         """
-        allowed_values = ["ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"]
+        allowed_values = ["ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             raise ValueError(
                 "Invalid value for `model_type`, must be None or one of {0}"
@@ -267,7 +283,7 @@ class ConnectionDetails(object):
     def name(self):
         """
         Gets the name of this ConnectionDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this ConnectionDetails.
@@ -279,7 +295,7 @@ class ConnectionDetails(object):
     def name(self, name):
         """
         Sets the name of this ConnectionDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this ConnectionDetails.
@@ -291,7 +307,7 @@ class ConnectionDetails(object):
     def description(self):
         """
         Gets the description of this ConnectionDetails.
-        Detailed description for the object.
+        User-defined description for the connection.
 
 
         :return: The description of this ConnectionDetails.
@@ -303,7 +319,7 @@ class ConnectionDetails(object):
     def description(self, description):
         """
         Sets the description of this ConnectionDetails.
-        Detailed description for the object.
+        User-defined description for the connection.
 
 
         :param description: The description of this ConnectionDetails.
@@ -363,7 +379,7 @@ class ConnectionDetails(object):
     def identifier(self):
         """
         Gets the identifier of this ConnectionDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this ConnectionDetails.
@@ -375,7 +391,7 @@ class ConnectionDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this ConnectionDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this ConnectionDetails.

--- a/src/oci/data_integration/models/connection_from_adwc.py
+++ b/src/oci/data_integration/models/connection_from_adwc.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionFromAdwc(Connection):
     """
-    The ADWC connection details object.
+    The connection details for an Autonomous Data Warehouse data asset.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class ConnectionFromAdwc(Connection):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionFromAdwc.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/connection_from_adwc_details.py
+++ b/src/oci/data_integration/models/connection_from_adwc_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionFromAdwcDetails(ConnectionDetails):
     """
-    The ADWC connection details object.
+    The connection details for an Autonomous Data Warehouse data asset.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class ConnectionFromAdwcDetails(ConnectionDetails):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionFromAdwcDetails.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/connection_from_atp.py
+++ b/src/oci/data_integration/models/connection_from_atp.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionFromAtp(Connection):
     """
-    The ATP connection details.
+    The connection details for an Autonomous Transaction Processing data asset.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class ConnectionFromAtp(Connection):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionFromAtp.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/connection_from_atp_details.py
+++ b/src/oci/data_integration/models/connection_from_atp_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionFromAtpDetails(ConnectionDetails):
     """
-    The ATP connection details.
+    The connection details for an Autonomous Transaction Processing data asset.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class ConnectionFromAtpDetails(ConnectionDetails):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionFromAtpDetails.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/connection_from_jdbc.py
+++ b/src/oci/data_integration/models/connection_from_jdbc.py
@@ -1,0 +1,171 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .connection import Connection
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ConnectionFromJdbc(Connection):
+    """
+    The connection details for a generic JDBC data asset.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ConnectionFromJdbc object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.ConnectionFromJdbc.model_type` attribute
+        of this class is ``GENERIC_JDBC_CONNECTION`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this ConnectionFromJdbc.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this ConnectionFromJdbc.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this ConnectionFromJdbc.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this ConnectionFromJdbc.
+        :type parent_ref: ParentReference
+
+        :param name:
+            The value to assign to the name property of this ConnectionFromJdbc.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this ConnectionFromJdbc.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this ConnectionFromJdbc.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this ConnectionFromJdbc.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this ConnectionFromJdbc.
+        :type identifier: str
+
+        :param primary_schema:
+            The value to assign to the primary_schema property of this ConnectionFromJdbc.
+        :type primary_schema: Schema
+
+        :param connection_properties:
+            The value to assign to the connection_properties property of this ConnectionFromJdbc.
+        :type connection_properties: list[ConnectionProperty]
+
+        :param is_default:
+            The value to assign to the is_default property of this ConnectionFromJdbc.
+        :type is_default: bool
+
+        :param metadata:
+            The value to assign to the metadata property of this ConnectionFromJdbc.
+        :type metadata: ObjectMetadata
+
+        :param key_map:
+            The value to assign to the key_map property of this ConnectionFromJdbc.
+        :type key_map: dict(str, str)
+
+        :param username:
+            The value to assign to the username property of this ConnectionFromJdbc.
+        :type username: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'primary_schema': 'Schema',
+            'connection_properties': 'list[ConnectionProperty]',
+            'is_default': 'bool',
+            'metadata': 'ObjectMetadata',
+            'key_map': 'dict(str, str)',
+            'username': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'primary_schema': 'primarySchema',
+            'connection_properties': 'connectionProperties',
+            'is_default': 'isDefault',
+            'metadata': 'metadata',
+            'key_map': 'keyMap',
+            'username': 'username'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._primary_schema = None
+        self._connection_properties = None
+        self._is_default = None
+        self._metadata = None
+        self._key_map = None
+        self._username = None
+        self._model_type = 'GENERIC_JDBC_CONNECTION'
+
+    @property
+    def username(self):
+        """
+        Gets the username of this ConnectionFromJdbc.
+        The user name for the connection.
+
+
+        :return: The username of this ConnectionFromJdbc.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this ConnectionFromJdbc.
+        The user name for the connection.
+
+
+        :param username: The username of this ConnectionFromJdbc.
+        :type: str
+        """
+        self._username = username
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/connection_from_jdbc_details.py
+++ b/src/oci/data_integration/models/connection_from_jdbc_details.py
@@ -1,0 +1,164 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .connection_details import ConnectionDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ConnectionFromJdbcDetails(ConnectionDetails):
+    """
+    The connection details for a generic JDBC data asset.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ConnectionFromJdbcDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.ConnectionFromJdbcDetails.model_type` attribute
+        of this class is ``GENERIC_JDBC_CONNECTION`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this ConnectionFromJdbcDetails.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this ConnectionFromJdbcDetails.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this ConnectionFromJdbcDetails.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this ConnectionFromJdbcDetails.
+        :type parent_ref: ParentReference
+
+        :param name:
+            The value to assign to the name property of this ConnectionFromJdbcDetails.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this ConnectionFromJdbcDetails.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this ConnectionFromJdbcDetails.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this ConnectionFromJdbcDetails.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this ConnectionFromJdbcDetails.
+        :type identifier: str
+
+        :param primary_schema:
+            The value to assign to the primary_schema property of this ConnectionFromJdbcDetails.
+        :type primary_schema: Schema
+
+        :param connection_properties:
+            The value to assign to the connection_properties property of this ConnectionFromJdbcDetails.
+        :type connection_properties: list[ConnectionProperty]
+
+        :param is_default:
+            The value to assign to the is_default property of this ConnectionFromJdbcDetails.
+        :type is_default: bool
+
+        :param metadata:
+            The value to assign to the metadata property of this ConnectionFromJdbcDetails.
+        :type metadata: ObjectMetadata
+
+        :param username:
+            The value to assign to the username property of this ConnectionFromJdbcDetails.
+        :type username: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'primary_schema': 'Schema',
+            'connection_properties': 'list[ConnectionProperty]',
+            'is_default': 'bool',
+            'metadata': 'ObjectMetadata',
+            'username': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'primary_schema': 'primarySchema',
+            'connection_properties': 'connectionProperties',
+            'is_default': 'isDefault',
+            'metadata': 'metadata',
+            'username': 'username'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._primary_schema = None
+        self._connection_properties = None
+        self._is_default = None
+        self._metadata = None
+        self._username = None
+        self._model_type = 'GENERIC_JDBC_CONNECTION'
+
+    @property
+    def username(self):
+        """
+        Gets the username of this ConnectionFromJdbcDetails.
+        The user name for the connection.
+
+
+        :return: The username of this ConnectionFromJdbcDetails.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this ConnectionFromJdbcDetails.
+        The user name for the connection.
+
+
+        :param username: The username of this ConnectionFromJdbcDetails.
+        :type: str
+        """
+        self._username = username
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/connection_from_my_sql.py
+++ b/src/oci/data_integration/models/connection_from_my_sql.py
@@ -1,0 +1,171 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .connection import Connection
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ConnectionFromMySQL(Connection):
+    """
+    The connection details for a MYSQL data asset.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ConnectionFromMySQL object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.ConnectionFromMySQL.model_type` attribute
+        of this class is ``MYSQL_CONNECTION`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this ConnectionFromMySQL.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this ConnectionFromMySQL.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this ConnectionFromMySQL.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this ConnectionFromMySQL.
+        :type parent_ref: ParentReference
+
+        :param name:
+            The value to assign to the name property of this ConnectionFromMySQL.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this ConnectionFromMySQL.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this ConnectionFromMySQL.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this ConnectionFromMySQL.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this ConnectionFromMySQL.
+        :type identifier: str
+
+        :param primary_schema:
+            The value to assign to the primary_schema property of this ConnectionFromMySQL.
+        :type primary_schema: Schema
+
+        :param connection_properties:
+            The value to assign to the connection_properties property of this ConnectionFromMySQL.
+        :type connection_properties: list[ConnectionProperty]
+
+        :param is_default:
+            The value to assign to the is_default property of this ConnectionFromMySQL.
+        :type is_default: bool
+
+        :param metadata:
+            The value to assign to the metadata property of this ConnectionFromMySQL.
+        :type metadata: ObjectMetadata
+
+        :param key_map:
+            The value to assign to the key_map property of this ConnectionFromMySQL.
+        :type key_map: dict(str, str)
+
+        :param username:
+            The value to assign to the username property of this ConnectionFromMySQL.
+        :type username: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'primary_schema': 'Schema',
+            'connection_properties': 'list[ConnectionProperty]',
+            'is_default': 'bool',
+            'metadata': 'ObjectMetadata',
+            'key_map': 'dict(str, str)',
+            'username': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'primary_schema': 'primarySchema',
+            'connection_properties': 'connectionProperties',
+            'is_default': 'isDefault',
+            'metadata': 'metadata',
+            'key_map': 'keyMap',
+            'username': 'username'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._primary_schema = None
+        self._connection_properties = None
+        self._is_default = None
+        self._metadata = None
+        self._key_map = None
+        self._username = None
+        self._model_type = 'MYSQL_CONNECTION'
+
+    @property
+    def username(self):
+        """
+        Gets the username of this ConnectionFromMySQL.
+        The user name for the connection.
+
+
+        :return: The username of this ConnectionFromMySQL.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this ConnectionFromMySQL.
+        The user name for the connection.
+
+
+        :param username: The username of this ConnectionFromMySQL.
+        :type: str
+        """
+        self._username = username
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/connection_from_my_sql_details.py
+++ b/src/oci/data_integration/models/connection_from_my_sql_details.py
@@ -1,0 +1,164 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .connection_details import ConnectionDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ConnectionFromMySQLDetails(ConnectionDetails):
+    """
+    The connection details for a MYSQL data asset.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ConnectionFromMySQLDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.ConnectionFromMySQLDetails.model_type` attribute
+        of this class is ``MYSQL_CONNECTION`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this ConnectionFromMySQLDetails.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this ConnectionFromMySQLDetails.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this ConnectionFromMySQLDetails.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this ConnectionFromMySQLDetails.
+        :type parent_ref: ParentReference
+
+        :param name:
+            The value to assign to the name property of this ConnectionFromMySQLDetails.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this ConnectionFromMySQLDetails.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this ConnectionFromMySQLDetails.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this ConnectionFromMySQLDetails.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this ConnectionFromMySQLDetails.
+        :type identifier: str
+
+        :param primary_schema:
+            The value to assign to the primary_schema property of this ConnectionFromMySQLDetails.
+        :type primary_schema: Schema
+
+        :param connection_properties:
+            The value to assign to the connection_properties property of this ConnectionFromMySQLDetails.
+        :type connection_properties: list[ConnectionProperty]
+
+        :param is_default:
+            The value to assign to the is_default property of this ConnectionFromMySQLDetails.
+        :type is_default: bool
+
+        :param metadata:
+            The value to assign to the metadata property of this ConnectionFromMySQLDetails.
+        :type metadata: ObjectMetadata
+
+        :param username:
+            The value to assign to the username property of this ConnectionFromMySQLDetails.
+        :type username: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'primary_schema': 'Schema',
+            'connection_properties': 'list[ConnectionProperty]',
+            'is_default': 'bool',
+            'metadata': 'ObjectMetadata',
+            'username': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'primary_schema': 'primarySchema',
+            'connection_properties': 'connectionProperties',
+            'is_default': 'isDefault',
+            'metadata': 'metadata',
+            'username': 'username'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._primary_schema = None
+        self._connection_properties = None
+        self._is_default = None
+        self._metadata = None
+        self._username = None
+        self._model_type = 'MYSQL_CONNECTION'
+
+    @property
+    def username(self):
+        """
+        Gets the username of this ConnectionFromMySQLDetails.
+        The user name for the connection.
+
+
+        :return: The username of this ConnectionFromMySQLDetails.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this ConnectionFromMySQLDetails.
+        The user name for the connection.
+
+
+        :param username: The username of this ConnectionFromMySQLDetails.
+        :type: str
+        """
+        self._username = username
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/connection_from_object_storage.py
+++ b/src/oci/data_integration/models/connection_from_object_storage.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionFromObjectStorage(Connection):
     """
-    The Object Storage connection details.
+    The connection details for an Oracle Object Storage data asset.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class ConnectionFromObjectStorage(Connection):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionFromObjectStorage.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:
@@ -159,7 +159,7 @@ class ConnectionFromObjectStorage(Connection):
     def credential_file_content(self):
         """
         Gets the credential_file_content of this ConnectionFromObjectStorage.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Oracle Object Storage wallet.
 
 
         :return: The credential_file_content of this ConnectionFromObjectStorage.
@@ -171,7 +171,7 @@ class ConnectionFromObjectStorage(Connection):
     def credential_file_content(self, credential_file_content):
         """
         Sets the credential_file_content of this ConnectionFromObjectStorage.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Oracle Object Storage wallet.
 
 
         :param credential_file_content: The credential_file_content of this ConnectionFromObjectStorage.
@@ -207,7 +207,7 @@ class ConnectionFromObjectStorage(Connection):
     def finger_print(self):
         """
         Gets the finger_print of this ConnectionFromObjectStorage.
-        The fingeprint for the user.
+        The fingerprint for the user.
 
 
         :return: The finger_print of this ConnectionFromObjectStorage.
@@ -219,7 +219,7 @@ class ConnectionFromObjectStorage(Connection):
     def finger_print(self, finger_print):
         """
         Sets the finger_print of this ConnectionFromObjectStorage.
-        The fingeprint for the user.
+        The fingerprint for the user.
 
 
         :param finger_print: The finger_print of this ConnectionFromObjectStorage.
@@ -231,7 +231,7 @@ class ConnectionFromObjectStorage(Connection):
     def pass_phrase(self):
         """
         Gets the pass_phrase of this ConnectionFromObjectStorage.
-        The pass phrase for the connection.
+        The passphrase for the connection.
 
 
         :return: The pass_phrase of this ConnectionFromObjectStorage.
@@ -243,7 +243,7 @@ class ConnectionFromObjectStorage(Connection):
     def pass_phrase(self, pass_phrase):
         """
         Sets the pass_phrase of this ConnectionFromObjectStorage.
-        The pass phrase for the connection.
+        The passphrase for the connection.
 
 
         :param pass_phrase: The pass_phrase of this ConnectionFromObjectStorage.

--- a/src/oci/data_integration/models/connection_from_object_storage_details.py
+++ b/src/oci/data_integration/models/connection_from_object_storage_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionFromObjectStorageDetails(ConnectionDetails):
     """
-    The Object Storage connection details.
+    The connection summary details for an Oracle Object Storage data asset.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class ConnectionFromObjectStorageDetails(ConnectionDetails):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionFromObjectStorageDetails.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:
@@ -152,7 +152,7 @@ class ConnectionFromObjectStorageDetails(ConnectionDetails):
     def credential_file_content(self):
         """
         Gets the credential_file_content of this ConnectionFromObjectStorageDetails.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Oracle Object Storage wallet.
 
 
         :return: The credential_file_content of this ConnectionFromObjectStorageDetails.
@@ -164,7 +164,7 @@ class ConnectionFromObjectStorageDetails(ConnectionDetails):
     def credential_file_content(self, credential_file_content):
         """
         Sets the credential_file_content of this ConnectionFromObjectStorageDetails.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Oracle Object Storage wallet.
 
 
         :param credential_file_content: The credential_file_content of this ConnectionFromObjectStorageDetails.
@@ -200,7 +200,7 @@ class ConnectionFromObjectStorageDetails(ConnectionDetails):
     def finger_print(self):
         """
         Gets the finger_print of this ConnectionFromObjectStorageDetails.
-        The fingeprint for the user.
+        The fingerprint for the user.
 
 
         :return: The finger_print of this ConnectionFromObjectStorageDetails.
@@ -212,7 +212,7 @@ class ConnectionFromObjectStorageDetails(ConnectionDetails):
     def finger_print(self, finger_print):
         """
         Sets the finger_print of this ConnectionFromObjectStorageDetails.
-        The fingeprint for the user.
+        The fingerprint for the user.
 
 
         :param finger_print: The finger_print of this ConnectionFromObjectStorageDetails.
@@ -224,7 +224,7 @@ class ConnectionFromObjectStorageDetails(ConnectionDetails):
     def pass_phrase(self):
         """
         Gets the pass_phrase of this ConnectionFromObjectStorageDetails.
-        The pass phrase for the connection.
+        The passphrase for the connection.
 
 
         :return: The pass_phrase of this ConnectionFromObjectStorageDetails.
@@ -236,7 +236,7 @@ class ConnectionFromObjectStorageDetails(ConnectionDetails):
     def pass_phrase(self, pass_phrase):
         """
         Sets the pass_phrase of this ConnectionFromObjectStorageDetails.
-        The pass phrase for the connection.
+        The passphrase for the connection.
 
 
         :param pass_phrase: The pass_phrase of this ConnectionFromObjectStorageDetails.

--- a/src/oci/data_integration/models/connection_from_oracle.py
+++ b/src/oci/data_integration/models/connection_from_oracle.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionFromOracle(Connection):
     """
-    The Oracle connection details object.
+    The connection details for an Oracle Database data asset.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class ConnectionFromOracle(Connection):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionFromOracle.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/connection_from_oracle_details.py
+++ b/src/oci/data_integration/models/connection_from_oracle_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionFromOracleDetails(ConnectionDetails):
     """
-    The Oracle connection details object.
+    The connection details for an Oracle Database data asset.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class ConnectionFromOracleDetails(ConnectionDetails):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionFromOracleDetails.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 

--- a/src/oci/data_integration/models/connection_property.py
+++ b/src/oci/data_integration/models/connection_property.py
@@ -44,7 +44,7 @@ class ConnectionProperty(object):
     def name(self):
         """
         Gets the name of this ConnectionProperty.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this ConnectionProperty.
@@ -56,7 +56,7 @@ class ConnectionProperty(object):
     def name(self, name):
         """
         Sets the name of this ConnectionProperty.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this ConnectionProperty.
@@ -68,7 +68,7 @@ class ConnectionProperty(object):
     def value(self):
         """
         Gets the value of this ConnectionProperty.
-        value
+        The value for the connection name property.
 
 
         :return: The value of this ConnectionProperty.
@@ -80,7 +80,7 @@ class ConnectionProperty(object):
     def value(self, value):
         """
         Sets the value of this ConnectionProperty.
-        value
+        The value for the connection name property.
 
 
         :param value: The value of this ConnectionProperty.

--- a/src/oci/data_integration/models/connection_summary.py
+++ b/src/oci/data_integration/models/connection_summary.py
@@ -29,21 +29,31 @@ class ConnectionSummary(object):
     #: This constant has a value of "ORACLEDB_CONNECTION"
     MODEL_TYPE_ORACLEDB_CONNECTION = "ORACLEDB_CONNECTION"
 
+    #: A constant which can be used with the model_type property of a ConnectionSummary.
+    #: This constant has a value of "MYSQL_CONNECTION"
+    MODEL_TYPE_MYSQL_CONNECTION = "MYSQL_CONNECTION"
+
+    #: A constant which can be used with the model_type property of a ConnectionSummary.
+    #: This constant has a value of "GENERIC_JDBC_CONNECTION"
+    MODEL_TYPE_GENERIC_JDBC_CONNECTION = "GENERIC_JDBC_CONNECTION"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ConnectionSummary object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.data_integration.models.ConnectionSummaryFromJdbc`
         * :class:`~oci.data_integration.models.ConnectionSummaryFromAtp`
         * :class:`~oci.data_integration.models.ConnectionSummaryFromOracle`
         * :class:`~oci.data_integration.models.ConnectionSummaryFromAdwc`
+        * :class:`~oci.data_integration.models.ConnectionSummaryFromMySQL`
         * :class:`~oci.data_integration.models.ConnectionSummaryFromObjectStorage`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionSummary.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -157,6 +167,9 @@ class ConnectionSummary(object):
         """
         type = object_dictionary['modelType']
 
+        if type == 'GENERIC_JDBC_CONNECTION':
+            return 'ConnectionSummaryFromJdbc'
+
         if type == 'ORACLE_ATP_CONNECTION':
             return 'ConnectionSummaryFromAtp'
 
@@ -165,6 +178,9 @@ class ConnectionSummary(object):
 
         if type == 'ORACLE_ADWC_CONNECTION':
             return 'ConnectionSummaryFromAdwc'
+
+        if type == 'MYSQL_CONNECTION':
+            return 'ConnectionSummaryFromMySQL'
 
         if type == 'ORACLE_OBJECT_STORAGE_CONNECTION':
             return 'ConnectionSummaryFromObjectStorage'
@@ -177,7 +193,7 @@ class ConnectionSummary(object):
         **[Required]** Gets the model_type of this ConnectionSummary.
         The type of the connection.
 
-        Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -196,7 +212,7 @@ class ConnectionSummary(object):
         :param model_type: The model_type of this ConnectionSummary.
         :type: str
         """
-        allowed_values = ["ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"]
+        allowed_values = ["ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type
@@ -273,7 +289,7 @@ class ConnectionSummary(object):
     def name(self):
         """
         Gets the name of this ConnectionSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this ConnectionSummary.
@@ -285,7 +301,7 @@ class ConnectionSummary(object):
     def name(self, name):
         """
         Sets the name of this ConnectionSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this ConnectionSummary.
@@ -297,7 +313,7 @@ class ConnectionSummary(object):
     def description(self):
         """
         Gets the description of this ConnectionSummary.
-        Detailed description for the object.
+        User-defined description for the connection.
 
 
         :return: The description of this ConnectionSummary.
@@ -309,7 +325,7 @@ class ConnectionSummary(object):
     def description(self, description):
         """
         Sets the description of this ConnectionSummary.
-        Detailed description for the object.
+        User-defined description for the connection.
 
 
         :param description: The description of this ConnectionSummary.
@@ -369,7 +385,7 @@ class ConnectionSummary(object):
     def identifier(self):
         """
         Gets the identifier of this ConnectionSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this ConnectionSummary.
@@ -381,7 +397,7 @@ class ConnectionSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this ConnectionSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this ConnectionSummary.
@@ -481,7 +497,7 @@ class ConnectionSummary(object):
     def key_map(self):
         """
         Gets the key_map of this ConnectionSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this ConnectionSummary.
@@ -493,7 +509,7 @@ class ConnectionSummary(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this ConnectionSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this ConnectionSummary.

--- a/src/oci/data_integration/models/connection_summary_collection.py
+++ b/src/oci/data_integration/models/connection_summary_collection.py
@@ -37,7 +37,7 @@ class ConnectionSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this ConnectionSummaryCollection.
-        The array of Connection summaries
+        The array of connection summaries.
 
 
         :return: The items of this ConnectionSummaryCollection.
@@ -49,7 +49,7 @@ class ConnectionSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this ConnectionSummaryCollection.
-        The array of Connection summaries
+        The array of connection summaries.
 
 
         :param items: The items of this ConnectionSummaryCollection.

--- a/src/oci/data_integration/models/connection_summary_from_adwc.py
+++ b/src/oci/data_integration/models/connection_summary_from_adwc.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionSummaryFromAdwc(ConnectionSummary):
     """
-    The ADWC connection details object.
+    The connection summary details for an Autonomous Data Warehouse data asset.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class ConnectionSummaryFromAdwc(ConnectionSummary):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionSummaryFromAdwc.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/connection_summary_from_atp.py
+++ b/src/oci/data_integration/models/connection_summary_from_atp.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionSummaryFromAtp(ConnectionSummary):
     """
-    The ATP connection details.
+    The connection details for an Autonomous Transaction Processing data asset.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class ConnectionSummaryFromAtp(ConnectionSummary):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionSummaryFromAtp.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/connection_summary_from_jdbc.py
+++ b/src/oci/data_integration/models/connection_summary_from_jdbc.py
@@ -1,0 +1,171 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .connection_summary import ConnectionSummary
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ConnectionSummaryFromJdbc(ConnectionSummary):
+    """
+    The connection details for a generic JDBC data asset.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ConnectionSummaryFromJdbc object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.ConnectionSummaryFromJdbc.model_type` attribute
+        of this class is ``GENERIC_JDBC_CONNECTION`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this ConnectionSummaryFromJdbc.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this ConnectionSummaryFromJdbc.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this ConnectionSummaryFromJdbc.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this ConnectionSummaryFromJdbc.
+        :type parent_ref: ParentReference
+
+        :param name:
+            The value to assign to the name property of this ConnectionSummaryFromJdbc.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this ConnectionSummaryFromJdbc.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this ConnectionSummaryFromJdbc.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this ConnectionSummaryFromJdbc.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this ConnectionSummaryFromJdbc.
+        :type identifier: str
+
+        :param primary_schema:
+            The value to assign to the primary_schema property of this ConnectionSummaryFromJdbc.
+        :type primary_schema: Schema
+
+        :param connection_properties:
+            The value to assign to the connection_properties property of this ConnectionSummaryFromJdbc.
+        :type connection_properties: list[ConnectionProperty]
+
+        :param is_default:
+            The value to assign to the is_default property of this ConnectionSummaryFromJdbc.
+        :type is_default: bool
+
+        :param metadata:
+            The value to assign to the metadata property of this ConnectionSummaryFromJdbc.
+        :type metadata: ObjectMetadata
+
+        :param key_map:
+            The value to assign to the key_map property of this ConnectionSummaryFromJdbc.
+        :type key_map: dict(str, str)
+
+        :param username:
+            The value to assign to the username property of this ConnectionSummaryFromJdbc.
+        :type username: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'primary_schema': 'Schema',
+            'connection_properties': 'list[ConnectionProperty]',
+            'is_default': 'bool',
+            'metadata': 'ObjectMetadata',
+            'key_map': 'dict(str, str)',
+            'username': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'primary_schema': 'primarySchema',
+            'connection_properties': 'connectionProperties',
+            'is_default': 'isDefault',
+            'metadata': 'metadata',
+            'key_map': 'keyMap',
+            'username': 'username'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._primary_schema = None
+        self._connection_properties = None
+        self._is_default = None
+        self._metadata = None
+        self._key_map = None
+        self._username = None
+        self._model_type = 'GENERIC_JDBC_CONNECTION'
+
+    @property
+    def username(self):
+        """
+        Gets the username of this ConnectionSummaryFromJdbc.
+        The user name for the connection.
+
+
+        :return: The username of this ConnectionSummaryFromJdbc.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this ConnectionSummaryFromJdbc.
+        The user name for the connection.
+
+
+        :param username: The username of this ConnectionSummaryFromJdbc.
+        :type: str
+        """
+        self._username = username
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/connection_summary_from_my_sql.py
+++ b/src/oci/data_integration/models/connection_summary_from_my_sql.py
@@ -1,0 +1,171 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .connection_summary import ConnectionSummary
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ConnectionSummaryFromMySQL(ConnectionSummary):
+    """
+    The connection details for a MYSQL data asset.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ConnectionSummaryFromMySQL object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.ConnectionSummaryFromMySQL.model_type` attribute
+        of this class is ``MYSQL_CONNECTION`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this ConnectionSummaryFromMySQL.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this ConnectionSummaryFromMySQL.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this ConnectionSummaryFromMySQL.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this ConnectionSummaryFromMySQL.
+        :type parent_ref: ParentReference
+
+        :param name:
+            The value to assign to the name property of this ConnectionSummaryFromMySQL.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this ConnectionSummaryFromMySQL.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this ConnectionSummaryFromMySQL.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this ConnectionSummaryFromMySQL.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this ConnectionSummaryFromMySQL.
+        :type identifier: str
+
+        :param primary_schema:
+            The value to assign to the primary_schema property of this ConnectionSummaryFromMySQL.
+        :type primary_schema: Schema
+
+        :param connection_properties:
+            The value to assign to the connection_properties property of this ConnectionSummaryFromMySQL.
+        :type connection_properties: list[ConnectionProperty]
+
+        :param is_default:
+            The value to assign to the is_default property of this ConnectionSummaryFromMySQL.
+        :type is_default: bool
+
+        :param metadata:
+            The value to assign to the metadata property of this ConnectionSummaryFromMySQL.
+        :type metadata: ObjectMetadata
+
+        :param key_map:
+            The value to assign to the key_map property of this ConnectionSummaryFromMySQL.
+        :type key_map: dict(str, str)
+
+        :param username:
+            The value to assign to the username property of this ConnectionSummaryFromMySQL.
+        :type username: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'primary_schema': 'Schema',
+            'connection_properties': 'list[ConnectionProperty]',
+            'is_default': 'bool',
+            'metadata': 'ObjectMetadata',
+            'key_map': 'dict(str, str)',
+            'username': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'primary_schema': 'primarySchema',
+            'connection_properties': 'connectionProperties',
+            'is_default': 'isDefault',
+            'metadata': 'metadata',
+            'key_map': 'keyMap',
+            'username': 'username'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._primary_schema = None
+        self._connection_properties = None
+        self._is_default = None
+        self._metadata = None
+        self._key_map = None
+        self._username = None
+        self._model_type = 'MYSQL_CONNECTION'
+
+    @property
+    def username(self):
+        """
+        Gets the username of this ConnectionSummaryFromMySQL.
+        The user name for the connection.
+
+
+        :return: The username of this ConnectionSummaryFromMySQL.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this ConnectionSummaryFromMySQL.
+        The user name for the connection.
+
+
+        :param username: The username of this ConnectionSummaryFromMySQL.
+        :type: str
+        """
+        self._username = username
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/connection_summary_from_object_storage.py
+++ b/src/oci/data_integration/models/connection_summary_from_object_storage.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionSummaryFromObjectStorage(ConnectionSummary):
     """
-    The Object Storage connection details.
+    The connection details for an Oracle Object Storage data asset.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class ConnectionSummaryFromObjectStorage(ConnectionSummary):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionSummaryFromObjectStorage.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:
@@ -159,7 +159,7 @@ class ConnectionSummaryFromObjectStorage(ConnectionSummary):
     def credential_file_content(self):
         """
         Gets the credential_file_content of this ConnectionSummaryFromObjectStorage.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Oracle Object Storage wallet.
 
 
         :return: The credential_file_content of this ConnectionSummaryFromObjectStorage.
@@ -171,7 +171,7 @@ class ConnectionSummaryFromObjectStorage(ConnectionSummary):
     def credential_file_content(self, credential_file_content):
         """
         Sets the credential_file_content of this ConnectionSummaryFromObjectStorage.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Oracle Object Storage wallet.
 
 
         :param credential_file_content: The credential_file_content of this ConnectionSummaryFromObjectStorage.
@@ -207,7 +207,7 @@ class ConnectionSummaryFromObjectStorage(ConnectionSummary):
     def finger_print(self):
         """
         Gets the finger_print of this ConnectionSummaryFromObjectStorage.
-        The fingeprint for the user.
+        The fingerprint for the user.
 
 
         :return: The finger_print of this ConnectionSummaryFromObjectStorage.
@@ -219,7 +219,7 @@ class ConnectionSummaryFromObjectStorage(ConnectionSummary):
     def finger_print(self, finger_print):
         """
         Sets the finger_print of this ConnectionSummaryFromObjectStorage.
-        The fingeprint for the user.
+        The fingerprint for the user.
 
 
         :param finger_print: The finger_print of this ConnectionSummaryFromObjectStorage.
@@ -231,7 +231,7 @@ class ConnectionSummaryFromObjectStorage(ConnectionSummary):
     def pass_phrase(self):
         """
         Gets the pass_phrase of this ConnectionSummaryFromObjectStorage.
-        The pass phrase for the connection.
+        The passphrase for the connection.
 
 
         :return: The pass_phrase of this ConnectionSummaryFromObjectStorage.
@@ -243,7 +243,7 @@ class ConnectionSummaryFromObjectStorage(ConnectionSummary):
     def pass_phrase(self, pass_phrase):
         """
         Sets the pass_phrase of this ConnectionSummaryFromObjectStorage.
-        The pass phrase for the connection.
+        The passphrase for the connection.
 
 
         :param pass_phrase: The pass_phrase of this ConnectionSummaryFromObjectStorage.

--- a/src/oci/data_integration/models/connection_summary_from_oracle.py
+++ b/src/oci/data_integration/models/connection_summary_from_oracle.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionSummaryFromOracle(ConnectionSummary):
     """
-    The Oracle connection details object.
+    The connection summary details for an Oracle Database data asset.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class ConnectionSummaryFromOracle(ConnectionSummary):
 
         :param model_type:
             The value to assign to the model_type property of this ConnectionSummaryFromOracle.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 

--- a/src/oci/data_integration/models/connection_validation.py
+++ b/src/oci/data_integration/models/connection_validation.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionValidation(object):
     """
-    The information about connection validation
+    The information about connection validation.
     """
 
     def __init__(self, **kwargs):
@@ -127,7 +127,7 @@ class ConnectionValidation(object):
     def key(self):
         """
         Gets the key of this ConnectionValidation.
-        Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+        Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
 
 
         :return: The key of this ConnectionValidation.
@@ -139,7 +139,7 @@ class ConnectionValidation(object):
     def key(self, key):
         """
         Sets the key of this ConnectionValidation.
-        Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+        Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
 
 
         :param key: The key of this ConnectionValidation.
@@ -219,7 +219,7 @@ class ConnectionValidation(object):
     def name(self):
         """
         Gets the name of this ConnectionValidation.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this ConnectionValidation.
@@ -231,7 +231,7 @@ class ConnectionValidation(object):
     def name(self, name):
         """
         Sets the name of this ConnectionValidation.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this ConnectionValidation.
@@ -315,7 +315,7 @@ class ConnectionValidation(object):
     def identifier(self):
         """
         Gets the identifier of this ConnectionValidation.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this ConnectionValidation.
@@ -327,7 +327,7 @@ class ConnectionValidation(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this ConnectionValidation.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this ConnectionValidation.

--- a/src/oci/data_integration/models/connection_validation_summary.py
+++ b/src/oci/data_integration/models/connection_validation_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionValidationSummary(object):
     """
-    The information about connection validation
+    The information about connection validation.
     """
 
     def __init__(self, **kwargs):
@@ -127,7 +127,7 @@ class ConnectionValidationSummary(object):
     def key(self):
         """
         Gets the key of this ConnectionValidationSummary.
-        Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+        Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
 
 
         :return: The key of this ConnectionValidationSummary.
@@ -139,7 +139,7 @@ class ConnectionValidationSummary(object):
     def key(self, key):
         """
         Sets the key of this ConnectionValidationSummary.
-        Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+        Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
 
 
         :param key: The key of this ConnectionValidationSummary.
@@ -219,7 +219,7 @@ class ConnectionValidationSummary(object):
     def name(self):
         """
         Gets the name of this ConnectionValidationSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this ConnectionValidationSummary.
@@ -231,7 +231,7 @@ class ConnectionValidationSummary(object):
     def name(self, name):
         """
         Sets the name of this ConnectionValidationSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this ConnectionValidationSummary.
@@ -315,7 +315,7 @@ class ConnectionValidationSummary(object):
     def identifier(self):
         """
         Gets the identifier of this ConnectionValidationSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this ConnectionValidationSummary.
@@ -327,7 +327,7 @@ class ConnectionValidationSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this ConnectionValidationSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this ConnectionValidationSummary.

--- a/src/oci/data_integration/models/connection_validation_summary_collection.py
+++ b/src/oci/data_integration/models/connection_validation_summary_collection.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ConnectionValidationSummaryCollection(object):
     """
-    List of connection validation summaries
+    A list of connection validation summaries.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +37,7 @@ class ConnectionValidationSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this ConnectionValidationSummaryCollection.
-        The array of validation summaries
+        An array of connection validation summaries.
 
 
         :return: The items of this ConnectionValidationSummaryCollection.
@@ -49,7 +49,7 @@ class ConnectionValidationSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this ConnectionValidationSummaryCollection.
-        The array of validation summaries
+        An array of connection validation summaries.
 
 
         :param items: The items of this ConnectionValidationSummaryCollection.

--- a/src/oci/data_integration/models/count_statistic.py
+++ b/src/oci/data_integration/models/count_statistic.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CountStatistic(object):
     """
-    A count statistics
+    A count statistics.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +37,7 @@ class CountStatistic(object):
     def object_type_count_list(self):
         """
         **[Required]** Gets the object_type_count_list of this CountStatistic.
-        The array of statistics
+        The array of statistics.
 
 
         :return: The object_type_count_list of this CountStatistic.
@@ -49,7 +49,7 @@ class CountStatistic(object):
     def object_type_count_list(self, object_type_count_list):
         """
         Sets the object_type_count_list of this CountStatistic.
-        The array of statistics
+        The array of statistics.
 
 
         :param object_type_count_list: The object_type_count_list of this CountStatistic.

--- a/src/oci/data_integration/models/count_statistic_summary.py
+++ b/src/oci/data_integration/models/count_statistic_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CountStatisticSummary(object):
     """
-    Detail of object.
+    Details of the count statistic summary object.
     """
 
     #: A constant which can be used with the object_type property of a CountStatisticSummary.
@@ -74,7 +74,7 @@ class CountStatisticSummary(object):
     def object_type(self):
         """
         Gets the object_type of this CountStatisticSummary.
-        the type of object for the object count statistic.
+        The type of object for the count statistic object.
 
         Allowed values for this property are: "PROJECT", "FOLDER", "DATA_FLOW", "DATA_ASSET", "CONNECTION", "TASK", "APPLICATION", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -89,7 +89,7 @@ class CountStatisticSummary(object):
     def object_type(self, object_type):
         """
         Sets the object_type of this CountStatisticSummary.
-        the type of object for the object count statistic.
+        The type of object for the count statistic object.
 
 
         :param object_type: The object_type of this CountStatisticSummary.
@@ -104,7 +104,7 @@ class CountStatisticSummary(object):
     def object_count(self):
         """
         Gets the object_count of this CountStatisticSummary.
-        the value for the object count statistic.
+        The value for the count statistic object.
 
 
         :return: The object_count of this CountStatisticSummary.
@@ -116,7 +116,7 @@ class CountStatisticSummary(object):
     def object_count(self, object_count):
         """
         Sets the object_count of this CountStatisticSummary.
-        the value for the object count statistic.
+        The value for the count statistic object.
 
 
         :param object_count: The object_count of this CountStatisticSummary.

--- a/src/oci/data_integration/models/create_application_details.py
+++ b/src/oci/data_integration/models/create_application_details.py
@@ -51,6 +51,10 @@ class CreateApplicationDetails(object):
             The value to assign to the identifier property of this CreateApplicationDetails.
         :type identifier: str
 
+        :param source_application_info:
+            The value to assign to the source_application_info property of this CreateApplicationDetails.
+        :type source_application_info: CreateSourceApplicationInfo
+
         :param registry_metadata:
             The value to assign to the registry_metadata property of this CreateApplicationDetails.
         :type registry_metadata: RegistryMetadata
@@ -64,6 +68,7 @@ class CreateApplicationDetails(object):
             'description': 'str',
             'object_status': 'int',
             'identifier': 'str',
+            'source_application_info': 'CreateSourceApplicationInfo',
             'registry_metadata': 'RegistryMetadata'
         }
 
@@ -75,6 +80,7 @@ class CreateApplicationDetails(object):
             'description': 'description',
             'object_status': 'objectStatus',
             'identifier': 'identifier',
+            'source_application_info': 'sourceApplicationInfo',
             'registry_metadata': 'registryMetadata'
         }
 
@@ -85,6 +91,7 @@ class CreateApplicationDetails(object):
         self._description = None
         self._object_status = None
         self._identifier = None
+        self._source_application_info = None
         self._registry_metadata = None
 
     @property
@@ -115,7 +122,7 @@ class CreateApplicationDetails(object):
     def model_version(self):
         """
         Gets the model_version of this CreateApplicationDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this CreateApplicationDetails.
@@ -127,7 +134,7 @@ class CreateApplicationDetails(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this CreateApplicationDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this CreateApplicationDetails.
@@ -171,7 +178,7 @@ class CreateApplicationDetails(object):
     def name(self):
         """
         **[Required]** Gets the name of this CreateApplicationDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this CreateApplicationDetails.
@@ -183,7 +190,7 @@ class CreateApplicationDetails(object):
     def name(self, name):
         """
         Sets the name of this CreateApplicationDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this CreateApplicationDetails.
@@ -243,7 +250,7 @@ class CreateApplicationDetails(object):
     def identifier(self):
         """
         **[Required]** Gets the identifier of this CreateApplicationDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this CreateApplicationDetails.
@@ -255,13 +262,33 @@ class CreateApplicationDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this CreateApplicationDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this CreateApplicationDetails.
         :type: str
         """
         self._identifier = identifier
+
+    @property
+    def source_application_info(self):
+        """
+        Gets the source_application_info of this CreateApplicationDetails.
+
+        :return: The source_application_info of this CreateApplicationDetails.
+        :rtype: CreateSourceApplicationInfo
+        """
+        return self._source_application_info
+
+    @source_application_info.setter
+    def source_application_info(self, source_application_info):
+        """
+        Sets the source_application_info of this CreateApplicationDetails.
+
+        :param source_application_info: The source_application_info of this CreateApplicationDetails.
+        :type: CreateSourceApplicationInfo
+        """
+        self._source_application_info = source_application_info
 
     @property
     def registry_metadata(self):

--- a/src/oci/data_integration/models/create_connection_details.py
+++ b/src/oci/data_integration/models/create_connection_details.py
@@ -29,11 +29,21 @@ class CreateConnectionDetails(object):
     #: This constant has a value of "ORACLEDB_CONNECTION"
     MODEL_TYPE_ORACLEDB_CONNECTION = "ORACLEDB_CONNECTION"
 
+    #: A constant which can be used with the model_type property of a CreateConnectionDetails.
+    #: This constant has a value of "MYSQL_CONNECTION"
+    MODEL_TYPE_MYSQL_CONNECTION = "MYSQL_CONNECTION"
+
+    #: A constant which can be used with the model_type property of a CreateConnectionDetails.
+    #: This constant has a value of "GENERIC_JDBC_CONNECTION"
+    MODEL_TYPE_GENERIC_JDBC_CONNECTION = "GENERIC_JDBC_CONNECTION"
+
     def __init__(self, **kwargs):
         """
         Initializes a new CreateConnectionDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.data_integration.models.CreateConnectionFromMySQL`
+        * :class:`~oci.data_integration.models.CreateConnectionFromJdbc`
         * :class:`~oci.data_integration.models.CreateConnectionFromAtp`
         * :class:`~oci.data_integration.models.CreateConnectionFromAdwc`
         * :class:`~oci.data_integration.models.CreateConnectionFromOracle`
@@ -43,7 +53,7 @@ class CreateConnectionDetails(object):
 
         :param model_type:
             The value to assign to the model_type property of this CreateConnectionDetails.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:
@@ -128,6 +138,12 @@ class CreateConnectionDetails(object):
         """
         type = object_dictionary['modelType']
 
+        if type == 'MYSQL_CONNECTION':
+            return 'CreateConnectionFromMySQL'
+
+        if type == 'GENERIC_JDBC_CONNECTION':
+            return 'CreateConnectionFromJdbc'
+
         if type == 'ORACLE_ATP_CONNECTION':
             return 'CreateConnectionFromAtp'
 
@@ -148,7 +164,7 @@ class CreateConnectionDetails(object):
         Gets the model_type of this CreateConnectionDetails.
         The type of the connection.
 
-        Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+        Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
 
 
         :return: The model_type of this CreateConnectionDetails.
@@ -166,7 +182,7 @@ class CreateConnectionDetails(object):
         :param model_type: The model_type of this CreateConnectionDetails.
         :type: str
         """
-        allowed_values = ["ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"]
+        allowed_values = ["ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             raise ValueError(
                 "Invalid value for `model_type`, must be None or one of {0}"
@@ -246,7 +262,7 @@ class CreateConnectionDetails(object):
     def name(self):
         """
         **[Required]** Gets the name of this CreateConnectionDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this CreateConnectionDetails.
@@ -258,7 +274,7 @@ class CreateConnectionDetails(object):
     def name(self, name):
         """
         Sets the name of this CreateConnectionDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this CreateConnectionDetails.
@@ -270,7 +286,7 @@ class CreateConnectionDetails(object):
     def description(self):
         """
         Gets the description of this CreateConnectionDetails.
-        Detailed description for the object.
+        User-defined description for the connection.
 
 
         :return: The description of this CreateConnectionDetails.
@@ -282,7 +298,7 @@ class CreateConnectionDetails(object):
     def description(self, description):
         """
         Sets the description of this CreateConnectionDetails.
-        Detailed description for the object.
+        User-defined description for the connection.
 
 
         :param description: The description of this CreateConnectionDetails.
@@ -318,7 +334,7 @@ class CreateConnectionDetails(object):
     def identifier(self):
         """
         **[Required]** Gets the identifier of this CreateConnectionDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this CreateConnectionDetails.
@@ -330,7 +346,7 @@ class CreateConnectionDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this CreateConnectionDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this CreateConnectionDetails.

--- a/src/oci/data_integration/models/create_connection_from_adwc.py
+++ b/src/oci/data_integration/models/create_connection_from_adwc.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateConnectionFromAdwc(CreateConnectionDetails):
     """
-    The ADWC connection details object.
+    The details to create an Autonomous Data Warehouse data asset connection.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class CreateConnectionFromAdwc(CreateConnectionDetails):
 
         :param model_type:
             The value to assign to the model_type property of this CreateConnectionFromAdwc.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/create_connection_from_atp.py
+++ b/src/oci/data_integration/models/create_connection_from_atp.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateConnectionFromAtp(CreateConnectionDetails):
     """
-    The ATP connection details.
+    The details to create an Autonomous Transaction Processing data asset connection.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class CreateConnectionFromAtp(CreateConnectionDetails):
 
         :param model_type:
             The value to assign to the model_type property of this CreateConnectionFromAtp.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/create_connection_from_jdbc.py
+++ b/src/oci/data_integration/models/create_connection_from_jdbc.py
@@ -1,0 +1,174 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_connection_details import CreateConnectionDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateConnectionFromJdbc(CreateConnectionDetails):
+    """
+    The details to create a generic JDBC data asset connection.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateConnectionFromJdbc object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.CreateConnectionFromJdbc.model_type` attribute
+        of this class is ``GENERIC_JDBC_CONNECTION`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this CreateConnectionFromJdbc.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this CreateConnectionFromJdbc.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this CreateConnectionFromJdbc.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this CreateConnectionFromJdbc.
+        :type parent_ref: ParentReference
+
+        :param name:
+            The value to assign to the name property of this CreateConnectionFromJdbc.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this CreateConnectionFromJdbc.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this CreateConnectionFromJdbc.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this CreateConnectionFromJdbc.
+        :type identifier: str
+
+        :param connection_properties:
+            The value to assign to the connection_properties property of this CreateConnectionFromJdbc.
+        :type connection_properties: list[ConnectionProperty]
+
+        :param registry_metadata:
+            The value to assign to the registry_metadata property of this CreateConnectionFromJdbc.
+        :type registry_metadata: RegistryMetadata
+
+        :param username:
+            The value to assign to the username property of this CreateConnectionFromJdbc.
+        :type username: str
+
+        :param password:
+            The value to assign to the password property of this CreateConnectionFromJdbc.
+        :type password: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'identifier': 'str',
+            'connection_properties': 'list[ConnectionProperty]',
+            'registry_metadata': 'RegistryMetadata',
+            'username': 'str',
+            'password': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'connection_properties': 'connectionProperties',
+            'registry_metadata': 'registryMetadata',
+            'username': 'username',
+            'password': 'password'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._identifier = None
+        self._connection_properties = None
+        self._registry_metadata = None
+        self._username = None
+        self._password = None
+        self._model_type = 'GENERIC_JDBC_CONNECTION'
+
+    @property
+    def username(self):
+        """
+        Gets the username of this CreateConnectionFromJdbc.
+        The user name for the connection.
+
+
+        :return: The username of this CreateConnectionFromJdbc.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this CreateConnectionFromJdbc.
+        The user name for the connection.
+
+
+        :param username: The username of this CreateConnectionFromJdbc.
+        :type: str
+        """
+        self._username = username
+
+    @property
+    def password(self):
+        """
+        Gets the password of this CreateConnectionFromJdbc.
+        The password for the connection.
+
+
+        :return: The password of this CreateConnectionFromJdbc.
+        :rtype: str
+        """
+        return self._password
+
+    @password.setter
+    def password(self, password):
+        """
+        Sets the password of this CreateConnectionFromJdbc.
+        The password for the connection.
+
+
+        :param password: The password of this CreateConnectionFromJdbc.
+        :type: str
+        """
+        self._password = password
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/create_connection_from_my_sql.py
+++ b/src/oci/data_integration/models/create_connection_from_my_sql.py
@@ -1,0 +1,174 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_connection_details import CreateConnectionDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateConnectionFromMySQL(CreateConnectionDetails):
+    """
+    The details to create a MYSQL data asset connection.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateConnectionFromMySQL object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.CreateConnectionFromMySQL.model_type` attribute
+        of this class is ``MYSQL_CONNECTION`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this CreateConnectionFromMySQL.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this CreateConnectionFromMySQL.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this CreateConnectionFromMySQL.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this CreateConnectionFromMySQL.
+        :type parent_ref: ParentReference
+
+        :param name:
+            The value to assign to the name property of this CreateConnectionFromMySQL.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this CreateConnectionFromMySQL.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this CreateConnectionFromMySQL.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this CreateConnectionFromMySQL.
+        :type identifier: str
+
+        :param connection_properties:
+            The value to assign to the connection_properties property of this CreateConnectionFromMySQL.
+        :type connection_properties: list[ConnectionProperty]
+
+        :param registry_metadata:
+            The value to assign to the registry_metadata property of this CreateConnectionFromMySQL.
+        :type registry_metadata: RegistryMetadata
+
+        :param username:
+            The value to assign to the username property of this CreateConnectionFromMySQL.
+        :type username: str
+
+        :param password:
+            The value to assign to the password property of this CreateConnectionFromMySQL.
+        :type password: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'identifier': 'str',
+            'connection_properties': 'list[ConnectionProperty]',
+            'registry_metadata': 'RegistryMetadata',
+            'username': 'str',
+            'password': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'connection_properties': 'connectionProperties',
+            'registry_metadata': 'registryMetadata',
+            'username': 'username',
+            'password': 'password'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._identifier = None
+        self._connection_properties = None
+        self._registry_metadata = None
+        self._username = None
+        self._password = None
+        self._model_type = 'MYSQL_CONNECTION'
+
+    @property
+    def username(self):
+        """
+        Gets the username of this CreateConnectionFromMySQL.
+        The user name for the connection.
+
+
+        :return: The username of this CreateConnectionFromMySQL.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this CreateConnectionFromMySQL.
+        The user name for the connection.
+
+
+        :param username: The username of this CreateConnectionFromMySQL.
+        :type: str
+        """
+        self._username = username
+
+    @property
+    def password(self):
+        """
+        Gets the password of this CreateConnectionFromMySQL.
+        The password for the connection.
+
+
+        :return: The password of this CreateConnectionFromMySQL.
+        :rtype: str
+        """
+        return self._password
+
+    @password.setter
+    def password(self, password):
+        """
+        Sets the password of this CreateConnectionFromMySQL.
+        The password for the connection.
+
+
+        :param password: The password of this CreateConnectionFromMySQL.
+        :type: str
+        """
+        self._password = password
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/create_connection_from_object_storage.py
+++ b/src/oci/data_integration/models/create_connection_from_object_storage.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateConnectionFromObjectStorage(CreateConnectionDetails):
     """
-    The Object Storage connection details.
+    The details to create an Oracle Object Storage data asset connection.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class CreateConnectionFromObjectStorage(CreateConnectionDetails):
 
         :param model_type:
             The value to assign to the model_type property of this CreateConnectionFromObjectStorage.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:
@@ -131,7 +131,7 @@ class CreateConnectionFromObjectStorage(CreateConnectionDetails):
     def credential_file_content(self):
         """
         Gets the credential_file_content of this CreateConnectionFromObjectStorage.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Oracle Object Storage wallet.
 
 
         :return: The credential_file_content of this CreateConnectionFromObjectStorage.
@@ -143,7 +143,7 @@ class CreateConnectionFromObjectStorage(CreateConnectionDetails):
     def credential_file_content(self, credential_file_content):
         """
         Sets the credential_file_content of this CreateConnectionFromObjectStorage.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Oracle Object Storage wallet.
 
 
         :param credential_file_content: The credential_file_content of this CreateConnectionFromObjectStorage.
@@ -179,7 +179,7 @@ class CreateConnectionFromObjectStorage(CreateConnectionDetails):
     def finger_print(self):
         """
         Gets the finger_print of this CreateConnectionFromObjectStorage.
-        The fingeprint for the user.
+        The fingerprint for the user.
 
 
         :return: The finger_print of this CreateConnectionFromObjectStorage.
@@ -191,7 +191,7 @@ class CreateConnectionFromObjectStorage(CreateConnectionDetails):
     def finger_print(self, finger_print):
         """
         Sets the finger_print of this CreateConnectionFromObjectStorage.
-        The fingeprint for the user.
+        The fingerprint for the user.
 
 
         :param finger_print: The finger_print of this CreateConnectionFromObjectStorage.
@@ -203,7 +203,7 @@ class CreateConnectionFromObjectStorage(CreateConnectionDetails):
     def pass_phrase(self):
         """
         Gets the pass_phrase of this CreateConnectionFromObjectStorage.
-        The pass phrase for the connection.
+        The passphrase for the connection.
 
 
         :return: The pass_phrase of this CreateConnectionFromObjectStorage.
@@ -215,7 +215,7 @@ class CreateConnectionFromObjectStorage(CreateConnectionDetails):
     def pass_phrase(self, pass_phrase):
         """
         Sets the pass_phrase of this CreateConnectionFromObjectStorage.
-        The pass phrase for the connection.
+        The passphrase for the connection.
 
 
         :param pass_phrase: The pass_phrase of this CreateConnectionFromObjectStorage.

--- a/src/oci/data_integration/models/create_connection_from_oracle.py
+++ b/src/oci/data_integration/models/create_connection_from_oracle.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateConnectionFromOracle(CreateConnectionDetails):
     """
-    The Oracle connection details object.
+    The details to create an Oracle Database data asset connection.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class CreateConnectionFromOracle(CreateConnectionDetails):
 
         :param model_type:
             The value to assign to the model_type property of this CreateConnectionFromOracle.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/create_connection_validation_details.py
+++ b/src/oci/data_integration/models/create_connection_validation_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateConnectionValidationDetails(object):
     """
-    Connection validation definition
+    The properties used in create connection validation operations.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/data_integration/models/create_data_asset_details.py
+++ b/src/oci/data_integration/models/create_data_asset_details.py
@@ -29,11 +29,21 @@ class CreateDataAssetDetails(object):
     #: This constant has a value of "ORACLE_ADWC_DATA_ASSET"
     MODEL_TYPE_ORACLE_ADWC_DATA_ASSET = "ORACLE_ADWC_DATA_ASSET"
 
+    #: A constant which can be used with the model_type property of a CreateDataAssetDetails.
+    #: This constant has a value of "MYSQL_DATA_ASSET"
+    MODEL_TYPE_MYSQL_DATA_ASSET = "MYSQL_DATA_ASSET"
+
+    #: A constant which can be used with the model_type property of a CreateDataAssetDetails.
+    #: This constant has a value of "GENERIC_JDBC_DATA_ASSET"
+    MODEL_TYPE_GENERIC_JDBC_DATA_ASSET = "GENERIC_JDBC_DATA_ASSET"
+
     def __init__(self, **kwargs):
         """
         Initializes a new CreateDataAssetDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.data_integration.models.CreateDataAssetFromJdbc`
+        * :class:`~oci.data_integration.models.CreateDataAssetFromMySQL`
         * :class:`~oci.data_integration.models.CreateDataAssetFromOracle`
         * :class:`~oci.data_integration.models.CreateDataAssetFromAdwc`
         * :class:`~oci.data_integration.models.CreateDataAssetFromAtp`
@@ -43,7 +53,7 @@ class CreateDataAssetDetails(object):
 
         :param model_type:
             The value to assign to the model_type property of this CreateDataAssetDetails.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -128,6 +138,12 @@ class CreateDataAssetDetails(object):
         """
         type = object_dictionary['modelType']
 
+        if type == 'GENERIC_JDBC_DATA_ASSET':
+            return 'CreateDataAssetFromJdbc'
+
+        if type == 'MYSQL_DATA_ASSET':
+            return 'CreateDataAssetFromMySQL'
+
         if type == 'ORACLE_DATA_ASSET':
             return 'CreateDataAssetFromOracle'
 
@@ -148,7 +164,7 @@ class CreateDataAssetDetails(object):
         **[Required]** Gets the model_type of this CreateDataAssetDetails.
         The type of the data asset.
 
-        Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+        Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
 
 
         :return: The model_type of this CreateDataAssetDetails.
@@ -166,7 +182,7 @@ class CreateDataAssetDetails(object):
         :param model_type: The model_type of this CreateDataAssetDetails.
         :type: str
         """
-        allowed_values = ["ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"]
+        allowed_values = ["ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             raise ValueError(
                 "Invalid value for `model_type`, must be None or one of {0}"
@@ -226,7 +242,7 @@ class CreateDataAssetDetails(object):
     def name(self):
         """
         **[Required]** Gets the name of this CreateDataAssetDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this CreateDataAssetDetails.
@@ -238,7 +254,7 @@ class CreateDataAssetDetails(object):
     def name(self, name):
         """
         Sets the name of this CreateDataAssetDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this CreateDataAssetDetails.
@@ -250,7 +266,7 @@ class CreateDataAssetDetails(object):
     def description(self):
         """
         Gets the description of this CreateDataAssetDetails.
-        Detailed description for the object.
+        User-defined description of the data asset.
 
 
         :return: The description of this CreateDataAssetDetails.
@@ -262,7 +278,7 @@ class CreateDataAssetDetails(object):
     def description(self, description):
         """
         Sets the description of this CreateDataAssetDetails.
-        Detailed description for the object.
+        User-defined description of the data asset.
 
 
         :param description: The description of this CreateDataAssetDetails.
@@ -298,7 +314,7 @@ class CreateDataAssetDetails(object):
     def identifier(self):
         """
         **[Required]** Gets the identifier of this CreateDataAssetDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this CreateDataAssetDetails.
@@ -310,7 +326,7 @@ class CreateDataAssetDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this CreateDataAssetDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this CreateDataAssetDetails.
@@ -322,7 +338,7 @@ class CreateDataAssetDetails(object):
     def external_key(self):
         """
         Gets the external_key of this CreateDataAssetDetails.
-        The external key for the object
+        The external key for the object.
 
 
         :return: The external_key of this CreateDataAssetDetails.
@@ -334,7 +350,7 @@ class CreateDataAssetDetails(object):
     def external_key(self, external_key):
         """
         Sets the external_key of this CreateDataAssetDetails.
-        The external key for the object
+        The external key for the object.
 
 
         :param external_key: The external_key of this CreateDataAssetDetails.
@@ -346,7 +362,7 @@ class CreateDataAssetDetails(object):
     def asset_properties(self):
         """
         Gets the asset_properties of this CreateDataAssetDetails.
-        assetProperties
+        Additional properties for the data asset.
 
 
         :return: The asset_properties of this CreateDataAssetDetails.
@@ -358,7 +374,7 @@ class CreateDataAssetDetails(object):
     def asset_properties(self, asset_properties):
         """
         Sets the asset_properties of this CreateDataAssetDetails.
-        assetProperties
+        Additional properties for the data asset.
 
 
         :param asset_properties: The asset_properties of this CreateDataAssetDetails.

--- a/src/oci/data_integration/models/create_data_asset_from_adwc.py
+++ b/src/oci/data_integration/models/create_data_asset_from_adwc.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateDataAssetFromAdwc(CreateDataAssetDetails):
     """
-    The ADWC data asset details.
+    Details for the Autonomous Data Warehouse data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class CreateDataAssetFromAdwc(CreateDataAssetDetails):
 
         :param model_type:
             The value to assign to the model_type property of this CreateDataAssetFromAdwc.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -131,7 +131,7 @@ class CreateDataAssetFromAdwc(CreateDataAssetDetails):
     def service_name(self):
         """
         Gets the service_name of this CreateDataAssetFromAdwc.
-        The service name for the data asset.
+        The Autonomous Data Warehouse instance service name.
 
 
         :return: The service_name of this CreateDataAssetFromAdwc.
@@ -143,7 +143,7 @@ class CreateDataAssetFromAdwc(CreateDataAssetDetails):
     def service_name(self, service_name):
         """
         Sets the service_name of this CreateDataAssetFromAdwc.
-        The service name for the data asset.
+        The Autonomous Data Warehouse instance service name.
 
 
         :param service_name: The service_name of this CreateDataAssetFromAdwc.
@@ -155,7 +155,7 @@ class CreateDataAssetFromAdwc(CreateDataAssetDetails):
     def driver_class(self):
         """
         Gets the driver_class of this CreateDataAssetFromAdwc.
-        The driver class for the data asset.
+        The Autonomous Data Warehouse driver class.
 
 
         :return: The driver_class of this CreateDataAssetFromAdwc.
@@ -167,7 +167,7 @@ class CreateDataAssetFromAdwc(CreateDataAssetDetails):
     def driver_class(self, driver_class):
         """
         Sets the driver_class of this CreateDataAssetFromAdwc.
-        The driver class for the data asset.
+        The Autonomous Data Warehouse driver class.
 
 
         :param driver_class: The driver_class of this CreateDataAssetFromAdwc.
@@ -179,7 +179,7 @@ class CreateDataAssetFromAdwc(CreateDataAssetDetails):
     def credential_file_content(self):
         """
         Gets the credential_file_content of this CreateDataAssetFromAdwc.
-        The credential file content from a wallet for the data asset.
+        The credential file content from a Autonomous Data Warehouse wallet.
 
 
         :return: The credential_file_content of this CreateDataAssetFromAdwc.
@@ -191,7 +191,7 @@ class CreateDataAssetFromAdwc(CreateDataAssetDetails):
     def credential_file_content(self, credential_file_content):
         """
         Sets the credential_file_content of this CreateDataAssetFromAdwc.
-        The credential file content from a wallet for the data asset.
+        The credential file content from a Autonomous Data Warehouse wallet.
 
 
         :param credential_file_content: The credential_file_content of this CreateDataAssetFromAdwc.

--- a/src/oci/data_integration/models/create_data_asset_from_atp.py
+++ b/src/oci/data_integration/models/create_data_asset_from_atp.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateDataAssetFromAtp(CreateDataAssetDetails):
     """
-    The ATP data asset details.
+    Details for the Autonomous Transaction Processing data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class CreateDataAssetFromAtp(CreateDataAssetDetails):
 
         :param model_type:
             The value to assign to the model_type property of this CreateDataAssetFromAtp.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -131,7 +131,7 @@ class CreateDataAssetFromAtp(CreateDataAssetDetails):
     def service_name(self):
         """
         Gets the service_name of this CreateDataAssetFromAtp.
-        The service name for the data asset.
+        The Autonomous Transaction Processing instance service name.
 
 
         :return: The service_name of this CreateDataAssetFromAtp.
@@ -143,7 +143,7 @@ class CreateDataAssetFromAtp(CreateDataAssetDetails):
     def service_name(self, service_name):
         """
         Sets the service_name of this CreateDataAssetFromAtp.
-        The service name for the data asset.
+        The Autonomous Transaction Processing instance service name.
 
 
         :param service_name: The service_name of this CreateDataAssetFromAtp.
@@ -155,7 +155,7 @@ class CreateDataAssetFromAtp(CreateDataAssetDetails):
     def driver_class(self):
         """
         Gets the driver_class of this CreateDataAssetFromAtp.
-        The driver class for the data asset.
+        The Autonomous Transaction Processing driver class.
 
 
         :return: The driver_class of this CreateDataAssetFromAtp.
@@ -167,7 +167,7 @@ class CreateDataAssetFromAtp(CreateDataAssetDetails):
     def driver_class(self, driver_class):
         """
         Sets the driver_class of this CreateDataAssetFromAtp.
-        The driver class for the data asset.
+        The Autonomous Transaction Processing driver class.
 
 
         :param driver_class: The driver_class of this CreateDataAssetFromAtp.
@@ -179,7 +179,7 @@ class CreateDataAssetFromAtp(CreateDataAssetDetails):
     def credential_file_content(self):
         """
         Gets the credential_file_content of this CreateDataAssetFromAtp.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Autonomous Transaction Processing wallet.
 
 
         :return: The credential_file_content of this CreateDataAssetFromAtp.
@@ -191,7 +191,7 @@ class CreateDataAssetFromAtp(CreateDataAssetDetails):
     def credential_file_content(self, credential_file_content):
         """
         Sets the credential_file_content of this CreateDataAssetFromAtp.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Autonomous Transaction Processing wallet.
 
 
         :param credential_file_content: The credential_file_content of this CreateDataAssetFromAtp.

--- a/src/oci/data_integration/models/create_data_asset_from_jdbc.py
+++ b/src/oci/data_integration/models/create_data_asset_from_jdbc.py
@@ -1,0 +1,232 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_data_asset_details import CreateDataAssetDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDataAssetFromJdbc(CreateDataAssetDetails):
+    """
+    Details for the generic JDBC data asset type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDataAssetFromJdbc object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.CreateDataAssetFromJdbc.model_type` attribute
+        of this class is ``GENERIC_JDBC_DATA_ASSET`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this CreateDataAssetFromJdbc.
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this CreateDataAssetFromJdbc.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this CreateDataAssetFromJdbc.
+        :type model_version: str
+
+        :param name:
+            The value to assign to the name property of this CreateDataAssetFromJdbc.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this CreateDataAssetFromJdbc.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this CreateDataAssetFromJdbc.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this CreateDataAssetFromJdbc.
+        :type identifier: str
+
+        :param external_key:
+            The value to assign to the external_key property of this CreateDataAssetFromJdbc.
+        :type external_key: str
+
+        :param asset_properties:
+            The value to assign to the asset_properties property of this CreateDataAssetFromJdbc.
+        :type asset_properties: dict(str, str)
+
+        :param registry_metadata:
+            The value to assign to the registry_metadata property of this CreateDataAssetFromJdbc.
+        :type registry_metadata: RegistryMetadata
+
+        :param host:
+            The value to assign to the host property of this CreateDataAssetFromJdbc.
+        :type host: str
+
+        :param port:
+            The value to assign to the port property of this CreateDataAssetFromJdbc.
+        :type port: str
+
+        :param data_asset_type:
+            The value to assign to the data_asset_type property of this CreateDataAssetFromJdbc.
+        :type data_asset_type: str
+
+        :param default_connection:
+            The value to assign to the default_connection property of this CreateDataAssetFromJdbc.
+        :type default_connection: CreateConnectionFromJdbc
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'identifier': 'str',
+            'external_key': 'str',
+            'asset_properties': 'dict(str, str)',
+            'registry_metadata': 'RegistryMetadata',
+            'host': 'str',
+            'port': 'str',
+            'data_asset_type': 'str',
+            'default_connection': 'CreateConnectionFromJdbc'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'external_key': 'externalKey',
+            'asset_properties': 'assetProperties',
+            'registry_metadata': 'registryMetadata',
+            'host': 'host',
+            'port': 'port',
+            'data_asset_type': 'dataAssetType',
+            'default_connection': 'defaultConnection'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._identifier = None
+        self._external_key = None
+        self._asset_properties = None
+        self._registry_metadata = None
+        self._host = None
+        self._port = None
+        self._data_asset_type = None
+        self._default_connection = None
+        self._model_type = 'GENERIC_JDBC_DATA_ASSET'
+
+    @property
+    def host(self):
+        """
+        Gets the host of this CreateDataAssetFromJdbc.
+        The generic JDBC host name.
+
+
+        :return: The host of this CreateDataAssetFromJdbc.
+        :rtype: str
+        """
+        return self._host
+
+    @host.setter
+    def host(self, host):
+        """
+        Sets the host of this CreateDataAssetFromJdbc.
+        The generic JDBC host name.
+
+
+        :param host: The host of this CreateDataAssetFromJdbc.
+        :type: str
+        """
+        self._host = host
+
+    @property
+    def port(self):
+        """
+        Gets the port of this CreateDataAssetFromJdbc.
+        The generic JDBC port number.
+
+
+        :return: The port of this CreateDataAssetFromJdbc.
+        :rtype: str
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this CreateDataAssetFromJdbc.
+        The generic JDBC port number.
+
+
+        :param port: The port of this CreateDataAssetFromJdbc.
+        :type: str
+        """
+        self._port = port
+
+    @property
+    def data_asset_type(self):
+        """
+        Gets the data_asset_type of this CreateDataAssetFromJdbc.
+        The data asset type for the generic JDBC data asset.
+
+
+        :return: The data_asset_type of this CreateDataAssetFromJdbc.
+        :rtype: str
+        """
+        return self._data_asset_type
+
+    @data_asset_type.setter
+    def data_asset_type(self, data_asset_type):
+        """
+        Sets the data_asset_type of this CreateDataAssetFromJdbc.
+        The data asset type for the generic JDBC data asset.
+
+
+        :param data_asset_type: The data_asset_type of this CreateDataAssetFromJdbc.
+        :type: str
+        """
+        self._data_asset_type = data_asset_type
+
+    @property
+    def default_connection(self):
+        """
+        Gets the default_connection of this CreateDataAssetFromJdbc.
+
+        :return: The default_connection of this CreateDataAssetFromJdbc.
+        :rtype: CreateConnectionFromJdbc
+        """
+        return self._default_connection
+
+    @default_connection.setter
+    def default_connection(self, default_connection):
+        """
+        Sets the default_connection of this CreateDataAssetFromJdbc.
+
+        :param default_connection: The default_connection of this CreateDataAssetFromJdbc.
+        :type: CreateConnectionFromJdbc
+        """
+        self._default_connection = default_connection
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/create_data_asset_from_my_sql.py
+++ b/src/oci/data_integration/models/create_data_asset_from_my_sql.py
@@ -1,0 +1,232 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_data_asset_details import CreateDataAssetDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDataAssetFromMySQL(CreateDataAssetDetails):
+    """
+    Details for the MYSQL data asset type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDataAssetFromMySQL object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.CreateDataAssetFromMySQL.model_type` attribute
+        of this class is ``MYSQL_DATA_ASSET`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this CreateDataAssetFromMySQL.
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this CreateDataAssetFromMySQL.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this CreateDataAssetFromMySQL.
+        :type model_version: str
+
+        :param name:
+            The value to assign to the name property of this CreateDataAssetFromMySQL.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this CreateDataAssetFromMySQL.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this CreateDataAssetFromMySQL.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this CreateDataAssetFromMySQL.
+        :type identifier: str
+
+        :param external_key:
+            The value to assign to the external_key property of this CreateDataAssetFromMySQL.
+        :type external_key: str
+
+        :param asset_properties:
+            The value to assign to the asset_properties property of this CreateDataAssetFromMySQL.
+        :type asset_properties: dict(str, str)
+
+        :param registry_metadata:
+            The value to assign to the registry_metadata property of this CreateDataAssetFromMySQL.
+        :type registry_metadata: RegistryMetadata
+
+        :param host:
+            The value to assign to the host property of this CreateDataAssetFromMySQL.
+        :type host: str
+
+        :param port:
+            The value to assign to the port property of this CreateDataAssetFromMySQL.
+        :type port: str
+
+        :param service_name:
+            The value to assign to the service_name property of this CreateDataAssetFromMySQL.
+        :type service_name: str
+
+        :param default_connection:
+            The value to assign to the default_connection property of this CreateDataAssetFromMySQL.
+        :type default_connection: CreateConnectionFromMySQL
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'identifier': 'str',
+            'external_key': 'str',
+            'asset_properties': 'dict(str, str)',
+            'registry_metadata': 'RegistryMetadata',
+            'host': 'str',
+            'port': 'str',
+            'service_name': 'str',
+            'default_connection': 'CreateConnectionFromMySQL'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'external_key': 'externalKey',
+            'asset_properties': 'assetProperties',
+            'registry_metadata': 'registryMetadata',
+            'host': 'host',
+            'port': 'port',
+            'service_name': 'serviceName',
+            'default_connection': 'defaultConnection'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._identifier = None
+        self._external_key = None
+        self._asset_properties = None
+        self._registry_metadata = None
+        self._host = None
+        self._port = None
+        self._service_name = None
+        self._default_connection = None
+        self._model_type = 'MYSQL_DATA_ASSET'
+
+    @property
+    def host(self):
+        """
+        Gets the host of this CreateDataAssetFromMySQL.
+        The generic JDBC host name.
+
+
+        :return: The host of this CreateDataAssetFromMySQL.
+        :rtype: str
+        """
+        return self._host
+
+    @host.setter
+    def host(self, host):
+        """
+        Sets the host of this CreateDataAssetFromMySQL.
+        The generic JDBC host name.
+
+
+        :param host: The host of this CreateDataAssetFromMySQL.
+        :type: str
+        """
+        self._host = host
+
+    @property
+    def port(self):
+        """
+        Gets the port of this CreateDataAssetFromMySQL.
+        The generic JDBC port number.
+
+
+        :return: The port of this CreateDataAssetFromMySQL.
+        :rtype: str
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this CreateDataAssetFromMySQL.
+        The generic JDBC port number.
+
+
+        :param port: The port of this CreateDataAssetFromMySQL.
+        :type: str
+        """
+        self._port = port
+
+    @property
+    def service_name(self):
+        """
+        Gets the service_name of this CreateDataAssetFromMySQL.
+        The generic JDBC service name for the database.
+
+
+        :return: The service_name of this CreateDataAssetFromMySQL.
+        :rtype: str
+        """
+        return self._service_name
+
+    @service_name.setter
+    def service_name(self, service_name):
+        """
+        Sets the service_name of this CreateDataAssetFromMySQL.
+        The generic JDBC service name for the database.
+
+
+        :param service_name: The service_name of this CreateDataAssetFromMySQL.
+        :type: str
+        """
+        self._service_name = service_name
+
+    @property
+    def default_connection(self):
+        """
+        Gets the default_connection of this CreateDataAssetFromMySQL.
+
+        :return: The default_connection of this CreateDataAssetFromMySQL.
+        :rtype: CreateConnectionFromMySQL
+        """
+        return self._default_connection
+
+    @default_connection.setter
+    def default_connection(self, default_connection):
+        """
+        Sets the default_connection of this CreateDataAssetFromMySQL.
+
+        :param default_connection: The default_connection of this CreateDataAssetFromMySQL.
+        :type: CreateConnectionFromMySQL
+        """
+        self._default_connection = default_connection
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/create_data_asset_from_object_storage.py
+++ b/src/oci/data_integration/models/create_data_asset_from_object_storage.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateDataAssetFromObjectStorage(CreateDataAssetDetails):
     """
-    The Object Storage data asset details.
+    Details for the Oracle Object storage data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class CreateDataAssetFromObjectStorage(CreateDataAssetDetails):
 
         :param model_type:
             The value to assign to the model_type property of this CreateDataAssetFromObjectStorage.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -131,7 +131,7 @@ class CreateDataAssetFromObjectStorage(CreateDataAssetDetails):
     def url(self):
         """
         Gets the url of this CreateDataAssetFromObjectStorage.
-        url
+        The Oracle Object storage URL.
 
 
         :return: The url of this CreateDataAssetFromObjectStorage.
@@ -143,7 +143,7 @@ class CreateDataAssetFromObjectStorage(CreateDataAssetDetails):
     def url(self, url):
         """
         Sets the url of this CreateDataAssetFromObjectStorage.
-        url
+        The Oracle Object storage URL.
 
 
         :param url: The url of this CreateDataAssetFromObjectStorage.
@@ -179,7 +179,7 @@ class CreateDataAssetFromObjectStorage(CreateDataAssetDetails):
     def namespace(self):
         """
         Gets the namespace of this CreateDataAssetFromObjectStorage.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        The namespace for the specified Oracle Object storage resource. You can find the namespace under Object Storage Settings in the Console.
 
 
         :return: The namespace of this CreateDataAssetFromObjectStorage.
@@ -191,7 +191,7 @@ class CreateDataAssetFromObjectStorage(CreateDataAssetDetails):
     def namespace(self, namespace):
         """
         Sets the namespace of this CreateDataAssetFromObjectStorage.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        The namespace for the specified Oracle Object storage resource. You can find the namespace under Object Storage Settings in the Console.
 
 
         :param namespace: The namespace of this CreateDataAssetFromObjectStorage.

--- a/src/oci/data_integration/models/create_data_asset_from_oracle.py
+++ b/src/oci/data_integration/models/create_data_asset_from_oracle.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateDataAssetFromOracle(CreateDataAssetDetails):
     """
-    The Oracle data asset details.
+    Details for the Oracle Database data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
 
         :param model_type:
             The value to assign to the model_type property of this CreateDataAssetFromOracle.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -152,7 +152,7 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
     def host(self):
         """
         Gets the host of this CreateDataAssetFromOracle.
-        The host details for the data asset.
+        The Oracle Database hostname.
 
 
         :return: The host of this CreateDataAssetFromOracle.
@@ -164,7 +164,7 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
     def host(self, host):
         """
         Sets the host of this CreateDataAssetFromOracle.
-        The host details for the data asset.
+        The Oracle Database hostname.
 
 
         :param host: The host of this CreateDataAssetFromOracle.
@@ -176,7 +176,7 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
     def port(self):
         """
         Gets the port of this CreateDataAssetFromOracle.
-        The port details for the data asset.
+        The Oracle Database port.
 
 
         :return: The port of this CreateDataAssetFromOracle.
@@ -188,7 +188,7 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
     def port(self, port):
         """
         Sets the port of this CreateDataAssetFromOracle.
-        The port details for the data asset.
+        The Oracle Database port.
 
 
         :param port: The port of this CreateDataAssetFromOracle.
@@ -224,7 +224,7 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
     def driver_class(self):
         """
         Gets the driver_class of this CreateDataAssetFromOracle.
-        The driver class for the data asset.
+        The Oracle Database driver class.
 
 
         :return: The driver_class of this CreateDataAssetFromOracle.
@@ -236,7 +236,7 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
     def driver_class(self, driver_class):
         """
         Sets the driver_class of this CreateDataAssetFromOracle.
-        The driver class for the data asset.
+        The Oracle Database driver class.
 
 
         :param driver_class: The driver_class of this CreateDataAssetFromOracle.
@@ -248,7 +248,7 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
     def sid(self):
         """
         Gets the sid of this CreateDataAssetFromOracle.
-        sid
+        The Oracle Database SID.
 
 
         :return: The sid of this CreateDataAssetFromOracle.
@@ -260,7 +260,7 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
     def sid(self, sid):
         """
         Sets the sid of this CreateDataAssetFromOracle.
-        sid
+        The Oracle Database SID.
 
 
         :param sid: The sid of this CreateDataAssetFromOracle.

--- a/src/oci/data_integration/models/create_data_flow_details.py
+++ b/src/oci/data_integration/models/create_data_flow_details.py
@@ -175,7 +175,7 @@ class CreateDataFlowDetails(object):
     def name(self):
         """
         **[Required]** Gets the name of this CreateDataFlowDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this CreateDataFlowDetails.
@@ -187,7 +187,7 @@ class CreateDataFlowDetails(object):
     def name(self, name):
         """
         Sets the name of this CreateDataFlowDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this CreateDataFlowDetails.
@@ -199,7 +199,7 @@ class CreateDataFlowDetails(object):
     def identifier(self):
         """
         **[Required]** Gets the identifier of this CreateDataFlowDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this CreateDataFlowDetails.
@@ -211,7 +211,7 @@ class CreateDataFlowDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this CreateDataFlowDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this CreateDataFlowDetails.

--- a/src/oci/data_integration/models/create_data_flow_validation_details.py
+++ b/src/oci/data_integration/models/create_data_flow_validation_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateDataFlowValidationDetails(object):
     """
-    The information about integration dataflow validation.
+    The properties used in create dataflow validation operations.
     """
 
     def __init__(self, **kwargs):
@@ -220,7 +220,7 @@ class CreateDataFlowValidationDetails(object):
     def name(self):
         """
         Gets the name of this CreateDataFlowValidationDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this CreateDataFlowValidationDetails.
@@ -232,7 +232,7 @@ class CreateDataFlowValidationDetails(object):
     def name(self, name):
         """
         Sets the name of this CreateDataFlowValidationDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this CreateDataFlowValidationDetails.
@@ -244,7 +244,7 @@ class CreateDataFlowValidationDetails(object):
     def identifier(self):
         """
         Gets the identifier of this CreateDataFlowValidationDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this CreateDataFlowValidationDetails.
@@ -256,7 +256,7 @@ class CreateDataFlowValidationDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this CreateDataFlowValidationDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this CreateDataFlowValidationDetails.
@@ -428,7 +428,7 @@ class CreateDataFlowValidationDetails(object):
     def key_map(self):
         """
         Gets the key_map of this CreateDataFlowValidationDetails.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this CreateDataFlowValidationDetails.
@@ -440,7 +440,7 @@ class CreateDataFlowValidationDetails(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this CreateDataFlowValidationDetails.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this CreateDataFlowValidationDetails.

--- a/src/oci/data_integration/models/create_entity_shape_from_file.py
+++ b/src/oci/data_integration/models/create_entity_shape_from_file.py
@@ -191,7 +191,7 @@ class CreateEntityShapeFromFile(CreateEntityShapeDetails):
     def key(self):
         """
         Gets the key of this CreateEntityShapeFromFile.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this CreateEntityShapeFromFile.
@@ -203,7 +203,7 @@ class CreateEntityShapeFromFile(CreateEntityShapeDetails):
     def key(self, key):
         """
         Sets the key of this CreateEntityShapeFromFile.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this CreateEntityShapeFromFile.
@@ -215,7 +215,7 @@ class CreateEntityShapeFromFile(CreateEntityShapeDetails):
     def model_version(self):
         """
         Gets the model_version of this CreateEntityShapeFromFile.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this CreateEntityShapeFromFile.
@@ -227,7 +227,7 @@ class CreateEntityShapeFromFile(CreateEntityShapeDetails):
     def model_version(self, model_version):
         """
         Sets the model_version of this CreateEntityShapeFromFile.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this CreateEntityShapeFromFile.
@@ -259,7 +259,7 @@ class CreateEntityShapeFromFile(CreateEntityShapeDetails):
     def name(self):
         """
         Gets the name of this CreateEntityShapeFromFile.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this CreateEntityShapeFromFile.
@@ -271,7 +271,7 @@ class CreateEntityShapeFromFile(CreateEntityShapeDetails):
     def name(self, name):
         """
         Sets the name of this CreateEntityShapeFromFile.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this CreateEntityShapeFromFile.
@@ -591,7 +591,7 @@ class CreateEntityShapeFromFile(CreateEntityShapeDetails):
     def identifier(self):
         """
         Gets the identifier of this CreateEntityShapeFromFile.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this CreateEntityShapeFromFile.
@@ -603,7 +603,7 @@ class CreateEntityShapeFromFile(CreateEntityShapeDetails):
     def identifier(self, identifier):
         """
         Sets the identifier of this CreateEntityShapeFromFile.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this CreateEntityShapeFromFile.

--- a/src/oci/data_integration/models/create_external_publication_details.py
+++ b/src/oci/data_integration/models/create_external_publication_details.py
@@ -1,0 +1,217 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateExternalPublicationDetails(object):
+    """
+    Properties used to publish an Oracle Cloud Infrastructure Data Flow object.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateExternalPublicationDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param application_id:
+            The value to assign to the application_id property of this CreateExternalPublicationDetails.
+        :type application_id: str
+
+        :param application_compartment_id:
+            The value to assign to the application_compartment_id property of this CreateExternalPublicationDetails.
+        :type application_compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateExternalPublicationDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this CreateExternalPublicationDetails.
+        :type description: str
+
+        :param resource_configuration:
+            The value to assign to the resource_configuration property of this CreateExternalPublicationDetails.
+        :type resource_configuration: ResourceConfiguration
+
+        :param configuration_details:
+            The value to assign to the configuration_details property of this CreateExternalPublicationDetails.
+        :type configuration_details: ConfigurationDetails
+
+        """
+        self.swagger_types = {
+            'application_id': 'str',
+            'application_compartment_id': 'str',
+            'display_name': 'str',
+            'description': 'str',
+            'resource_configuration': 'ResourceConfiguration',
+            'configuration_details': 'ConfigurationDetails'
+        }
+
+        self.attribute_map = {
+            'application_id': 'applicationId',
+            'application_compartment_id': 'applicationCompartmentId',
+            'display_name': 'displayName',
+            'description': 'description',
+            'resource_configuration': 'resourceConfiguration',
+            'configuration_details': 'configurationDetails'
+        }
+
+        self._application_id = None
+        self._application_compartment_id = None
+        self._display_name = None
+        self._description = None
+        self._resource_configuration = None
+        self._configuration_details = None
+
+    @property
+    def application_id(self):
+        """
+        Gets the application_id of this CreateExternalPublicationDetails.
+        The unique OCID of the identifier that is returned after creating the Oracle Cloud Infrastructure Data Flow application.
+
+
+        :return: The application_id of this CreateExternalPublicationDetails.
+        :rtype: str
+        """
+        return self._application_id
+
+    @application_id.setter
+    def application_id(self, application_id):
+        """
+        Sets the application_id of this CreateExternalPublicationDetails.
+        The unique OCID of the identifier that is returned after creating the Oracle Cloud Infrastructure Data Flow application.
+
+
+        :param application_id: The application_id of this CreateExternalPublicationDetails.
+        :type: str
+        """
+        self._application_id = application_id
+
+    @property
+    def application_compartment_id(self):
+        """
+        **[Required]** Gets the application_compartment_id of this CreateExternalPublicationDetails.
+        The OCID of the compartment where the application is created in the Oracle Cloud Infrastructure Data Flow Service.
+
+
+        :return: The application_compartment_id of this CreateExternalPublicationDetails.
+        :rtype: str
+        """
+        return self._application_compartment_id
+
+    @application_compartment_id.setter
+    def application_compartment_id(self, application_compartment_id):
+        """
+        Sets the application_compartment_id of this CreateExternalPublicationDetails.
+        The OCID of the compartment where the application is created in the Oracle Cloud Infrastructure Data Flow Service.
+
+
+        :param application_compartment_id: The application_compartment_id of this CreateExternalPublicationDetails.
+        :type: str
+        """
+        self._application_compartment_id = application_compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateExternalPublicationDetails.
+        The name of the application.
+
+
+        :return: The display_name of this CreateExternalPublicationDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateExternalPublicationDetails.
+        The name of the application.
+
+
+        :param display_name: The display_name of this CreateExternalPublicationDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this CreateExternalPublicationDetails.
+        The details of the data flow or the application.
+
+
+        :return: The description of this CreateExternalPublicationDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this CreateExternalPublicationDetails.
+        The details of the data flow or the application.
+
+
+        :param description: The description of this CreateExternalPublicationDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def resource_configuration(self):
+        """
+        Gets the resource_configuration of this CreateExternalPublicationDetails.
+
+        :return: The resource_configuration of this CreateExternalPublicationDetails.
+        :rtype: ResourceConfiguration
+        """
+        return self._resource_configuration
+
+    @resource_configuration.setter
+    def resource_configuration(self, resource_configuration):
+        """
+        Sets the resource_configuration of this CreateExternalPublicationDetails.
+
+        :param resource_configuration: The resource_configuration of this CreateExternalPublicationDetails.
+        :type: ResourceConfiguration
+        """
+        self._resource_configuration = resource_configuration
+
+    @property
+    def configuration_details(self):
+        """
+        Gets the configuration_details of this CreateExternalPublicationDetails.
+
+        :return: The configuration_details of this CreateExternalPublicationDetails.
+        :rtype: ConfigurationDetails
+        """
+        return self._configuration_details
+
+    @configuration_details.setter
+    def configuration_details(self, configuration_details):
+        """
+        Sets the configuration_details of this CreateExternalPublicationDetails.
+
+        :param configuration_details: The configuration_details of this CreateExternalPublicationDetails.
+        :type: ConfigurationDetails
+        """
+        self._configuration_details = configuration_details
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/create_external_publication_validation_details.py
+++ b/src/oci/data_integration/models/create_external_publication_validation_details.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateExternalPublicationValidationDetails(object):
+    """
+    The task type contains the audit summary information and the definition of the task that is published externally.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateExternalPublicationValidationDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this CreateExternalPublicationValidationDetails.
+        :type key: str
+
+        """
+        self.swagger_types = {
+            'key': 'str'
+        }
+
+        self.attribute_map = {
+            'key': 'key'
+        }
+
+        self._key = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this CreateExternalPublicationValidationDetails.
+        Generated key that can be used in API calls to identify the task. On scenarios where reference to the task is needed, a value can be passed in the create operation.
+
+
+        :return: The key of this CreateExternalPublicationValidationDetails.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this CreateExternalPublicationValidationDetails.
+        Generated key that can be used in API calls to identify the task. On scenarios where reference to the task is needed, a value can be passed in the create operation.
+
+
+        :param key: The key of this CreateExternalPublicationValidationDetails.
+        :type: str
+        """
+        self._key = key
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/create_folder_details.py
+++ b/src/oci/data_integration/models/create_folder_details.py
@@ -134,7 +134,7 @@ class CreateFolderDetails(object):
     def name(self):
         """
         **[Required]** Gets the name of this CreateFolderDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this CreateFolderDetails.
@@ -146,7 +146,7 @@ class CreateFolderDetails(object):
     def name(self, name):
         """
         Sets the name of this CreateFolderDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this CreateFolderDetails.
@@ -158,7 +158,7 @@ class CreateFolderDetails(object):
     def description(self):
         """
         Gets the description of this CreateFolderDetails.
-        Detailed description for the object.
+        A user defined description for the folder.
 
 
         :return: The description of this CreateFolderDetails.
@@ -170,7 +170,7 @@ class CreateFolderDetails(object):
     def description(self, description):
         """
         Sets the description of this CreateFolderDetails.
-        Detailed description for the object.
+        A user defined description for the folder.
 
 
         :param description: The description of this CreateFolderDetails.
@@ -182,7 +182,7 @@ class CreateFolderDetails(object):
     def category_name(self):
         """
         Gets the category_name of this CreateFolderDetails.
-        categoryName
+        The category name.
 
 
         :return: The category_name of this CreateFolderDetails.
@@ -194,7 +194,7 @@ class CreateFolderDetails(object):
     def category_name(self, category_name):
         """
         Sets the category_name of this CreateFolderDetails.
-        categoryName
+        The category name.
 
 
         :param category_name: The category_name of this CreateFolderDetails.
@@ -230,7 +230,7 @@ class CreateFolderDetails(object):
     def identifier(self):
         """
         **[Required]** Gets the identifier of this CreateFolderDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this CreateFolderDetails.
@@ -242,7 +242,7 @@ class CreateFolderDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this CreateFolderDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this CreateFolderDetails.

--- a/src/oci/data_integration/models/create_patch_details.py
+++ b/src/oci/data_integration/models/create_patch_details.py
@@ -18,6 +18,10 @@ class CreatePatchDetails(object):
     PATCH_TYPE_PUBLISH = "PUBLISH"
 
     #: A constant which can be used with the patch_type property of a CreatePatchDetails.
+    #: This constant has a value of "REFRESH"
+    PATCH_TYPE_REFRESH = "REFRESH"
+
+    #: A constant which can be used with the patch_type property of a CreatePatchDetails.
     #: This constant has a value of "UNPUBLISH"
     PATCH_TYPE_UNPUBLISH = "UNPUBLISH"
 
@@ -52,7 +56,7 @@ class CreatePatchDetails(object):
 
         :param patch_type:
             The value to assign to the patch_type property of this CreatePatchDetails.
-            Allowed values for this property are: "PUBLISH", "UNPUBLISH"
+            Allowed values for this property are: "PUBLISH", "REFRESH", "UNPUBLISH"
         :type patch_type: str
 
         :param object_keys:
@@ -102,7 +106,7 @@ class CreatePatchDetails(object):
     def key(self):
         """
         Gets the key of this CreatePatchDetails.
-        The key of the object.
+        The object's key.
 
 
         :return: The key of this CreatePatchDetails.
@@ -114,7 +118,7 @@ class CreatePatchDetails(object):
     def key(self, key):
         """
         Sets the key of this CreatePatchDetails.
-        The key of the object.
+        The object's key.
 
 
         :param key: The key of this CreatePatchDetails.
@@ -126,7 +130,7 @@ class CreatePatchDetails(object):
     def model_version(self):
         """
         Gets the model_version of this CreatePatchDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this CreatePatchDetails.
@@ -138,7 +142,7 @@ class CreatePatchDetails(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this CreatePatchDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this CreatePatchDetails.
@@ -150,7 +154,7 @@ class CreatePatchDetails(object):
     def name(self):
         """
         **[Required]** Gets the name of this CreatePatchDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this CreatePatchDetails.
@@ -162,7 +166,7 @@ class CreatePatchDetails(object):
     def name(self, name):
         """
         Sets the name of this CreatePatchDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this CreatePatchDetails.
@@ -222,7 +226,7 @@ class CreatePatchDetails(object):
     def identifier(self):
         """
         **[Required]** Gets the identifier of this CreatePatchDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this CreatePatchDetails.
@@ -234,7 +238,7 @@ class CreatePatchDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this CreatePatchDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this CreatePatchDetails.
@@ -248,7 +252,7 @@ class CreatePatchDetails(object):
         **[Required]** Gets the patch_type of this CreatePatchDetails.
         The type of the patch applied or being applied on the application.
 
-        Allowed values for this property are: "PUBLISH", "UNPUBLISH"
+        Allowed values for this property are: "PUBLISH", "REFRESH", "UNPUBLISH"
 
 
         :return: The patch_type of this CreatePatchDetails.
@@ -266,7 +270,7 @@ class CreatePatchDetails(object):
         :param patch_type: The patch_type of this CreatePatchDetails.
         :type: str
         """
-        allowed_values = ["PUBLISH", "UNPUBLISH"]
+        allowed_values = ["PUBLISH", "REFRESH", "UNPUBLISH"]
         if not value_allowed_none_or_none_sentinel(patch_type, allowed_values):
             raise ValueError(
                 "Invalid value for `patch_type`, must be None or one of {0}"

--- a/src/oci/data_integration/models/create_project_details.py
+++ b/src/oci/data_integration/models/create_project_details.py
@@ -103,7 +103,7 @@ class CreateProjectDetails(object):
     def name(self):
         """
         **[Required]** Gets the name of this CreateProjectDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this CreateProjectDetails.
@@ -115,7 +115,7 @@ class CreateProjectDetails(object):
     def name(self, name):
         """
         Sets the name of this CreateProjectDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this CreateProjectDetails.
@@ -127,7 +127,7 @@ class CreateProjectDetails(object):
     def description(self):
         """
         Gets the description of this CreateProjectDetails.
-        Detailed description for the object.
+        A user defined description for the project.
 
 
         :return: The description of this CreateProjectDetails.
@@ -139,7 +139,7 @@ class CreateProjectDetails(object):
     def description(self, description):
         """
         Sets the description of this CreateProjectDetails.
-        Detailed description for the object.
+        A user defined description for the project.
 
 
         :param description: The description of this CreateProjectDetails.
@@ -175,7 +175,7 @@ class CreateProjectDetails(object):
     def identifier(self):
         """
         **[Required]** Gets the identifier of this CreateProjectDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this CreateProjectDetails.
@@ -187,7 +187,7 @@ class CreateProjectDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this CreateProjectDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this CreateProjectDetails.

--- a/src/oci/data_integration/models/create_source_application_info.py
+++ b/src/oci/data_integration/models/create_source_application_info.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateSourceApplicationInfo(object):
+    """
+    The information about the application.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateSourceApplicationInfo object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param workspace_id:
+            The value to assign to the workspace_id property of this CreateSourceApplicationInfo.
+        :type workspace_id: str
+
+        :param application_key:
+            The value to assign to the application_key property of this CreateSourceApplicationInfo.
+        :type application_key: str
+
+        """
+        self.swagger_types = {
+            'workspace_id': 'str',
+            'application_key': 'str'
+        }
+
+        self.attribute_map = {
+            'workspace_id': 'workspaceId',
+            'application_key': 'applicationKey'
+        }
+
+        self._workspace_id = None
+        self._application_key = None
+
+    @property
+    def workspace_id(self):
+        """
+        Gets the workspace_id of this CreateSourceApplicationInfo.
+        The OCID of the workspace containing the application. This allows cross workspace deployment to publish an application from a different workspace into the current workspace specified in this operation.
+
+
+        :return: The workspace_id of this CreateSourceApplicationInfo.
+        :rtype: str
+        """
+        return self._workspace_id
+
+    @workspace_id.setter
+    def workspace_id(self, workspace_id):
+        """
+        Sets the workspace_id of this CreateSourceApplicationInfo.
+        The OCID of the workspace containing the application. This allows cross workspace deployment to publish an application from a different workspace into the current workspace specified in this operation.
+
+
+        :param workspace_id: The workspace_id of this CreateSourceApplicationInfo.
+        :type: str
+        """
+        self._workspace_id = workspace_id
+
+    @property
+    def application_key(self):
+        """
+        Gets the application_key of this CreateSourceApplicationInfo.
+        The source application key to use when creating the application.
+
+
+        :return: The application_key of this CreateSourceApplicationInfo.
+        :rtype: str
+        """
+        return self._application_key
+
+    @application_key.setter
+    def application_key(self, application_key):
+        """
+        Sets the application_key of this CreateSourceApplicationInfo.
+        The source application key to use when creating the application.
+
+
+        :param application_key: The application_key of this CreateSourceApplicationInfo.
+        :type: str
+        """
+        self._application_key = application_key
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/create_task_details.py
+++ b/src/oci/data_integration/models/create_task_details.py
@@ -214,7 +214,7 @@ class CreateTaskDetails(object):
     def model_version(self):
         """
         Gets the model_version of this CreateTaskDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this CreateTaskDetails.
@@ -226,7 +226,7 @@ class CreateTaskDetails(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this CreateTaskDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this CreateTaskDetails.
@@ -258,7 +258,7 @@ class CreateTaskDetails(object):
     def name(self):
         """
         **[Required]** Gets the name of this CreateTaskDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this CreateTaskDetails.
@@ -270,7 +270,7 @@ class CreateTaskDetails(object):
     def name(self, name):
         """
         Sets the name of this CreateTaskDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this CreateTaskDetails.
@@ -330,7 +330,7 @@ class CreateTaskDetails(object):
     def identifier(self):
         """
         **[Required]** Gets the identifier of this CreateTaskDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this CreateTaskDetails.
@@ -342,7 +342,7 @@ class CreateTaskDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this CreateTaskDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this CreateTaskDetails.

--- a/src/oci/data_integration/models/create_task_run_details.py
+++ b/src/oci/data_integration/models/create_task_run_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateTaskRunDetails(object):
     """
-    Properties used in task run create operations.
+    The properties used in task run create operations.
     """
 
     def __init__(self, **kwargs):
@@ -158,7 +158,7 @@ class CreateTaskRunDetails(object):
     def name(self):
         """
         Gets the name of this CreateTaskRunDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this CreateTaskRunDetails.
@@ -170,7 +170,7 @@ class CreateTaskRunDetails(object):
     def name(self, name):
         """
         Sets the name of this CreateTaskRunDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this CreateTaskRunDetails.
@@ -226,7 +226,7 @@ class CreateTaskRunDetails(object):
     def identifier(self):
         """
         Gets the identifier of this CreateTaskRunDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this CreateTaskRunDetails.
@@ -238,7 +238,7 @@ class CreateTaskRunDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this CreateTaskRunDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this CreateTaskRunDetails.

--- a/src/oci/data_integration/models/create_task_validation_details.py
+++ b/src/oci/data_integration/models/create_task_validation_details.py
@@ -197,7 +197,7 @@ class CreateTaskValidationDetails(object):
     def key(self):
         """
         Gets the key of this CreateTaskValidationDetails.
-        Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+        Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in the create operation.
 
 
         :return: The key of this CreateTaskValidationDetails.
@@ -209,7 +209,7 @@ class CreateTaskValidationDetails(object):
     def key(self, key):
         """
         Sets the key of this CreateTaskValidationDetails.
-        Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+        Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in the create operation.
 
 
         :param key: The key of this CreateTaskValidationDetails.
@@ -265,7 +265,7 @@ class CreateTaskValidationDetails(object):
     def name(self):
         """
         Gets the name of this CreateTaskValidationDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this CreateTaskValidationDetails.
@@ -277,7 +277,7 @@ class CreateTaskValidationDetails(object):
     def name(self, name):
         """
         Sets the name of this CreateTaskValidationDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this CreateTaskValidationDetails.
@@ -361,7 +361,7 @@ class CreateTaskValidationDetails(object):
     def identifier(self):
         """
         Gets the identifier of this CreateTaskValidationDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this CreateTaskValidationDetails.
@@ -373,7 +373,7 @@ class CreateTaskValidationDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this CreateTaskValidationDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this CreateTaskValidationDetails.

--- a/src/oci/data_integration/models/create_workspace_details.py
+++ b/src/oci/data_integration/models/create_workspace_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateWorkspaceDetails(object):
     """
-    The information about new Workspace.
+    The information needed to create a new workspace.
     """
 
     def __init__(self, **kwargs):
@@ -256,7 +256,7 @@ class CreateWorkspaceDetails(object):
     def description(self):
         """
         Gets the description of this CreateWorkspaceDetails.
-        A detailed description for the workspace.
+        A user defined description for the workspace.
 
 
         :return: The description of this CreateWorkspaceDetails.
@@ -268,7 +268,7 @@ class CreateWorkspaceDetails(object):
     def description(self, description):
         """
         Sets the description of this CreateWorkspaceDetails.
-        A detailed description for the workspace.
+        A user defined description for the workspace.
 
 
         :param description: The description of this CreateWorkspaceDetails.
@@ -328,7 +328,7 @@ class CreateWorkspaceDetails(object):
     def is_private_network_enabled(self):
         """
         Gets the is_private_network_enabled of this CreateWorkspaceDetails.
-        Whether the private network connection is enabled or disabled.
+        Specifies whether the private network connection is enabled or disabled.
 
 
         :return: The is_private_network_enabled of this CreateWorkspaceDetails.
@@ -340,7 +340,7 @@ class CreateWorkspaceDetails(object):
     def is_private_network_enabled(self, is_private_network_enabled):
         """
         Sets the is_private_network_enabled of this CreateWorkspaceDetails.
-        Whether the private network connection is enabled or disabled.
+        Specifies whether the private network connection is enabled or disabled.
 
 
         :param is_private_network_enabled: The is_private_network_enabled of this CreateWorkspaceDetails.

--- a/src/oci/data_integration/models/csv_format_attribute.py
+++ b/src/oci/data_integration/models/csv_format_attribute.py
@@ -21,7 +21,7 @@ class CsvFormatAttribute(AbstractFormatAttribute):
 
         :param model_type:
             The value to assign to the model_type property of this CsvFormatAttribute.
-            Allowed values for this property are: "JSON_FORMAT", "CSV_FORMAT"
+            Allowed values for this property are: "JSON_FORMAT", "CSV_FORMAT", "AVRO_FORMAT"
         :type model_type: str
 
         :param encoding:
@@ -44,6 +44,10 @@ class CsvFormatAttribute(AbstractFormatAttribute):
             The value to assign to the has_header property of this CsvFormatAttribute.
         :type has_header: bool
 
+        :param is_file_pattern:
+            The value to assign to the is_file_pattern property of this CsvFormatAttribute.
+        :type is_file_pattern: bool
+
         :param timestamp_format:
             The value to assign to the timestamp_format property of this CsvFormatAttribute.
         :type timestamp_format: str
@@ -56,6 +60,7 @@ class CsvFormatAttribute(AbstractFormatAttribute):
             'delimiter': 'str',
             'quote_character': 'str',
             'has_header': 'bool',
+            'is_file_pattern': 'bool',
             'timestamp_format': 'str'
         }
 
@@ -66,6 +71,7 @@ class CsvFormatAttribute(AbstractFormatAttribute):
             'delimiter': 'delimiter',
             'quote_character': 'quoteCharacter',
             'has_header': 'hasHeader',
+            'is_file_pattern': 'isFilePattern',
             'timestamp_format': 'timestampFormat'
         }
 
@@ -75,6 +81,7 @@ class CsvFormatAttribute(AbstractFormatAttribute):
         self._delimiter = None
         self._quote_character = None
         self._has_header = None
+        self._is_file_pattern = None
         self._timestamp_format = None
         self._model_type = 'CSV_FORMAT'
 
@@ -199,10 +206,34 @@ class CsvFormatAttribute(AbstractFormatAttribute):
         self._has_header = has_header
 
     @property
+    def is_file_pattern(self):
+        """
+        Gets the is_file_pattern of this CsvFormatAttribute.
+        Defines whether a file pattern is supported.
+
+
+        :return: The is_file_pattern of this CsvFormatAttribute.
+        :rtype: bool
+        """
+        return self._is_file_pattern
+
+    @is_file_pattern.setter
+    def is_file_pattern(self, is_file_pattern):
+        """
+        Sets the is_file_pattern of this CsvFormatAttribute.
+        Defines whether a file pattern is supported.
+
+
+        :param is_file_pattern: The is_file_pattern of this CsvFormatAttribute.
+        :type: bool
+        """
+        self._is_file_pattern = is_file_pattern
+
+    @property
     def timestamp_format(self):
         """
         Gets the timestamp_format of this CsvFormatAttribute.
-        Format for timestamp data.
+        Format for timestamp information.
 
 
         :return: The timestamp_format of this CsvFormatAttribute.
@@ -214,7 +245,7 @@ class CsvFormatAttribute(AbstractFormatAttribute):
     def timestamp_format(self, timestamp_format):
         """
         Sets the timestamp_format of this CsvFormatAttribute.
-        Format for timestamp data.
+        Format for timestamp information.
 
 
         :param timestamp_format: The timestamp_format of this CsvFormatAttribute.

--- a/src/oci/data_integration/models/data_asset.py
+++ b/src/oci/data_integration/models/data_asset.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataAsset(object):
     """
-    The data asset type.
+    Represents a data source in the Data Integration service.
     """
 
     #: A constant which can be used with the model_type property of a DataAsset.
@@ -29,21 +29,31 @@ class DataAsset(object):
     #: This constant has a value of "ORACLE_ADWC_DATA_ASSET"
     MODEL_TYPE_ORACLE_ADWC_DATA_ASSET = "ORACLE_ADWC_DATA_ASSET"
 
+    #: A constant which can be used with the model_type property of a DataAsset.
+    #: This constant has a value of "MYSQL_DATA_ASSET"
+    MODEL_TYPE_MYSQL_DATA_ASSET = "MYSQL_DATA_ASSET"
+
+    #: A constant which can be used with the model_type property of a DataAsset.
+    #: This constant has a value of "GENERIC_JDBC_DATA_ASSET"
+    MODEL_TYPE_GENERIC_JDBC_DATA_ASSET = "GENERIC_JDBC_DATA_ASSET"
+
     def __init__(self, **kwargs):
         """
         Initializes a new DataAsset object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.data_integration.models.DataAssetFromJdbc`
         * :class:`~oci.data_integration.models.DataAssetFromOracleDetails`
         * :class:`~oci.data_integration.models.DataAssetFromAdwcDetails`
         * :class:`~oci.data_integration.models.DataAssetFromObjectStorageDetails`
         * :class:`~oci.data_integration.models.DataAssetFromAtpDetails`
+        * :class:`~oci.data_integration.models.DataAssetFromMySQL`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param model_type:
             The value to assign to the model_type property of this DataAsset.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -157,6 +167,9 @@ class DataAsset(object):
         """
         type = object_dictionary['modelType']
 
+        if type == 'GENERIC_JDBC_DATA_ASSET':
+            return 'DataAssetFromJdbc'
+
         if type == 'ORACLE_DATA_ASSET':
             return 'DataAssetFromOracleDetails'
 
@@ -168,6 +181,9 @@ class DataAsset(object):
 
         if type == 'ORACLE_ATP_DATA_ASSET':
             return 'DataAssetFromAtpDetails'
+
+        if type == 'MYSQL_DATA_ASSET':
+            return 'DataAssetFromMySQL'
         else:
             return 'DataAsset'
 
@@ -177,7 +193,7 @@ class DataAsset(object):
         Gets the model_type of this DataAsset.
         The type of the data asset.
 
-        Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -196,7 +212,7 @@ class DataAsset(object):
         :param model_type: The model_type of this DataAsset.
         :type: str
         """
-        allowed_values = ["ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"]
+        allowed_values = ["ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type
@@ -253,7 +269,7 @@ class DataAsset(object):
     def name(self):
         """
         Gets the name of this DataAsset.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataAsset.
@@ -265,7 +281,7 @@ class DataAsset(object):
     def name(self, name):
         """
         Sets the name of this DataAsset.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataAsset.
@@ -277,7 +293,7 @@ class DataAsset(object):
     def description(self):
         """
         Gets the description of this DataAsset.
-        Detailed description for the object.
+        User-defined description of the data asset.
 
 
         :return: The description of this DataAsset.
@@ -289,7 +305,7 @@ class DataAsset(object):
     def description(self, description):
         """
         Sets the description of this DataAsset.
-        Detailed description for the object.
+        User-defined description of the data asset.
 
 
         :param description: The description of this DataAsset.
@@ -325,7 +341,7 @@ class DataAsset(object):
     def identifier(self):
         """
         Gets the identifier of this DataAsset.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataAsset.
@@ -337,7 +353,7 @@ class DataAsset(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataAsset.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataAsset.
@@ -349,7 +365,7 @@ class DataAsset(object):
     def external_key(self):
         """
         Gets the external_key of this DataAsset.
-        The external key for the object
+        The external key for the object.
 
 
         :return: The external_key of this DataAsset.
@@ -361,7 +377,7 @@ class DataAsset(object):
     def external_key(self, external_key):
         """
         Sets the external_key of this DataAsset.
-        The external key for the object
+        The external key for the object.
 
 
         :param external_key: The external_key of this DataAsset.
@@ -373,7 +389,7 @@ class DataAsset(object):
     def asset_properties(self):
         """
         Gets the asset_properties of this DataAsset.
-        assetProperties
+        Additional properties for the data asset.
 
 
         :return: The asset_properties of this DataAsset.
@@ -385,7 +401,7 @@ class DataAsset(object):
     def asset_properties(self, asset_properties):
         """
         Sets the asset_properties of this DataAsset.
-        assetProperties
+        Additional properties for the data asset.
 
 
         :param asset_properties: The asset_properties of this DataAsset.
@@ -481,7 +497,7 @@ class DataAsset(object):
     def key_map(self):
         """
         Gets the key_map of this DataAsset.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this DataAsset.
@@ -493,7 +509,7 @@ class DataAsset(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this DataAsset.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this DataAsset.

--- a/src/oci/data_integration/models/data_asset_from_adwc_details.py
+++ b/src/oci/data_integration/models/data_asset_from_adwc_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataAssetFromAdwcDetails(DataAsset):
     """
-    The ADWC data asset details.
+    Details for the Autonomous Data Warehouse data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class DataAssetFromAdwcDetails(DataAsset):
 
         :param model_type:
             The value to assign to the model_type property of this DataAssetFromAdwcDetails.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -159,7 +159,7 @@ class DataAssetFromAdwcDetails(DataAsset):
     def service_name(self):
         """
         Gets the service_name of this DataAssetFromAdwcDetails.
-        The service name for the data asset.
+        The Autonomous Data Warehouse instance service name.
 
 
         :return: The service_name of this DataAssetFromAdwcDetails.
@@ -171,7 +171,7 @@ class DataAssetFromAdwcDetails(DataAsset):
     def service_name(self, service_name):
         """
         Sets the service_name of this DataAssetFromAdwcDetails.
-        The service name for the data asset.
+        The Autonomous Data Warehouse instance service name.
 
 
         :param service_name: The service_name of this DataAssetFromAdwcDetails.
@@ -207,7 +207,7 @@ class DataAssetFromAdwcDetails(DataAsset):
     def driver_class(self):
         """
         Gets the driver_class of this DataAssetFromAdwcDetails.
-        The driver class for the data asset.
+        The Autonomous Data Warehouse driver class.
 
 
         :return: The driver_class of this DataAssetFromAdwcDetails.
@@ -219,7 +219,7 @@ class DataAssetFromAdwcDetails(DataAsset):
     def driver_class(self, driver_class):
         """
         Sets the driver_class of this DataAssetFromAdwcDetails.
-        The driver class for the data asset.
+        The Autonomous Data Warehouse driver class.
 
 
         :param driver_class: The driver_class of this DataAssetFromAdwcDetails.

--- a/src/oci/data_integration/models/data_asset_from_atp_details.py
+++ b/src/oci/data_integration/models/data_asset_from_atp_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataAssetFromAtpDetails(DataAsset):
     """
-    The ATP data asset details.
+    Details for the Autonomous Transaction Processing data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class DataAssetFromAtpDetails(DataAsset):
 
         :param model_type:
             The value to assign to the model_type property of this DataAssetFromAtpDetails.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -159,7 +159,7 @@ class DataAssetFromAtpDetails(DataAsset):
     def service_name(self):
         """
         Gets the service_name of this DataAssetFromAtpDetails.
-        The service name for the data asset.
+        The Autonomous Transaction Processing instance service name.
 
 
         :return: The service_name of this DataAssetFromAtpDetails.
@@ -171,7 +171,7 @@ class DataAssetFromAtpDetails(DataAsset):
     def service_name(self, service_name):
         """
         Sets the service_name of this DataAssetFromAtpDetails.
-        The service name for the data asset.
+        The Autonomous Transaction Processing instance service name.
 
 
         :param service_name: The service_name of this DataAssetFromAtpDetails.
@@ -207,7 +207,7 @@ class DataAssetFromAtpDetails(DataAsset):
     def driver_class(self):
         """
         Gets the driver_class of this DataAssetFromAtpDetails.
-        The driver class for the data asset.
+        The Autonomous Transaction Processing driver class.
 
 
         :return: The driver_class of this DataAssetFromAtpDetails.
@@ -219,7 +219,7 @@ class DataAssetFromAtpDetails(DataAsset):
     def driver_class(self, driver_class):
         """
         Sets the driver_class of this DataAssetFromAtpDetails.
-        The driver class for the data asset.
+        The Autonomous Transaction Processing driver class.
 
 
         :param driver_class: The driver_class of this DataAssetFromAtpDetails.

--- a/src/oci/data_integration/models/data_asset_from_jdbc.py
+++ b/src/oci/data_integration/models/data_asset_from_jdbc.py
@@ -1,0 +1,260 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .data_asset import DataAsset
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DataAssetFromJdbc(DataAsset):
+    """
+    Details for the generic JDBC data asset type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DataAssetFromJdbc object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.DataAssetFromJdbc.model_type` attribute
+        of this class is ``GENERIC_JDBC_DATA_ASSET`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this DataAssetFromJdbc.
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this DataAssetFromJdbc.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this DataAssetFromJdbc.
+        :type model_version: str
+
+        :param name:
+            The value to assign to the name property of this DataAssetFromJdbc.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this DataAssetFromJdbc.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this DataAssetFromJdbc.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this DataAssetFromJdbc.
+        :type identifier: str
+
+        :param external_key:
+            The value to assign to the external_key property of this DataAssetFromJdbc.
+        :type external_key: str
+
+        :param asset_properties:
+            The value to assign to the asset_properties property of this DataAssetFromJdbc.
+        :type asset_properties: dict(str, str)
+
+        :param native_type_system:
+            The value to assign to the native_type_system property of this DataAssetFromJdbc.
+        :type native_type_system: TypeSystem
+
+        :param object_version:
+            The value to assign to the object_version property of this DataAssetFromJdbc.
+        :type object_version: int
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this DataAssetFromJdbc.
+        :type parent_ref: ParentReference
+
+        :param metadata:
+            The value to assign to the metadata property of this DataAssetFromJdbc.
+        :type metadata: ObjectMetadata
+
+        :param key_map:
+            The value to assign to the key_map property of this DataAssetFromJdbc.
+        :type key_map: dict(str, str)
+
+        :param host:
+            The value to assign to the host property of this DataAssetFromJdbc.
+        :type host: str
+
+        :param port:
+            The value to assign to the port property of this DataAssetFromJdbc.
+        :type port: str
+
+        :param data_asset_type:
+            The value to assign to the data_asset_type property of this DataAssetFromJdbc.
+        :type data_asset_type: str
+
+        :param default_connection:
+            The value to assign to the default_connection property of this DataAssetFromJdbc.
+        :type default_connection: ConnectionFromJdbcDetails
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'identifier': 'str',
+            'external_key': 'str',
+            'asset_properties': 'dict(str, str)',
+            'native_type_system': 'TypeSystem',
+            'object_version': 'int',
+            'parent_ref': 'ParentReference',
+            'metadata': 'ObjectMetadata',
+            'key_map': 'dict(str, str)',
+            'host': 'str',
+            'port': 'str',
+            'data_asset_type': 'str',
+            'default_connection': 'ConnectionFromJdbcDetails'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'external_key': 'externalKey',
+            'asset_properties': 'assetProperties',
+            'native_type_system': 'nativeTypeSystem',
+            'object_version': 'objectVersion',
+            'parent_ref': 'parentRef',
+            'metadata': 'metadata',
+            'key_map': 'keyMap',
+            'host': 'host',
+            'port': 'port',
+            'data_asset_type': 'dataAssetType',
+            'default_connection': 'defaultConnection'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._identifier = None
+        self._external_key = None
+        self._asset_properties = None
+        self._native_type_system = None
+        self._object_version = None
+        self._parent_ref = None
+        self._metadata = None
+        self._key_map = None
+        self._host = None
+        self._port = None
+        self._data_asset_type = None
+        self._default_connection = None
+        self._model_type = 'GENERIC_JDBC_DATA_ASSET'
+
+    @property
+    def host(self):
+        """
+        Gets the host of this DataAssetFromJdbc.
+        The generic JDBC host name.
+
+
+        :return: The host of this DataAssetFromJdbc.
+        :rtype: str
+        """
+        return self._host
+
+    @host.setter
+    def host(self, host):
+        """
+        Sets the host of this DataAssetFromJdbc.
+        The generic JDBC host name.
+
+
+        :param host: The host of this DataAssetFromJdbc.
+        :type: str
+        """
+        self._host = host
+
+    @property
+    def port(self):
+        """
+        Gets the port of this DataAssetFromJdbc.
+        The generic JDBC port number.
+
+
+        :return: The port of this DataAssetFromJdbc.
+        :rtype: str
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this DataAssetFromJdbc.
+        The generic JDBC port number.
+
+
+        :param port: The port of this DataAssetFromJdbc.
+        :type: str
+        """
+        self._port = port
+
+    @property
+    def data_asset_type(self):
+        """
+        Gets the data_asset_type of this DataAssetFromJdbc.
+        The data asset type for the generic JDBC data asset.
+
+
+        :return: The data_asset_type of this DataAssetFromJdbc.
+        :rtype: str
+        """
+        return self._data_asset_type
+
+    @data_asset_type.setter
+    def data_asset_type(self, data_asset_type):
+        """
+        Sets the data_asset_type of this DataAssetFromJdbc.
+        The data asset type for the generic JDBC data asset.
+
+
+        :param data_asset_type: The data_asset_type of this DataAssetFromJdbc.
+        :type: str
+        """
+        self._data_asset_type = data_asset_type
+
+    @property
+    def default_connection(self):
+        """
+        Gets the default_connection of this DataAssetFromJdbc.
+
+        :return: The default_connection of this DataAssetFromJdbc.
+        :rtype: ConnectionFromJdbcDetails
+        """
+        return self._default_connection
+
+    @default_connection.setter
+    def default_connection(self, default_connection):
+        """
+        Sets the default_connection of this DataAssetFromJdbc.
+
+        :param default_connection: The default_connection of this DataAssetFromJdbc.
+        :type: ConnectionFromJdbcDetails
+        """
+        self._default_connection = default_connection
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/data_asset_from_my_sql.py
+++ b/src/oci/data_integration/models/data_asset_from_my_sql.py
@@ -1,0 +1,260 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .data_asset import DataAsset
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DataAssetFromMySQL(DataAsset):
+    """
+    Details for the MYSQL data asset type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DataAssetFromMySQL object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.DataAssetFromMySQL.model_type` attribute
+        of this class is ``MYSQL_DATA_ASSET`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this DataAssetFromMySQL.
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this DataAssetFromMySQL.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this DataAssetFromMySQL.
+        :type model_version: str
+
+        :param name:
+            The value to assign to the name property of this DataAssetFromMySQL.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this DataAssetFromMySQL.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this DataAssetFromMySQL.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this DataAssetFromMySQL.
+        :type identifier: str
+
+        :param external_key:
+            The value to assign to the external_key property of this DataAssetFromMySQL.
+        :type external_key: str
+
+        :param asset_properties:
+            The value to assign to the asset_properties property of this DataAssetFromMySQL.
+        :type asset_properties: dict(str, str)
+
+        :param native_type_system:
+            The value to assign to the native_type_system property of this DataAssetFromMySQL.
+        :type native_type_system: TypeSystem
+
+        :param object_version:
+            The value to assign to the object_version property of this DataAssetFromMySQL.
+        :type object_version: int
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this DataAssetFromMySQL.
+        :type parent_ref: ParentReference
+
+        :param metadata:
+            The value to assign to the metadata property of this DataAssetFromMySQL.
+        :type metadata: ObjectMetadata
+
+        :param key_map:
+            The value to assign to the key_map property of this DataAssetFromMySQL.
+        :type key_map: dict(str, str)
+
+        :param host:
+            The value to assign to the host property of this DataAssetFromMySQL.
+        :type host: str
+
+        :param port:
+            The value to assign to the port property of this DataAssetFromMySQL.
+        :type port: str
+
+        :param service_name:
+            The value to assign to the service_name property of this DataAssetFromMySQL.
+        :type service_name: str
+
+        :param default_connection:
+            The value to assign to the default_connection property of this DataAssetFromMySQL.
+        :type default_connection: ConnectionFromMySQLDetails
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'identifier': 'str',
+            'external_key': 'str',
+            'asset_properties': 'dict(str, str)',
+            'native_type_system': 'TypeSystem',
+            'object_version': 'int',
+            'parent_ref': 'ParentReference',
+            'metadata': 'ObjectMetadata',
+            'key_map': 'dict(str, str)',
+            'host': 'str',
+            'port': 'str',
+            'service_name': 'str',
+            'default_connection': 'ConnectionFromMySQLDetails'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'external_key': 'externalKey',
+            'asset_properties': 'assetProperties',
+            'native_type_system': 'nativeTypeSystem',
+            'object_version': 'objectVersion',
+            'parent_ref': 'parentRef',
+            'metadata': 'metadata',
+            'key_map': 'keyMap',
+            'host': 'host',
+            'port': 'port',
+            'service_name': 'serviceName',
+            'default_connection': 'defaultConnection'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._identifier = None
+        self._external_key = None
+        self._asset_properties = None
+        self._native_type_system = None
+        self._object_version = None
+        self._parent_ref = None
+        self._metadata = None
+        self._key_map = None
+        self._host = None
+        self._port = None
+        self._service_name = None
+        self._default_connection = None
+        self._model_type = 'MYSQL_DATA_ASSET'
+
+    @property
+    def host(self):
+        """
+        Gets the host of this DataAssetFromMySQL.
+        The generic JDBC host name.
+
+
+        :return: The host of this DataAssetFromMySQL.
+        :rtype: str
+        """
+        return self._host
+
+    @host.setter
+    def host(self, host):
+        """
+        Sets the host of this DataAssetFromMySQL.
+        The generic JDBC host name.
+
+
+        :param host: The host of this DataAssetFromMySQL.
+        :type: str
+        """
+        self._host = host
+
+    @property
+    def port(self):
+        """
+        Gets the port of this DataAssetFromMySQL.
+        The generic JDBC port number.
+
+
+        :return: The port of this DataAssetFromMySQL.
+        :rtype: str
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this DataAssetFromMySQL.
+        The generic JDBC port number.
+
+
+        :param port: The port of this DataAssetFromMySQL.
+        :type: str
+        """
+        self._port = port
+
+    @property
+    def service_name(self):
+        """
+        Gets the service_name of this DataAssetFromMySQL.
+        The generic JDBC service name for the database.
+
+
+        :return: The service_name of this DataAssetFromMySQL.
+        :rtype: str
+        """
+        return self._service_name
+
+    @service_name.setter
+    def service_name(self, service_name):
+        """
+        Sets the service_name of this DataAssetFromMySQL.
+        The generic JDBC service name for the database.
+
+
+        :param service_name: The service_name of this DataAssetFromMySQL.
+        :type: str
+        """
+        self._service_name = service_name
+
+    @property
+    def default_connection(self):
+        """
+        Gets the default_connection of this DataAssetFromMySQL.
+
+        :return: The default_connection of this DataAssetFromMySQL.
+        :rtype: ConnectionFromMySQLDetails
+        """
+        return self._default_connection
+
+    @default_connection.setter
+    def default_connection(self, default_connection):
+        """
+        Sets the default_connection of this DataAssetFromMySQL.
+
+        :param default_connection: The default_connection of this DataAssetFromMySQL.
+        :type: ConnectionFromMySQLDetails
+        """
+        self._default_connection = default_connection
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/data_asset_from_object_storage_details.py
+++ b/src/oci/data_integration/models/data_asset_from_object_storage_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataAssetFromObjectStorageDetails(DataAsset):
     """
-    The Object Storage data asset details.
+    Details for the Oracle Object storage data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class DataAssetFromObjectStorageDetails(DataAsset):
 
         :param model_type:
             The value to assign to the model_type property of this DataAssetFromObjectStorageDetails.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -159,7 +159,7 @@ class DataAssetFromObjectStorageDetails(DataAsset):
     def url(self):
         """
         Gets the url of this DataAssetFromObjectStorageDetails.
-        url
+        The Oracle Object storage URL.
 
 
         :return: The url of this DataAssetFromObjectStorageDetails.
@@ -171,7 +171,7 @@ class DataAssetFromObjectStorageDetails(DataAsset):
     def url(self, url):
         """
         Sets the url of this DataAssetFromObjectStorageDetails.
-        url
+        The Oracle Object storage URL.
 
 
         :param url: The url of this DataAssetFromObjectStorageDetails.
@@ -207,7 +207,7 @@ class DataAssetFromObjectStorageDetails(DataAsset):
     def namespace(self):
         """
         Gets the namespace of this DataAssetFromObjectStorageDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        The namespace for the specified Oracle Object storage resource. You can find the namespace under Object Storage Settings in the Console.
 
 
         :return: The namespace of this DataAssetFromObjectStorageDetails.
@@ -219,7 +219,7 @@ class DataAssetFromObjectStorageDetails(DataAsset):
     def namespace(self, namespace):
         """
         Sets the namespace of this DataAssetFromObjectStorageDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        The namespace for the specified Oracle Object storage resource. You can find the namespace under Object Storage Settings in the Console.
 
 
         :param namespace: The namespace of this DataAssetFromObjectStorageDetails.

--- a/src/oci/data_integration/models/data_asset_from_oracle_details.py
+++ b/src/oci/data_integration/models/data_asset_from_oracle_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataAssetFromOracleDetails(DataAsset):
     """
-    The Oracle data asset details.
+    Details for the Oracle Database data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class DataAssetFromOracleDetails(DataAsset):
 
         :param model_type:
             The value to assign to the model_type property of this DataAssetFromOracleDetails.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -180,7 +180,7 @@ class DataAssetFromOracleDetails(DataAsset):
     def host(self):
         """
         Gets the host of this DataAssetFromOracleDetails.
-        The host details for the data asset.
+        The Oracle Database hostname.
 
 
         :return: The host of this DataAssetFromOracleDetails.
@@ -192,7 +192,7 @@ class DataAssetFromOracleDetails(DataAsset):
     def host(self, host):
         """
         Sets the host of this DataAssetFromOracleDetails.
-        The host details for the data asset.
+        The Oracle Database hostname.
 
 
         :param host: The host of this DataAssetFromOracleDetails.
@@ -204,7 +204,7 @@ class DataAssetFromOracleDetails(DataAsset):
     def port(self):
         """
         Gets the port of this DataAssetFromOracleDetails.
-        The port details for the data asset.
+        The Oracle Database port.
 
 
         :return: The port of this DataAssetFromOracleDetails.
@@ -216,7 +216,7 @@ class DataAssetFromOracleDetails(DataAsset):
     def port(self, port):
         """
         Sets the port of this DataAssetFromOracleDetails.
-        The port details for the data asset.
+        The Oracle Database port.
 
 
         :param port: The port of this DataAssetFromOracleDetails.
@@ -228,7 +228,7 @@ class DataAssetFromOracleDetails(DataAsset):
     def service_name(self):
         """
         Gets the service_name of this DataAssetFromOracleDetails.
-        The service name for the data asset.
+        The Oracle Database service name.
 
 
         :return: The service_name of this DataAssetFromOracleDetails.
@@ -240,7 +240,7 @@ class DataAssetFromOracleDetails(DataAsset):
     def service_name(self, service_name):
         """
         Sets the service_name of this DataAssetFromOracleDetails.
-        The service name for the data asset.
+        The Oracle Database service name.
 
 
         :param service_name: The service_name of this DataAssetFromOracleDetails.
@@ -252,7 +252,7 @@ class DataAssetFromOracleDetails(DataAsset):
     def driver_class(self):
         """
         Gets the driver_class of this DataAssetFromOracleDetails.
-        The driver class for the data asset.
+        The Oracle Database driver class.
 
 
         :return: The driver_class of this DataAssetFromOracleDetails.
@@ -264,7 +264,7 @@ class DataAssetFromOracleDetails(DataAsset):
     def driver_class(self, driver_class):
         """
         Sets the driver_class of this DataAssetFromOracleDetails.
-        The driver class for the data asset.
+        The Oracle Database driver class.
 
 
         :param driver_class: The driver_class of this DataAssetFromOracleDetails.
@@ -276,7 +276,7 @@ class DataAssetFromOracleDetails(DataAsset):
     def sid(self):
         """
         Gets the sid of this DataAssetFromOracleDetails.
-        sid
+        The Oracle Database SID.
 
 
         :return: The sid of this DataAssetFromOracleDetails.
@@ -288,7 +288,7 @@ class DataAssetFromOracleDetails(DataAsset):
     def sid(self, sid):
         """
         Sets the sid of this DataAssetFromOracleDetails.
-        sid
+        The Oracle Database SID.
 
 
         :param sid: The sid of this DataAssetFromOracleDetails.

--- a/src/oci/data_integration/models/data_asset_summary.py
+++ b/src/oci/data_integration/models/data_asset_summary.py
@@ -29,13 +29,23 @@ class DataAssetSummary(object):
     #: This constant has a value of "ORACLE_ADWC_DATA_ASSET"
     MODEL_TYPE_ORACLE_ADWC_DATA_ASSET = "ORACLE_ADWC_DATA_ASSET"
 
+    #: A constant which can be used with the model_type property of a DataAssetSummary.
+    #: This constant has a value of "MYSQL_DATA_ASSET"
+    MODEL_TYPE_MYSQL_DATA_ASSET = "MYSQL_DATA_ASSET"
+
+    #: A constant which can be used with the model_type property of a DataAssetSummary.
+    #: This constant has a value of "GENERIC_JDBC_DATA_ASSET"
+    MODEL_TYPE_GENERIC_JDBC_DATA_ASSET = "GENERIC_JDBC_DATA_ASSET"
+
     def __init__(self, **kwargs):
         """
         Initializes a new DataAssetSummary object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.data_integration.models.DataAssetSummaryFromMySQL`
         * :class:`~oci.data_integration.models.DataAssetSummaryFromAtp`
         * :class:`~oci.data_integration.models.DataAssetSummaryFromAdwc`
+        * :class:`~oci.data_integration.models.DataAssetSummaryFromJdbc`
         * :class:`~oci.data_integration.models.DataAssetSummaryFromObjectStorage`
         * :class:`~oci.data_integration.models.DataAssetSummaryFromOracle`
 
@@ -43,7 +53,7 @@ class DataAssetSummary(object):
 
         :param model_type:
             The value to assign to the model_type property of this DataAssetSummary.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -150,11 +160,17 @@ class DataAssetSummary(object):
         """
         type = object_dictionary['modelType']
 
+        if type == 'MYSQL_DATA_ASSET':
+            return 'DataAssetSummaryFromMySQL'
+
         if type == 'ORACLE_ATP_DATA_ASSET':
             return 'DataAssetSummaryFromAtp'
 
         if type == 'ORACLE_ADWC_DATA_ASSET':
             return 'DataAssetSummaryFromAdwc'
+
+        if type == 'GENERIC_JDBC_DATA_ASSET':
+            return 'DataAssetSummaryFromJdbc'
 
         if type == 'ORACLE_OBJECT_STORAGE_DATA_ASSET':
             return 'DataAssetSummaryFromObjectStorage'
@@ -170,7 +186,7 @@ class DataAssetSummary(object):
         Gets the model_type of this DataAssetSummary.
         The type of the data asset.
 
-        Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -189,7 +205,7 @@ class DataAssetSummary(object):
         :param model_type: The model_type of this DataAssetSummary.
         :type: str
         """
-        allowed_values = ["ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"]
+        allowed_values = ["ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type
@@ -246,7 +262,7 @@ class DataAssetSummary(object):
     def name(self):
         """
         Gets the name of this DataAssetSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataAssetSummary.
@@ -258,7 +274,7 @@ class DataAssetSummary(object):
     def name(self, name):
         """
         Sets the name of this DataAssetSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataAssetSummary.
@@ -270,7 +286,7 @@ class DataAssetSummary(object):
     def description(self):
         """
         Gets the description of this DataAssetSummary.
-        Detailed description for the object.
+        The user-defined description of the data asset.
 
 
         :return: The description of this DataAssetSummary.
@@ -282,7 +298,7 @@ class DataAssetSummary(object):
     def description(self, description):
         """
         Sets the description of this DataAssetSummary.
-        Detailed description for the object.
+        The user-defined description of the data asset.
 
 
         :param description: The description of this DataAssetSummary.
@@ -318,7 +334,7 @@ class DataAssetSummary(object):
     def identifier(self):
         """
         Gets the identifier of this DataAssetSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataAssetSummary.
@@ -330,7 +346,7 @@ class DataAssetSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataAssetSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataAssetSummary.
@@ -342,7 +358,7 @@ class DataAssetSummary(object):
     def external_key(self):
         """
         Gets the external_key of this DataAssetSummary.
-        The external key for the object
+        The external key for the object.
 
 
         :return: The external_key of this DataAssetSummary.
@@ -354,7 +370,7 @@ class DataAssetSummary(object):
     def external_key(self, external_key):
         """
         Sets the external_key of this DataAssetSummary.
-        The external key for the object
+        The external key for the object.
 
 
         :param external_key: The external_key of this DataAssetSummary.
@@ -366,7 +382,7 @@ class DataAssetSummary(object):
     def asset_properties(self):
         """
         Gets the asset_properties of this DataAssetSummary.
-        assetProperties
+        Additional properties for the data asset.
 
 
         :return: The asset_properties of this DataAssetSummary.
@@ -378,7 +394,7 @@ class DataAssetSummary(object):
     def asset_properties(self, asset_properties):
         """
         Sets the asset_properties of this DataAssetSummary.
-        assetProperties
+        Additional properties for the data asset.
 
 
         :param asset_properties: The asset_properties of this DataAssetSummary.

--- a/src/oci/data_integration/models/data_asset_summary_collection.py
+++ b/src/oci/data_integration/models/data_asset_summary_collection.py
@@ -37,7 +37,7 @@ class DataAssetSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this DataAssetSummaryCollection.
-        The array of DataAsset summaries
+        The array of data asset summaries.
 
 
         :return: The items of this DataAssetSummaryCollection.
@@ -49,7 +49,7 @@ class DataAssetSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this DataAssetSummaryCollection.
-        The array of DataAsset summaries
+        The array of data asset summaries.
 
 
         :param items: The items of this DataAssetSummaryCollection.

--- a/src/oci/data_integration/models/data_asset_summary_from_adwc.py
+++ b/src/oci/data_integration/models/data_asset_summary_from_adwc.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataAssetSummaryFromAdwc(DataAssetSummary):
     """
-    The Oracle data asset details.
+    Summary details for the Autonomous Data Warehouse data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class DataAssetSummaryFromAdwc(DataAssetSummary):
 
         :param model_type:
             The value to assign to the model_type property of this DataAssetSummaryFromAdwc.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -152,7 +152,7 @@ class DataAssetSummaryFromAdwc(DataAssetSummary):
     def service_name(self):
         """
         Gets the service_name of this DataAssetSummaryFromAdwc.
-        The service name for the data asset.
+        The Autonomous Data Warehouse instance service name.
 
 
         :return: The service_name of this DataAssetSummaryFromAdwc.
@@ -164,7 +164,7 @@ class DataAssetSummaryFromAdwc(DataAssetSummary):
     def service_name(self, service_name):
         """
         Sets the service_name of this DataAssetSummaryFromAdwc.
-        The service name for the data asset.
+        The Autonomous Data Warehouse instance service name.
 
 
         :param service_name: The service_name of this DataAssetSummaryFromAdwc.
@@ -200,7 +200,7 @@ class DataAssetSummaryFromAdwc(DataAssetSummary):
     def driver_class(self):
         """
         Gets the driver_class of this DataAssetSummaryFromAdwc.
-        The driver class for the data asset.
+        The Autonomous Data Warehouse driver class.
 
 
         :return: The driver_class of this DataAssetSummaryFromAdwc.
@@ -212,7 +212,7 @@ class DataAssetSummaryFromAdwc(DataAssetSummary):
     def driver_class(self, driver_class):
         """
         Sets the driver_class of this DataAssetSummaryFromAdwc.
-        The driver class for the data asset.
+        The Autonomous Data Warehouse driver class.
 
 
         :param driver_class: The driver_class of this DataAssetSummaryFromAdwc.

--- a/src/oci/data_integration/models/data_asset_summary_from_atp.py
+++ b/src/oci/data_integration/models/data_asset_summary_from_atp.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataAssetSummaryFromAtp(DataAssetSummary):
     """
-    The Oracle data asset details.
+    Summary details for the Autonomous Transaction Processing data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class DataAssetSummaryFromAtp(DataAssetSummary):
 
         :param model_type:
             The value to assign to the model_type property of this DataAssetSummaryFromAtp.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -152,7 +152,7 @@ class DataAssetSummaryFromAtp(DataAssetSummary):
     def service_name(self):
         """
         Gets the service_name of this DataAssetSummaryFromAtp.
-        The service name for the data asset.
+        The Autonomous Transaction Processing instance service name.
 
 
         :return: The service_name of this DataAssetSummaryFromAtp.
@@ -164,7 +164,7 @@ class DataAssetSummaryFromAtp(DataAssetSummary):
     def service_name(self, service_name):
         """
         Sets the service_name of this DataAssetSummaryFromAtp.
-        The service name for the data asset.
+        The Autonomous Transaction Processing instance service name.
 
 
         :param service_name: The service_name of this DataAssetSummaryFromAtp.
@@ -200,7 +200,7 @@ class DataAssetSummaryFromAtp(DataAssetSummary):
     def driver_class(self):
         """
         Gets the driver_class of this DataAssetSummaryFromAtp.
-        The driver class for the data asset.
+        The Autonomous Transaction Processing driver class.
 
 
         :return: The driver_class of this DataAssetSummaryFromAtp.
@@ -212,7 +212,7 @@ class DataAssetSummaryFromAtp(DataAssetSummary):
     def driver_class(self, driver_class):
         """
         Sets the driver_class of this DataAssetSummaryFromAtp.
-        The driver class for the data asset.
+        The Autonomous Transaction Processing driver class.
 
 
         :param driver_class: The driver_class of this DataAssetSummaryFromAtp.

--- a/src/oci/data_integration/models/data_asset_summary_from_jdbc.py
+++ b/src/oci/data_integration/models/data_asset_summary_from_jdbc.py
@@ -1,0 +1,253 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .data_asset_summary import DataAssetSummary
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DataAssetSummaryFromJdbc(DataAssetSummary):
+    """
+    Summary details for the generic JDBC data asset type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DataAssetSummaryFromJdbc object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.DataAssetSummaryFromJdbc.model_type` attribute
+        of this class is ``GENERIC_JDBC_DATA_ASSET`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this DataAssetSummaryFromJdbc.
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this DataAssetSummaryFromJdbc.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this DataAssetSummaryFromJdbc.
+        :type model_version: str
+
+        :param name:
+            The value to assign to the name property of this DataAssetSummaryFromJdbc.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this DataAssetSummaryFromJdbc.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this DataAssetSummaryFromJdbc.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this DataAssetSummaryFromJdbc.
+        :type identifier: str
+
+        :param external_key:
+            The value to assign to the external_key property of this DataAssetSummaryFromJdbc.
+        :type external_key: str
+
+        :param asset_properties:
+            The value to assign to the asset_properties property of this DataAssetSummaryFromJdbc.
+        :type asset_properties: dict(str, str)
+
+        :param native_type_system:
+            The value to assign to the native_type_system property of this DataAssetSummaryFromJdbc.
+        :type native_type_system: TypeSystem
+
+        :param object_version:
+            The value to assign to the object_version property of this DataAssetSummaryFromJdbc.
+        :type object_version: int
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this DataAssetSummaryFromJdbc.
+        :type parent_ref: ParentReference
+
+        :param metadata:
+            The value to assign to the metadata property of this DataAssetSummaryFromJdbc.
+        :type metadata: ObjectMetadata
+
+        :param host:
+            The value to assign to the host property of this DataAssetSummaryFromJdbc.
+        :type host: str
+
+        :param port:
+            The value to assign to the port property of this DataAssetSummaryFromJdbc.
+        :type port: str
+
+        :param data_asset_type:
+            The value to assign to the data_asset_type property of this DataAssetSummaryFromJdbc.
+        :type data_asset_type: str
+
+        :param default_connection:
+            The value to assign to the default_connection property of this DataAssetSummaryFromJdbc.
+        :type default_connection: ConnectionSummaryFromJdbc
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'identifier': 'str',
+            'external_key': 'str',
+            'asset_properties': 'dict(str, str)',
+            'native_type_system': 'TypeSystem',
+            'object_version': 'int',
+            'parent_ref': 'ParentReference',
+            'metadata': 'ObjectMetadata',
+            'host': 'str',
+            'port': 'str',
+            'data_asset_type': 'str',
+            'default_connection': 'ConnectionSummaryFromJdbc'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'external_key': 'externalKey',
+            'asset_properties': 'assetProperties',
+            'native_type_system': 'nativeTypeSystem',
+            'object_version': 'objectVersion',
+            'parent_ref': 'parentRef',
+            'metadata': 'metadata',
+            'host': 'host',
+            'port': 'port',
+            'data_asset_type': 'dataAssetType',
+            'default_connection': 'defaultConnection'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._identifier = None
+        self._external_key = None
+        self._asset_properties = None
+        self._native_type_system = None
+        self._object_version = None
+        self._parent_ref = None
+        self._metadata = None
+        self._host = None
+        self._port = None
+        self._data_asset_type = None
+        self._default_connection = None
+        self._model_type = 'GENERIC_JDBC_DATA_ASSET'
+
+    @property
+    def host(self):
+        """
+        Gets the host of this DataAssetSummaryFromJdbc.
+        The generic JDBC host name.
+
+
+        :return: The host of this DataAssetSummaryFromJdbc.
+        :rtype: str
+        """
+        return self._host
+
+    @host.setter
+    def host(self, host):
+        """
+        Sets the host of this DataAssetSummaryFromJdbc.
+        The generic JDBC host name.
+
+
+        :param host: The host of this DataAssetSummaryFromJdbc.
+        :type: str
+        """
+        self._host = host
+
+    @property
+    def port(self):
+        """
+        Gets the port of this DataAssetSummaryFromJdbc.
+        The generic JDBC port number.
+
+
+        :return: The port of this DataAssetSummaryFromJdbc.
+        :rtype: str
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this DataAssetSummaryFromJdbc.
+        The generic JDBC port number.
+
+
+        :param port: The port of this DataAssetSummaryFromJdbc.
+        :type: str
+        """
+        self._port = port
+
+    @property
+    def data_asset_type(self):
+        """
+        Gets the data_asset_type of this DataAssetSummaryFromJdbc.
+        The data asset type for the generic JDBC data asset.
+
+
+        :return: The data_asset_type of this DataAssetSummaryFromJdbc.
+        :rtype: str
+        """
+        return self._data_asset_type
+
+    @data_asset_type.setter
+    def data_asset_type(self, data_asset_type):
+        """
+        Sets the data_asset_type of this DataAssetSummaryFromJdbc.
+        The data asset type for the generic JDBC data asset.
+
+
+        :param data_asset_type: The data_asset_type of this DataAssetSummaryFromJdbc.
+        :type: str
+        """
+        self._data_asset_type = data_asset_type
+
+    @property
+    def default_connection(self):
+        """
+        Gets the default_connection of this DataAssetSummaryFromJdbc.
+
+        :return: The default_connection of this DataAssetSummaryFromJdbc.
+        :rtype: ConnectionSummaryFromJdbc
+        """
+        return self._default_connection
+
+    @default_connection.setter
+    def default_connection(self, default_connection):
+        """
+        Sets the default_connection of this DataAssetSummaryFromJdbc.
+
+        :param default_connection: The default_connection of this DataAssetSummaryFromJdbc.
+        :type: ConnectionSummaryFromJdbc
+        """
+        self._default_connection = default_connection
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/data_asset_summary_from_my_sql.py
+++ b/src/oci/data_integration/models/data_asset_summary_from_my_sql.py
@@ -1,0 +1,253 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .data_asset_summary import DataAssetSummary
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DataAssetSummaryFromMySQL(DataAssetSummary):
+    """
+    Summary details for the MYSQL data asset type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DataAssetSummaryFromMySQL object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.DataAssetSummaryFromMySQL.model_type` attribute
+        of this class is ``MYSQL_DATA_ASSET`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this DataAssetSummaryFromMySQL.
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this DataAssetSummaryFromMySQL.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this DataAssetSummaryFromMySQL.
+        :type model_version: str
+
+        :param name:
+            The value to assign to the name property of this DataAssetSummaryFromMySQL.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this DataAssetSummaryFromMySQL.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this DataAssetSummaryFromMySQL.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this DataAssetSummaryFromMySQL.
+        :type identifier: str
+
+        :param external_key:
+            The value to assign to the external_key property of this DataAssetSummaryFromMySQL.
+        :type external_key: str
+
+        :param asset_properties:
+            The value to assign to the asset_properties property of this DataAssetSummaryFromMySQL.
+        :type asset_properties: dict(str, str)
+
+        :param native_type_system:
+            The value to assign to the native_type_system property of this DataAssetSummaryFromMySQL.
+        :type native_type_system: TypeSystem
+
+        :param object_version:
+            The value to assign to the object_version property of this DataAssetSummaryFromMySQL.
+        :type object_version: int
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this DataAssetSummaryFromMySQL.
+        :type parent_ref: ParentReference
+
+        :param metadata:
+            The value to assign to the metadata property of this DataAssetSummaryFromMySQL.
+        :type metadata: ObjectMetadata
+
+        :param host:
+            The value to assign to the host property of this DataAssetSummaryFromMySQL.
+        :type host: str
+
+        :param port:
+            The value to assign to the port property of this DataAssetSummaryFromMySQL.
+        :type port: str
+
+        :param service_name:
+            The value to assign to the service_name property of this DataAssetSummaryFromMySQL.
+        :type service_name: str
+
+        :param default_connection:
+            The value to assign to the default_connection property of this DataAssetSummaryFromMySQL.
+        :type default_connection: ConnectionSummaryFromMySQL
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'identifier': 'str',
+            'external_key': 'str',
+            'asset_properties': 'dict(str, str)',
+            'native_type_system': 'TypeSystem',
+            'object_version': 'int',
+            'parent_ref': 'ParentReference',
+            'metadata': 'ObjectMetadata',
+            'host': 'str',
+            'port': 'str',
+            'service_name': 'str',
+            'default_connection': 'ConnectionSummaryFromMySQL'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'external_key': 'externalKey',
+            'asset_properties': 'assetProperties',
+            'native_type_system': 'nativeTypeSystem',
+            'object_version': 'objectVersion',
+            'parent_ref': 'parentRef',
+            'metadata': 'metadata',
+            'host': 'host',
+            'port': 'port',
+            'service_name': 'serviceName',
+            'default_connection': 'defaultConnection'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._identifier = None
+        self._external_key = None
+        self._asset_properties = None
+        self._native_type_system = None
+        self._object_version = None
+        self._parent_ref = None
+        self._metadata = None
+        self._host = None
+        self._port = None
+        self._service_name = None
+        self._default_connection = None
+        self._model_type = 'MYSQL_DATA_ASSET'
+
+    @property
+    def host(self):
+        """
+        Gets the host of this DataAssetSummaryFromMySQL.
+        The generic JDBC host name.
+
+
+        :return: The host of this DataAssetSummaryFromMySQL.
+        :rtype: str
+        """
+        return self._host
+
+    @host.setter
+    def host(self, host):
+        """
+        Sets the host of this DataAssetSummaryFromMySQL.
+        The generic JDBC host name.
+
+
+        :param host: The host of this DataAssetSummaryFromMySQL.
+        :type: str
+        """
+        self._host = host
+
+    @property
+    def port(self):
+        """
+        Gets the port of this DataAssetSummaryFromMySQL.
+        The generic JDBC port number.
+
+
+        :return: The port of this DataAssetSummaryFromMySQL.
+        :rtype: str
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this DataAssetSummaryFromMySQL.
+        The generic JDBC port number.
+
+
+        :param port: The port of this DataAssetSummaryFromMySQL.
+        :type: str
+        """
+        self._port = port
+
+    @property
+    def service_name(self):
+        """
+        Gets the service_name of this DataAssetSummaryFromMySQL.
+        The generic JDBC service name for the database.
+
+
+        :return: The service_name of this DataAssetSummaryFromMySQL.
+        :rtype: str
+        """
+        return self._service_name
+
+    @service_name.setter
+    def service_name(self, service_name):
+        """
+        Sets the service_name of this DataAssetSummaryFromMySQL.
+        The generic JDBC service name for the database.
+
+
+        :param service_name: The service_name of this DataAssetSummaryFromMySQL.
+        :type: str
+        """
+        self._service_name = service_name
+
+    @property
+    def default_connection(self):
+        """
+        Gets the default_connection of this DataAssetSummaryFromMySQL.
+
+        :return: The default_connection of this DataAssetSummaryFromMySQL.
+        :rtype: ConnectionSummaryFromMySQL
+        """
+        return self._default_connection
+
+    @default_connection.setter
+    def default_connection(self, default_connection):
+        """
+        Sets the default_connection of this DataAssetSummaryFromMySQL.
+
+        :param default_connection: The default_connection of this DataAssetSummaryFromMySQL.
+        :type: ConnectionSummaryFromMySQL
+        """
+        self._default_connection = default_connection
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/data_asset_summary_from_object_storage.py
+++ b/src/oci/data_integration/models/data_asset_summary_from_object_storage.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataAssetSummaryFromObjectStorage(DataAssetSummary):
     """
-    The Oracle data asset details.
+    Summary details for the Oracle Object storage data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class DataAssetSummaryFromObjectStorage(DataAssetSummary):
 
         :param model_type:
             The value to assign to the model_type property of this DataAssetSummaryFromObjectStorage.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -152,7 +152,7 @@ class DataAssetSummaryFromObjectStorage(DataAssetSummary):
     def url(self):
         """
         Gets the url of this DataAssetSummaryFromObjectStorage.
-        url
+        The Oracle Object storage URL.
 
 
         :return: The url of this DataAssetSummaryFromObjectStorage.
@@ -164,7 +164,7 @@ class DataAssetSummaryFromObjectStorage(DataAssetSummary):
     def url(self, url):
         """
         Sets the url of this DataAssetSummaryFromObjectStorage.
-        url
+        The Oracle Object storage URL.
 
 
         :param url: The url of this DataAssetSummaryFromObjectStorage.
@@ -200,7 +200,7 @@ class DataAssetSummaryFromObjectStorage(DataAssetSummary):
     def namespace(self):
         """
         Gets the namespace of this DataAssetSummaryFromObjectStorage.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        The namespace for the specified Oracle Object storage resource. You can find the namespace under Object Storage Settings in the Console.
 
 
         :return: The namespace of this DataAssetSummaryFromObjectStorage.
@@ -212,7 +212,7 @@ class DataAssetSummaryFromObjectStorage(DataAssetSummary):
     def namespace(self, namespace):
         """
         Sets the namespace of this DataAssetSummaryFromObjectStorage.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        The namespace for the specified Oracle Object storage resource. You can find the namespace under Object Storage Settings in the Console.
 
 
         :param namespace: The namespace of this DataAssetSummaryFromObjectStorage.

--- a/src/oci/data_integration/models/data_asset_summary_from_oracle.py
+++ b/src/oci/data_integration/models/data_asset_summary_from_oracle.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataAssetSummaryFromOracle(DataAssetSummary):
     """
-    The Oracle data asset details.
+    Summary details for the Oracle Database data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
 
         :param model_type:
             The value to assign to the model_type property of this DataAssetSummaryFromOracle.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -173,7 +173,7 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
     def host(self):
         """
         Gets the host of this DataAssetSummaryFromOracle.
-        The host details for the data asset.
+        The Oracle Database hostname.
 
 
         :return: The host of this DataAssetSummaryFromOracle.
@@ -185,7 +185,7 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
     def host(self, host):
         """
         Sets the host of this DataAssetSummaryFromOracle.
-        The host details for the data asset.
+        The Oracle Database hostname.
 
 
         :param host: The host of this DataAssetSummaryFromOracle.
@@ -197,7 +197,7 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
     def port(self):
         """
         Gets the port of this DataAssetSummaryFromOracle.
-        The port details for the data asset.
+        The Oracle Database port.
 
 
         :return: The port of this DataAssetSummaryFromOracle.
@@ -209,7 +209,7 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
     def port(self, port):
         """
         Sets the port of this DataAssetSummaryFromOracle.
-        The port details for the data asset.
+        The Oracle Database port.
 
 
         :param port: The port of this DataAssetSummaryFromOracle.
@@ -221,7 +221,7 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
     def service_name(self):
         """
         Gets the service_name of this DataAssetSummaryFromOracle.
-        The service name for the data asset.
+        The Oracle Database service name.
 
 
         :return: The service_name of this DataAssetSummaryFromOracle.
@@ -233,7 +233,7 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
     def service_name(self, service_name):
         """
         Sets the service_name of this DataAssetSummaryFromOracle.
-        The service name for the data asset.
+        The Oracle Database service name.
 
 
         :param service_name: The service_name of this DataAssetSummaryFromOracle.
@@ -245,7 +245,7 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
     def driver_class(self):
         """
         Gets the driver_class of this DataAssetSummaryFromOracle.
-        The driver class for the data asset.
+        The Oracle Database driver class.
 
 
         :return: The driver_class of this DataAssetSummaryFromOracle.
@@ -257,7 +257,7 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
     def driver_class(self, driver_class):
         """
         Sets the driver_class of this DataAssetSummaryFromOracle.
-        The driver class for the data asset.
+        The Oracle Database driver class.
 
 
         :param driver_class: The driver_class of this DataAssetSummaryFromOracle.
@@ -269,7 +269,7 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
     def sid(self):
         """
         Gets the sid of this DataAssetSummaryFromOracle.
-        sid
+        The Oracle Database SID.
 
 
         :return: The sid of this DataAssetSummaryFromOracle.
@@ -281,7 +281,7 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
     def sid(self, sid):
         """
         Sets the sid of this DataAssetSummaryFromOracle.
-        sid
+        The Oracle Database SID.
 
 
         :param sid: The sid of this DataAssetSummaryFromOracle.

--- a/src/oci/data_integration/models/data_entity_from_file.py
+++ b/src/oci/data_integration/models/data_entity_from_file.py
@@ -200,7 +200,7 @@ class DataEntityFromFile(DataEntity):
     def key(self):
         """
         Gets the key of this DataEntityFromFile.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this DataEntityFromFile.
@@ -212,7 +212,7 @@ class DataEntityFromFile(DataEntity):
     def key(self, key):
         """
         Sets the key of this DataEntityFromFile.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this DataEntityFromFile.
@@ -224,7 +224,7 @@ class DataEntityFromFile(DataEntity):
     def model_version(self):
         """
         Gets the model_version of this DataEntityFromFile.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this DataEntityFromFile.
@@ -236,7 +236,7 @@ class DataEntityFromFile(DataEntity):
     def model_version(self, model_version):
         """
         Sets the model_version of this DataEntityFromFile.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this DataEntityFromFile.
@@ -268,7 +268,7 @@ class DataEntityFromFile(DataEntity):
     def name(self):
         """
         Gets the name of this DataEntityFromFile.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataEntityFromFile.
@@ -280,7 +280,7 @@ class DataEntityFromFile(DataEntity):
     def name(self, name):
         """
         Sets the name of this DataEntityFromFile.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataEntityFromFile.
@@ -598,7 +598,7 @@ class DataEntityFromFile(DataEntity):
     def identifier(self):
         """
         Gets the identifier of this DataEntityFromFile.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataEntityFromFile.
@@ -610,7 +610,7 @@ class DataEntityFromFile(DataEntity):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataEntityFromFile.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataEntityFromFile.

--- a/src/oci/data_integration/models/data_entity_from_file_entity_details.py
+++ b/src/oci/data_integration/models/data_entity_from_file_entity_details.py
@@ -191,7 +191,7 @@ class DataEntityFromFileEntityDetails(DataEntityDetails):
     def key(self):
         """
         Gets the key of this DataEntityFromFileEntityDetails.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this DataEntityFromFileEntityDetails.
@@ -203,7 +203,7 @@ class DataEntityFromFileEntityDetails(DataEntityDetails):
     def key(self, key):
         """
         Sets the key of this DataEntityFromFileEntityDetails.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this DataEntityFromFileEntityDetails.
@@ -215,7 +215,7 @@ class DataEntityFromFileEntityDetails(DataEntityDetails):
     def model_version(self):
         """
         Gets the model_version of this DataEntityFromFileEntityDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this DataEntityFromFileEntityDetails.
@@ -227,7 +227,7 @@ class DataEntityFromFileEntityDetails(DataEntityDetails):
     def model_version(self, model_version):
         """
         Sets the model_version of this DataEntityFromFileEntityDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this DataEntityFromFileEntityDetails.
@@ -259,7 +259,7 @@ class DataEntityFromFileEntityDetails(DataEntityDetails):
     def name(self):
         """
         Gets the name of this DataEntityFromFileEntityDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataEntityFromFileEntityDetails.
@@ -271,7 +271,7 @@ class DataEntityFromFileEntityDetails(DataEntityDetails):
     def name(self, name):
         """
         Sets the name of this DataEntityFromFileEntityDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataEntityFromFileEntityDetails.
@@ -591,7 +591,7 @@ class DataEntityFromFileEntityDetails(DataEntityDetails):
     def identifier(self):
         """
         Gets the identifier of this DataEntityFromFileEntityDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataEntityFromFileEntityDetails.
@@ -603,7 +603,7 @@ class DataEntityFromFileEntityDetails(DataEntityDetails):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataEntityFromFileEntityDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataEntityFromFileEntityDetails.

--- a/src/oci/data_integration/models/data_entity_from_table.py
+++ b/src/oci/data_integration/models/data_entity_from_table.py
@@ -193,7 +193,7 @@ class DataEntityFromTable(DataEntity):
     def key(self):
         """
         Gets the key of this DataEntityFromTable.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this DataEntityFromTable.
@@ -205,7 +205,7 @@ class DataEntityFromTable(DataEntity):
     def key(self, key):
         """
         Sets the key of this DataEntityFromTable.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this DataEntityFromTable.
@@ -217,7 +217,7 @@ class DataEntityFromTable(DataEntity):
     def model_version(self):
         """
         Gets the model_version of this DataEntityFromTable.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this DataEntityFromTable.
@@ -229,7 +229,7 @@ class DataEntityFromTable(DataEntity):
     def model_version(self, model_version):
         """
         Sets the model_version of this DataEntityFromTable.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this DataEntityFromTable.
@@ -261,7 +261,7 @@ class DataEntityFromTable(DataEntity):
     def name(self):
         """
         Gets the name of this DataEntityFromTable.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataEntityFromTable.
@@ -273,7 +273,7 @@ class DataEntityFromTable(DataEntity):
     def name(self, name):
         """
         Sets the name of this DataEntityFromTable.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataEntityFromTable.
@@ -571,7 +571,7 @@ class DataEntityFromTable(DataEntity):
     def identifier(self):
         """
         Gets the identifier of this DataEntityFromTable.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataEntityFromTable.
@@ -583,7 +583,7 @@ class DataEntityFromTable(DataEntity):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataEntityFromTable.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataEntityFromTable.

--- a/src/oci/data_integration/models/data_entity_from_table_entity_details.py
+++ b/src/oci/data_integration/models/data_entity_from_table_entity_details.py
@@ -184,7 +184,7 @@ class DataEntityFromTableEntityDetails(DataEntityDetails):
     def key(self):
         """
         Gets the key of this DataEntityFromTableEntityDetails.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this DataEntityFromTableEntityDetails.
@@ -196,7 +196,7 @@ class DataEntityFromTableEntityDetails(DataEntityDetails):
     def key(self, key):
         """
         Sets the key of this DataEntityFromTableEntityDetails.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this DataEntityFromTableEntityDetails.
@@ -208,7 +208,7 @@ class DataEntityFromTableEntityDetails(DataEntityDetails):
     def model_version(self):
         """
         Gets the model_version of this DataEntityFromTableEntityDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this DataEntityFromTableEntityDetails.
@@ -220,7 +220,7 @@ class DataEntityFromTableEntityDetails(DataEntityDetails):
     def model_version(self, model_version):
         """
         Sets the model_version of this DataEntityFromTableEntityDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this DataEntityFromTableEntityDetails.
@@ -252,7 +252,7 @@ class DataEntityFromTableEntityDetails(DataEntityDetails):
     def name(self):
         """
         Gets the name of this DataEntityFromTableEntityDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataEntityFromTableEntityDetails.
@@ -264,7 +264,7 @@ class DataEntityFromTableEntityDetails(DataEntityDetails):
     def name(self, name):
         """
         Sets the name of this DataEntityFromTableEntityDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataEntityFromTableEntityDetails.
@@ -564,7 +564,7 @@ class DataEntityFromTableEntityDetails(DataEntityDetails):
     def identifier(self):
         """
         Gets the identifier of this DataEntityFromTableEntityDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataEntityFromTableEntityDetails.
@@ -576,7 +576,7 @@ class DataEntityFromTableEntityDetails(DataEntityDetails):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataEntityFromTableEntityDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataEntityFromTableEntityDetails.

--- a/src/oci/data_integration/models/data_entity_from_view.py
+++ b/src/oci/data_integration/models/data_entity_from_view.py
@@ -193,7 +193,7 @@ class DataEntityFromView(DataEntity):
     def key(self):
         """
         Gets the key of this DataEntityFromView.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this DataEntityFromView.
@@ -205,7 +205,7 @@ class DataEntityFromView(DataEntity):
     def key(self, key):
         """
         Sets the key of this DataEntityFromView.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this DataEntityFromView.
@@ -217,7 +217,7 @@ class DataEntityFromView(DataEntity):
     def model_version(self):
         """
         Gets the model_version of this DataEntityFromView.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this DataEntityFromView.
@@ -229,7 +229,7 @@ class DataEntityFromView(DataEntity):
     def model_version(self, model_version):
         """
         Sets the model_version of this DataEntityFromView.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this DataEntityFromView.
@@ -261,7 +261,7 @@ class DataEntityFromView(DataEntity):
     def name(self):
         """
         Gets the name of this DataEntityFromView.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataEntityFromView.
@@ -273,7 +273,7 @@ class DataEntityFromView(DataEntity):
     def name(self, name):
         """
         Sets the name of this DataEntityFromView.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataEntityFromView.
@@ -571,7 +571,7 @@ class DataEntityFromView(DataEntity):
     def identifier(self):
         """
         Gets the identifier of this DataEntityFromView.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataEntityFromView.
@@ -583,7 +583,7 @@ class DataEntityFromView(DataEntity):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataEntityFromView.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataEntityFromView.

--- a/src/oci/data_integration/models/data_entity_from_view_entity_details.py
+++ b/src/oci/data_integration/models/data_entity_from_view_entity_details.py
@@ -184,7 +184,7 @@ class DataEntityFromViewEntityDetails(DataEntityDetails):
     def key(self):
         """
         Gets the key of this DataEntityFromViewEntityDetails.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this DataEntityFromViewEntityDetails.
@@ -196,7 +196,7 @@ class DataEntityFromViewEntityDetails(DataEntityDetails):
     def key(self, key):
         """
         Sets the key of this DataEntityFromViewEntityDetails.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this DataEntityFromViewEntityDetails.
@@ -208,7 +208,7 @@ class DataEntityFromViewEntityDetails(DataEntityDetails):
     def model_version(self):
         """
         Gets the model_version of this DataEntityFromViewEntityDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this DataEntityFromViewEntityDetails.
@@ -220,7 +220,7 @@ class DataEntityFromViewEntityDetails(DataEntityDetails):
     def model_version(self, model_version):
         """
         Sets the model_version of this DataEntityFromViewEntityDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this DataEntityFromViewEntityDetails.
@@ -252,7 +252,7 @@ class DataEntityFromViewEntityDetails(DataEntityDetails):
     def name(self):
         """
         Gets the name of this DataEntityFromViewEntityDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataEntityFromViewEntityDetails.
@@ -264,7 +264,7 @@ class DataEntityFromViewEntityDetails(DataEntityDetails):
     def name(self, name):
         """
         Sets the name of this DataEntityFromViewEntityDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataEntityFromViewEntityDetails.
@@ -564,7 +564,7 @@ class DataEntityFromViewEntityDetails(DataEntityDetails):
     def identifier(self):
         """
         Gets the identifier of this DataEntityFromViewEntityDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataEntityFromViewEntityDetails.
@@ -576,7 +576,7 @@ class DataEntityFromViewEntityDetails(DataEntityDetails):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataEntityFromViewEntityDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataEntityFromViewEntityDetails.

--- a/src/oci/data_integration/models/data_entity_summary_collection.py
+++ b/src/oci/data_integration/models/data_entity_summary_collection.py
@@ -37,7 +37,7 @@ class DataEntitySummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this DataEntitySummaryCollection.
-        The array of DataEntity summaries
+        The array of data entity summaries.
 
 
         :return: The items of this DataEntitySummaryCollection.
@@ -49,7 +49,7 @@ class DataEntitySummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this DataEntitySummaryCollection.
-        The array of DataEntity summaries
+        The array of data entity summaries.
 
 
         :param items: The items of this DataEntitySummaryCollection.

--- a/src/oci/data_integration/models/data_entity_summary_from_file.py
+++ b/src/oci/data_integration/models/data_entity_summary_from_file.py
@@ -200,7 +200,7 @@ class DataEntitySummaryFromFile(DataEntitySummary):
     def key(self):
         """
         Gets the key of this DataEntitySummaryFromFile.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this DataEntitySummaryFromFile.
@@ -212,7 +212,7 @@ class DataEntitySummaryFromFile(DataEntitySummary):
     def key(self, key):
         """
         Sets the key of this DataEntitySummaryFromFile.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this DataEntitySummaryFromFile.
@@ -224,7 +224,7 @@ class DataEntitySummaryFromFile(DataEntitySummary):
     def model_version(self):
         """
         Gets the model_version of this DataEntitySummaryFromFile.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this DataEntitySummaryFromFile.
@@ -236,7 +236,7 @@ class DataEntitySummaryFromFile(DataEntitySummary):
     def model_version(self, model_version):
         """
         Sets the model_version of this DataEntitySummaryFromFile.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this DataEntitySummaryFromFile.
@@ -268,7 +268,7 @@ class DataEntitySummaryFromFile(DataEntitySummary):
     def name(self):
         """
         Gets the name of this DataEntitySummaryFromFile.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataEntitySummaryFromFile.
@@ -280,7 +280,7 @@ class DataEntitySummaryFromFile(DataEntitySummary):
     def name(self, name):
         """
         Sets the name of this DataEntitySummaryFromFile.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataEntitySummaryFromFile.
@@ -598,7 +598,7 @@ class DataEntitySummaryFromFile(DataEntitySummary):
     def identifier(self):
         """
         Gets the identifier of this DataEntitySummaryFromFile.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataEntitySummaryFromFile.
@@ -610,7 +610,7 @@ class DataEntitySummaryFromFile(DataEntitySummary):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataEntitySummaryFromFile.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataEntitySummaryFromFile.

--- a/src/oci/data_integration/models/data_entity_summary_from_table.py
+++ b/src/oci/data_integration/models/data_entity_summary_from_table.py
@@ -193,7 +193,7 @@ class DataEntitySummaryFromTable(DataEntitySummary):
     def key(self):
         """
         Gets the key of this DataEntitySummaryFromTable.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this DataEntitySummaryFromTable.
@@ -205,7 +205,7 @@ class DataEntitySummaryFromTable(DataEntitySummary):
     def key(self, key):
         """
         Sets the key of this DataEntitySummaryFromTable.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this DataEntitySummaryFromTable.
@@ -217,7 +217,7 @@ class DataEntitySummaryFromTable(DataEntitySummary):
     def model_version(self):
         """
         Gets the model_version of this DataEntitySummaryFromTable.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this DataEntitySummaryFromTable.
@@ -229,7 +229,7 @@ class DataEntitySummaryFromTable(DataEntitySummary):
     def model_version(self, model_version):
         """
         Sets the model_version of this DataEntitySummaryFromTable.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this DataEntitySummaryFromTable.
@@ -261,7 +261,7 @@ class DataEntitySummaryFromTable(DataEntitySummary):
     def name(self):
         """
         Gets the name of this DataEntitySummaryFromTable.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataEntitySummaryFromTable.
@@ -273,7 +273,7 @@ class DataEntitySummaryFromTable(DataEntitySummary):
     def name(self, name):
         """
         Sets the name of this DataEntitySummaryFromTable.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataEntitySummaryFromTable.
@@ -571,7 +571,7 @@ class DataEntitySummaryFromTable(DataEntitySummary):
     def identifier(self):
         """
         Gets the identifier of this DataEntitySummaryFromTable.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataEntitySummaryFromTable.
@@ -583,7 +583,7 @@ class DataEntitySummaryFromTable(DataEntitySummary):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataEntitySummaryFromTable.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataEntitySummaryFromTable.

--- a/src/oci/data_integration/models/data_entity_summary_from_view.py
+++ b/src/oci/data_integration/models/data_entity_summary_from_view.py
@@ -193,7 +193,7 @@ class DataEntitySummaryFromView(DataEntitySummary):
     def key(self):
         """
         Gets the key of this DataEntitySummaryFromView.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this DataEntitySummaryFromView.
@@ -205,7 +205,7 @@ class DataEntitySummaryFromView(DataEntitySummary):
     def key(self, key):
         """
         Sets the key of this DataEntitySummaryFromView.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this DataEntitySummaryFromView.
@@ -217,7 +217,7 @@ class DataEntitySummaryFromView(DataEntitySummary):
     def model_version(self):
         """
         Gets the model_version of this DataEntitySummaryFromView.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this DataEntitySummaryFromView.
@@ -229,7 +229,7 @@ class DataEntitySummaryFromView(DataEntitySummary):
     def model_version(self, model_version):
         """
         Sets the model_version of this DataEntitySummaryFromView.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this DataEntitySummaryFromView.
@@ -261,7 +261,7 @@ class DataEntitySummaryFromView(DataEntitySummary):
     def name(self):
         """
         Gets the name of this DataEntitySummaryFromView.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataEntitySummaryFromView.
@@ -273,7 +273,7 @@ class DataEntitySummaryFromView(DataEntitySummary):
     def name(self, name):
         """
         Sets the name of this DataEntitySummaryFromView.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataEntitySummaryFromView.
@@ -571,7 +571,7 @@ class DataEntitySummaryFromView(DataEntitySummary):
     def identifier(self):
         """
         Gets the identifier of this DataEntitySummaryFromView.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataEntitySummaryFromView.
@@ -583,7 +583,7 @@ class DataEntitySummaryFromView(DataEntitySummary):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataEntitySummaryFromView.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataEntitySummaryFromView.

--- a/src/oci/data_integration/models/data_flow.py
+++ b/src/oci/data_integration/models/data_flow.py
@@ -220,7 +220,7 @@ class DataFlow(object):
     def name(self):
         """
         Gets the name of this DataFlow.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataFlow.
@@ -232,7 +232,7 @@ class DataFlow(object):
     def name(self, name):
         """
         Sets the name of this DataFlow.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataFlow.
@@ -244,7 +244,7 @@ class DataFlow(object):
     def identifier(self):
         """
         Gets the identifier of this DataFlow.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataFlow.
@@ -256,7 +256,7 @@ class DataFlow(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataFlow.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataFlow.
@@ -428,7 +428,7 @@ class DataFlow(object):
     def key_map(self):
         """
         Gets the key_map of this DataFlow.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this DataFlow.
@@ -440,7 +440,7 @@ class DataFlow(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this DataFlow.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this DataFlow.

--- a/src/oci/data_integration/models/data_flow_details.py
+++ b/src/oci/data_integration/models/data_flow_details.py
@@ -213,7 +213,7 @@ class DataFlowDetails(object):
     def name(self):
         """
         Gets the name of this DataFlowDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataFlowDetails.
@@ -225,7 +225,7 @@ class DataFlowDetails(object):
     def name(self, name):
         """
         Sets the name of this DataFlowDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataFlowDetails.
@@ -237,7 +237,7 @@ class DataFlowDetails(object):
     def identifier(self):
         """
         Gets the identifier of this DataFlowDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataFlowDetails.
@@ -249,7 +249,7 @@ class DataFlowDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataFlowDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataFlowDetails.

--- a/src/oci/data_integration/models/data_flow_summary.py
+++ b/src/oci/data_integration/models/data_flow_summary.py
@@ -220,7 +220,7 @@ class DataFlowSummary(object):
     def name(self):
         """
         Gets the name of this DataFlowSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataFlowSummary.
@@ -232,7 +232,7 @@ class DataFlowSummary(object):
     def name(self, name):
         """
         Sets the name of this DataFlowSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataFlowSummary.
@@ -244,7 +244,7 @@ class DataFlowSummary(object):
     def identifier(self):
         """
         Gets the identifier of this DataFlowSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataFlowSummary.
@@ -256,7 +256,7 @@ class DataFlowSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataFlowSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataFlowSummary.
@@ -428,7 +428,7 @@ class DataFlowSummary(object):
     def key_map(self):
         """
         Gets the key_map of this DataFlowSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this DataFlowSummary.
@@ -440,7 +440,7 @@ class DataFlowSummary(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this DataFlowSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this DataFlowSummary.

--- a/src/oci/data_integration/models/data_flow_summary_collection.py
+++ b/src/oci/data_integration/models/data_flow_summary_collection.py
@@ -37,7 +37,7 @@ class DataFlowSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this DataFlowSummaryCollection.
-        The array of DataFlow summaries
+        The array of data flow summaries.
 
 
         :return: The items of this DataFlowSummaryCollection.
@@ -49,7 +49,7 @@ class DataFlowSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this DataFlowSummaryCollection.
-        The array of DataFlow summaries
+        The array of data flow summaries.
 
 
         :param items: The items of this DataFlowSummaryCollection.

--- a/src/oci/data_integration/models/data_flow_validation.py
+++ b/src/oci/data_integration/models/data_flow_validation.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataFlowValidation(object):
     """
-    The information about dataflow validation
+    The information about a data flow validation.
     """
 
     def __init__(self, **kwargs):
@@ -135,7 +135,7 @@ class DataFlowValidation(object):
     def total_message_count(self):
         """
         Gets the total_message_count of this DataFlowValidation.
-        Total number of validation messages
+        The total number of validation messages.
 
 
         :return: The total_message_count of this DataFlowValidation.
@@ -147,7 +147,7 @@ class DataFlowValidation(object):
     def total_message_count(self, total_message_count):
         """
         Sets the total_message_count of this DataFlowValidation.
-        Total number of validation messages
+        The total number of validation messages.
 
 
         :param total_message_count: The total_message_count of this DataFlowValidation.
@@ -159,7 +159,7 @@ class DataFlowValidation(object):
     def error_message_count(self):
         """
         Gets the error_message_count of this DataFlowValidation.
-        Total number of validation error messages
+        The total number of validation error messages.
 
 
         :return: The error_message_count of this DataFlowValidation.
@@ -171,7 +171,7 @@ class DataFlowValidation(object):
     def error_message_count(self, error_message_count):
         """
         Sets the error_message_count of this DataFlowValidation.
-        Total number of validation error messages
+        The total number of validation error messages.
 
 
         :param error_message_count: The error_message_count of this DataFlowValidation.
@@ -183,7 +183,7 @@ class DataFlowValidation(object):
     def warn_message_count(self):
         """
         Gets the warn_message_count of this DataFlowValidation.
-        Total number of validation warning messages
+        The total number of validation warning messages.
 
 
         :return: The warn_message_count of this DataFlowValidation.
@@ -195,7 +195,7 @@ class DataFlowValidation(object):
     def warn_message_count(self, warn_message_count):
         """
         Sets the warn_message_count of this DataFlowValidation.
-        Total number of validation warning messages
+        The total number of validation warning messages.
 
 
         :param warn_message_count: The warn_message_count of this DataFlowValidation.
@@ -207,7 +207,7 @@ class DataFlowValidation(object):
     def info_message_count(self):
         """
         Gets the info_message_count of this DataFlowValidation.
-        Total number of validation information messages
+        The total number of validation information messages.
 
 
         :return: The info_message_count of this DataFlowValidation.
@@ -219,7 +219,7 @@ class DataFlowValidation(object):
     def info_message_count(self, info_message_count):
         """
         Sets the info_message_count of this DataFlowValidation.
-        Total number of validation information messages
+        The total number of validation information messages.
 
 
         :param info_message_count: The info_message_count of this DataFlowValidation.
@@ -231,7 +231,7 @@ class DataFlowValidation(object):
     def validation_messages(self):
         """
         Gets the validation_messages of this DataFlowValidation.
-        Detailed information of the DataFlow object validation.
+        The detailed information of the data flow object validation.
 
 
         :return: The validation_messages of this DataFlowValidation.
@@ -243,7 +243,7 @@ class DataFlowValidation(object):
     def validation_messages(self, validation_messages):
         """
         Sets the validation_messages of this DataFlowValidation.
-        Detailed information of the DataFlow object validation.
+        The detailed information of the data flow object validation.
 
 
         :param validation_messages: The validation_messages of this DataFlowValidation.
@@ -255,7 +255,7 @@ class DataFlowValidation(object):
     def key(self):
         """
         Gets the key of this DataFlowValidation.
-        Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+        Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
 
 
         :return: The key of this DataFlowValidation.
@@ -267,7 +267,7 @@ class DataFlowValidation(object):
     def key(self, key):
         """
         Sets the key of this DataFlowValidation.
-        Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+        Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
 
 
         :param key: The key of this DataFlowValidation.
@@ -303,7 +303,7 @@ class DataFlowValidation(object):
     def model_version(self):
         """
         Gets the model_version of this DataFlowValidation.
-        The model version of an object.
+        The model version of the object.
 
 
         :return: The model_version of this DataFlowValidation.
@@ -315,7 +315,7 @@ class DataFlowValidation(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this DataFlowValidation.
-        The model version of an object.
+        The model version of the object.
 
 
         :param model_version: The model_version of this DataFlowValidation.
@@ -347,7 +347,7 @@ class DataFlowValidation(object):
     def name(self):
         """
         Gets the name of this DataFlowValidation.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataFlowValidation.
@@ -359,7 +359,7 @@ class DataFlowValidation(object):
     def name(self, name):
         """
         Sets the name of this DataFlowValidation.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataFlowValidation.
@@ -443,7 +443,7 @@ class DataFlowValidation(object):
     def identifier(self):
         """
         Gets the identifier of this DataFlowValidation.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataFlowValidation.
@@ -455,7 +455,7 @@ class DataFlowValidation(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataFlowValidation.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataFlowValidation.

--- a/src/oci/data_integration/models/data_flow_validation_summary.py
+++ b/src/oci/data_integration/models/data_flow_validation_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataFlowValidationSummary(object):
     """
-    The information about dataflow validation
+    The information about a data flow validation.
     """
 
     def __init__(self, **kwargs):
@@ -135,7 +135,7 @@ class DataFlowValidationSummary(object):
     def total_message_count(self):
         """
         Gets the total_message_count of this DataFlowValidationSummary.
-        Total number of validation messages
+        The total number of validation messages.
 
 
         :return: The total_message_count of this DataFlowValidationSummary.
@@ -147,7 +147,7 @@ class DataFlowValidationSummary(object):
     def total_message_count(self, total_message_count):
         """
         Sets the total_message_count of this DataFlowValidationSummary.
-        Total number of validation messages
+        The total number of validation messages.
 
 
         :param total_message_count: The total_message_count of this DataFlowValidationSummary.
@@ -159,7 +159,7 @@ class DataFlowValidationSummary(object):
     def error_message_count(self):
         """
         Gets the error_message_count of this DataFlowValidationSummary.
-        Total number of validation error messages
+        The total number of validation error messages.
 
 
         :return: The error_message_count of this DataFlowValidationSummary.
@@ -171,7 +171,7 @@ class DataFlowValidationSummary(object):
     def error_message_count(self, error_message_count):
         """
         Sets the error_message_count of this DataFlowValidationSummary.
-        Total number of validation error messages
+        The total number of validation error messages.
 
 
         :param error_message_count: The error_message_count of this DataFlowValidationSummary.
@@ -183,7 +183,7 @@ class DataFlowValidationSummary(object):
     def warn_message_count(self):
         """
         Gets the warn_message_count of this DataFlowValidationSummary.
-        Total number of validation warning messages
+        The total number of validation warning messages.
 
 
         :return: The warn_message_count of this DataFlowValidationSummary.
@@ -195,7 +195,7 @@ class DataFlowValidationSummary(object):
     def warn_message_count(self, warn_message_count):
         """
         Sets the warn_message_count of this DataFlowValidationSummary.
-        Total number of validation warning messages
+        The total number of validation warning messages.
 
 
         :param warn_message_count: The warn_message_count of this DataFlowValidationSummary.
@@ -207,7 +207,7 @@ class DataFlowValidationSummary(object):
     def info_message_count(self):
         """
         Gets the info_message_count of this DataFlowValidationSummary.
-        Total number of validation information messages
+        The total number of validation information messages.
 
 
         :return: The info_message_count of this DataFlowValidationSummary.
@@ -219,7 +219,7 @@ class DataFlowValidationSummary(object):
     def info_message_count(self, info_message_count):
         """
         Sets the info_message_count of this DataFlowValidationSummary.
-        Total number of validation information messages
+        The total number of validation information messages.
 
 
         :param info_message_count: The info_message_count of this DataFlowValidationSummary.
@@ -231,7 +231,7 @@ class DataFlowValidationSummary(object):
     def validation_messages(self):
         """
         Gets the validation_messages of this DataFlowValidationSummary.
-        Detailed information of the DataFlow object validation.
+        The detailed information of the data flow object validation.
 
 
         :return: The validation_messages of this DataFlowValidationSummary.
@@ -243,7 +243,7 @@ class DataFlowValidationSummary(object):
     def validation_messages(self, validation_messages):
         """
         Sets the validation_messages of this DataFlowValidationSummary.
-        Detailed information of the DataFlow object validation.
+        The detailed information of the data flow object validation.
 
 
         :param validation_messages: The validation_messages of this DataFlowValidationSummary.
@@ -255,7 +255,7 @@ class DataFlowValidationSummary(object):
     def key(self):
         """
         Gets the key of this DataFlowValidationSummary.
-        Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+        Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
 
 
         :return: The key of this DataFlowValidationSummary.
@@ -267,7 +267,7 @@ class DataFlowValidationSummary(object):
     def key(self, key):
         """
         Sets the key of this DataFlowValidationSummary.
-        Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+        Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
 
 
         :param key: The key of this DataFlowValidationSummary.
@@ -303,7 +303,7 @@ class DataFlowValidationSummary(object):
     def model_version(self):
         """
         Gets the model_version of this DataFlowValidationSummary.
-        The model version of an object.
+        The model version of the object.
 
 
         :return: The model_version of this DataFlowValidationSummary.
@@ -315,7 +315,7 @@ class DataFlowValidationSummary(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this DataFlowValidationSummary.
-        The model version of an object.
+        The model version of the object.
 
 
         :param model_version: The model_version of this DataFlowValidationSummary.
@@ -347,7 +347,7 @@ class DataFlowValidationSummary(object):
     def name(self):
         """
         Gets the name of this DataFlowValidationSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DataFlowValidationSummary.
@@ -359,7 +359,7 @@ class DataFlowValidationSummary(object):
     def name(self, name):
         """
         Sets the name of this DataFlowValidationSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DataFlowValidationSummary.
@@ -443,7 +443,7 @@ class DataFlowValidationSummary(object):
     def identifier(self):
         """
         Gets the identifier of this DataFlowValidationSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DataFlowValidationSummary.
@@ -455,7 +455,7 @@ class DataFlowValidationSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this DataFlowValidationSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DataFlowValidationSummary.

--- a/src/oci/data_integration/models/data_flow_validation_summary_collection.py
+++ b/src/oci/data_integration/models/data_flow_validation_summary_collection.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataFlowValidationSummaryCollection(object):
     """
-    List of dataflow validation summaries
+    A list of data flow validation summaries.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +37,7 @@ class DataFlowValidationSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this DataFlowValidationSummaryCollection.
-        The array of validation summaries
+        The array of validation summaries.
 
 
         :return: The items of this DataFlowValidationSummaryCollection.
@@ -49,7 +49,7 @@ class DataFlowValidationSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this DataFlowValidationSummaryCollection.
-        The array of validation summaries
+        The array of validation summaries.
 
 
         :param items: The items of this DataFlowValidationSummaryCollection.

--- a/src/oci/data_integration/models/data_format.py
+++ b/src/oci/data_integration/models/data_format.py
@@ -33,6 +33,10 @@ class DataFormat(object):
     #: This constant has a value of "PARQUET"
     TYPE_PARQUET = "PARQUET"
 
+    #: A constant which can be used with the type property of a DataFormat.
+    #: This constant has a value of "AVRO"
+    TYPE_AVRO = "AVRO"
+
     def __init__(self, **kwargs):
         """
         Initializes a new DataFormat object with values from keyword arguments.
@@ -44,7 +48,7 @@ class DataFormat(object):
 
         :param type:
             The value to assign to the type property of this DataFormat.
-            Allowed values for this property are: "XML", "JSON", "CSV", "ORC", "PARQUET", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "XML", "JSON", "CSV", "ORC", "PARQUET", "AVRO", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type type: str
 
@@ -88,7 +92,7 @@ class DataFormat(object):
         Gets the type of this DataFormat.
         type
 
-        Allowed values for this property are: "XML", "JSON", "CSV", "ORC", "PARQUET", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "XML", "JSON", "CSV", "ORC", "PARQUET", "AVRO", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -107,7 +111,7 @@ class DataFormat(object):
         :param type: The type of this DataFormat.
         :type: str
         """
-        allowed_values = ["XML", "JSON", "CSV", "ORC", "PARQUET"]
+        allowed_values = ["XML", "JSON", "CSV", "ORC", "PARQUET", "AVRO"]
         if not value_allowed_none_or_none_sentinel(type, allowed_values):
             type = 'UNKNOWN_ENUM_VALUE'
         self._type = type

--- a/src/oci/data_integration/models/data_type.py
+++ b/src/oci/data_integration/models/data_type.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataType(BaseType):
     """
-    A DataType object is a simple primitive type that describes the type of a single atomic unit of data.  For example, INT, VARCHAR, NUMBER, etc.
+    A `DataType` object is a simple primitive type that describes the type of a single atomic unit of data.  For example, `INT`, `VARCHAR`, `NUMBER`, and so on.
     """
 
     #: A constant which can be used with the dt_type property of a DataType.
@@ -114,7 +114,7 @@ class DataType(BaseType):
     def dt_type(self):
         """
         Gets the dt_type of this DataType.
-        dtType
+        The data type.
 
         Allowed values for this property are: "PRIMITIVE", "STRUCTURED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -129,7 +129,7 @@ class DataType(BaseType):
     def dt_type(self, dt_type):
         """
         Sets the dt_type of this DataType.
-        dtType
+        The data type.
 
 
         :param dt_type: The dt_type of this DataType.
@@ -144,7 +144,7 @@ class DataType(BaseType):
     def type_system_name(self):
         """
         Gets the type_system_name of this DataType.
-        typeSystemName
+        The data type system name.
 
 
         :return: The type_system_name of this DataType.
@@ -156,7 +156,7 @@ class DataType(BaseType):
     def type_system_name(self, type_system_name):
         """
         Sets the type_system_name of this DataType.
-        typeSystemName
+        The data type system name.
 
 
         :param type_system_name: The type_system_name of this DataType.

--- a/src/oci/data_integration/models/dependent_object.py
+++ b/src/oci/data_integration/models/dependent_object.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DependentObject(object):
     """
-    A DependentObject object.
+    The information about a dependent object.
     """
 
     def __init__(self, **kwargs):
@@ -66,6 +66,14 @@ class DependentObject(object):
             The value to assign to the published_object_metadata property of this DependentObject.
         :type published_object_metadata: dict(str, PatchObjectMetadata)
 
+        :param source_application_info:
+            The value to assign to the source_application_info property of this DependentObject.
+        :type source_application_info: SourceApplicationInfo
+
+        :param time_patched:
+            The value to assign to the time_patched property of this DependentObject.
+        :type time_patched: datetime
+
         :param metadata:
             The value to assign to the metadata property of this DependentObject.
         :type metadata: ObjectMetadata
@@ -88,6 +96,8 @@ class DependentObject(object):
             'object_version': 'int',
             'dependent_object_metadata': 'list[PatchObjectMetadata]',
             'published_object_metadata': 'dict(str, PatchObjectMetadata)',
+            'source_application_info': 'SourceApplicationInfo',
+            'time_patched': 'datetime',
             'metadata': 'ObjectMetadata',
             'key_map': 'dict(str, str)'
         }
@@ -105,6 +115,8 @@ class DependentObject(object):
             'object_version': 'objectVersion',
             'dependent_object_metadata': 'dependentObjectMetadata',
             'published_object_metadata': 'publishedObjectMetadata',
+            'source_application_info': 'sourceApplicationInfo',
+            'time_patched': 'timePatched',
             'metadata': 'metadata',
             'key_map': 'keyMap'
         }
@@ -121,6 +133,8 @@ class DependentObject(object):
         self._object_version = None
         self._dependent_object_metadata = None
         self._published_object_metadata = None
+        self._source_application_info = None
+        self._time_patched = None
         self._metadata = None
         self._key_map = None
 
@@ -152,7 +166,7 @@ class DependentObject(object):
     def model_type(self):
         """
         Gets the model_type of this DependentObject.
-        The type of the object.
+        The object type.
 
 
         :return: The model_type of this DependentObject.
@@ -164,7 +178,7 @@ class DependentObject(object):
     def model_type(self, model_type):
         """
         Sets the model_type of this DependentObject.
-        The type of the object.
+        The object type.
 
 
         :param model_type: The model_type of this DependentObject.
@@ -176,7 +190,7 @@ class DependentObject(object):
     def model_version(self):
         """
         Gets the model_version of this DependentObject.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this DependentObject.
@@ -188,7 +202,7 @@ class DependentObject(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this DependentObject.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this DependentObject.
@@ -200,7 +214,7 @@ class DependentObject(object):
     def name(self):
         """
         Gets the name of this DependentObject.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this DependentObject.
@@ -212,7 +226,7 @@ class DependentObject(object):
     def name(self, name):
         """
         Sets the name of this DependentObject.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this DependentObject.
@@ -248,7 +262,7 @@ class DependentObject(object):
     def application_version(self):
         """
         Gets the application_version of this DependentObject.
-        version
+        The application's version.
 
 
         :return: The application_version of this DependentObject.
@@ -260,7 +274,7 @@ class DependentObject(object):
     def application_version(self, application_version):
         """
         Sets the application_version of this DependentObject.
-        version
+        The application's version.
 
 
         :param application_version: The application_version of this DependentObject.
@@ -296,7 +310,7 @@ class DependentObject(object):
     def identifier(self):
         """
         Gets the identifier of this DependentObject.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this DependentObject.
@@ -308,7 +322,7 @@ class DependentObject(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this DependentObject.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this DependentObject.
@@ -364,7 +378,7 @@ class DependentObject(object):
     def dependent_object_metadata(self):
         """
         Gets the dependent_object_metadata of this DependentObject.
-        List of dependent objects in this patch.
+        A list of dependent objects in this patch.
 
 
         :return: The dependent_object_metadata of this DependentObject.
@@ -376,7 +390,7 @@ class DependentObject(object):
     def dependent_object_metadata(self, dependent_object_metadata):
         """
         Sets the dependent_object_metadata of this DependentObject.
-        List of dependent objects in this patch.
+        A list of dependent objects in this patch.
 
 
         :param dependent_object_metadata: The dependent_object_metadata of this DependentObject.
@@ -388,7 +402,7 @@ class DependentObject(object):
     def published_object_metadata(self):
         """
         Gets the published_object_metadata of this DependentObject.
-        List of objects that are published / unpublished in this patch.
+        A list of objects that are published or unpublished in this patch.
 
 
         :return: The published_object_metadata of this DependentObject.
@@ -400,13 +414,57 @@ class DependentObject(object):
     def published_object_metadata(self, published_object_metadata):
         """
         Sets the published_object_metadata of this DependentObject.
-        List of objects that are published / unpublished in this patch.
+        A list of objects that are published or unpublished in this patch.
 
 
         :param published_object_metadata: The published_object_metadata of this DependentObject.
         :type: dict(str, PatchObjectMetadata)
         """
         self._published_object_metadata = published_object_metadata
+
+    @property
+    def source_application_info(self):
+        """
+        Gets the source_application_info of this DependentObject.
+
+        :return: The source_application_info of this DependentObject.
+        :rtype: SourceApplicationInfo
+        """
+        return self._source_application_info
+
+    @source_application_info.setter
+    def source_application_info(self, source_application_info):
+        """
+        Sets the source_application_info of this DependentObject.
+
+        :param source_application_info: The source_application_info of this DependentObject.
+        :type: SourceApplicationInfo
+        """
+        self._source_application_info = source_application_info
+
+    @property
+    def time_patched(self):
+        """
+        Gets the time_patched of this DependentObject.
+        The date and time the application was patched, in the timestamp format defined by RFC3339.
+
+
+        :return: The time_patched of this DependentObject.
+        :rtype: datetime
+        """
+        return self._time_patched
+
+    @time_patched.setter
+    def time_patched(self, time_patched):
+        """
+        Sets the time_patched of this DependentObject.
+        The date and time the application was patched, in the timestamp format defined by RFC3339.
+
+
+        :param time_patched: The time_patched of this DependentObject.
+        :type: datetime
+        """
+        self._time_patched = time_patched
 
     @property
     def metadata(self):
@@ -432,7 +490,7 @@ class DependentObject(object):
     def key_map(self):
         """
         Gets the key_map of this DependentObject.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this DependentObject.
@@ -444,7 +502,7 @@ class DependentObject(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this DependentObject.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this DependentObject.

--- a/src/oci/data_integration/models/dependent_object_summary.py
+++ b/src/oci/data_integration/models/dependent_object_summary.py
@@ -62,6 +62,10 @@ class DependentObjectSummary(object):
             The value to assign to the labels property of this DependentObjectSummary.
         :type labels: list[str]
 
+        :param is_favorite:
+            The value to assign to the is_favorite property of this DependentObjectSummary.
+        :type is_favorite: bool
+
         """
         self.swagger_types = {
             'created_by': 'str',
@@ -74,7 +78,8 @@ class DependentObjectSummary(object):
             'identifier_path': 'str',
             'info_fields': 'dict(str, str)',
             'registry_version': 'int',
-            'labels': 'list[str]'
+            'labels': 'list[str]',
+            'is_favorite': 'bool'
         }
 
         self.attribute_map = {
@@ -88,7 +93,8 @@ class DependentObjectSummary(object):
             'identifier_path': 'identifierPath',
             'info_fields': 'infoFields',
             'registry_version': 'registryVersion',
-            'labels': 'labels'
+            'labels': 'labels',
+            'is_favorite': 'isFavorite'
         }
 
         self._created_by = None
@@ -102,6 +108,7 @@ class DependentObjectSummary(object):
         self._info_fields = None
         self._registry_version = None
         self._labels = None
+        self._is_favorite = None
 
     @property
     def created_by(self):
@@ -299,7 +306,7 @@ class DependentObjectSummary(object):
     def info_fields(self):
         """
         Gets the info_fields of this DependentObjectSummary.
-        infoFields
+        Information property fields.
 
 
         :return: The info_fields of this DependentObjectSummary.
@@ -311,7 +318,7 @@ class DependentObjectSummary(object):
     def info_fields(self, info_fields):
         """
         Sets the info_fields of this DependentObjectSummary.
-        infoFields
+        Information property fields.
 
 
         :param info_fields: The info_fields of this DependentObjectSummary.
@@ -323,7 +330,7 @@ class DependentObjectSummary(object):
     def registry_version(self):
         """
         Gets the registry_version of this DependentObjectSummary.
-        registryVersion
+        The registry version of the object.
 
 
         :return: The registry_version of this DependentObjectSummary.
@@ -335,7 +342,7 @@ class DependentObjectSummary(object):
     def registry_version(self, registry_version):
         """
         Sets the registry_version of this DependentObjectSummary.
-        registryVersion
+        The registry version of the object.
 
 
         :param registry_version: The registry_version of this DependentObjectSummary.
@@ -347,7 +354,7 @@ class DependentObjectSummary(object):
     def labels(self):
         """
         Gets the labels of this DependentObjectSummary.
-        Labels are keywords or tags that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or tags that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :return: The labels of this DependentObjectSummary.
@@ -359,13 +366,37 @@ class DependentObjectSummary(object):
     def labels(self, labels):
         """
         Sets the labels of this DependentObjectSummary.
-        Labels are keywords or tags that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or tags that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :param labels: The labels of this DependentObjectSummary.
         :type: list[str]
         """
         self._labels = labels
+
+    @property
+    def is_favorite(self):
+        """
+        Gets the is_favorite of this DependentObjectSummary.
+        Specifies whether this object is a favorite or not.
+
+
+        :return: The is_favorite of this DependentObjectSummary.
+        :rtype: bool
+        """
+        return self._is_favorite
+
+    @is_favorite.setter
+    def is_favorite(self, is_favorite):
+        """
+        Sets the is_favorite of this DependentObjectSummary.
+        Specifies whether this object is a favorite or not.
+
+
+        :param is_favorite: The is_favorite of this DependentObjectSummary.
+        :type: bool
+        """
+        self._is_favorite = is_favorite
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/dependent_object_summary_collection.py
+++ b/src/oci/data_integration/models/dependent_object_summary_collection.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DependentObjectSummaryCollection(object):
     """
-    List of DependentObject summaries
+    A list of dependent object summaries.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +37,7 @@ class DependentObjectSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this DependentObjectSummaryCollection.
-        The array of DependentObject summaries
+        An array of dependent object summaries.
 
 
         :return: The items of this DependentObjectSummaryCollection.
@@ -49,7 +49,7 @@ class DependentObjectSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this DependentObjectSummaryCollection.
-        The array of DependentObject summaries
+        An array of dependent object summaries.
 
 
         :param items: The items of this DependentObjectSummaryCollection.

--- a/src/oci/data_integration/models/derived_field.py
+++ b/src/oci/data_integration/models/derived_field.py
@@ -21,7 +21,7 @@ class DerivedField(TypedObject):
 
         :param model_type:
             The value to assign to the model_type property of this DerivedField.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
         :type model_type: str
 
         :param key:
@@ -154,7 +154,7 @@ class DerivedField(TypedObject):
     def labels(self):
         """
         Gets the labels of this DerivedField.
-        Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or labels that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :return: The labels of this DerivedField.
@@ -166,7 +166,7 @@ class DerivedField(TypedObject):
     def labels(self, labels):
         """
         Sets the labels of this DerivedField.
-        Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or labels that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :param labels: The labels of this DerivedField.

--- a/src/oci/data_integration/models/derived_type.py
+++ b/src/oci/data_integration/models/derived_type.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DerivedType(BaseType):
     """
-    A DerivedType object represents a more complex type that is derived from a set of simple types, for example an Address or SSN data type;
+    A `DerivedType` object represents a more complex type that is derived from a set of simple types, for example an `Address` or `SSN` data type.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/data_integration/models/direct_field_map.py
+++ b/src/oci/data_integration/models/direct_field_map.py
@@ -96,7 +96,7 @@ class DirectFieldMap(FieldMap):
     def key(self):
         """
         Gets the key of this DirectFieldMap.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this DirectFieldMap.
@@ -108,7 +108,7 @@ class DirectFieldMap(FieldMap):
     def key(self, key):
         """
         Sets the key of this DirectFieldMap.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this DirectFieldMap.
@@ -120,7 +120,7 @@ class DirectFieldMap(FieldMap):
     def model_version(self):
         """
         Gets the model_version of this DirectFieldMap.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this DirectFieldMap.
@@ -132,7 +132,7 @@ class DirectFieldMap(FieldMap):
     def model_version(self, model_version):
         """
         Sets the model_version of this DirectFieldMap.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this DirectFieldMap.
@@ -184,7 +184,7 @@ class DirectFieldMap(FieldMap):
     def source_typed_object(self):
         """
         Gets the source_typed_object of this DirectFieldMap.
-        Reference to a typed object
+        Reference to a typed object.
 
 
         :return: The source_typed_object of this DirectFieldMap.
@@ -196,7 +196,7 @@ class DirectFieldMap(FieldMap):
     def source_typed_object(self, source_typed_object):
         """
         Sets the source_typed_object of this DirectFieldMap.
-        Reference to a typed object
+        Reference to a typed object.
 
 
         :param source_typed_object: The source_typed_object of this DirectFieldMap.
@@ -208,7 +208,7 @@ class DirectFieldMap(FieldMap):
     def target_typed_object(self):
         """
         Gets the target_typed_object of this DirectFieldMap.
-        Reference to a typed object
+        Reference to a typed object.
 
 
         :return: The target_typed_object of this DirectFieldMap.
@@ -220,7 +220,7 @@ class DirectFieldMap(FieldMap):
     def target_typed_object(self, target_typed_object):
         """
         Sets the target_typed_object of this DirectFieldMap.
-        Reference to a typed object
+        Reference to a typed object.
 
 
         :param target_typed_object: The target_typed_object of this DirectFieldMap.

--- a/src/oci/data_integration/models/direct_named_field_map.py
+++ b/src/oci/data_integration/models/direct_named_field_map.py
@@ -110,7 +110,7 @@ class DirectNamedFieldMap(FieldMap):
     def key(self):
         """
         Gets the key of this DirectNamedFieldMap.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this DirectNamedFieldMap.
@@ -122,7 +122,7 @@ class DirectNamedFieldMap(FieldMap):
     def key(self, key):
         """
         Sets the key of this DirectNamedFieldMap.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this DirectNamedFieldMap.
@@ -134,7 +134,7 @@ class DirectNamedFieldMap(FieldMap):
     def model_version(self):
         """
         Gets the model_version of this DirectNamedFieldMap.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this DirectNamedFieldMap.
@@ -146,7 +146,7 @@ class DirectNamedFieldMap(FieldMap):
     def model_version(self, model_version):
         """
         Sets the model_version of this DirectNamedFieldMap.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this DirectNamedFieldMap.

--- a/src/oci/data_integration/models/distinct.py
+++ b/src/oci/data_integration/models/distinct.py
@@ -1,0 +1,133 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .operator import Operator
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Distinct(Operator):
+    """
+    The information about the distinct operator.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Distinct object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.Distinct.model_type` attribute
+        of this class is ``DISTINCT_OPERATOR`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this Distinct.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this Distinct.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this Distinct.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this Distinct.
+        :type parent_ref: ParentReference
+
+        :param name:
+            The value to assign to the name property of this Distinct.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this Distinct.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this Distinct.
+        :type object_version: int
+
+        :param input_ports:
+            The value to assign to the input_ports property of this Distinct.
+        :type input_ports: list[InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this Distinct.
+        :type output_ports: list[OutputPort]
+
+        :param object_status:
+            The value to assign to the object_status property of this Distinct.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this Distinct.
+        :type identifier: str
+
+        :param parameters:
+            The value to assign to the parameters property of this Distinct.
+        :type parameters: list[Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this Distinct.
+        :type op_config_values: ConfigValues
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'object_status': 'int',
+            'identifier': 'str',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._input_ports = None
+        self._output_ports = None
+        self._object_status = None
+        self._identifier = None
+        self._parameters = None
+        self._op_config_values = None
+        self._model_type = 'DISTINCT_OPERATOR'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/dynamic_input_field.py
+++ b/src/oci/data_integration/models/dynamic_input_field.py
@@ -21,7 +21,7 @@ class DynamicInputField(TypedObject):
 
         :param model_type:
             The value to assign to the model_type property of this DynamicInputField.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
         :type model_type: str
 
         :param key:
@@ -123,7 +123,7 @@ class DynamicInputField(TypedObject):
     def labels(self):
         """
         Gets the labels of this DynamicInputField.
-        Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or labels that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :return: The labels of this DynamicInputField.
@@ -135,7 +135,7 @@ class DynamicInputField(TypedObject):
     def labels(self, labels):
         """
         Sets the labels of this DynamicInputField.
-        Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or labels that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :param labels: The labels of this DynamicInputField.

--- a/src/oci/data_integration/models/dynamic_proxy_field.py
+++ b/src/oci/data_integration/models/dynamic_proxy_field.py
@@ -21,7 +21,7 @@ class DynamicProxyField(TypedObject):
 
         :param model_type:
             The value to assign to the model_type property of this DynamicProxyField.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
         :type model_type: str
 
         :param key:
@@ -123,7 +123,7 @@ class DynamicProxyField(TypedObject):
     def labels(self):
         """
         Gets the labels of this DynamicProxyField.
-        Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or labels that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :return: The labels of this DynamicProxyField.
@@ -135,7 +135,7 @@ class DynamicProxyField(TypedObject):
     def labels(self, labels):
         """
         Sets the labels of this DynamicProxyField.
-        Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or labels that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :param labels: The labels of this DynamicProxyField.

--- a/src/oci/data_integration/models/enriched_entity.py
+++ b/src/oci/data_integration/models/enriched_entity.py
@@ -1,0 +1,93 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EnrichedEntity(object):
+    """
+    This is used to specify runtime parameters for data entities such as files that need both the data entity and the format.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EnrichedEntity object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param entity:
+            The value to assign to the entity property of this EnrichedEntity.
+        :type entity: DataEntity
+
+        :param data_format:
+            The value to assign to the data_format property of this EnrichedEntity.
+        :type data_format: DataFormat
+
+        """
+        self.swagger_types = {
+            'entity': 'DataEntity',
+            'data_format': 'DataFormat'
+        }
+
+        self.attribute_map = {
+            'entity': 'entity',
+            'data_format': 'dataFormat'
+        }
+
+        self._entity = None
+        self._data_format = None
+
+    @property
+    def entity(self):
+        """
+        Gets the entity of this EnrichedEntity.
+
+        :return: The entity of this EnrichedEntity.
+        :rtype: DataEntity
+        """
+        return self._entity
+
+    @entity.setter
+    def entity(self, entity):
+        """
+        Sets the entity of this EnrichedEntity.
+
+        :param entity: The entity of this EnrichedEntity.
+        :type: DataEntity
+        """
+        self._entity = entity
+
+    @property
+    def data_format(self):
+        """
+        Gets the data_format of this EnrichedEntity.
+
+        :return: The data_format of this EnrichedEntity.
+        :rtype: DataFormat
+        """
+        return self._data_format
+
+    @data_format.setter
+    def data_format(self, data_format):
+        """
+        Sets the data_format of this EnrichedEntity.
+
+        :param data_format: The data_format of this EnrichedEntity.
+        :type: DataFormat
+        """
+        self._data_format = data_format
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/entity_shape_from_file.py
+++ b/src/oci/data_integration/models/entity_shape_from_file.py
@@ -200,7 +200,7 @@ class EntityShapeFromFile(EntityShape):
     def key(self):
         """
         Gets the key of this EntityShapeFromFile.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this EntityShapeFromFile.
@@ -212,7 +212,7 @@ class EntityShapeFromFile(EntityShape):
     def key(self, key):
         """
         Sets the key of this EntityShapeFromFile.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this EntityShapeFromFile.
@@ -224,7 +224,7 @@ class EntityShapeFromFile(EntityShape):
     def model_version(self):
         """
         Gets the model_version of this EntityShapeFromFile.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this EntityShapeFromFile.
@@ -236,7 +236,7 @@ class EntityShapeFromFile(EntityShape):
     def model_version(self, model_version):
         """
         Sets the model_version of this EntityShapeFromFile.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this EntityShapeFromFile.
@@ -268,7 +268,7 @@ class EntityShapeFromFile(EntityShape):
     def name(self):
         """
         Gets the name of this EntityShapeFromFile.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this EntityShapeFromFile.
@@ -280,7 +280,7 @@ class EntityShapeFromFile(EntityShape):
     def name(self, name):
         """
         Sets the name of this EntityShapeFromFile.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this EntityShapeFromFile.
@@ -598,7 +598,7 @@ class EntityShapeFromFile(EntityShape):
     def identifier(self):
         """
         Gets the identifier of this EntityShapeFromFile.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this EntityShapeFromFile.
@@ -610,7 +610,7 @@ class EntityShapeFromFile(EntityShape):
     def identifier(self, identifier):
         """
         Sets the identifier of this EntityShapeFromFile.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this EntityShapeFromFile.

--- a/src/oci/data_integration/models/expression.py
+++ b/src/oci/data_integration/models/expression.py
@@ -79,7 +79,7 @@ class Expression(object):
     def key(self):
         """
         Gets the key of this Expression.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this Expression.
@@ -91,7 +91,7 @@ class Expression(object):
     def key(self, key):
         """
         Sets the key of this Expression.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this Expression.
@@ -103,7 +103,7 @@ class Expression(object):
     def model_type(self):
         """
         Gets the model_type of this Expression.
-        The type of the object.
+        The object type.
 
 
         :return: The model_type of this Expression.
@@ -115,7 +115,7 @@ class Expression(object):
     def model_type(self, model_type):
         """
         Sets the model_type of this Expression.
-        The type of the object.
+        The object type.
 
 
         :param model_type: The model_type of this Expression.
@@ -127,7 +127,7 @@ class Expression(object):
     def model_version(self):
         """
         Gets the model_version of this Expression.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this Expression.
@@ -139,7 +139,7 @@ class Expression(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this Expression.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this Expression.

--- a/src/oci/data_integration/models/external_publication.py
+++ b/src/oci/data_integration/models/external_publication.py
@@ -1,0 +1,601 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalPublication(object):
+    """
+    The external published object contains the audit summary information and the definition of the task.
+    """
+
+    #: A constant which can be used with the status property of a ExternalPublication.
+    #: This constant has a value of "SUCCESSFUL"
+    STATUS_SUCCESSFUL = "SUCCESSFUL"
+
+    #: A constant which can be used with the status property of a ExternalPublication.
+    #: This constant has a value of "FAILED"
+    STATUS_FAILED = "FAILED"
+
+    #: A constant which can be used with the status property of a ExternalPublication.
+    #: This constant has a value of "PUBLISHING"
+    STATUS_PUBLISHING = "PUBLISHING"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalPublication object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param application_id:
+            The value to assign to the application_id property of this ExternalPublication.
+        :type application_id: str
+
+        :param application_compartment_id:
+            The value to assign to the application_compartment_id property of this ExternalPublication.
+        :type application_compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this ExternalPublication.
+        :type display_name: str
+
+        :param resource_configuration:
+            The value to assign to the resource_configuration property of this ExternalPublication.
+        :type resource_configuration: ResourceConfiguration
+
+        :param configuration_details:
+            The value to assign to the configuration_details property of this ExternalPublication.
+        :type configuration_details: ConfigurationDetails
+
+        :param status:
+            The value to assign to the status property of this ExternalPublication.
+            Allowed values for this property are: "SUCCESSFUL", "FAILED", "PUBLISHING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param error_message:
+            The value to assign to the error_message property of this ExternalPublication.
+        :type error_message: str
+
+        :param key:
+            The value to assign to the key property of this ExternalPublication.
+        :type key: str
+
+        :param model_type:
+            The value to assign to the model_type property of this ExternalPublication.
+        :type model_type: str
+
+        :param model_version:
+            The value to assign to the model_version property of this ExternalPublication.
+        :type model_version: str
+
+        :param name:
+            The value to assign to the name property of this ExternalPublication.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this ExternalPublication.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this ExternalPublication.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this ExternalPublication.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this ExternalPublication.
+        :type identifier: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this ExternalPublication.
+        :type parent_ref: ParentReference
+
+        :param metadata:
+            The value to assign to the metadata property of this ExternalPublication.
+        :type metadata: ObjectMetadata
+
+        :param key_map:
+            The value to assign to the key_map property of this ExternalPublication.
+        :type key_map: dict(str, str)
+
+        """
+        self.swagger_types = {
+            'application_id': 'str',
+            'application_compartment_id': 'str',
+            'display_name': 'str',
+            'resource_configuration': 'ResourceConfiguration',
+            'configuration_details': 'ConfigurationDetails',
+            'status': 'str',
+            'error_message': 'str',
+            'key': 'str',
+            'model_type': 'str',
+            'model_version': 'str',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'parent_ref': 'ParentReference',
+            'metadata': 'ObjectMetadata',
+            'key_map': 'dict(str, str)'
+        }
+
+        self.attribute_map = {
+            'application_id': 'applicationId',
+            'application_compartment_id': 'applicationCompartmentId',
+            'display_name': 'displayName',
+            'resource_configuration': 'resourceConfiguration',
+            'configuration_details': 'configurationDetails',
+            'status': 'status',
+            'error_message': 'errorMessage',
+            'key': 'key',
+            'model_type': 'modelType',
+            'model_version': 'modelVersion',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'parent_ref': 'parentRef',
+            'metadata': 'metadata',
+            'key_map': 'keyMap'
+        }
+
+        self._application_id = None
+        self._application_compartment_id = None
+        self._display_name = None
+        self._resource_configuration = None
+        self._configuration_details = None
+        self._status = None
+        self._error_message = None
+        self._key = None
+        self._model_type = None
+        self._model_version = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._parent_ref = None
+        self._metadata = None
+        self._key_map = None
+
+    @property
+    def application_id(self):
+        """
+        Gets the application_id of this ExternalPublication.
+        The unique OCID of the identifier that is returned after creating the Oracle Cloud Infrastructure Data Flow application.
+
+
+        :return: The application_id of this ExternalPublication.
+        :rtype: str
+        """
+        return self._application_id
+
+    @application_id.setter
+    def application_id(self, application_id):
+        """
+        Sets the application_id of this ExternalPublication.
+        The unique OCID of the identifier that is returned after creating the Oracle Cloud Infrastructure Data Flow application.
+
+
+        :param application_id: The application_id of this ExternalPublication.
+        :type: str
+        """
+        self._application_id = application_id
+
+    @property
+    def application_compartment_id(self):
+        """
+        Gets the application_compartment_id of this ExternalPublication.
+        The OCID of the compartment where the application is created in the Oracle Cloud Infrastructure Data Flow Service.
+
+
+        :return: The application_compartment_id of this ExternalPublication.
+        :rtype: str
+        """
+        return self._application_compartment_id
+
+    @application_compartment_id.setter
+    def application_compartment_id(self, application_compartment_id):
+        """
+        Sets the application_compartment_id of this ExternalPublication.
+        The OCID of the compartment where the application is created in the Oracle Cloud Infrastructure Data Flow Service.
+
+
+        :param application_compartment_id: The application_compartment_id of this ExternalPublication.
+        :type: str
+        """
+        self._application_compartment_id = application_compartment_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this ExternalPublication.
+        The name of the application.
+
+
+        :return: The display_name of this ExternalPublication.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ExternalPublication.
+        The name of the application.
+
+
+        :param display_name: The display_name of this ExternalPublication.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def resource_configuration(self):
+        """
+        Gets the resource_configuration of this ExternalPublication.
+
+        :return: The resource_configuration of this ExternalPublication.
+        :rtype: ResourceConfiguration
+        """
+        return self._resource_configuration
+
+    @resource_configuration.setter
+    def resource_configuration(self, resource_configuration):
+        """
+        Sets the resource_configuration of this ExternalPublication.
+
+        :param resource_configuration: The resource_configuration of this ExternalPublication.
+        :type: ResourceConfiguration
+        """
+        self._resource_configuration = resource_configuration
+
+    @property
+    def configuration_details(self):
+        """
+        Gets the configuration_details of this ExternalPublication.
+
+        :return: The configuration_details of this ExternalPublication.
+        :rtype: ConfigurationDetails
+        """
+        return self._configuration_details
+
+    @configuration_details.setter
+    def configuration_details(self, configuration_details):
+        """
+        Sets the configuration_details of this ExternalPublication.
+
+        :param configuration_details: The configuration_details of this ExternalPublication.
+        :type: ConfigurationDetails
+        """
+        self._configuration_details = configuration_details
+
+    @property
+    def status(self):
+        """
+        Gets the status of this ExternalPublication.
+        The status of the publishing action to Oracle Cloud Infrastructure Data Flow.
+
+        Allowed values for this property are: "SUCCESSFUL", "FAILED", "PUBLISHING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this ExternalPublication.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this ExternalPublication.
+        The status of the publishing action to Oracle Cloud Infrastructure Data Flow.
+
+
+        :param status: The status of this ExternalPublication.
+        :type: str
+        """
+        allowed_values = ["SUCCESSFUL", "FAILED", "PUBLISHING"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def error_message(self):
+        """
+        Gets the error_message of this ExternalPublication.
+        The error of the published object in the application.
+
+
+        :return: The error_message of this ExternalPublication.
+        :rtype: str
+        """
+        return self._error_message
+
+    @error_message.setter
+    def error_message(self, error_message):
+        """
+        Sets the error_message of this ExternalPublication.
+        The error of the published object in the application.
+
+
+        :param error_message: The error_message of this ExternalPublication.
+        :type: str
+        """
+        self._error_message = error_message
+
+    @property
+    def key(self):
+        """
+        Gets the key of this ExternalPublication.
+        The object key.
+
+
+        :return: The key of this ExternalPublication.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this ExternalPublication.
+        The object key.
+
+
+        :param key: The key of this ExternalPublication.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def model_type(self):
+        """
+        Gets the model_type of this ExternalPublication.
+        The object type.
+
+
+        :return: The model_type of this ExternalPublication.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this ExternalPublication.
+        The object type.
+
+
+        :param model_type: The model_type of this ExternalPublication.
+        :type: str
+        """
+        self._model_type = model_type
+
+    @property
+    def model_version(self):
+        """
+        Gets the model_version of this ExternalPublication.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :return: The model_version of this ExternalPublication.
+        :rtype: str
+        """
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Sets the model_version of this ExternalPublication.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :param model_version: The model_version of this ExternalPublication.
+        :type: str
+        """
+        self._model_version = model_version
+
+    @property
+    def name(self):
+        """
+        Gets the name of this ExternalPublication.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this ExternalPublication.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this ExternalPublication.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this ExternalPublication.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this ExternalPublication.
+        Detailed description for the object.
+
+
+        :return: The description of this ExternalPublication.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this ExternalPublication.
+        Detailed description for the object.
+
+
+        :param description: The description of this ExternalPublication.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def object_version(self):
+        """
+        Gets the object_version of this ExternalPublication.
+        The version of the object that is used to track changes in the object instance.
+
+
+        :return: The object_version of this ExternalPublication.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this ExternalPublication.
+        The version of the object that is used to track changes in the object instance.
+
+
+        :param object_version: The object_version of this ExternalPublication.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def object_status(self):
+        """
+        Gets the object_status of this ExternalPublication.
+        The status of an object that can be set to value 1 for shallow references across objects. Other values are reserved.
+
+
+        :return: The object_status of this ExternalPublication.
+        :rtype: int
+        """
+        return self._object_status
+
+    @object_status.setter
+    def object_status(self, object_status):
+        """
+        Sets the object_status of this ExternalPublication.
+        The status of an object that can be set to value 1 for shallow references across objects. Other values are reserved.
+
+
+        :param object_status: The object_status of this ExternalPublication.
+        :type: int
+        """
+        self._object_status = object_status
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this ExternalPublication.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this ExternalPublication.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this ExternalPublication.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this ExternalPublication.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def parent_ref(self):
+        """
+        Gets the parent_ref of this ExternalPublication.
+
+        :return: The parent_ref of this ExternalPublication.
+        :rtype: ParentReference
+        """
+        return self._parent_ref
+
+    @parent_ref.setter
+    def parent_ref(self, parent_ref):
+        """
+        Sets the parent_ref of this ExternalPublication.
+
+        :param parent_ref: The parent_ref of this ExternalPublication.
+        :type: ParentReference
+        """
+        self._parent_ref = parent_ref
+
+    @property
+    def metadata(self):
+        """
+        Gets the metadata of this ExternalPublication.
+
+        :return: The metadata of this ExternalPublication.
+        :rtype: ObjectMetadata
+        """
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        """
+        Sets the metadata of this ExternalPublication.
+
+        :param metadata: The metadata of this ExternalPublication.
+        :type: ObjectMetadata
+        """
+        self._metadata = metadata
+
+    @property
+    def key_map(self):
+        """
+        Gets the key_map of this ExternalPublication.
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
+
+
+        :return: The key_map of this ExternalPublication.
+        :rtype: dict(str, str)
+        """
+        return self._key_map
+
+    @key_map.setter
+    def key_map(self, key_map):
+        """
+        Sets the key_map of this ExternalPublication.
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
+
+
+        :param key_map: The key_map of this ExternalPublication.
+        :type: dict(str, str)
+        """
+        self._key_map = key_map
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/external_publication_summary.py
+++ b/src/oci/data_integration/models/external_publication_summary.py
@@ -1,0 +1,601 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalPublicationSummary(object):
+    """
+    The external publication summary contains the audit summary information and the definition of the external object.
+    """
+
+    #: A constant which can be used with the status property of a ExternalPublicationSummary.
+    #: This constant has a value of "SUCCESSFUL"
+    STATUS_SUCCESSFUL = "SUCCESSFUL"
+
+    #: A constant which can be used with the status property of a ExternalPublicationSummary.
+    #: This constant has a value of "FAILED"
+    STATUS_FAILED = "FAILED"
+
+    #: A constant which can be used with the status property of a ExternalPublicationSummary.
+    #: This constant has a value of "PUBLISHING"
+    STATUS_PUBLISHING = "PUBLISHING"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalPublicationSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param application_id:
+            The value to assign to the application_id property of this ExternalPublicationSummary.
+        :type application_id: str
+
+        :param application_compartment_id:
+            The value to assign to the application_compartment_id property of this ExternalPublicationSummary.
+        :type application_compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this ExternalPublicationSummary.
+        :type display_name: str
+
+        :param resource_configuration:
+            The value to assign to the resource_configuration property of this ExternalPublicationSummary.
+        :type resource_configuration: ResourceConfiguration
+
+        :param configuration_details:
+            The value to assign to the configuration_details property of this ExternalPublicationSummary.
+        :type configuration_details: ConfigurationDetails
+
+        :param status:
+            The value to assign to the status property of this ExternalPublicationSummary.
+            Allowed values for this property are: "SUCCESSFUL", "FAILED", "PUBLISHING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param error_message:
+            The value to assign to the error_message property of this ExternalPublicationSummary.
+        :type error_message: str
+
+        :param key:
+            The value to assign to the key property of this ExternalPublicationSummary.
+        :type key: str
+
+        :param model_type:
+            The value to assign to the model_type property of this ExternalPublicationSummary.
+        :type model_type: str
+
+        :param model_version:
+            The value to assign to the model_version property of this ExternalPublicationSummary.
+        :type model_version: str
+
+        :param name:
+            The value to assign to the name property of this ExternalPublicationSummary.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this ExternalPublicationSummary.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this ExternalPublicationSummary.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this ExternalPublicationSummary.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this ExternalPublicationSummary.
+        :type identifier: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this ExternalPublicationSummary.
+        :type parent_ref: ParentReference
+
+        :param metadata:
+            The value to assign to the metadata property of this ExternalPublicationSummary.
+        :type metadata: ObjectMetadata
+
+        :param key_map:
+            The value to assign to the key_map property of this ExternalPublicationSummary.
+        :type key_map: dict(str, str)
+
+        """
+        self.swagger_types = {
+            'application_id': 'str',
+            'application_compartment_id': 'str',
+            'display_name': 'str',
+            'resource_configuration': 'ResourceConfiguration',
+            'configuration_details': 'ConfigurationDetails',
+            'status': 'str',
+            'error_message': 'str',
+            'key': 'str',
+            'model_type': 'str',
+            'model_version': 'str',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'parent_ref': 'ParentReference',
+            'metadata': 'ObjectMetadata',
+            'key_map': 'dict(str, str)'
+        }
+
+        self.attribute_map = {
+            'application_id': 'applicationId',
+            'application_compartment_id': 'applicationCompartmentId',
+            'display_name': 'displayName',
+            'resource_configuration': 'resourceConfiguration',
+            'configuration_details': 'configurationDetails',
+            'status': 'status',
+            'error_message': 'errorMessage',
+            'key': 'key',
+            'model_type': 'modelType',
+            'model_version': 'modelVersion',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'parent_ref': 'parentRef',
+            'metadata': 'metadata',
+            'key_map': 'keyMap'
+        }
+
+        self._application_id = None
+        self._application_compartment_id = None
+        self._display_name = None
+        self._resource_configuration = None
+        self._configuration_details = None
+        self._status = None
+        self._error_message = None
+        self._key = None
+        self._model_type = None
+        self._model_version = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._parent_ref = None
+        self._metadata = None
+        self._key_map = None
+
+    @property
+    def application_id(self):
+        """
+        Gets the application_id of this ExternalPublicationSummary.
+        The unique OCID of the identifier that is returned after creating the Oracle Cloud Infrastructure Data Flow application.
+
+
+        :return: The application_id of this ExternalPublicationSummary.
+        :rtype: str
+        """
+        return self._application_id
+
+    @application_id.setter
+    def application_id(self, application_id):
+        """
+        Sets the application_id of this ExternalPublicationSummary.
+        The unique OCID of the identifier that is returned after creating the Oracle Cloud Infrastructure Data Flow application.
+
+
+        :param application_id: The application_id of this ExternalPublicationSummary.
+        :type: str
+        """
+        self._application_id = application_id
+
+    @property
+    def application_compartment_id(self):
+        """
+        Gets the application_compartment_id of this ExternalPublicationSummary.
+        The OCID of the compartment where the application is created in the Oracle Cloud Infrastructure Data Flow Service.
+
+
+        :return: The application_compartment_id of this ExternalPublicationSummary.
+        :rtype: str
+        """
+        return self._application_compartment_id
+
+    @application_compartment_id.setter
+    def application_compartment_id(self, application_compartment_id):
+        """
+        Sets the application_compartment_id of this ExternalPublicationSummary.
+        The OCID of the compartment where the application is created in the Oracle Cloud Infrastructure Data Flow Service.
+
+
+        :param application_compartment_id: The application_compartment_id of this ExternalPublicationSummary.
+        :type: str
+        """
+        self._application_compartment_id = application_compartment_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this ExternalPublicationSummary.
+        The name of the application.
+
+
+        :return: The display_name of this ExternalPublicationSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ExternalPublicationSummary.
+        The name of the application.
+
+
+        :param display_name: The display_name of this ExternalPublicationSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def resource_configuration(self):
+        """
+        Gets the resource_configuration of this ExternalPublicationSummary.
+
+        :return: The resource_configuration of this ExternalPublicationSummary.
+        :rtype: ResourceConfiguration
+        """
+        return self._resource_configuration
+
+    @resource_configuration.setter
+    def resource_configuration(self, resource_configuration):
+        """
+        Sets the resource_configuration of this ExternalPublicationSummary.
+
+        :param resource_configuration: The resource_configuration of this ExternalPublicationSummary.
+        :type: ResourceConfiguration
+        """
+        self._resource_configuration = resource_configuration
+
+    @property
+    def configuration_details(self):
+        """
+        Gets the configuration_details of this ExternalPublicationSummary.
+
+        :return: The configuration_details of this ExternalPublicationSummary.
+        :rtype: ConfigurationDetails
+        """
+        return self._configuration_details
+
+    @configuration_details.setter
+    def configuration_details(self, configuration_details):
+        """
+        Sets the configuration_details of this ExternalPublicationSummary.
+
+        :param configuration_details: The configuration_details of this ExternalPublicationSummary.
+        :type: ConfigurationDetails
+        """
+        self._configuration_details = configuration_details
+
+    @property
+    def status(self):
+        """
+        Gets the status of this ExternalPublicationSummary.
+        The status of the publishing action to Oracle Cloud Infrastructure Data Flow.
+
+        Allowed values for this property are: "SUCCESSFUL", "FAILED", "PUBLISHING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this ExternalPublicationSummary.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this ExternalPublicationSummary.
+        The status of the publishing action to Oracle Cloud Infrastructure Data Flow.
+
+
+        :param status: The status of this ExternalPublicationSummary.
+        :type: str
+        """
+        allowed_values = ["SUCCESSFUL", "FAILED", "PUBLISHING"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def error_message(self):
+        """
+        Gets the error_message of this ExternalPublicationSummary.
+        The error of the published object in the application.
+
+
+        :return: The error_message of this ExternalPublicationSummary.
+        :rtype: str
+        """
+        return self._error_message
+
+    @error_message.setter
+    def error_message(self, error_message):
+        """
+        Sets the error_message of this ExternalPublicationSummary.
+        The error of the published object in the application.
+
+
+        :param error_message: The error_message of this ExternalPublicationSummary.
+        :type: str
+        """
+        self._error_message = error_message
+
+    @property
+    def key(self):
+        """
+        Gets the key of this ExternalPublicationSummary.
+        The object key.
+
+
+        :return: The key of this ExternalPublicationSummary.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this ExternalPublicationSummary.
+        The object key.
+
+
+        :param key: The key of this ExternalPublicationSummary.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def model_type(self):
+        """
+        Gets the model_type of this ExternalPublicationSummary.
+        The object type.
+
+
+        :return: The model_type of this ExternalPublicationSummary.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this ExternalPublicationSummary.
+        The object type.
+
+
+        :param model_type: The model_type of this ExternalPublicationSummary.
+        :type: str
+        """
+        self._model_type = model_type
+
+    @property
+    def model_version(self):
+        """
+        Gets the model_version of this ExternalPublicationSummary.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :return: The model_version of this ExternalPublicationSummary.
+        :rtype: str
+        """
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Sets the model_version of this ExternalPublicationSummary.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :param model_version: The model_version of this ExternalPublicationSummary.
+        :type: str
+        """
+        self._model_version = model_version
+
+    @property
+    def name(self):
+        """
+        Gets the name of this ExternalPublicationSummary.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this ExternalPublicationSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this ExternalPublicationSummary.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this ExternalPublicationSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this ExternalPublicationSummary.
+        Detailed description for the object.
+
+
+        :return: The description of this ExternalPublicationSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this ExternalPublicationSummary.
+        Detailed description for the object.
+
+
+        :param description: The description of this ExternalPublicationSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def object_version(self):
+        """
+        Gets the object_version of this ExternalPublicationSummary.
+        The version of the object that is used to track changes in the object instance.
+
+
+        :return: The object_version of this ExternalPublicationSummary.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this ExternalPublicationSummary.
+        The version of the object that is used to track changes in the object instance.
+
+
+        :param object_version: The object_version of this ExternalPublicationSummary.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def object_status(self):
+        """
+        Gets the object_status of this ExternalPublicationSummary.
+        The status of an object that can be set to value 1 for shallow references across objects. Other values are reserved.
+
+
+        :return: The object_status of this ExternalPublicationSummary.
+        :rtype: int
+        """
+        return self._object_status
+
+    @object_status.setter
+    def object_status(self, object_status):
+        """
+        Sets the object_status of this ExternalPublicationSummary.
+        The status of an object that can be set to value 1 for shallow references across objects. Other values are reserved.
+
+
+        :param object_status: The object_status of this ExternalPublicationSummary.
+        :type: int
+        """
+        self._object_status = object_status
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this ExternalPublicationSummary.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this ExternalPublicationSummary.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this ExternalPublicationSummary.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this ExternalPublicationSummary.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def parent_ref(self):
+        """
+        Gets the parent_ref of this ExternalPublicationSummary.
+
+        :return: The parent_ref of this ExternalPublicationSummary.
+        :rtype: ParentReference
+        """
+        return self._parent_ref
+
+    @parent_ref.setter
+    def parent_ref(self, parent_ref):
+        """
+        Sets the parent_ref of this ExternalPublicationSummary.
+
+        :param parent_ref: The parent_ref of this ExternalPublicationSummary.
+        :type: ParentReference
+        """
+        self._parent_ref = parent_ref
+
+    @property
+    def metadata(self):
+        """
+        Gets the metadata of this ExternalPublicationSummary.
+
+        :return: The metadata of this ExternalPublicationSummary.
+        :rtype: ObjectMetadata
+        """
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        """
+        Sets the metadata of this ExternalPublicationSummary.
+
+        :param metadata: The metadata of this ExternalPublicationSummary.
+        :type: ObjectMetadata
+        """
+        self._metadata = metadata
+
+    @property
+    def key_map(self):
+        """
+        Gets the key_map of this ExternalPublicationSummary.
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
+
+
+        :return: The key_map of this ExternalPublicationSummary.
+        :rtype: dict(str, str)
+        """
+        return self._key_map
+
+    @key_map.setter
+    def key_map(self, key_map):
+        """
+        Sets the key_map of this ExternalPublicationSummary.
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
+
+
+        :param key_map: The key_map of this ExternalPublicationSummary.
+        :type: dict(str, str)
+        """
+        self._key_map = key_map
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/external_publication_summary_collection.py
+++ b/src/oci/data_integration/models/external_publication_summary_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalPublicationSummaryCollection(object):
+    """
+    This is the collection of external publication summaries. It may be a collection of lightweight details or full definitions.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalPublicationSummaryCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this ExternalPublicationSummaryCollection.
+        :type items: list[ExternalPublicationSummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[ExternalPublicationSummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this ExternalPublicationSummaryCollection.
+        The array of external publication summaries.
+
+
+        :return: The items of this ExternalPublicationSummaryCollection.
+        :rtype: list[ExternalPublicationSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this ExternalPublicationSummaryCollection.
+        The array of external publication summaries.
+
+
+        :param items: The items of this ExternalPublicationSummaryCollection.
+        :type: list[ExternalPublicationSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/external_publication_validation.py
+++ b/src/oci/data_integration/models/external_publication_validation.py
@@ -1,0 +1,225 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalPublicationValidation(object):
+    """
+    The information about external published task validation.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalPublicationValidation object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param total_message_count:
+            The value to assign to the total_message_count property of this ExternalPublicationValidation.
+        :type total_message_count: int
+
+        :param error_message_count:
+            The value to assign to the error_message_count property of this ExternalPublicationValidation.
+        :type error_message_count: int
+
+        :param warn_message_count:
+            The value to assign to the warn_message_count property of this ExternalPublicationValidation.
+        :type warn_message_count: int
+
+        :param info_message_count:
+            The value to assign to the info_message_count property of this ExternalPublicationValidation.
+        :type info_message_count: int
+
+        :param validation_messages:
+            The value to assign to the validation_messages property of this ExternalPublicationValidation.
+        :type validation_messages: dict(str, list[ValidationMessage])
+
+        :param key:
+            The value to assign to the key property of this ExternalPublicationValidation.
+        :type key: str
+
+        """
+        self.swagger_types = {
+            'total_message_count': 'int',
+            'error_message_count': 'int',
+            'warn_message_count': 'int',
+            'info_message_count': 'int',
+            'validation_messages': 'dict(str, list[ValidationMessage])',
+            'key': 'str'
+        }
+
+        self.attribute_map = {
+            'total_message_count': 'totalMessageCount',
+            'error_message_count': 'errorMessageCount',
+            'warn_message_count': 'warnMessageCount',
+            'info_message_count': 'infoMessageCount',
+            'validation_messages': 'validationMessages',
+            'key': 'key'
+        }
+
+        self._total_message_count = None
+        self._error_message_count = None
+        self._warn_message_count = None
+        self._info_message_count = None
+        self._validation_messages = None
+        self._key = None
+
+    @property
+    def total_message_count(self):
+        """
+        Gets the total_message_count of this ExternalPublicationValidation.
+        Total number of validation messages.
+
+
+        :return: The total_message_count of this ExternalPublicationValidation.
+        :rtype: int
+        """
+        return self._total_message_count
+
+    @total_message_count.setter
+    def total_message_count(self, total_message_count):
+        """
+        Sets the total_message_count of this ExternalPublicationValidation.
+        Total number of validation messages.
+
+
+        :param total_message_count: The total_message_count of this ExternalPublicationValidation.
+        :type: int
+        """
+        self._total_message_count = total_message_count
+
+    @property
+    def error_message_count(self):
+        """
+        Gets the error_message_count of this ExternalPublicationValidation.
+        Total number of validation error messages.
+
+
+        :return: The error_message_count of this ExternalPublicationValidation.
+        :rtype: int
+        """
+        return self._error_message_count
+
+    @error_message_count.setter
+    def error_message_count(self, error_message_count):
+        """
+        Sets the error_message_count of this ExternalPublicationValidation.
+        Total number of validation error messages.
+
+
+        :param error_message_count: The error_message_count of this ExternalPublicationValidation.
+        :type: int
+        """
+        self._error_message_count = error_message_count
+
+    @property
+    def warn_message_count(self):
+        """
+        Gets the warn_message_count of this ExternalPublicationValidation.
+        Total number of validation warning messages.
+
+
+        :return: The warn_message_count of this ExternalPublicationValidation.
+        :rtype: int
+        """
+        return self._warn_message_count
+
+    @warn_message_count.setter
+    def warn_message_count(self, warn_message_count):
+        """
+        Sets the warn_message_count of this ExternalPublicationValidation.
+        Total number of validation warning messages.
+
+
+        :param warn_message_count: The warn_message_count of this ExternalPublicationValidation.
+        :type: int
+        """
+        self._warn_message_count = warn_message_count
+
+    @property
+    def info_message_count(self):
+        """
+        Gets the info_message_count of this ExternalPublicationValidation.
+        Total number of validation information messages.
+
+
+        :return: The info_message_count of this ExternalPublicationValidation.
+        :rtype: int
+        """
+        return self._info_message_count
+
+    @info_message_count.setter
+    def info_message_count(self, info_message_count):
+        """
+        Sets the info_message_count of this ExternalPublicationValidation.
+        Total number of validation information messages.
+
+
+        :param info_message_count: The info_message_count of this ExternalPublicationValidation.
+        :type: int
+        """
+        self._info_message_count = info_message_count
+
+    @property
+    def validation_messages(self):
+        """
+        Gets the validation_messages of this ExternalPublicationValidation.
+        Detailed information of the data flow object validation.
+
+
+        :return: The validation_messages of this ExternalPublicationValidation.
+        :rtype: dict(str, list[ValidationMessage])
+        """
+        return self._validation_messages
+
+    @validation_messages.setter
+    def validation_messages(self, validation_messages):
+        """
+        Sets the validation_messages of this ExternalPublicationValidation.
+        Detailed information of the data flow object validation.
+
+
+        :param validation_messages: The validation_messages of this ExternalPublicationValidation.
+        :type: dict(str, list[ValidationMessage])
+        """
+        self._validation_messages = validation_messages
+
+    @property
+    def key(self):
+        """
+        Gets the key of this ExternalPublicationValidation.
+        Objects use a 36 character key as unique ID. It is system generated and cannot be modified.
+
+
+        :return: The key of this ExternalPublicationValidation.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this ExternalPublicationValidation.
+        Objects use a 36 character key as unique ID. It is system generated and cannot be modified.
+
+
+        :param key: The key of this ExternalPublicationValidation.
+        :type: str
+        """
+        self._key = key
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/external_publication_validation_summary.py
+++ b/src/oci/data_integration/models/external_publication_validation_summary.py
@@ -1,0 +1,225 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalPublicationValidationSummary(object):
+    """
+    The external publication validation summary contains the validation summary information and the definition of the external object.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalPublicationValidationSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param total_message_count:
+            The value to assign to the total_message_count property of this ExternalPublicationValidationSummary.
+        :type total_message_count: int
+
+        :param error_message_count:
+            The value to assign to the error_message_count property of this ExternalPublicationValidationSummary.
+        :type error_message_count: int
+
+        :param warn_message_count:
+            The value to assign to the warn_message_count property of this ExternalPublicationValidationSummary.
+        :type warn_message_count: int
+
+        :param info_message_count:
+            The value to assign to the info_message_count property of this ExternalPublicationValidationSummary.
+        :type info_message_count: int
+
+        :param validation_messages:
+            The value to assign to the validation_messages property of this ExternalPublicationValidationSummary.
+        :type validation_messages: dict(str, list[ValidationMessage])
+
+        :param key:
+            The value to assign to the key property of this ExternalPublicationValidationSummary.
+        :type key: str
+
+        """
+        self.swagger_types = {
+            'total_message_count': 'int',
+            'error_message_count': 'int',
+            'warn_message_count': 'int',
+            'info_message_count': 'int',
+            'validation_messages': 'dict(str, list[ValidationMessage])',
+            'key': 'str'
+        }
+
+        self.attribute_map = {
+            'total_message_count': 'totalMessageCount',
+            'error_message_count': 'errorMessageCount',
+            'warn_message_count': 'warnMessageCount',
+            'info_message_count': 'infoMessageCount',
+            'validation_messages': 'validationMessages',
+            'key': 'key'
+        }
+
+        self._total_message_count = None
+        self._error_message_count = None
+        self._warn_message_count = None
+        self._info_message_count = None
+        self._validation_messages = None
+        self._key = None
+
+    @property
+    def total_message_count(self):
+        """
+        Gets the total_message_count of this ExternalPublicationValidationSummary.
+        Total number of validation messages.
+
+
+        :return: The total_message_count of this ExternalPublicationValidationSummary.
+        :rtype: int
+        """
+        return self._total_message_count
+
+    @total_message_count.setter
+    def total_message_count(self, total_message_count):
+        """
+        Sets the total_message_count of this ExternalPublicationValidationSummary.
+        Total number of validation messages.
+
+
+        :param total_message_count: The total_message_count of this ExternalPublicationValidationSummary.
+        :type: int
+        """
+        self._total_message_count = total_message_count
+
+    @property
+    def error_message_count(self):
+        """
+        Gets the error_message_count of this ExternalPublicationValidationSummary.
+        Total number of validation error messages.
+
+
+        :return: The error_message_count of this ExternalPublicationValidationSummary.
+        :rtype: int
+        """
+        return self._error_message_count
+
+    @error_message_count.setter
+    def error_message_count(self, error_message_count):
+        """
+        Sets the error_message_count of this ExternalPublicationValidationSummary.
+        Total number of validation error messages.
+
+
+        :param error_message_count: The error_message_count of this ExternalPublicationValidationSummary.
+        :type: int
+        """
+        self._error_message_count = error_message_count
+
+    @property
+    def warn_message_count(self):
+        """
+        Gets the warn_message_count of this ExternalPublicationValidationSummary.
+        Total number of validation warning messages.
+
+
+        :return: The warn_message_count of this ExternalPublicationValidationSummary.
+        :rtype: int
+        """
+        return self._warn_message_count
+
+    @warn_message_count.setter
+    def warn_message_count(self, warn_message_count):
+        """
+        Sets the warn_message_count of this ExternalPublicationValidationSummary.
+        Total number of validation warning messages.
+
+
+        :param warn_message_count: The warn_message_count of this ExternalPublicationValidationSummary.
+        :type: int
+        """
+        self._warn_message_count = warn_message_count
+
+    @property
+    def info_message_count(self):
+        """
+        Gets the info_message_count of this ExternalPublicationValidationSummary.
+        Total number of validation information messages.
+
+
+        :return: The info_message_count of this ExternalPublicationValidationSummary.
+        :rtype: int
+        """
+        return self._info_message_count
+
+    @info_message_count.setter
+    def info_message_count(self, info_message_count):
+        """
+        Sets the info_message_count of this ExternalPublicationValidationSummary.
+        Total number of validation information messages.
+
+
+        :param info_message_count: The info_message_count of this ExternalPublicationValidationSummary.
+        :type: int
+        """
+        self._info_message_count = info_message_count
+
+    @property
+    def validation_messages(self):
+        """
+        Gets the validation_messages of this ExternalPublicationValidationSummary.
+        Detailed information of the data flow object validation.
+
+
+        :return: The validation_messages of this ExternalPublicationValidationSummary.
+        :rtype: dict(str, list[ValidationMessage])
+        """
+        return self._validation_messages
+
+    @validation_messages.setter
+    def validation_messages(self, validation_messages):
+        """
+        Sets the validation_messages of this ExternalPublicationValidationSummary.
+        Detailed information of the data flow object validation.
+
+
+        :param validation_messages: The validation_messages of this ExternalPublicationValidationSummary.
+        :type: dict(str, list[ValidationMessage])
+        """
+        self._validation_messages = validation_messages
+
+    @property
+    def key(self):
+        """
+        Gets the key of this ExternalPublicationValidationSummary.
+        Objects use a 36 character key as unique ID. It is system generated and cannot be modified.
+
+
+        :return: The key of this ExternalPublicationValidationSummary.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this ExternalPublicationValidationSummary.
+        Objects use a 36 character key as unique ID. It is system generated and cannot be modified.
+
+
+        :param key: The key of this ExternalPublicationValidationSummary.
+        :type: str
+        """
+        self._key = key
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/external_publication_validation_summary_collection.py
+++ b/src/oci/data_integration/models/external_publication_validation_summary_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalPublicationValidationSummaryCollection(object):
+    """
+    This is the collection of external publication validation  summaries. It may be a collection of lightweight details or full definitions.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalPublicationValidationSummaryCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this ExternalPublicationValidationSummaryCollection.
+        :type items: list[ExternalPublicationValidationSummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[ExternalPublicationValidationSummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this ExternalPublicationValidationSummaryCollection.
+        The array of external publication summaries.
+
+
+        :return: The items of this ExternalPublicationValidationSummaryCollection.
+        :rtype: list[ExternalPublicationValidationSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this ExternalPublicationValidationSummaryCollection.
+        The array of external publication summaries.
+
+
+        :param items: The items of this ExternalPublicationValidationSummaryCollection.
+        :type: list[ExternalPublicationValidationSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/filter.py
+++ b/src/oci/data_integration/models/filter.py
@@ -21,7 +21,7 @@ class Filter(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this Filter.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR"
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/flow_node.py
+++ b/src/oci/data_integration/models/flow_node.py
@@ -206,7 +206,7 @@ class FlowNode(object):
     def name(self):
         """
         Gets the name of this FlowNode.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this FlowNode.
@@ -218,7 +218,7 @@ class FlowNode(object):
     def name(self, name):
         """
         Sets the name of this FlowNode.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this FlowNode.
@@ -254,7 +254,7 @@ class FlowNode(object):
     def input_links(self):
         """
         Gets the input_links of this FlowNode.
-        inputLinks
+        An array of input links.
 
 
         :return: The input_links of this FlowNode.
@@ -266,7 +266,7 @@ class FlowNode(object):
     def input_links(self, input_links):
         """
         Sets the input_links of this FlowNode.
-        inputLinks
+        An array of input links.
 
 
         :param input_links: The input_links of this FlowNode.
@@ -278,7 +278,7 @@ class FlowNode(object):
     def output_links(self):
         """
         Gets the output_links of this FlowNode.
-        outputLinks
+        An array of output links.
 
 
         :return: The output_links of this FlowNode.
@@ -290,7 +290,7 @@ class FlowNode(object):
     def output_links(self, output_links):
         """
         Sets the output_links of this FlowNode.
-        outputLinks
+        An array of output links.
 
 
         :param output_links: The output_links of this FlowNode.

--- a/src/oci/data_integration/models/flow_port.py
+++ b/src/oci/data_integration/models/flow_port.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class FlowPort(TypedObject):
     """
-    Each operator owns a set of InputPort and OutputPort objects (can scale to zero), which represent the ports that can be connected to/from the Operator.
+    Each operator owns a set of `InputPort` and `OutputPort` objects (can scale to zero), which represent the ports that can be connected to/from the operator.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class FlowPort(TypedObject):
 
         :param model_type:
             The value to assign to the model_type property of this FlowPort.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/flow_port_link.py
+++ b/src/oci/data_integration/models/flow_port_link.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class FlowPortLink(object):
     """
-    The details of the flow port links.
+    Details about the link between two data flow operators.
     """
 
     #: A constant which can be used with the model_type property of a FlowPortLink.

--- a/src/oci/data_integration/models/folder.py
+++ b/src/oci/data_integration/models/folder.py
@@ -186,7 +186,7 @@ class Folder(object):
     def name(self):
         """
         Gets the name of this Folder.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this Folder.
@@ -198,7 +198,7 @@ class Folder(object):
     def name(self, name):
         """
         Sets the name of this Folder.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this Folder.
@@ -210,7 +210,7 @@ class Folder(object):
     def description(self):
         """
         Gets the description of this Folder.
-        Detailed description for the object.
+        A user defined description for the folder.
 
 
         :return: The description of this Folder.
@@ -222,7 +222,7 @@ class Folder(object):
     def description(self, description):
         """
         Sets the description of this Folder.
-        Detailed description for the object.
+        A user defined description for the folder.
 
 
         :param description: The description of this Folder.
@@ -234,7 +234,7 @@ class Folder(object):
     def category_name(self):
         """
         Gets the category_name of this Folder.
-        categoryName
+        The category name.
 
 
         :return: The category_name of this Folder.
@@ -246,7 +246,7 @@ class Folder(object):
     def category_name(self, category_name):
         """
         Sets the category_name of this Folder.
-        categoryName
+        The category name.
 
 
         :param category_name: The category_name of this Folder.
@@ -282,7 +282,7 @@ class Folder(object):
     def identifier(self):
         """
         Gets the identifier of this Folder.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this Folder.
@@ -294,7 +294,7 @@ class Folder(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this Folder.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this Folder.
@@ -370,7 +370,7 @@ class Folder(object):
     def key_map(self):
         """
         Gets the key_map of this Folder.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, the key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this Folder.
@@ -382,7 +382,7 @@ class Folder(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this Folder.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, the key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this Folder.

--- a/src/oci/data_integration/models/folder_details.py
+++ b/src/oci/data_integration/models/folder_details.py
@@ -179,7 +179,7 @@ class FolderDetails(object):
     def name(self):
         """
         Gets the name of this FolderDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this FolderDetails.
@@ -191,7 +191,7 @@ class FolderDetails(object):
     def name(self, name):
         """
         Sets the name of this FolderDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this FolderDetails.
@@ -203,7 +203,7 @@ class FolderDetails(object):
     def description(self):
         """
         Gets the description of this FolderDetails.
-        Detailed description for the object.
+        A user defined description for the folder.
 
 
         :return: The description of this FolderDetails.
@@ -215,7 +215,7 @@ class FolderDetails(object):
     def description(self, description):
         """
         Sets the description of this FolderDetails.
-        Detailed description for the object.
+        A user defined description for the folder.
 
 
         :param description: The description of this FolderDetails.
@@ -227,7 +227,7 @@ class FolderDetails(object):
     def category_name(self):
         """
         Gets the category_name of this FolderDetails.
-        categoryName
+        The category name.
 
 
         :return: The category_name of this FolderDetails.
@@ -239,7 +239,7 @@ class FolderDetails(object):
     def category_name(self, category_name):
         """
         Sets the category_name of this FolderDetails.
-        categoryName
+        The category name.
 
 
         :param category_name: The category_name of this FolderDetails.
@@ -275,7 +275,7 @@ class FolderDetails(object):
     def identifier(self):
         """
         Gets the identifier of this FolderDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this FolderDetails.
@@ -287,7 +287,7 @@ class FolderDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this FolderDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this FolderDetails.

--- a/src/oci/data_integration/models/folder_summary.py
+++ b/src/oci/data_integration/models/folder_summary.py
@@ -186,7 +186,7 @@ class FolderSummary(object):
     def name(self):
         """
         Gets the name of this FolderSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this FolderSummary.
@@ -198,7 +198,7 @@ class FolderSummary(object):
     def name(self, name):
         """
         Sets the name of this FolderSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this FolderSummary.
@@ -210,7 +210,7 @@ class FolderSummary(object):
     def description(self):
         """
         Gets the description of this FolderSummary.
-        Detailed description for the object.
+        A user defined description for the folder.
 
 
         :return: The description of this FolderSummary.
@@ -222,7 +222,7 @@ class FolderSummary(object):
     def description(self, description):
         """
         Sets the description of this FolderSummary.
-        Detailed description for the object.
+        A user defined description for the folder.
 
 
         :param description: The description of this FolderSummary.
@@ -234,7 +234,7 @@ class FolderSummary(object):
     def category_name(self):
         """
         Gets the category_name of this FolderSummary.
-        categoryName
+        The category name.
 
 
         :return: The category_name of this FolderSummary.
@@ -246,7 +246,7 @@ class FolderSummary(object):
     def category_name(self, category_name):
         """
         Sets the category_name of this FolderSummary.
-        categoryName
+        The category name.
 
 
         :param category_name: The category_name of this FolderSummary.
@@ -282,7 +282,7 @@ class FolderSummary(object):
     def identifier(self):
         """
         Gets the identifier of this FolderSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this FolderSummary.
@@ -294,7 +294,7 @@ class FolderSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this FolderSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this FolderSummary.
@@ -370,7 +370,7 @@ class FolderSummary(object):
     def key_map(self):
         """
         Gets the key_map of this FolderSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, the key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this FolderSummary.
@@ -382,7 +382,7 @@ class FolderSummary(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this FolderSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, the key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this FolderSummary.

--- a/src/oci/data_integration/models/folder_summary_collection.py
+++ b/src/oci/data_integration/models/folder_summary_collection.py
@@ -37,7 +37,7 @@ class FolderSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this FolderSummaryCollection.
-        The array of Folder summaries
+        The array of folder summaries.
 
 
         :return: The items of this FolderSummaryCollection.
@@ -49,7 +49,7 @@ class FolderSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this FolderSummaryCollection.
-        The array of Folder summaries
+        The array of folder summaries.
 
 
         :param items: The items of this FolderSummaryCollection.

--- a/src/oci/data_integration/models/foreign_key.py
+++ b/src/oci/data_integration/models/foreign_key.py
@@ -103,7 +103,7 @@ class ForeignKey(Key):
     def key(self):
         """
         Gets the key of this ForeignKey.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this ForeignKey.
@@ -115,7 +115,7 @@ class ForeignKey(Key):
     def key(self, key):
         """
         Sets the key of this ForeignKey.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this ForeignKey.
@@ -127,7 +127,7 @@ class ForeignKey(Key):
     def model_version(self):
         """
         Gets the model_version of this ForeignKey.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this ForeignKey.
@@ -139,7 +139,7 @@ class ForeignKey(Key):
     def model_version(self, model_version):
         """
         Sets the model_version of this ForeignKey.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this ForeignKey.
@@ -171,7 +171,7 @@ class ForeignKey(Key):
     def name(self):
         """
         Gets the name of this ForeignKey.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this ForeignKey.
@@ -183,7 +183,7 @@ class ForeignKey(Key):
     def name(self, name):
         """
         Sets the name of this ForeignKey.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this ForeignKey.
@@ -195,7 +195,7 @@ class ForeignKey(Key):
     def attribute_refs(self):
         """
         Gets the attribute_refs of this ForeignKey.
-        attributeRefs
+        An array of attribute references.
 
 
         :return: The attribute_refs of this ForeignKey.
@@ -207,7 +207,7 @@ class ForeignKey(Key):
     def attribute_refs(self, attribute_refs):
         """
         Sets the attribute_refs of this ForeignKey.
-        attributeRefs
+        An array of attribute references.
 
 
         :param attribute_refs: The attribute_refs of this ForeignKey.
@@ -219,7 +219,7 @@ class ForeignKey(Key):
     def update_rule(self):
         """
         Gets the update_rule of this ForeignKey.
-        updateRule
+        The update rule.
 
 
         :return: The update_rule of this ForeignKey.
@@ -231,7 +231,7 @@ class ForeignKey(Key):
     def update_rule(self, update_rule):
         """
         Sets the update_rule of this ForeignKey.
-        updateRule
+        The update rule.
 
 
         :param update_rule: The update_rule of this ForeignKey.
@@ -243,7 +243,7 @@ class ForeignKey(Key):
     def delete_rule(self):
         """
         Gets the delete_rule of this ForeignKey.
-        deleteRule
+        The delete rule.
 
 
         :return: The delete_rule of this ForeignKey.
@@ -255,7 +255,7 @@ class ForeignKey(Key):
     def delete_rule(self, delete_rule):
         """
         Sets the delete_rule of this ForeignKey.
-        deleteRule
+        The delete rule.
 
 
         :param delete_rule: The delete_rule of this ForeignKey.

--- a/src/oci/data_integration/models/input_field.py
+++ b/src/oci/data_integration/models/input_field.py
@@ -21,7 +21,7 @@ class InputField(TypedObject):
 
         :param model_type:
             The value to assign to the model_type property of this InputField.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
         :type model_type: str
 
         :param key:
@@ -123,7 +123,7 @@ class InputField(TypedObject):
     def labels(self):
         """
         Gets the labels of this InputField.
-        Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or labels that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :return: The labels of this InputField.
@@ -135,7 +135,7 @@ class InputField(TypedObject):
     def labels(self, labels):
         """
         Sets the labels of this InputField.
-        Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or labels that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :param labels: The labels of this InputField.

--- a/src/oci/data_integration/models/input_link.py
+++ b/src/oci/data_integration/models/input_link.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class InputLink(FlowPortLink):
     """
-    The information about input links.
+    Details about the incoming data to an operator in a data flow design.
     """
 
     def __init__(self, **kwargs):
@@ -97,7 +97,7 @@ class InputLink(FlowPortLink):
     def from_link(self):
         """
         Gets the from_link of this InputLink.
-        From link reference.
+        The from link reference.
 
 
         :return: The from_link of this InputLink.
@@ -109,7 +109,7 @@ class InputLink(FlowPortLink):
     def from_link(self, from_link):
         """
         Sets the from_link of this InputLink.
-        From link reference.
+        The from link reference.
 
 
         :param from_link: The from_link of this InputLink.

--- a/src/oci/data_integration/models/input_port.py
+++ b/src/oci/data_integration/models/input_port.py
@@ -33,7 +33,7 @@ class InputPort(TypedObject):
 
         :param model_type:
             The value to assign to the model_type property of this InputPort.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -118,7 +118,7 @@ class InputPort(TypedObject):
     def port_type(self):
         """
         Gets the port_type of this InputPort.
-        The port details for the data asset.Type
+        The port details for the data asset.Type.
 
         Allowed values for this property are: "DATA", "CONTROL", "MODEL", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -133,7 +133,7 @@ class InputPort(TypedObject):
     def port_type(self, port_type):
         """
         Sets the port_type of this InputPort.
-        The port details for the data asset.Type
+        The port details for the data asset.Type.
 
 
         :param port_type: The port_type of this InputPort.
@@ -148,7 +148,7 @@ class InputPort(TypedObject):
     def fields(self):
         """
         Gets the fields of this InputPort.
-        fields
+        An array of fields.
 
 
         :return: The fields of this InputPort.
@@ -160,7 +160,7 @@ class InputPort(TypedObject):
     def fields(self, fields):
         """
         Sets the fields of this InputPort.
-        fields
+        An array of fields.
 
 
         :param fields: The fields of this InputPort.

--- a/src/oci/data_integration/models/java_type.py
+++ b/src/oci/data_integration/models/java_type.py
@@ -96,7 +96,7 @@ class JavaType(BaseType):
     def java_type_name(self):
         """
         Gets the java_type_name of this JavaType.
-        javaTypeName
+        The java type name.
 
 
         :return: The java_type_name of this JavaType.
@@ -108,7 +108,7 @@ class JavaType(BaseType):
     def java_type_name(self, java_type_name):
         """
         Sets the java_type_name of this JavaType.
-        javaTypeName
+        The java type name.
 
 
         :param java_type_name: The java_type_name of this JavaType.

--- a/src/oci/data_integration/models/joiner.py
+++ b/src/oci/data_integration/models/joiner.py
@@ -37,7 +37,7 @@ class Joiner(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this Joiner.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 

--- a/src/oci/data_integration/models/json_format_attribute.py
+++ b/src/oci/data_integration/models/json_format_attribute.py
@@ -21,7 +21,7 @@ class JsonFormatAttribute(AbstractFormatAttribute):
 
         :param model_type:
             The value to assign to the model_type property of this JsonFormatAttribute.
-            Allowed values for this property are: "JSON_FORMAT", "CSV_FORMAT"
+            Allowed values for this property are: "JSON_FORMAT", "CSV_FORMAT", "AVRO_FORMAT"
         :type model_type: str
 
         :param encoding:

--- a/src/oci/data_integration/models/key.py
+++ b/src/oci/data_integration/models/key.py
@@ -71,7 +71,7 @@ class Key(object):
     def model_type(self):
         """
         **[Required]** Gets the model_type of this Key.
-        The type of the key.
+        The key type.
 
         Allowed values for this property are: "FOREIGN_KEY", "PRIMARY_KEY", "UNIQUE_KEY"
 
@@ -85,7 +85,7 @@ class Key(object):
     def model_type(self, model_type):
         """
         Sets the model_type of this Key.
-        The type of the key.
+        The key type.
 
 
         :param model_type: The model_type of this Key.

--- a/src/oci/data_integration/models/macro_field.py
+++ b/src/oci/data_integration/models/macro_field.py
@@ -1,0 +1,241 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .typed_object import TypedObject
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class MacroField(TypedObject):
+    """
+    The type representing the macro field concept. Macro fields have an expression to define a macro.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new MacroField object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.MacroField.model_type` attribute
+        of this class is ``MACRO_FIELD`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this MacroField.
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this MacroField.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this MacroField.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this MacroField.
+        :type parent_ref: ParentReference
+
+        :param config_values:
+            The value to assign to the config_values property of this MacroField.
+        :type config_values: ConfigValues
+
+        :param object_status:
+            The value to assign to the object_status property of this MacroField.
+        :type object_status: int
+
+        :param name:
+            The value to assign to the name property of this MacroField.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this MacroField.
+        :type description: str
+
+        :param expr:
+            The value to assign to the expr property of this MacroField.
+        :type expr: Expression
+
+        :param type:
+            The value to assign to the type property of this MacroField.
+        :type type: BaseType
+
+        :param is_use_source_type:
+            The value to assign to the is_use_source_type property of this MacroField.
+        :type is_use_source_type: bool
+
+        :param use_type:
+            The value to assign to the use_type property of this MacroField.
+        :type use_type: ConfiguredType
+
+        :param labels:
+            The value to assign to the labels property of this MacroField.
+        :type labels: list[str]
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'config_values': 'ConfigValues',
+            'object_status': 'int',
+            'name': 'str',
+            'description': 'str',
+            'expr': 'Expression',
+            'type': 'BaseType',
+            'is_use_source_type': 'bool',
+            'use_type': 'ConfiguredType',
+            'labels': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'config_values': 'configValues',
+            'object_status': 'objectStatus',
+            'name': 'name',
+            'description': 'description',
+            'expr': 'expr',
+            'type': 'type',
+            'is_use_source_type': 'isUseSourceType',
+            'use_type': 'useType',
+            'labels': 'labels'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._config_values = None
+        self._object_status = None
+        self._name = None
+        self._description = None
+        self._expr = None
+        self._type = None
+        self._is_use_source_type = None
+        self._use_type = None
+        self._labels = None
+        self._model_type = 'MACRO_FIELD'
+
+    @property
+    def expr(self):
+        """
+        Gets the expr of this MacroField.
+
+        :return: The expr of this MacroField.
+        :rtype: Expression
+        """
+        return self._expr
+
+    @expr.setter
+    def expr(self, expr):
+        """
+        Sets the expr of this MacroField.
+
+        :param expr: The expr of this MacroField.
+        :type: Expression
+        """
+        self._expr = expr
+
+    @property
+    def type(self):
+        """
+        Gets the type of this MacroField.
+
+        :return: The type of this MacroField.
+        :rtype: BaseType
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this MacroField.
+
+        :param type: The type of this MacroField.
+        :type: BaseType
+        """
+        self._type = type
+
+    @property
+    def is_use_source_type(self):
+        """
+        Gets the is_use_source_type of this MacroField.
+        Specifies whether the type of macro fields is inferred from an expression or useType (false) or the source field (true).
+
+
+        :return: The is_use_source_type of this MacroField.
+        :rtype: bool
+        """
+        return self._is_use_source_type
+
+    @is_use_source_type.setter
+    def is_use_source_type(self, is_use_source_type):
+        """
+        Sets the is_use_source_type of this MacroField.
+        Specifies whether the type of macro fields is inferred from an expression or useType (false) or the source field (true).
+
+
+        :param is_use_source_type: The is_use_source_type of this MacroField.
+        :type: bool
+        """
+        self._is_use_source_type = is_use_source_type
+
+    @property
+    def use_type(self):
+        """
+        Gets the use_type of this MacroField.
+
+        :return: The use_type of this MacroField.
+        :rtype: ConfiguredType
+        """
+        return self._use_type
+
+    @use_type.setter
+    def use_type(self, use_type):
+        """
+        Sets the use_type of this MacroField.
+
+        :param use_type: The use_type of this MacroField.
+        :type: ConfiguredType
+        """
+        self._use_type = use_type
+
+    @property
+    def labels(self):
+        """
+        Gets the labels of this MacroField.
+        Labels are keywords or labels that you can add to data assets, dataflows, and so on. You can define your own labels and use them to categorize content.
+
+
+        :return: The labels of this MacroField.
+        :rtype: list[str]
+        """
+        return self._labels
+
+    @labels.setter
+    def labels(self, labels):
+        """
+        Sets the labels of this MacroField.
+        Labels are keywords or labels that you can add to data assets, dataflows, and so on. You can define your own labels and use them to categorize content.
+
+
+        :param labels: The labels of this MacroField.
+        :type: list[str]
+        """
+        self._labels = labels
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/message.py
+++ b/src/oci/data_integration/models/message.py
@@ -95,7 +95,7 @@ class Message(object):
     def code(self):
         """
         **[Required]** Gets the code of this Message.
-        The message code
+        The message code.
 
 
         :return: The code of this Message.
@@ -107,7 +107,7 @@ class Message(object):
     def code(self, code):
         """
         Sets the code of this Message.
-        The message code
+        The message code.
 
 
         :param code: The code of this Message.
@@ -119,7 +119,7 @@ class Message(object):
     def message(self):
         """
         **[Required]** Gets the message of this Message.
-        The message text
+        The message text.
 
 
         :return: The message of this Message.
@@ -131,7 +131,7 @@ class Message(object):
     def message(self, message):
         """
         Sets the message of this Message.
-        The message text
+        The message text.
 
 
         :param message: The message of this Message.

--- a/src/oci/data_integration/models/name_list_rule.py
+++ b/src/oci/data_integration/models/name_list_rule.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class NameListRule(ProjectionRule):
     """
-    The name list rule which defines how fields are projected. For example this may be all fields begining with STR.
+    The name list rule which defines how fields are projected. For example, this may be all fields begining with STR.
     """
 
     #: A constant which can be used with the matching_strategy property of a NameListRule.
@@ -163,7 +163,7 @@ class NameListRule(ProjectionRule):
     def is_skip_remaining_rules_on_match(self):
         """
         Gets the is_skip_remaining_rules_on_match of this NameListRule.
-        skipRemainingRulesOnMatch
+        Specifies whether to skip remaining rules when a match is found.
 
 
         :return: The is_skip_remaining_rules_on_match of this NameListRule.
@@ -175,7 +175,7 @@ class NameListRule(ProjectionRule):
     def is_skip_remaining_rules_on_match(self, is_skip_remaining_rules_on_match):
         """
         Sets the is_skip_remaining_rules_on_match of this NameListRule.
-        skipRemainingRulesOnMatch
+        Specifies whether to skip remaining rules when a match is found.
 
 
         :param is_skip_remaining_rules_on_match: The is_skip_remaining_rules_on_match of this NameListRule.
@@ -187,7 +187,7 @@ class NameListRule(ProjectionRule):
     def scope(self):
         """
         Gets the scope of this NameListRule.
-        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+        Reference to a typed object. This can be either a key value to an object within the document, a shall referenced to a `TypedObject`, or a full `TypedObject` definition.
 
 
         :return: The scope of this NameListRule.
@@ -199,7 +199,7 @@ class NameListRule(ProjectionRule):
     def scope(self, scope):
         """
         Sets the scope of this NameListRule.
-        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+        Reference to a typed object. This can be either a key value to an object within the document, a shall referenced to a `TypedObject`, or a full `TypedObject` definition.
 
 
         :param scope: The scope of this NameListRule.
@@ -211,7 +211,7 @@ class NameListRule(ProjectionRule):
     def is_cascade(self):
         """
         Gets the is_cascade of this NameListRule.
-        cascade
+        Specifies whether to cascade or not.
 
 
         :return: The is_cascade of this NameListRule.
@@ -223,7 +223,7 @@ class NameListRule(ProjectionRule):
     def is_cascade(self, is_cascade):
         """
         Sets the is_cascade of this NameListRule.
-        cascade
+        Specifies whether to cascade or not.
 
 
         :param is_cascade: The is_cascade of this NameListRule.
@@ -235,7 +235,7 @@ class NameListRule(ProjectionRule):
     def matching_strategy(self):
         """
         Gets the matching_strategy of this NameListRule.
-        matchingStrategy
+        The pattern matching strategy.
 
         Allowed values for this property are: "NAME_OR_TAGS", "TAGS_ONLY", "NAME_ONLY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -250,7 +250,7 @@ class NameListRule(ProjectionRule):
     def matching_strategy(self, matching_strategy):
         """
         Sets the matching_strategy of this NameListRule.
-        matchingStrategy
+        The pattern matching strategy.
 
 
         :param matching_strategy: The matching_strategy of this NameListRule.
@@ -265,7 +265,7 @@ class NameListRule(ProjectionRule):
     def is_case_sensitive(self):
         """
         Gets the is_case_sensitive of this NameListRule.
-        caseSensitive
+        Specifies if the rule is case sensitive.
 
 
         :return: The is_case_sensitive of this NameListRule.
@@ -277,7 +277,7 @@ class NameListRule(ProjectionRule):
     def is_case_sensitive(self, is_case_sensitive):
         """
         Sets the is_case_sensitive of this NameListRule.
-        caseSensitive
+        Specifies if the rule is case sensitive.
 
 
         :param is_case_sensitive: The is_case_sensitive of this NameListRule.
@@ -289,7 +289,7 @@ class NameListRule(ProjectionRule):
     def rule_type(self):
         """
         Gets the rule_type of this NameListRule.
-        ruleType
+        The rule type.
 
         Allowed values for this property are: "INCLUDE", "EXCLUDE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -304,7 +304,7 @@ class NameListRule(ProjectionRule):
     def rule_type(self, rule_type):
         """
         Sets the rule_type of this NameListRule.
-        ruleType
+        The rule type.
 
 
         :param rule_type: The rule_type of this NameListRule.
@@ -319,7 +319,7 @@ class NameListRule(ProjectionRule):
     def names(self):
         """
         Gets the names of this NameListRule.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The names of this NameListRule.
@@ -331,7 +331,7 @@ class NameListRule(ProjectionRule):
     def names(self, names):
         """
         Sets the names of this NameListRule.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param names: The names of this NameListRule.

--- a/src/oci/data_integration/models/name_pattern_rule.py
+++ b/src/oci/data_integration/models/name_pattern_rule.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class NamePatternRule(ProjectionRule):
     """
-    This rule projects fields by a name pattern, for example it may start with STR_ or end with _DATE, this is defined using a regular expression.
+    This rule projects fields by a name pattern, for example it may start with STR_ or end with _DATE. This is defined using a regular expression.
     """
 
     #: A constant which can be used with the matching_strategy property of a NamePatternRule.
@@ -163,7 +163,7 @@ class NamePatternRule(ProjectionRule):
     def is_skip_remaining_rules_on_match(self):
         """
         Gets the is_skip_remaining_rules_on_match of this NamePatternRule.
-        skipRemainingRulesOnMatch
+        Specifies whether to skip remaining rules when a match is found.
 
 
         :return: The is_skip_remaining_rules_on_match of this NamePatternRule.
@@ -175,7 +175,7 @@ class NamePatternRule(ProjectionRule):
     def is_skip_remaining_rules_on_match(self, is_skip_remaining_rules_on_match):
         """
         Sets the is_skip_remaining_rules_on_match of this NamePatternRule.
-        skipRemainingRulesOnMatch
+        Specifies whether to skip remaining rules when a match is found.
 
 
         :param is_skip_remaining_rules_on_match: The is_skip_remaining_rules_on_match of this NamePatternRule.
@@ -187,7 +187,7 @@ class NamePatternRule(ProjectionRule):
     def scope(self):
         """
         Gets the scope of this NamePatternRule.
-        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+        Reference to a typed object. This can be either a key value to an object within the document, a shall referenced to a `TypedObject`, or a full `TypedObject` definition.
 
 
         :return: The scope of this NamePatternRule.
@@ -199,7 +199,7 @@ class NamePatternRule(ProjectionRule):
     def scope(self, scope):
         """
         Sets the scope of this NamePatternRule.
-        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+        Reference to a typed object. This can be either a key value to an object within the document, a shall referenced to a `TypedObject`, or a full `TypedObject` definition.
 
 
         :param scope: The scope of this NamePatternRule.
@@ -211,7 +211,7 @@ class NamePatternRule(ProjectionRule):
     def is_cascade(self):
         """
         Gets the is_cascade of this NamePatternRule.
-        cascade
+        Specifies whether to cascade or not.
 
 
         :return: The is_cascade of this NamePatternRule.
@@ -223,7 +223,7 @@ class NamePatternRule(ProjectionRule):
     def is_cascade(self, is_cascade):
         """
         Sets the is_cascade of this NamePatternRule.
-        cascade
+        Specifies whether to cascade or not.
 
 
         :param is_cascade: The is_cascade of this NamePatternRule.
@@ -235,7 +235,7 @@ class NamePatternRule(ProjectionRule):
     def matching_strategy(self):
         """
         Gets the matching_strategy of this NamePatternRule.
-        matchingStrategy
+        The pattern matching strategy.
 
         Allowed values for this property are: "NAME_OR_TAGS", "TAGS_ONLY", "NAME_ONLY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -250,7 +250,7 @@ class NamePatternRule(ProjectionRule):
     def matching_strategy(self, matching_strategy):
         """
         Sets the matching_strategy of this NamePatternRule.
-        matchingStrategy
+        The pattern matching strategy.
 
 
         :param matching_strategy: The matching_strategy of this NamePatternRule.
@@ -265,7 +265,7 @@ class NamePatternRule(ProjectionRule):
     def is_case_sensitive(self):
         """
         Gets the is_case_sensitive of this NamePatternRule.
-        caseSensitive
+        Specifies if the rule is case sensitive.
 
 
         :return: The is_case_sensitive of this NamePatternRule.
@@ -277,7 +277,7 @@ class NamePatternRule(ProjectionRule):
     def is_case_sensitive(self, is_case_sensitive):
         """
         Sets the is_case_sensitive of this NamePatternRule.
-        caseSensitive
+        Specifies if the rule is case sensitive.
 
 
         :param is_case_sensitive: The is_case_sensitive of this NamePatternRule.
@@ -289,7 +289,7 @@ class NamePatternRule(ProjectionRule):
     def rule_type(self):
         """
         Gets the rule_type of this NamePatternRule.
-        ruleType
+        The rule type.
 
         Allowed values for this property are: "INCLUDE", "EXCLUDE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -304,7 +304,7 @@ class NamePatternRule(ProjectionRule):
     def rule_type(self, rule_type):
         """
         Sets the rule_type of this NamePatternRule.
-        ruleType
+        The rule type.
 
 
         :param rule_type: The rule_type of this NamePatternRule.
@@ -319,7 +319,7 @@ class NamePatternRule(ProjectionRule):
     def pattern(self):
         """
         Gets the pattern of this NamePatternRule.
-        pattern
+        The rule pattern.
 
 
         :return: The pattern of this NamePatternRule.
@@ -331,7 +331,7 @@ class NamePatternRule(ProjectionRule):
     def pattern(self, pattern):
         """
         Sets the pattern of this NamePatternRule.
-        pattern
+        The rule pattern.
 
 
         :param pattern: The pattern of this NamePatternRule.

--- a/src/oci/data_integration/models/native_shape_field.py
+++ b/src/oci/data_integration/models/native_shape_field.py
@@ -79,7 +79,7 @@ class NativeShapeField(object):
     def name(self):
         """
         Gets the name of this NativeShapeField.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this NativeShapeField.
@@ -91,7 +91,7 @@ class NativeShapeField(object):
     def name(self, name):
         """
         Sets the name of this NativeShapeField.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this NativeShapeField.

--- a/src/oci/data_integration/models/object_metadata.py
+++ b/src/oci/data_integration/models/object_metadata.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ObjectMetadata(object):
     """
-    A summary type containing information about the object including its key, name and when/who created/updated it
+    A summary type containing information about the object including its key, name and when/who created/updated it.
     """
 
     def __init__(self, **kwargs):
@@ -62,6 +62,10 @@ class ObjectMetadata(object):
             The value to assign to the labels property of this ObjectMetadata.
         :type labels: list[str]
 
+        :param is_favorite:
+            The value to assign to the is_favorite property of this ObjectMetadata.
+        :type is_favorite: bool
+
         """
         self.swagger_types = {
             'created_by': 'str',
@@ -74,7 +78,8 @@ class ObjectMetadata(object):
             'identifier_path': 'str',
             'info_fields': 'dict(str, str)',
             'registry_version': 'int',
-            'labels': 'list[str]'
+            'labels': 'list[str]',
+            'is_favorite': 'bool'
         }
 
         self.attribute_map = {
@@ -88,7 +93,8 @@ class ObjectMetadata(object):
             'identifier_path': 'identifierPath',
             'info_fields': 'infoFields',
             'registry_version': 'registryVersion',
-            'labels': 'labels'
+            'labels': 'labels',
+            'is_favorite': 'isFavorite'
         }
 
         self._created_by = None
@@ -102,6 +108,7 @@ class ObjectMetadata(object):
         self._info_fields = None
         self._registry_version = None
         self._labels = None
+        self._is_favorite = None
 
     @property
     def created_by(self):
@@ -299,7 +306,7 @@ class ObjectMetadata(object):
     def info_fields(self):
         """
         Gets the info_fields of this ObjectMetadata.
-        infoFields
+        Information property fields.
 
 
         :return: The info_fields of this ObjectMetadata.
@@ -311,7 +318,7 @@ class ObjectMetadata(object):
     def info_fields(self, info_fields):
         """
         Sets the info_fields of this ObjectMetadata.
-        infoFields
+        Information property fields.
 
 
         :param info_fields: The info_fields of this ObjectMetadata.
@@ -323,7 +330,7 @@ class ObjectMetadata(object):
     def registry_version(self):
         """
         Gets the registry_version of this ObjectMetadata.
-        registryVersion
+        The registry version of the object.
 
 
         :return: The registry_version of this ObjectMetadata.
@@ -335,7 +342,7 @@ class ObjectMetadata(object):
     def registry_version(self, registry_version):
         """
         Sets the registry_version of this ObjectMetadata.
-        registryVersion
+        The registry version of the object.
 
 
         :param registry_version: The registry_version of this ObjectMetadata.
@@ -347,7 +354,7 @@ class ObjectMetadata(object):
     def labels(self):
         """
         Gets the labels of this ObjectMetadata.
-        Labels are keywords or tags that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or tags that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :return: The labels of this ObjectMetadata.
@@ -359,13 +366,37 @@ class ObjectMetadata(object):
     def labels(self, labels):
         """
         Sets the labels of this ObjectMetadata.
-        Labels are keywords or tags that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or tags that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :param labels: The labels of this ObjectMetadata.
         :type: list[str]
         """
         self._labels = labels
+
+    @property
+    def is_favorite(self):
+        """
+        Gets the is_favorite of this ObjectMetadata.
+        Specifies whether this object is a favorite or not.
+
+
+        :return: The is_favorite of this ObjectMetadata.
+        :rtype: bool
+        """
+        return self._is_favorite
+
+    @is_favorite.setter
+    def is_favorite(self, is_favorite):
+        """
+        Sets the is_favorite of this ObjectMetadata.
+        Specifies whether this object is a favorite or not.
+
+
+        :param is_favorite: The is_favorite of this ObjectMetadata.
+        :type: bool
+        """
+        self._is_favorite = is_favorite
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/operator.py
+++ b/src/oci/data_integration/models/operator.py
@@ -37,6 +37,14 @@ class Operator(object):
     #: This constant has a value of "TARGET_OPERATOR"
     MODEL_TYPE_TARGET_OPERATOR = "TARGET_OPERATOR"
 
+    #: A constant which can be used with the model_type property of a Operator.
+    #: This constant has a value of "DISTINCT_OPERATOR"
+    MODEL_TYPE_DISTINCT_OPERATOR = "DISTINCT_OPERATOR"
+
+    #: A constant which can be used with the model_type property of a Operator.
+    #: This constant has a value of "SORT_OPERATOR"
+    MODEL_TYPE_SORT_OPERATOR = "SORT_OPERATOR"
+
     def __init__(self, **kwargs):
         """
         Initializes a new Operator object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
@@ -44,8 +52,10 @@ class Operator(object):
 
         * :class:`~oci.data_integration.models.Target`
         * :class:`~oci.data_integration.models.Joiner`
+        * :class:`~oci.data_integration.models.Distinct`
         * :class:`~oci.data_integration.models.Filter`
         * :class:`~oci.data_integration.models.Aggregator`
+        * :class:`~oci.data_integration.models.SortOper`
         * :class:`~oci.data_integration.models.Projection`
         * :class:`~oci.data_integration.models.Source`
 
@@ -53,7 +63,7 @@ class Operator(object):
 
         :param model_type:
             The value to assign to the model_type property of this Operator.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -166,11 +176,17 @@ class Operator(object):
         if type == 'JOINER_OPERATOR':
             return 'Joiner'
 
+        if type == 'DISTINCT_OPERATOR':
+            return 'Distinct'
+
         if type == 'FILTER_OPERATOR':
             return 'Filter'
 
         if type == 'AGGREGATOR_OPERATOR':
             return 'Aggregator'
+
+        if type == 'SORT_OPERATOR':
+            return 'SortOper'
 
         if type == 'PROJECTION_OPERATOR':
             return 'Projection'
@@ -186,7 +202,7 @@ class Operator(object):
         **[Required]** Gets the model_type of this Operator.
         The model type of the operator.
 
-        Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -205,7 +221,7 @@ class Operator(object):
         :param model_type: The model_type of this Operator.
         :type: str
         """
-        allowed_values = ["SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR"]
+        allowed_values = ["SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type
@@ -282,7 +298,7 @@ class Operator(object):
     def name(self):
         """
         Gets the name of this Operator.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this Operator.
@@ -294,7 +310,7 @@ class Operator(object):
     def name(self, name):
         """
         Sets the name of this Operator.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this Operator.
@@ -306,7 +322,7 @@ class Operator(object):
     def description(self):
         """
         Gets the description of this Operator.
-        Detailed description for the object.
+        Details about the operator.
 
 
         :return: The description of this Operator.
@@ -318,7 +334,7 @@ class Operator(object):
     def description(self, description):
         """
         Sets the description of this Operator.
-        Detailed description for the object.
+        Details about the operator.
 
 
         :param description: The description of this Operator.
@@ -426,7 +442,7 @@ class Operator(object):
     def identifier(self):
         """
         Gets the identifier of this Operator.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this Operator.
@@ -438,7 +454,7 @@ class Operator(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this Operator.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this Operator.
@@ -450,7 +466,7 @@ class Operator(object):
     def parameters(self):
         """
         Gets the parameters of this Operator.
-        An array of parameters.
+        An array of parameters used in the data flow.
 
 
         :return: The parameters of this Operator.
@@ -462,7 +478,7 @@ class Operator(object):
     def parameters(self, parameters):
         """
         Sets the parameters of this Operator.
-        An array of parameters.
+        An array of parameters used in the data flow.
 
 
         :param parameters: The parameters of this Operator.

--- a/src/oci/data_integration/models/oracle_adwc_write_attribute.py
+++ b/src/oci/data_integration/models/oracle_adwc_write_attribute.py
@@ -21,7 +21,7 @@ class OracleAdwcWriteAttribute(AbstractWriteAttribute):
 
         :param model_type:
             The value to assign to the model_type property of this OracleAdwcWriteAttribute.
-            Allowed values for this property are: "ORACLEWRITEATTRIBUTE", "ORACLEATPWRITEATTRIBUTE", "ORACLEADWCWRITEATTRIBUTE"
+            Allowed values for this property are: "ORACLEWRITEATTRIBUTE", "ORACLEATPWRITEATTRIBUTE", "ORACLEADWCWRITEATTRIBUTE", "ORACLE_WRITE_ATTRIBUTE", "ORACLE_ATP_WRITE_ATTRIBUTE", "ORACLE_ADWC_WRITE_ATTRIBUTE"
         :type model_type: str
 
         :param bucket_name:

--- a/src/oci/data_integration/models/oracle_adwc_write_attributes.py
+++ b/src/oci/data_integration/models/oracle_adwc_write_attributes.py
@@ -1,0 +1,155 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OracleAdwcWriteAttributes(object):
+    """
+    Properties to configure when writing to Oracle Autonomous Data Warehouse Cloud.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OracleAdwcWriteAttributes object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param bucket_name:
+            The value to assign to the bucket_name property of this OracleAdwcWriteAttributes.
+        :type bucket_name: str
+
+        :param staging_file_name:
+            The value to assign to the staging_file_name property of this OracleAdwcWriteAttributes.
+        :type staging_file_name: str
+
+        :param staging_data_asset:
+            The value to assign to the staging_data_asset property of this OracleAdwcWriteAttributes.
+        :type staging_data_asset: DataAsset
+
+        :param staging_connection:
+            The value to assign to the staging_connection property of this OracleAdwcWriteAttributes.
+        :type staging_connection: Connection
+
+        """
+        self.swagger_types = {
+            'bucket_name': 'str',
+            'staging_file_name': 'str',
+            'staging_data_asset': 'DataAsset',
+            'staging_connection': 'Connection'
+        }
+
+        self.attribute_map = {
+            'bucket_name': 'bucketName',
+            'staging_file_name': 'stagingFileName',
+            'staging_data_asset': 'stagingDataAsset',
+            'staging_connection': 'stagingConnection'
+        }
+
+        self._bucket_name = None
+        self._staging_file_name = None
+        self._staging_data_asset = None
+        self._staging_connection = None
+
+    @property
+    def bucket_name(self):
+        """
+        Gets the bucket_name of this OracleAdwcWriteAttributes.
+        The bucket name for the attribute.
+
+
+        :return: The bucket_name of this OracleAdwcWriteAttributes.
+        :rtype: str
+        """
+        return self._bucket_name
+
+    @bucket_name.setter
+    def bucket_name(self, bucket_name):
+        """
+        Sets the bucket_name of this OracleAdwcWriteAttributes.
+        The bucket name for the attribute.
+
+
+        :param bucket_name: The bucket_name of this OracleAdwcWriteAttributes.
+        :type: str
+        """
+        self._bucket_name = bucket_name
+
+    @property
+    def staging_file_name(self):
+        """
+        Gets the staging_file_name of this OracleAdwcWriteAttributes.
+        The file name for the attribute.
+
+
+        :return: The staging_file_name of this OracleAdwcWriteAttributes.
+        :rtype: str
+        """
+        return self._staging_file_name
+
+    @staging_file_name.setter
+    def staging_file_name(self, staging_file_name):
+        """
+        Sets the staging_file_name of this OracleAdwcWriteAttributes.
+        The file name for the attribute.
+
+
+        :param staging_file_name: The staging_file_name of this OracleAdwcWriteAttributes.
+        :type: str
+        """
+        self._staging_file_name = staging_file_name
+
+    @property
+    def staging_data_asset(self):
+        """
+        Gets the staging_data_asset of this OracleAdwcWriteAttributes.
+
+        :return: The staging_data_asset of this OracleAdwcWriteAttributes.
+        :rtype: DataAsset
+        """
+        return self._staging_data_asset
+
+    @staging_data_asset.setter
+    def staging_data_asset(self, staging_data_asset):
+        """
+        Sets the staging_data_asset of this OracleAdwcWriteAttributes.
+
+        :param staging_data_asset: The staging_data_asset of this OracleAdwcWriteAttributes.
+        :type: DataAsset
+        """
+        self._staging_data_asset = staging_data_asset
+
+    @property
+    def staging_connection(self):
+        """
+        Gets the staging_connection of this OracleAdwcWriteAttributes.
+
+        :return: The staging_connection of this OracleAdwcWriteAttributes.
+        :rtype: Connection
+        """
+        return self._staging_connection
+
+    @staging_connection.setter
+    def staging_connection(self, staging_connection):
+        """
+        Sets the staging_connection of this OracleAdwcWriteAttributes.
+
+        :param staging_connection: The staging_connection of this OracleAdwcWriteAttributes.
+        :type: Connection
+        """
+        self._staging_connection = staging_connection
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/oracle_atp_write_attribute.py
+++ b/src/oci/data_integration/models/oracle_atp_write_attribute.py
@@ -21,7 +21,7 @@ class OracleAtpWriteAttribute(AbstractWriteAttribute):
 
         :param model_type:
             The value to assign to the model_type property of this OracleAtpWriteAttribute.
-            Allowed values for this property are: "ORACLEWRITEATTRIBUTE", "ORACLEATPWRITEATTRIBUTE", "ORACLEADWCWRITEATTRIBUTE"
+            Allowed values for this property are: "ORACLEWRITEATTRIBUTE", "ORACLEATPWRITEATTRIBUTE", "ORACLEADWCWRITEATTRIBUTE", "ORACLE_WRITE_ATTRIBUTE", "ORACLE_ATP_WRITE_ATTRIBUTE", "ORACLE_ADWC_WRITE_ATTRIBUTE"
         :type model_type: str
 
         :param bucket_name:

--- a/src/oci/data_integration/models/oracle_atp_write_attributes.py
+++ b/src/oci/data_integration/models/oracle_atp_write_attributes.py
@@ -1,0 +1,155 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OracleAtpWriteAttributes(object):
+    """
+    Properties to configure when writing to Oracle Autonomous Data Warehouse Cloud.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OracleAtpWriteAttributes object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param bucket_name:
+            The value to assign to the bucket_name property of this OracleAtpWriteAttributes.
+        :type bucket_name: str
+
+        :param staging_file_name:
+            The value to assign to the staging_file_name property of this OracleAtpWriteAttributes.
+        :type staging_file_name: str
+
+        :param staging_data_asset:
+            The value to assign to the staging_data_asset property of this OracleAtpWriteAttributes.
+        :type staging_data_asset: DataAsset
+
+        :param staging_connection:
+            The value to assign to the staging_connection property of this OracleAtpWriteAttributes.
+        :type staging_connection: Connection
+
+        """
+        self.swagger_types = {
+            'bucket_name': 'str',
+            'staging_file_name': 'str',
+            'staging_data_asset': 'DataAsset',
+            'staging_connection': 'Connection'
+        }
+
+        self.attribute_map = {
+            'bucket_name': 'bucketName',
+            'staging_file_name': 'stagingFileName',
+            'staging_data_asset': 'stagingDataAsset',
+            'staging_connection': 'stagingConnection'
+        }
+
+        self._bucket_name = None
+        self._staging_file_name = None
+        self._staging_data_asset = None
+        self._staging_connection = None
+
+    @property
+    def bucket_name(self):
+        """
+        Gets the bucket_name of this OracleAtpWriteAttributes.
+        The bucket name for the attribute.
+
+
+        :return: The bucket_name of this OracleAtpWriteAttributes.
+        :rtype: str
+        """
+        return self._bucket_name
+
+    @bucket_name.setter
+    def bucket_name(self, bucket_name):
+        """
+        Sets the bucket_name of this OracleAtpWriteAttributes.
+        The bucket name for the attribute.
+
+
+        :param bucket_name: The bucket_name of this OracleAtpWriteAttributes.
+        :type: str
+        """
+        self._bucket_name = bucket_name
+
+    @property
+    def staging_file_name(self):
+        """
+        Gets the staging_file_name of this OracleAtpWriteAttributes.
+        The file name for the attribute.
+
+
+        :return: The staging_file_name of this OracleAtpWriteAttributes.
+        :rtype: str
+        """
+        return self._staging_file_name
+
+    @staging_file_name.setter
+    def staging_file_name(self, staging_file_name):
+        """
+        Sets the staging_file_name of this OracleAtpWriteAttributes.
+        The file name for the attribute.
+
+
+        :param staging_file_name: The staging_file_name of this OracleAtpWriteAttributes.
+        :type: str
+        """
+        self._staging_file_name = staging_file_name
+
+    @property
+    def staging_data_asset(self):
+        """
+        Gets the staging_data_asset of this OracleAtpWriteAttributes.
+
+        :return: The staging_data_asset of this OracleAtpWriteAttributes.
+        :rtype: DataAsset
+        """
+        return self._staging_data_asset
+
+    @staging_data_asset.setter
+    def staging_data_asset(self, staging_data_asset):
+        """
+        Sets the staging_data_asset of this OracleAtpWriteAttributes.
+
+        :param staging_data_asset: The staging_data_asset of this OracleAtpWriteAttributes.
+        :type: DataAsset
+        """
+        self._staging_data_asset = staging_data_asset
+
+    @property
+    def staging_connection(self):
+        """
+        Gets the staging_connection of this OracleAtpWriteAttributes.
+
+        :return: The staging_connection of this OracleAtpWriteAttributes.
+        :rtype: Connection
+        """
+        return self._staging_connection
+
+    @staging_connection.setter
+    def staging_connection(self, staging_connection):
+        """
+        Sets the staging_connection of this OracleAtpWriteAttributes.
+
+        :param staging_connection: The staging_connection of this OracleAtpWriteAttributes.
+        :type: Connection
+        """
+        self._staging_connection = staging_connection
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/oracle_read_attribute.py
+++ b/src/oci/data_integration/models/oracle_read_attribute.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class OracleReadAttribute(AbstractReadAttribute):
     """
-    The Oracle read attribute
+    The Oracle read attribute.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class OracleReadAttribute(AbstractReadAttribute):
 
         :param model_type:
             The value to assign to the model_type property of this OracleReadAttribute.
-            Allowed values for this property are: "ORACLEREADATTRIBUTE"
+            Allowed values for this property are: "ORACLEREADATTRIBUTE", "ORACLE_READ_ATTRIBUTE"
         :type model_type: str
 
         :param fetch_size:

--- a/src/oci/data_integration/models/oracle_read_attributes.py
+++ b/src/oci/data_integration/models/oracle_read_attributes.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OracleReadAttributes(object):
+    """
+    Properties to configure reading from an Oracle Database.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OracleReadAttributes object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param fetch_size:
+            The value to assign to the fetch_size property of this OracleReadAttributes.
+        :type fetch_size: int
+
+        """
+        self.swagger_types = {
+            'fetch_size': 'int'
+        }
+
+        self.attribute_map = {
+            'fetch_size': 'fetchSize'
+        }
+
+        self._fetch_size = None
+
+    @property
+    def fetch_size(self):
+        """
+        Gets the fetch_size of this OracleReadAttributes.
+        The fetch size for reading.
+
+
+        :return: The fetch_size of this OracleReadAttributes.
+        :rtype: int
+        """
+        return self._fetch_size
+
+    @fetch_size.setter
+    def fetch_size(self, fetch_size):
+        """
+        Sets the fetch_size of this OracleReadAttributes.
+        The fetch size for reading.
+
+
+        :param fetch_size: The fetch_size of this OracleReadAttributes.
+        :type: int
+        """
+        self._fetch_size = fetch_size
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/oracle_write_attribute.py
+++ b/src/oci/data_integration/models/oracle_write_attribute.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class OracleWriteAttribute(AbstractWriteAttribute):
     """
-    The Oracle write attribute
+    The Oracle write attribute.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class OracleWriteAttribute(AbstractWriteAttribute):
 
         :param model_type:
             The value to assign to the model_type property of this OracleWriteAttribute.
-            Allowed values for this property are: "ORACLEWRITEATTRIBUTE", "ORACLEATPWRITEATTRIBUTE", "ORACLEADWCWRITEATTRIBUTE"
+            Allowed values for this property are: "ORACLEWRITEATTRIBUTE", "ORACLEATPWRITEATTRIBUTE", "ORACLEADWCWRITEATTRIBUTE", "ORACLE_WRITE_ATTRIBUTE", "ORACLE_ATP_WRITE_ATTRIBUTE", "ORACLE_ADWC_WRITE_ATTRIBUTE"
         :type model_type: str
 
         :param batch_size:

--- a/src/oci/data_integration/models/oracle_write_attributes.py
+++ b/src/oci/data_integration/models/oracle_write_attributes.py
@@ -1,0 +1,132 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OracleWriteAttributes(object):
+    """
+    Properties to configure when writing to an Oracle Database.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OracleWriteAttributes object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param batch_size:
+            The value to assign to the batch_size property of this OracleWriteAttributes.
+        :type batch_size: int
+
+        :param is_truncate:
+            The value to assign to the is_truncate property of this OracleWriteAttributes.
+        :type is_truncate: bool
+
+        :param isolation_level:
+            The value to assign to the isolation_level property of this OracleWriteAttributes.
+        :type isolation_level: str
+
+        """
+        self.swagger_types = {
+            'batch_size': 'int',
+            'is_truncate': 'bool',
+            'isolation_level': 'str'
+        }
+
+        self.attribute_map = {
+            'batch_size': 'batchSize',
+            'is_truncate': 'isTruncate',
+            'isolation_level': 'isolationLevel'
+        }
+
+        self._batch_size = None
+        self._is_truncate = None
+        self._isolation_level = None
+
+    @property
+    def batch_size(self):
+        """
+        Gets the batch_size of this OracleWriteAttributes.
+        The batch size for writing.
+
+
+        :return: The batch_size of this OracleWriteAttributes.
+        :rtype: int
+        """
+        return self._batch_size
+
+    @batch_size.setter
+    def batch_size(self, batch_size):
+        """
+        Sets the batch_size of this OracleWriteAttributes.
+        The batch size for writing.
+
+
+        :param batch_size: The batch_size of this OracleWriteAttributes.
+        :type: int
+        """
+        self._batch_size = batch_size
+
+    @property
+    def is_truncate(self):
+        """
+        Gets the is_truncate of this OracleWriteAttributes.
+        Specifies whether to truncate.
+
+
+        :return: The is_truncate of this OracleWriteAttributes.
+        :rtype: bool
+        """
+        return self._is_truncate
+
+    @is_truncate.setter
+    def is_truncate(self, is_truncate):
+        """
+        Sets the is_truncate of this OracleWriteAttributes.
+        Specifies whether to truncate.
+
+
+        :param is_truncate: The is_truncate of this OracleWriteAttributes.
+        :type: bool
+        """
+        self._is_truncate = is_truncate
+
+    @property
+    def isolation_level(self):
+        """
+        Gets the isolation_level of this OracleWriteAttributes.
+        Specifies the isolation level.
+
+
+        :return: The isolation_level of this OracleWriteAttributes.
+        :rtype: str
+        """
+        return self._isolation_level
+
+    @isolation_level.setter
+    def isolation_level(self, isolation_level):
+        """
+        Sets the isolation_level of this OracleWriteAttributes.
+        Specifies the isolation level.
+
+
+        :param isolation_level: The isolation_level of this OracleWriteAttributes.
+        :type: str
+        """
+        self._isolation_level = isolation_level
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/output_field.py
+++ b/src/oci/data_integration/models/output_field.py
@@ -21,7 +21,7 @@ class OutputField(TypedObject):
 
         :param model_type:
             The value to assign to the model_type property of this OutputField.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
         :type model_type: str
 
         :param key:
@@ -123,7 +123,7 @@ class OutputField(TypedObject):
     def labels(self):
         """
         Gets the labels of this OutputField.
-        Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or labels that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :return: The labels of this OutputField.
@@ -135,7 +135,7 @@ class OutputField(TypedObject):
     def labels(self, labels):
         """
         Sets the labels of this OutputField.
-        Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or labels that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :param labels: The labels of this OutputField.

--- a/src/oci/data_integration/models/output_link.py
+++ b/src/oci/data_integration/models/output_link.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class OutputLink(FlowPortLink):
     """
-    The information about output links.
+    Details about the outgoing data of an operator in a data flow design.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/data_integration/models/output_port.py
+++ b/src/oci/data_integration/models/output_port.py
@@ -33,7 +33,7 @@ class OutputPort(TypedObject):
 
         :param model_type:
             The value to assign to the model_type property of this OutputPort.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -118,7 +118,7 @@ class OutputPort(TypedObject):
     def port_type(self):
         """
         Gets the port_type of this OutputPort.
-        The port details for the data asset.Type
+        The port details for the data asset.Type.
 
         Allowed values for this property are: "DATA", "CONTROL", "MODEL", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -133,7 +133,7 @@ class OutputPort(TypedObject):
     def port_type(self, port_type):
         """
         Sets the port_type of this OutputPort.
-        The port details for the data asset.Type
+        The port details for the data asset.Type.
 
 
         :param port_type: The port_type of this OutputPort.
@@ -148,7 +148,7 @@ class OutputPort(TypedObject):
     def fields(self):
         """
         Gets the fields of this OutputPort.
-        fields
+        An array of fields.
 
 
         :return: The fields of this OutputPort.
@@ -160,7 +160,7 @@ class OutputPort(TypedObject):
     def fields(self, fields):
         """
         Sets the fields of this OutputPort.
-        fields
+        An array of fields.
 
 
         :param fields: The fields of this OutputPort.

--- a/src/oci/data_integration/models/parameter.py
+++ b/src/oci/data_integration/models/parameter.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Parameter(TypedObject):
     """
-    Parameters are created and assigned values that can be deferred to execution/runtime.
+    Parameters are created and assigned values that can be configured for each integration task.
     """
 
     #: A constant which can be used with the output_aggregation_type property of a Parameter.
@@ -37,7 +37,7 @@ class Parameter(TypedObject):
 
         :param model_type:
             The value to assign to the model_type property of this Parameter.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -225,7 +225,7 @@ class Parameter(TypedObject):
     def is_input(self):
         """
         Gets the is_input of this Parameter.
-        Whether the parameter is input value.
+        Specifies whether the parameter is input value.
 
 
         :return: The is_input of this Parameter.
@@ -237,7 +237,7 @@ class Parameter(TypedObject):
     def is_input(self, is_input):
         """
         Sets the is_input of this Parameter.
-        Whether the parameter is input value.
+        Specifies whether the parameter is input value.
 
 
         :param is_input: The is_input of this Parameter.
@@ -249,7 +249,7 @@ class Parameter(TypedObject):
     def is_output(self):
         """
         Gets the is_output of this Parameter.
-        Whether the parameter is output value.
+        Specifies whether the parameter is output value.
 
 
         :return: The is_output of this Parameter.
@@ -261,7 +261,7 @@ class Parameter(TypedObject):
     def is_output(self, is_output):
         """
         Sets the is_output of this Parameter.
-        Whether the parameter is output value.
+        Specifies whether the parameter is output value.
 
 
         :param is_output: The is_output of this Parameter.
@@ -273,7 +273,7 @@ class Parameter(TypedObject):
     def output_aggregation_type(self):
         """
         Gets the output_aggregation_type of this Parameter.
-        The output aggregation type
+        The output aggregation type.
 
         Allowed values for this property are: "MIN", "MAX", "COUNT", "SUM", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -288,7 +288,7 @@ class Parameter(TypedObject):
     def output_aggregation_type(self, output_aggregation_type):
         """
         Sets the output_aggregation_type of this Parameter.
-        The output aggregation type
+        The output aggregation type.
 
 
         :param output_aggregation_type: The output_aggregation_type of this Parameter.
@@ -303,7 +303,7 @@ class Parameter(TypedObject):
     def type_name(self):
         """
         Gets the type_name of this Parameter.
-        The name of the object type.
+        The type of value the parameter was created for.
 
 
         :return: The type_name of this Parameter.
@@ -315,7 +315,7 @@ class Parameter(TypedObject):
     def type_name(self, type_name):
         """
         Sets the type_name of this Parameter.
-        The name of the object type.
+        The type of value the parameter was created for.
 
 
         :param type_name: The type_name of this Parameter.

--- a/src/oci/data_integration/models/parameter_value.py
+++ b/src/oci/data_integration/models/parameter_value.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ParameterValue(object):
     """
-    A parameter value.
+    User defined value for a parameter.
     """
 
     def __init__(self, **kwargs):
@@ -68,7 +68,7 @@ class ParameterValue(object):
     def root_object_value(self):
         """
         Gets the root_object_value of this ParameterValue.
-        This can be any object such as a file entity, or a schema or a table.
+        This can be any object such as a file entity, a schema, or a table.
 
 
         :return: The root_object_value of this ParameterValue.
@@ -80,7 +80,7 @@ class ParameterValue(object):
     def root_object_value(self, root_object_value):
         """
         Sets the root_object_value of this ParameterValue.
-        This can be any object such as a file entity, or a schema or a table.
+        This can be any object such as a file entity, a schema, or a table.
 
 
         :param root_object_value: The root_object_value of this ParameterValue.

--- a/src/oci/data_integration/models/parent_reference.py
+++ b/src/oci/data_integration/models/parent_reference.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ParentReference(object):
     """
-    A reference to the object's parent
+    A reference to the object's parent.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +37,7 @@ class ParentReference(object):
     def parent(self):
         """
         Gets the parent of this ParentReference.
-        Key of the parent object
+        Key of the parent object.
 
 
         :return: The parent of this ParentReference.
@@ -49,7 +49,7 @@ class ParentReference(object):
     def parent(self, parent):
         """
         Sets the parent of this ParentReference.
-        Key of the parent object
+        Key of the parent object.
 
 
         :param parent: The parent of this ParentReference.

--- a/src/oci/data_integration/models/patch.py
+++ b/src/oci/data_integration/models/patch.py
@@ -18,6 +18,10 @@ class Patch(object):
     PATCH_TYPE_PUBLISH = "PUBLISH"
 
     #: A constant which can be used with the patch_type property of a Patch.
+    #: This constant has a value of "REFRESH"
+    PATCH_TYPE_REFRESH = "REFRESH"
+
+    #: A constant which can be used with the patch_type property of a Patch.
     #: This constant has a value of "UNPUBLISH"
     PATCH_TYPE_UNPUBLISH = "UNPUBLISH"
 
@@ -88,7 +92,7 @@ class Patch(object):
 
         :param patch_type:
             The value to assign to the patch_type property of this Patch.
-            Allowed values for this property are: "PUBLISH", "UNPUBLISH", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PUBLISH", "REFRESH", "UNPUBLISH", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type patch_type: str
 
@@ -184,7 +188,7 @@ class Patch(object):
     def key(self):
         """
         Gets the key of this Patch.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this Patch.
@@ -196,7 +200,7 @@ class Patch(object):
     def key(self, key):
         """
         Sets the key of this Patch.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this Patch.
@@ -208,7 +212,7 @@ class Patch(object):
     def model_type(self):
         """
         Gets the model_type of this Patch.
-        The type of the object.
+        The object type.
 
 
         :return: The model_type of this Patch.
@@ -220,7 +224,7 @@ class Patch(object):
     def model_type(self, model_type):
         """
         Sets the model_type of this Patch.
-        The type of the object.
+        The object type.
 
 
         :param model_type: The model_type of this Patch.
@@ -232,7 +236,7 @@ class Patch(object):
     def model_version(self):
         """
         Gets the model_version of this Patch.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this Patch.
@@ -244,7 +248,7 @@ class Patch(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this Patch.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this Patch.
@@ -256,7 +260,7 @@ class Patch(object):
     def name(self):
         """
         Gets the name of this Patch.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this Patch.
@@ -268,7 +272,7 @@ class Patch(object):
     def name(self, name):
         """
         Sets the name of this Patch.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this Patch.
@@ -352,7 +356,7 @@ class Patch(object):
     def identifier(self):
         """
         Gets the identifier of this Patch.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this Patch.
@@ -364,7 +368,7 @@ class Patch(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this Patch.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this Patch.
@@ -454,7 +458,7 @@ class Patch(object):
         Gets the patch_type of this Patch.
         The type of the patch applied or being applied on the application.
 
-        Allowed values for this property are: "PUBLISH", "UNPUBLISH", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PUBLISH", "REFRESH", "UNPUBLISH", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -473,7 +477,7 @@ class Patch(object):
         :param patch_type: The patch_type of this Patch.
         :type: str
         """
-        allowed_values = ["PUBLISH", "UNPUBLISH"]
+        allowed_values = ["PUBLISH", "REFRESH", "UNPUBLISH"]
         if not value_allowed_none_or_none_sentinel(patch_type, allowed_values):
             patch_type = 'UNKNOWN_ENUM_VALUE'
         self._patch_type = patch_type
@@ -536,7 +540,7 @@ class Patch(object):
     def patch_object_metadata(self):
         """
         Gets the patch_object_metadata of this Patch.
-        List of objects that are published / unpublished in this patch.
+        List of objects that are published or unpublished in this patch.
 
 
         :return: The patch_object_metadata of this Patch.
@@ -548,7 +552,7 @@ class Patch(object):
     def patch_object_metadata(self, patch_object_metadata):
         """
         Sets the patch_object_metadata of this Patch.
-        List of objects that are published / unpublished in this patch.
+        List of objects that are published or unpublished in this patch.
 
 
         :param patch_object_metadata: The patch_object_metadata of this Patch.
@@ -600,7 +604,7 @@ class Patch(object):
     def key_map(self):
         """
         Gets the key_map of this Patch.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this Patch.
@@ -612,7 +616,7 @@ class Patch(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this Patch.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this Patch.

--- a/src/oci/data_integration/models/patch_change_summary.py
+++ b/src/oci/data_integration/models/patch_change_summary.py
@@ -1,0 +1,292 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PatchChangeSummary(object):
+    """
+    This is the patch report summary information.
+    """
+
+    #: A constant which can be used with the type property of a PatchChangeSummary.
+    #: This constant has a value of "INTEGRATION_TASK"
+    TYPE_INTEGRATION_TASK = "INTEGRATION_TASK"
+
+    #: A constant which can be used with the type property of a PatchChangeSummary.
+    #: This constant has a value of "DATA_LOADER_TASK"
+    TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
+
+    #: A constant which can be used with the action property of a PatchChangeSummary.
+    #: This constant has a value of "CREATED"
+    ACTION_CREATED = "CREATED"
+
+    #: A constant which can be used with the action property of a PatchChangeSummary.
+    #: This constant has a value of "DELETED"
+    ACTION_DELETED = "DELETED"
+
+    #: A constant which can be used with the action property of a PatchChangeSummary.
+    #: This constant has a value of "UPDATED"
+    ACTION_UPDATED = "UPDATED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PatchChangeSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this PatchChangeSummary.
+        :type key: str
+
+        :param name:
+            The value to assign to the name property of this PatchChangeSummary.
+        :type name: str
+
+        :param name_path:
+            The value to assign to the name_path property of this PatchChangeSummary.
+        :type name_path: str
+
+        :param type:
+            The value to assign to the type property of this PatchChangeSummary.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type type: str
+
+        :param object_version:
+            The value to assign to the object_version property of this PatchChangeSummary.
+        :type object_version: int
+
+        :param identifier:
+            The value to assign to the identifier property of this PatchChangeSummary.
+        :type identifier: str
+
+        :param action:
+            The value to assign to the action property of this PatchChangeSummary.
+            Allowed values for this property are: "CREATED", "DELETED", "UPDATED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type action: str
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'name': 'str',
+            'name_path': 'str',
+            'type': 'str',
+            'object_version': 'int',
+            'identifier': 'str',
+            'action': 'str'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'name': 'name',
+            'name_path': 'namePath',
+            'type': 'type',
+            'object_version': 'objectVersion',
+            'identifier': 'identifier',
+            'action': 'action'
+        }
+
+        self._key = None
+        self._name = None
+        self._name_path = None
+        self._type = None
+        self._object_version = None
+        self._identifier = None
+        self._action = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this PatchChangeSummary.
+        The key of the object.
+
+
+        :return: The key of this PatchChangeSummary.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this PatchChangeSummary.
+        The key of the object.
+
+
+        :param key: The key of this PatchChangeSummary.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def name(self):
+        """
+        Gets the name of this PatchChangeSummary.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this PatchChangeSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this PatchChangeSummary.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this PatchChangeSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def name_path(self):
+        """
+        Gets the name_path of this PatchChangeSummary.
+        The fully qualified path of the published object, which would include its project and folder.
+
+
+        :return: The name_path of this PatchChangeSummary.
+        :rtype: str
+        """
+        return self._name_path
+
+    @name_path.setter
+    def name_path(self, name_path):
+        """
+        Sets the name_path of this PatchChangeSummary.
+        The fully qualified path of the published object, which would include its project and folder.
+
+
+        :param name_path: The name_path of this PatchChangeSummary.
+        :type: str
+        """
+        self._name_path = name_path
+
+    @property
+    def type(self):
+        """
+        Gets the type of this PatchChangeSummary.
+        The type of the object in patch.
+
+        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The type of this PatchChangeSummary.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this PatchChangeSummary.
+        The type of the object in patch.
+
+
+        :param type: The type of this PatchChangeSummary.
+        :type: str
+        """
+        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        if not value_allowed_none_or_none_sentinel(type, allowed_values):
+            type = 'UNKNOWN_ENUM_VALUE'
+        self._type = type
+
+    @property
+    def object_version(self):
+        """
+        Gets the object_version of this PatchChangeSummary.
+        The object version.
+
+
+        :return: The object_version of this PatchChangeSummary.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this PatchChangeSummary.
+        The object version.
+
+
+        :param object_version: The object_version of this PatchChangeSummary.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this PatchChangeSummary.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this PatchChangeSummary.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this PatchChangeSummary.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this PatchChangeSummary.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def action(self):
+        """
+        Gets the action of this PatchChangeSummary.
+        The patch action indicating if object was created, updated, or deleted.
+
+        Allowed values for this property are: "CREATED", "DELETED", "UPDATED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The action of this PatchChangeSummary.
+        :rtype: str
+        """
+        return self._action
+
+    @action.setter
+    def action(self, action):
+        """
+        Sets the action of this PatchChangeSummary.
+        The patch action indicating if object was created, updated, or deleted.
+
+
+        :param action: The action of this PatchChangeSummary.
+        :type: str
+        """
+        allowed_values = ["CREATED", "DELETED", "UPDATED"]
+        if not value_allowed_none_or_none_sentinel(action, allowed_values):
+            action = 'UNKNOWN_ENUM_VALUE'
+        self._action = action
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/patch_change_summary_collection.py
+++ b/src/oci/data_integration/models/patch_change_summary_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PatchChangeSummaryCollection(object):
+    """
+    This is the collection of patch report summaries,. It may be a collection of lightweight details or full definitions.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PatchChangeSummaryCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this PatchChangeSummaryCollection.
+        :type items: list[PatchChangeSummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[PatchChangeSummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this PatchChangeSummaryCollection.
+        The array of patch summaries.
+
+
+        :return: The items of this PatchChangeSummaryCollection.
+        :rtype: list[PatchChangeSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this PatchChangeSummaryCollection.
+        The array of patch summaries.
+
+
+        :param items: The items of this PatchChangeSummaryCollection.
+        :type: list[PatchChangeSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/patch_object_metadata.py
+++ b/src/oci/data_integration/models/patch_object_metadata.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class PatchObjectMetadata(object):
     """
-    A summary type containing information about the object including its key, name and when/who created/updated it
+    A summary type containing information about the object including its key, name and when/who created/updated it.
     """
 
     #: A constant which can be used with the type property of a PatchObjectMetadata.
@@ -127,7 +127,7 @@ class PatchObjectMetadata(object):
     def name(self):
         """
         Gets the name of this PatchObjectMetadata.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this PatchObjectMetadata.
@@ -139,7 +139,7 @@ class PatchObjectMetadata(object):
     def name(self, name):
         """
         Sets the name of this PatchObjectMetadata.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this PatchObjectMetadata.
@@ -151,7 +151,7 @@ class PatchObjectMetadata(object):
     def name_path(self):
         """
         Gets the name_path of this PatchObjectMetadata.
-        The fully qualified path of the published object which would include its project and folder.
+        The fully qualified path of the published object, which would include its project and folder.
 
 
         :return: The name_path of this PatchObjectMetadata.
@@ -163,7 +163,7 @@ class PatchObjectMetadata(object):
     def name_path(self, name_path):
         """
         Sets the name_path of this PatchObjectMetadata.
-        The fully qualified path of the published object which would include its project and folder.
+        The fully qualified path of the published object, which would include its project and folder.
 
 
         :param name_path: The name_path of this PatchObjectMetadata.
@@ -229,7 +229,7 @@ class PatchObjectMetadata(object):
     def identifier(self):
         """
         Gets the identifier of this PatchObjectMetadata.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this PatchObjectMetadata.
@@ -241,7 +241,7 @@ class PatchObjectMetadata(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this PatchObjectMetadata.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this PatchObjectMetadata.
@@ -253,7 +253,7 @@ class PatchObjectMetadata(object):
     def action(self):
         """
         Gets the action of this PatchObjectMetadata.
-        The patch action, if object was created, updated or deleted.
+        The patch action indicating if object was created, updated, or deleted.
 
         Allowed values for this property are: "CREATED", "DELETED", "UPDATED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -268,7 +268,7 @@ class PatchObjectMetadata(object):
     def action(self, action):
         """
         Sets the action of this PatchObjectMetadata.
-        The patch action, if object was created, updated or deleted.
+        The patch action indicating if object was created, updated, or deleted.
 
 
         :param action: The action of this PatchObjectMetadata.

--- a/src/oci/data_integration/models/patch_summary.py
+++ b/src/oci/data_integration/models/patch_summary.py
@@ -18,6 +18,10 @@ class PatchSummary(object):
     PATCH_TYPE_PUBLISH = "PUBLISH"
 
     #: A constant which can be used with the patch_type property of a PatchSummary.
+    #: This constant has a value of "REFRESH"
+    PATCH_TYPE_REFRESH = "REFRESH"
+
+    #: A constant which can be used with the patch_type property of a PatchSummary.
     #: This constant has a value of "UNPUBLISH"
     PATCH_TYPE_UNPUBLISH = "UNPUBLISH"
 
@@ -88,7 +92,7 @@ class PatchSummary(object):
 
         :param patch_type:
             The value to assign to the patch_type property of this PatchSummary.
-            Allowed values for this property are: "PUBLISH", "UNPUBLISH", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PUBLISH", "REFRESH", "UNPUBLISH", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type patch_type: str
 
@@ -184,7 +188,7 @@ class PatchSummary(object):
     def key(self):
         """
         Gets the key of this PatchSummary.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this PatchSummary.
@@ -196,7 +200,7 @@ class PatchSummary(object):
     def key(self, key):
         """
         Sets the key of this PatchSummary.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this PatchSummary.
@@ -208,7 +212,7 @@ class PatchSummary(object):
     def model_type(self):
         """
         Gets the model_type of this PatchSummary.
-        The type of the object.
+        The object type.
 
 
         :return: The model_type of this PatchSummary.
@@ -220,7 +224,7 @@ class PatchSummary(object):
     def model_type(self, model_type):
         """
         Sets the model_type of this PatchSummary.
-        The type of the object.
+        The object type.
 
 
         :param model_type: The model_type of this PatchSummary.
@@ -232,7 +236,7 @@ class PatchSummary(object):
     def model_version(self):
         """
         Gets the model_version of this PatchSummary.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this PatchSummary.
@@ -244,7 +248,7 @@ class PatchSummary(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this PatchSummary.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this PatchSummary.
@@ -256,7 +260,7 @@ class PatchSummary(object):
     def name(self):
         """
         Gets the name of this PatchSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this PatchSummary.
@@ -268,7 +272,7 @@ class PatchSummary(object):
     def name(self, name):
         """
         Sets the name of this PatchSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this PatchSummary.
@@ -352,7 +356,7 @@ class PatchSummary(object):
     def identifier(self):
         """
         Gets the identifier of this PatchSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this PatchSummary.
@@ -364,7 +368,7 @@ class PatchSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this PatchSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this PatchSummary.
@@ -454,7 +458,7 @@ class PatchSummary(object):
         Gets the patch_type of this PatchSummary.
         The type of the patch applied or being applied on the application.
 
-        Allowed values for this property are: "PUBLISH", "UNPUBLISH", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PUBLISH", "REFRESH", "UNPUBLISH", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -473,7 +477,7 @@ class PatchSummary(object):
         :param patch_type: The patch_type of this PatchSummary.
         :type: str
         """
-        allowed_values = ["PUBLISH", "UNPUBLISH"]
+        allowed_values = ["PUBLISH", "REFRESH", "UNPUBLISH"]
         if not value_allowed_none_or_none_sentinel(patch_type, allowed_values):
             patch_type = 'UNKNOWN_ENUM_VALUE'
         self._patch_type = patch_type
@@ -536,7 +540,7 @@ class PatchSummary(object):
     def patch_object_metadata(self):
         """
         Gets the patch_object_metadata of this PatchSummary.
-        List of objects that are published / unpublished in this patch.
+        List of objects that are published or unpublished in this patch.
 
 
         :return: The patch_object_metadata of this PatchSummary.
@@ -548,7 +552,7 @@ class PatchSummary(object):
     def patch_object_metadata(self, patch_object_metadata):
         """
         Sets the patch_object_metadata of this PatchSummary.
-        List of objects that are published / unpublished in this patch.
+        List of objects that are published or unpublished in this patch.
 
 
         :param patch_object_metadata: The patch_object_metadata of this PatchSummary.
@@ -600,7 +604,7 @@ class PatchSummary(object):
     def key_map(self):
         """
         Gets the key_map of this PatchSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this PatchSummary.
@@ -612,7 +616,7 @@ class PatchSummary(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this PatchSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this PatchSummary.

--- a/src/oci/data_integration/models/patch_summary_collection.py
+++ b/src/oci/data_integration/models/patch_summary_collection.py
@@ -37,7 +37,7 @@ class PatchSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this PatchSummaryCollection.
-        The array of patch summaries
+        The array of patch summaries.
 
 
         :return: The items of this PatchSummaryCollection.
@@ -49,7 +49,7 @@ class PatchSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this PatchSummaryCollection.
-        The array of patch summaries
+        The array of patch summaries.
 
 
         :param items: The items of this PatchSummaryCollection.

--- a/src/oci/data_integration/models/primary_key.py
+++ b/src/oci/data_integration/models/primary_key.py
@@ -72,7 +72,7 @@ class PrimaryKey(object):
     def key(self):
         """
         Gets the key of this PrimaryKey.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this PrimaryKey.
@@ -84,7 +84,7 @@ class PrimaryKey(object):
     def key(self, key):
         """
         Sets the key of this PrimaryKey.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this PrimaryKey.
@@ -96,7 +96,7 @@ class PrimaryKey(object):
     def model_version(self):
         """
         Gets the model_version of this PrimaryKey.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this PrimaryKey.
@@ -108,7 +108,7 @@ class PrimaryKey(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this PrimaryKey.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this PrimaryKey.
@@ -140,7 +140,7 @@ class PrimaryKey(object):
     def name(self):
         """
         Gets the name of this PrimaryKey.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this PrimaryKey.
@@ -152,7 +152,7 @@ class PrimaryKey(object):
     def name(self, name):
         """
         Sets the name of this PrimaryKey.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this PrimaryKey.
@@ -164,7 +164,7 @@ class PrimaryKey(object):
     def attribute_refs(self):
         """
         Gets the attribute_refs of this PrimaryKey.
-        attributeRefs
+        An array of attribute references.
 
 
         :return: The attribute_refs of this PrimaryKey.
@@ -176,7 +176,7 @@ class PrimaryKey(object):
     def attribute_refs(self, attribute_refs):
         """
         Sets the attribute_refs of this PrimaryKey.
-        attributeRefs
+        An array of attribute references.
 
 
         :param attribute_refs: The attribute_refs of this PrimaryKey.

--- a/src/oci/data_integration/models/project.py
+++ b/src/oci/data_integration/models/project.py
@@ -179,7 +179,7 @@ class Project(object):
     def name(self):
         """
         Gets the name of this Project.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this Project.
@@ -191,7 +191,7 @@ class Project(object):
     def name(self, name):
         """
         Sets the name of this Project.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this Project.
@@ -203,7 +203,7 @@ class Project(object):
     def description(self):
         """
         Gets the description of this Project.
-        Detailed description for the object.
+        A user defined description for the project.
 
 
         :return: The description of this Project.
@@ -215,7 +215,7 @@ class Project(object):
     def description(self, description):
         """
         Sets the description of this Project.
-        Detailed description for the object.
+        A user defined description for the project.
 
 
         :param description: The description of this Project.
@@ -251,7 +251,7 @@ class Project(object):
     def identifier(self):
         """
         Gets the identifier of this Project.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this Project.
@@ -263,7 +263,7 @@ class Project(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this Project.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this Project.
@@ -339,7 +339,7 @@ class Project(object):
     def key_map(self):
         """
         Gets the key_map of this Project.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, the key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this Project.
@@ -351,7 +351,7 @@ class Project(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this Project.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, the key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this Project.

--- a/src/oci/data_integration/models/project_details.py
+++ b/src/oci/data_integration/models/project_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ProjectDetails(object):
     """
-    The details including name, description for the project, which is a container of folders, tasks and dataflows.
+    The details including name and description for the project, which is a container of folders, tasks, and dataflows.
     """
 
     def __init__(self, **kwargs):
@@ -172,7 +172,7 @@ class ProjectDetails(object):
     def name(self):
         """
         Gets the name of this ProjectDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this ProjectDetails.
@@ -184,7 +184,7 @@ class ProjectDetails(object):
     def name(self, name):
         """
         Sets the name of this ProjectDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this ProjectDetails.
@@ -196,7 +196,7 @@ class ProjectDetails(object):
     def description(self):
         """
         Gets the description of this ProjectDetails.
-        Detailed description for the object.
+        A user defined description for the project.
 
 
         :return: The description of this ProjectDetails.
@@ -208,7 +208,7 @@ class ProjectDetails(object):
     def description(self, description):
         """
         Sets the description of this ProjectDetails.
-        Detailed description for the object.
+        A user defined description for the project.
 
 
         :param description: The description of this ProjectDetails.
@@ -244,7 +244,7 @@ class ProjectDetails(object):
     def identifier(self):
         """
         Gets the identifier of this ProjectDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this ProjectDetails.
@@ -256,7 +256,7 @@ class ProjectDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this ProjectDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this ProjectDetails.

--- a/src/oci/data_integration/models/project_summary.py
+++ b/src/oci/data_integration/models/project_summary.py
@@ -179,7 +179,7 @@ class ProjectSummary(object):
     def name(self):
         """
         Gets the name of this ProjectSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this ProjectSummary.
@@ -191,7 +191,7 @@ class ProjectSummary(object):
     def name(self, name):
         """
         Sets the name of this ProjectSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this ProjectSummary.
@@ -203,7 +203,7 @@ class ProjectSummary(object):
     def description(self):
         """
         Gets the description of this ProjectSummary.
-        Detailed description for the object.
+        A user defined description for the project.
 
 
         :return: The description of this ProjectSummary.
@@ -215,7 +215,7 @@ class ProjectSummary(object):
     def description(self, description):
         """
         Sets the description of this ProjectSummary.
-        Detailed description for the object.
+        A user defined description for the project.
 
 
         :param description: The description of this ProjectSummary.
@@ -251,7 +251,7 @@ class ProjectSummary(object):
     def identifier(self):
         """
         Gets the identifier of this ProjectSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this ProjectSummary.
@@ -263,7 +263,7 @@ class ProjectSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this ProjectSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this ProjectSummary.
@@ -339,7 +339,7 @@ class ProjectSummary(object):
     def key_map(self):
         """
         Gets the key_map of this ProjectSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, the key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this ProjectSummary.
@@ -351,7 +351,7 @@ class ProjectSummary(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this ProjectSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, the key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this ProjectSummary.

--- a/src/oci/data_integration/models/project_summary_collection.py
+++ b/src/oci/data_integration/models/project_summary_collection.py
@@ -37,7 +37,7 @@ class ProjectSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this ProjectSummaryCollection.
-        The array of Project summaries
+        The array of project summaries.
 
 
         :return: The items of this ProjectSummaryCollection.
@@ -49,7 +49,7 @@ class ProjectSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this ProjectSummaryCollection.
-        The array of Project summaries
+        The array of project summaries.
 
 
         :param items: The items of this ProjectSummaryCollection.

--- a/src/oci/data_integration/models/projection.py
+++ b/src/oci/data_integration/models/projection.py
@@ -21,7 +21,7 @@ class Projection(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this Projection.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR"
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/projection_rule.py
+++ b/src/oci/data_integration/models/projection_rule.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ProjectionRule(object):
     """
-    Base type for how fields are projected, there are many different mechanisms for doing this such as by a name patter, datatype etc. See the modelType property for the types.
+    Base type for how fields are projected. There are many different mechanisms for doing this such as by a name pattern, datatype and so on. See the `modelType` property for the types.
     """
 
     #: A constant which can be used with the model_type property of a ProjectionRule.
@@ -307,7 +307,7 @@ class ProjectionRule(object):
     def description(self):
         """
         Gets the description of this ProjectionRule.
-        Detailed description for the object.
+        A user defined description for the object.
 
 
         :return: The description of this ProjectionRule.
@@ -319,7 +319,7 @@ class ProjectionRule(object):
     def description(self, description):
         """
         Sets the description of this ProjectionRule.
-        Detailed description for the object.
+        A user defined description for the object.
 
 
         :param description: The description of this ProjectionRule.

--- a/src/oci/data_integration/models/proxy_field.py
+++ b/src/oci/data_integration/models/proxy_field.py
@@ -21,7 +21,7 @@ class ProxyField(TypedObject):
 
         :param model_type:
             The value to assign to the model_type property of this ProxyField.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
         :type model_type: str
 
         :param key:
@@ -110,7 +110,7 @@ class ProxyField(TypedObject):
     def scope(self):
         """
         Gets the scope of this ProxyField.
-        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+        Reference to a typed object. This can be either a key value to an object within the document, a shall referenced to a `TypedObject`, or a full `TypedObject` definition.
 
 
         :return: The scope of this ProxyField.
@@ -122,7 +122,7 @@ class ProxyField(TypedObject):
     def scope(self, scope):
         """
         Sets the scope of this ProxyField.
-        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+        Reference to a typed object. This can be either a key value to an object within the document, a shall referenced to a `TypedObject`, or a full `TypedObject` definition.
 
 
         :param scope: The scope of this ProxyField.
@@ -154,7 +154,7 @@ class ProxyField(TypedObject):
     def labels(self):
         """
         Gets the labels of this ProxyField.
-        Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or labels that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :return: The labels of this ProxyField.
@@ -166,7 +166,7 @@ class ProxyField(TypedObject):
     def labels(self, labels):
         """
         Sets the labels of this ProxyField.
-        Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+        Labels are keywords or labels that you can add to data assets, dataflows and so on. You can define your own labels and use them to categorize content.
 
 
         :param labels: The labels of this ProxyField.

--- a/src/oci/data_integration/models/published_object.py
+++ b/src/oci/data_integration/models/published_object.py
@@ -178,7 +178,7 @@ class PublishedObject(object):
     def model_version(self):
         """
         Gets the model_version of this PublishedObject.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this PublishedObject.
@@ -190,7 +190,7 @@ class PublishedObject(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this PublishedObject.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this PublishedObject.
@@ -222,7 +222,7 @@ class PublishedObject(object):
     def name(self):
         """
         Gets the name of this PublishedObject.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this PublishedObject.
@@ -234,7 +234,7 @@ class PublishedObject(object):
     def name(self, name):
         """
         Sets the name of this PublishedObject.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this PublishedObject.
@@ -318,7 +318,7 @@ class PublishedObject(object):
     def identifier(self):
         """
         Gets the identifier of this PublishedObject.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this PublishedObject.
@@ -330,7 +330,7 @@ class PublishedObject(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this PublishedObject.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this PublishedObject.

--- a/src/oci/data_integration/models/published_object_summary.py
+++ b/src/oci/data_integration/models/published_object_summary.py
@@ -185,7 +185,7 @@ class PublishedObjectSummary(object):
     def model_version(self):
         """
         Gets the model_version of this PublishedObjectSummary.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this PublishedObjectSummary.
@@ -197,7 +197,7 @@ class PublishedObjectSummary(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this PublishedObjectSummary.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this PublishedObjectSummary.
@@ -229,7 +229,7 @@ class PublishedObjectSummary(object):
     def name(self):
         """
         Gets the name of this PublishedObjectSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this PublishedObjectSummary.
@@ -241,7 +241,7 @@ class PublishedObjectSummary(object):
     def name(self, name):
         """
         Sets the name of this PublishedObjectSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this PublishedObjectSummary.
@@ -325,7 +325,7 @@ class PublishedObjectSummary(object):
     def identifier(self):
         """
         Gets the identifier of this PublishedObjectSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this PublishedObjectSummary.
@@ -337,7 +337,7 @@ class PublishedObjectSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this PublishedObjectSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this PublishedObjectSummary.

--- a/src/oci/data_integration/models/published_object_summary_collection.py
+++ b/src/oci/data_integration/models/published_object_summary_collection.py
@@ -37,7 +37,7 @@ class PublishedObjectSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this PublishedObjectSummaryCollection.
-        The array of PublishedObject summaries
+        The array of published object summaries.
 
 
         :return: The items of this PublishedObjectSummaryCollection.
@@ -49,7 +49,7 @@ class PublishedObjectSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this PublishedObjectSummaryCollection.
-        The array of PublishedObject summaries
+        The array of published object summaries.
 
 
         :param items: The items of this PublishedObjectSummaryCollection.

--- a/src/oci/data_integration/models/read_operation_config.py
+++ b/src/oci/data_integration/models/read_operation_config.py
@@ -97,7 +97,7 @@ class ReadOperationConfig(AbstractDataOperationConfig):
     def key(self):
         """
         Gets the key of this ReadOperationConfig.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this ReadOperationConfig.
@@ -109,7 +109,7 @@ class ReadOperationConfig(AbstractDataOperationConfig):
     def key(self, key):
         """
         Sets the key of this ReadOperationConfig.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this ReadOperationConfig.
@@ -121,7 +121,7 @@ class ReadOperationConfig(AbstractDataOperationConfig):
     def model_version(self):
         """
         Gets the model_version of this ReadOperationConfig.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this ReadOperationConfig.
@@ -133,7 +133,7 @@ class ReadOperationConfig(AbstractDataOperationConfig):
     def model_version(self, model_version):
         """
         Sets the model_version of this ReadOperationConfig.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this ReadOperationConfig.

--- a/src/oci/data_integration/models/reference.py
+++ b/src/oci/data_integration/models/reference.py
@@ -1,0 +1,381 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Reference(object):
+    """
+    Reference contains application configuration information.
+    """
+
+    #: A constant which can be used with the type property of a Reference.
+    #: This constant has a value of "ORACLE_DATA_ASSET"
+    TYPE_ORACLE_DATA_ASSET = "ORACLE_DATA_ASSET"
+
+    #: A constant which can be used with the type property of a Reference.
+    #: This constant has a value of "ORACLE_OBJECT_STORAGE_DATA_ASSET"
+    TYPE_ORACLE_OBJECT_STORAGE_DATA_ASSET = "ORACLE_OBJECT_STORAGE_DATA_ASSET"
+
+    #: A constant which can be used with the type property of a Reference.
+    #: This constant has a value of "ORACLE_ATP_DATA_ASSET"
+    TYPE_ORACLE_ATP_DATA_ASSET = "ORACLE_ATP_DATA_ASSET"
+
+    #: A constant which can be used with the type property of a Reference.
+    #: This constant has a value of "ORACLE_ADWC_DATA_ASSET"
+    TYPE_ORACLE_ADWC_DATA_ASSET = "ORACLE_ADWC_DATA_ASSET"
+
+    #: A constant which can be used with the type property of a Reference.
+    #: This constant has a value of "MYSQL_DATA_ASSET"
+    TYPE_MYSQL_DATA_ASSET = "MYSQL_DATA_ASSET"
+
+    #: A constant which can be used with the type property of a Reference.
+    #: This constant has a value of "GENERIC_JDBC_DATA_ASSET"
+    TYPE_GENERIC_JDBC_DATA_ASSET = "GENERIC_JDBC_DATA_ASSET"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Reference object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this Reference.
+        :type key: str
+
+        :param name:
+            The value to assign to the name property of this Reference.
+        :type name: str
+
+        :param identifier:
+            The value to assign to the identifier property of this Reference.
+        :type identifier: str
+
+        :param identifier_path:
+            The value to assign to the identifier_path property of this Reference.
+        :type identifier_path: str
+
+        :param description:
+            The value to assign to the description property of this Reference.
+        :type description: str
+
+        :param type:
+            The value to assign to the type property of this Reference.
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type type: str
+
+        :param target_object:
+            The value to assign to the target_object property of this Reference.
+        :type target_object: object
+
+        :param application_key:
+            The value to assign to the application_key property of this Reference.
+        :type application_key: str
+
+        :param used_by:
+            The value to assign to the used_by property of this Reference.
+        :type used_by: list[ReferenceUsedBy]
+
+        :param child_references:
+            The value to assign to the child_references property of this Reference.
+        :type child_references: list[ChildReference]
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'name': 'str',
+            'identifier': 'str',
+            'identifier_path': 'str',
+            'description': 'str',
+            'type': 'str',
+            'target_object': 'object',
+            'application_key': 'str',
+            'used_by': 'list[ReferenceUsedBy]',
+            'child_references': 'list[ChildReference]'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'name': 'name',
+            'identifier': 'identifier',
+            'identifier_path': 'identifierPath',
+            'description': 'description',
+            'type': 'type',
+            'target_object': 'targetObject',
+            'application_key': 'applicationKey',
+            'used_by': 'usedBy',
+            'child_references': 'childReferences'
+        }
+
+        self._key = None
+        self._name = None
+        self._identifier = None
+        self._identifier_path = None
+        self._description = None
+        self._type = None
+        self._target_object = None
+        self._application_key = None
+        self._used_by = None
+        self._child_references = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this Reference.
+        The reference's key, key of the object that is being used by a published object or its dependents.
+
+
+        :return: The key of this Reference.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this Reference.
+        The reference's key, key of the object that is being used by a published object or its dependents.
+
+
+        :param key: The key of this Reference.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def name(self):
+        """
+        Gets the name of this Reference.
+        The name of reference object.
+
+
+        :return: The name of this Reference.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this Reference.
+        The name of reference object.
+
+
+        :param name: The name of this Reference.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this Reference.
+        The identifier of reference object.
+
+
+        :return: The identifier of this Reference.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this Reference.
+        The identifier of reference object.
+
+
+        :param identifier: The identifier of this Reference.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def identifier_path(self):
+        """
+        Gets the identifier_path of this Reference.
+        The identifier path of reference object.
+
+
+        :return: The identifier_path of this Reference.
+        :rtype: str
+        """
+        return self._identifier_path
+
+    @identifier_path.setter
+    def identifier_path(self, identifier_path):
+        """
+        Sets the identifier_path of this Reference.
+        The identifier path of reference object.
+
+
+        :param identifier_path: The identifier_path of this Reference.
+        :type: str
+        """
+        self._identifier_path = identifier_path
+
+    @property
+    def description(self):
+        """
+        Gets the description of this Reference.
+        The description of reference object.
+
+
+        :return: The description of this Reference.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this Reference.
+        The description of reference object.
+
+
+        :param description: The description of this Reference.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def type(self):
+        """
+        Gets the type of this Reference.
+        The type of reference object.
+
+        Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The type of this Reference.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this Reference.
+        The type of reference object.
+
+
+        :param type: The type of this Reference.
+        :type: str
+        """
+        allowed_values = ["ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"]
+        if not value_allowed_none_or_none_sentinel(type, allowed_values):
+            type = 'UNKNOWN_ENUM_VALUE'
+        self._type = type
+
+    @property
+    def target_object(self):
+        """
+        Gets the target_object of this Reference.
+        The new reference object to use instead of the original reference. For example, this can be a data asset reference.
+
+
+        :return: The target_object of this Reference.
+        :rtype: object
+        """
+        return self._target_object
+
+    @target_object.setter
+    def target_object(self, target_object):
+        """
+        Sets the target_object of this Reference.
+        The new reference object to use instead of the original reference. For example, this can be a data asset reference.
+
+
+        :param target_object: The target_object of this Reference.
+        :type: object
+        """
+        self._target_object = target_object
+
+    @property
+    def application_key(self):
+        """
+        Gets the application_key of this Reference.
+        The application key of the reference object.
+
+
+        :return: The application_key of this Reference.
+        :rtype: str
+        """
+        return self._application_key
+
+    @application_key.setter
+    def application_key(self, application_key):
+        """
+        Sets the application_key of this Reference.
+        The application key of the reference object.
+
+
+        :param application_key: The application_key of this Reference.
+        :type: str
+        """
+        self._application_key = application_key
+
+    @property
+    def used_by(self):
+        """
+        Gets the used_by of this Reference.
+        List of published objects where this is used.
+
+
+        :return: The used_by of this Reference.
+        :rtype: list[ReferenceUsedBy]
+        """
+        return self._used_by
+
+    @used_by.setter
+    def used_by(self, used_by):
+        """
+        Sets the used_by of this Reference.
+        List of published objects where this is used.
+
+
+        :param used_by: The used_by of this Reference.
+        :type: list[ReferenceUsedBy]
+        """
+        self._used_by = used_by
+
+    @property
+    def child_references(self):
+        """
+        Gets the child_references of this Reference.
+        List of references that are dependent on this reference.
+
+
+        :return: The child_references of this Reference.
+        :rtype: list[ChildReference]
+        """
+        return self._child_references
+
+    @child_references.setter
+    def child_references(self, child_references):
+        """
+        Sets the child_references of this Reference.
+        List of references that are dependent on this reference.
+
+
+        :param child_references: The child_references of this Reference.
+        :type: list[ChildReference]
+        """
+        self._child_references = child_references
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/reference_summary.py
+++ b/src/oci/data_integration/models/reference_summary.py
@@ -1,0 +1,381 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ReferenceSummary(object):
+    """
+    This is the reference summary information.
+    """
+
+    #: A constant which can be used with the type property of a ReferenceSummary.
+    #: This constant has a value of "ORACLE_DATA_ASSET"
+    TYPE_ORACLE_DATA_ASSET = "ORACLE_DATA_ASSET"
+
+    #: A constant which can be used with the type property of a ReferenceSummary.
+    #: This constant has a value of "ORACLE_OBJECT_STORAGE_DATA_ASSET"
+    TYPE_ORACLE_OBJECT_STORAGE_DATA_ASSET = "ORACLE_OBJECT_STORAGE_DATA_ASSET"
+
+    #: A constant which can be used with the type property of a ReferenceSummary.
+    #: This constant has a value of "ORACLE_ATP_DATA_ASSET"
+    TYPE_ORACLE_ATP_DATA_ASSET = "ORACLE_ATP_DATA_ASSET"
+
+    #: A constant which can be used with the type property of a ReferenceSummary.
+    #: This constant has a value of "ORACLE_ADWC_DATA_ASSET"
+    TYPE_ORACLE_ADWC_DATA_ASSET = "ORACLE_ADWC_DATA_ASSET"
+
+    #: A constant which can be used with the type property of a ReferenceSummary.
+    #: This constant has a value of "MYSQL_DATA_ASSET"
+    TYPE_MYSQL_DATA_ASSET = "MYSQL_DATA_ASSET"
+
+    #: A constant which can be used with the type property of a ReferenceSummary.
+    #: This constant has a value of "GENERIC_JDBC_DATA_ASSET"
+    TYPE_GENERIC_JDBC_DATA_ASSET = "GENERIC_JDBC_DATA_ASSET"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ReferenceSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this ReferenceSummary.
+        :type key: str
+
+        :param name:
+            The value to assign to the name property of this ReferenceSummary.
+        :type name: str
+
+        :param identifier:
+            The value to assign to the identifier property of this ReferenceSummary.
+        :type identifier: str
+
+        :param identifier_path:
+            The value to assign to the identifier_path property of this ReferenceSummary.
+        :type identifier_path: str
+
+        :param description:
+            The value to assign to the description property of this ReferenceSummary.
+        :type description: str
+
+        :param type:
+            The value to assign to the type property of this ReferenceSummary.
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type type: str
+
+        :param target_object:
+            The value to assign to the target_object property of this ReferenceSummary.
+        :type target_object: object
+
+        :param aggregator_key:
+            The value to assign to the aggregator_key property of this ReferenceSummary.
+        :type aggregator_key: str
+
+        :param used_by:
+            The value to assign to the used_by property of this ReferenceSummary.
+        :type used_by: list[ReferenceUsedBy]
+
+        :param child_references:
+            The value to assign to the child_references property of this ReferenceSummary.
+        :type child_references: list[ChildReference]
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'name': 'str',
+            'identifier': 'str',
+            'identifier_path': 'str',
+            'description': 'str',
+            'type': 'str',
+            'target_object': 'object',
+            'aggregator_key': 'str',
+            'used_by': 'list[ReferenceUsedBy]',
+            'child_references': 'list[ChildReference]'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'name': 'name',
+            'identifier': 'identifier',
+            'identifier_path': 'identifierPath',
+            'description': 'description',
+            'type': 'type',
+            'target_object': 'targetObject',
+            'aggregator_key': 'aggregatorKey',
+            'used_by': 'usedBy',
+            'child_references': 'childReferences'
+        }
+
+        self._key = None
+        self._name = None
+        self._identifier = None
+        self._identifier_path = None
+        self._description = None
+        self._type = None
+        self._target_object = None
+        self._aggregator_key = None
+        self._used_by = None
+        self._child_references = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this ReferenceSummary.
+        The reference's key, key of the object that is being used by a published object or its dependents.
+
+
+        :return: The key of this ReferenceSummary.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this ReferenceSummary.
+        The reference's key, key of the object that is being used by a published object or its dependents.
+
+
+        :param key: The key of this ReferenceSummary.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def name(self):
+        """
+        Gets the name of this ReferenceSummary.
+        The name of reference object.
+
+
+        :return: The name of this ReferenceSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this ReferenceSummary.
+        The name of reference object.
+
+
+        :param name: The name of this ReferenceSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this ReferenceSummary.
+        The identifier of reference object.
+
+
+        :return: The identifier of this ReferenceSummary.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this ReferenceSummary.
+        The identifier of reference object.
+
+
+        :param identifier: The identifier of this ReferenceSummary.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def identifier_path(self):
+        """
+        Gets the identifier_path of this ReferenceSummary.
+        The identifier path of reference object.
+
+
+        :return: The identifier_path of this ReferenceSummary.
+        :rtype: str
+        """
+        return self._identifier_path
+
+    @identifier_path.setter
+    def identifier_path(self, identifier_path):
+        """
+        Sets the identifier_path of this ReferenceSummary.
+        The identifier path of reference object.
+
+
+        :param identifier_path: The identifier_path of this ReferenceSummary.
+        :type: str
+        """
+        self._identifier_path = identifier_path
+
+    @property
+    def description(self):
+        """
+        Gets the description of this ReferenceSummary.
+        The description of reference object.
+
+
+        :return: The description of this ReferenceSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this ReferenceSummary.
+        The description of reference object.
+
+
+        :param description: The description of this ReferenceSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def type(self):
+        """
+        Gets the type of this ReferenceSummary.
+        The type of reference object.
+
+        Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The type of this ReferenceSummary.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this ReferenceSummary.
+        The type of reference object.
+
+
+        :param type: The type of this ReferenceSummary.
+        :type: str
+        """
+        allowed_values = ["ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"]
+        if not value_allowed_none_or_none_sentinel(type, allowed_values):
+            type = 'UNKNOWN_ENUM_VALUE'
+        self._type = type
+
+    @property
+    def target_object(self):
+        """
+        Gets the target_object of this ReferenceSummary.
+        The target object referenced. References are made to data assets and child references are made to connections. The type defining this reference is mentioned in the property type.
+
+
+        :return: The target_object of this ReferenceSummary.
+        :rtype: object
+        """
+        return self._target_object
+
+    @target_object.setter
+    def target_object(self, target_object):
+        """
+        Sets the target_object of this ReferenceSummary.
+        The target object referenced. References are made to data assets and child references are made to connections. The type defining this reference is mentioned in the property type.
+
+
+        :param target_object: The target_object of this ReferenceSummary.
+        :type: object
+        """
+        self._target_object = target_object
+
+    @property
+    def aggregator_key(self):
+        """
+        Gets the aggregator_key of this ReferenceSummary.
+        The aggregator of reference object.
+
+
+        :return: The aggregator_key of this ReferenceSummary.
+        :rtype: str
+        """
+        return self._aggregator_key
+
+    @aggregator_key.setter
+    def aggregator_key(self, aggregator_key):
+        """
+        Sets the aggregator_key of this ReferenceSummary.
+        The aggregator of reference object.
+
+
+        :param aggregator_key: The aggregator_key of this ReferenceSummary.
+        :type: str
+        """
+        self._aggregator_key = aggregator_key
+
+    @property
+    def used_by(self):
+        """
+        Gets the used_by of this ReferenceSummary.
+        List of published objects where this is used.
+
+
+        :return: The used_by of this ReferenceSummary.
+        :rtype: list[ReferenceUsedBy]
+        """
+        return self._used_by
+
+    @used_by.setter
+    def used_by(self, used_by):
+        """
+        Sets the used_by of this ReferenceSummary.
+        List of published objects where this is used.
+
+
+        :param used_by: The used_by of this ReferenceSummary.
+        :type: list[ReferenceUsedBy]
+        """
+        self._used_by = used_by
+
+    @property
+    def child_references(self):
+        """
+        Gets the child_references of this ReferenceSummary.
+        List of references that are dependent on this reference.
+
+
+        :return: The child_references of this ReferenceSummary.
+        :rtype: list[ChildReference]
+        """
+        return self._child_references
+
+    @child_references.setter
+    def child_references(self, child_references):
+        """
+        Sets the child_references of this ReferenceSummary.
+        List of references that are dependent on this reference.
+
+
+        :param child_references: The child_references of this ReferenceSummary.
+        :type: list[ChildReference]
+        """
+        self._child_references = child_references
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/reference_summary_collection.py
+++ b/src/oci/data_integration/models/reference_summary_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ReferenceSummaryCollection(object):
+    """
+    This is the collection of references.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ReferenceSummaryCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this ReferenceSummaryCollection.
+        :type items: list[ReferenceSummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[ReferenceSummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this ReferenceSummaryCollection.
+        The array of application summaries.
+
+
+        :return: The items of this ReferenceSummaryCollection.
+        :rtype: list[ReferenceSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this ReferenceSummaryCollection.
+        The array of application summaries.
+
+
+        :param items: The items of this ReferenceSummaryCollection.
+        :type: list[ReferenceSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/reference_used_by.py
+++ b/src/oci/data_integration/models/reference_used_by.py
@@ -1,0 +1,132 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ReferenceUsedBy(object):
+    """
+    Referenced object information.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ReferenceUsedBy object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this ReferenceUsedBy.
+        :type key: str
+
+        :param name:
+            The value to assign to the name property of this ReferenceUsedBy.
+        :type name: str
+
+        :param name_path:
+            The value to assign to the name_path property of this ReferenceUsedBy.
+        :type name_path: str
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'name': 'str',
+            'name_path': 'str'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'name': 'name',
+            'name_path': 'namePath'
+        }
+
+        self._key = None
+        self._name = None
+        self._name_path = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this ReferenceUsedBy.
+        The key of the published object.
+
+
+        :return: The key of this ReferenceUsedBy.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this ReferenceUsedBy.
+        The key of the published object.
+
+
+        :param key: The key of this ReferenceUsedBy.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def name(self):
+        """
+        Gets the name of this ReferenceUsedBy.
+        The name of an published object.
+
+
+        :return: The name of this ReferenceUsedBy.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this ReferenceUsedBy.
+        The name of an published object.
+
+
+        :param name: The name of this ReferenceUsedBy.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def name_path(self):
+        """
+        Gets the name_path of this ReferenceUsedBy.
+        The name path of the published object.
+
+
+        :return: The name_path of this ReferenceUsedBy.
+        :rtype: str
+        """
+        return self._name_path
+
+    @name_path.setter
+    def name_path(self, name_path):
+        """
+        Sets the name_path of this ReferenceUsedBy.
+        The name path of the published object.
+
+
+        :param name_path: The name_path of this ReferenceUsedBy.
+        :type: str
+        """
+        self._name_path = name_path
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/registry_metadata.py
+++ b/src/oci/data_integration/models/registry_metadata.py
@@ -34,25 +34,32 @@ class RegistryMetadata(object):
             The value to assign to the key property of this RegistryMetadata.
         :type key: str
 
+        :param is_favorite:
+            The value to assign to the is_favorite property of this RegistryMetadata.
+        :type is_favorite: bool
+
         """
         self.swagger_types = {
             'aggregator_key': 'str',
             'labels': 'list[str]',
             'registry_version': 'int',
-            'key': 'str'
+            'key': 'str',
+            'is_favorite': 'bool'
         }
 
         self.attribute_map = {
             'aggregator_key': 'aggregatorKey',
             'labels': 'labels',
             'registry_version': 'registryVersion',
-            'key': 'key'
+            'key': 'key',
+            'is_favorite': 'isFavorite'
         }
 
         self._aggregator_key = None
         self._labels = None
         self._registry_version = None
         self._key = None
+        self._is_favorite = None
 
     @property
     def aggregator_key(self):
@@ -106,7 +113,7 @@ class RegistryMetadata(object):
     def registry_version(self):
         """
         Gets the registry_version of this RegistryMetadata.
-        Registry version.
+        The registry version.
 
 
         :return: The registry_version of this RegistryMetadata.
@@ -118,7 +125,7 @@ class RegistryMetadata(object):
     def registry_version(self, registry_version):
         """
         Sets the registry_version of this RegistryMetadata.
-        Registry version.
+        The registry version.
 
 
         :param registry_version: The registry_version of this RegistryMetadata.
@@ -149,6 +156,30 @@ class RegistryMetadata(object):
         :type: str
         """
         self._key = key
+
+    @property
+    def is_favorite(self):
+        """
+        Gets the is_favorite of this RegistryMetadata.
+        Specifies whether this object is a favorite or not.
+
+
+        :return: The is_favorite of this RegistryMetadata.
+        :rtype: bool
+        """
+        return self._is_favorite
+
+    @is_favorite.setter
+    def is_favorite(self, is_favorite):
+        """
+        Sets the is_favorite of this RegistryMetadata.
+        Specifies whether this object is a favorite or not.
+
+
+        :param is_favorite: The is_favorite of this RegistryMetadata.
+        :type: bool
+        """
+        self._is_favorite = is_favorite
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/rename_rule.py
+++ b/src/oci/data_integration/models/rename_rule.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class RenameRule(ProjectionRule):
     """
-    The rename rule can rename fields from one to another.
+    Lets you rename an attribute.
     """
 
     def __init__(self, **kwargs):
@@ -110,7 +110,7 @@ class RenameRule(ProjectionRule):
     def is_skip_remaining_rules_on_match(self):
         """
         Gets the is_skip_remaining_rules_on_match of this RenameRule.
-        skipRemainingRulesOnMatch
+        Specifies whether to skip remaining rules when a match is found.
 
 
         :return: The is_skip_remaining_rules_on_match of this RenameRule.
@@ -122,7 +122,7 @@ class RenameRule(ProjectionRule):
     def is_skip_remaining_rules_on_match(self, is_skip_remaining_rules_on_match):
         """
         Sets the is_skip_remaining_rules_on_match of this RenameRule.
-        skipRemainingRulesOnMatch
+        Specifies whether to skip remaining rules when a match is found.
 
 
         :param is_skip_remaining_rules_on_match: The is_skip_remaining_rules_on_match of this RenameRule.
@@ -134,7 +134,7 @@ class RenameRule(ProjectionRule):
     def from_name(self):
         """
         Gets the from_name of this RenameRule.
-        fromName
+        The attribute name that needs to be renamed.
 
 
         :return: The from_name of this RenameRule.
@@ -146,7 +146,7 @@ class RenameRule(ProjectionRule):
     def from_name(self, from_name):
         """
         Sets the from_name of this RenameRule.
-        fromName
+        The attribute name that needs to be renamed.
 
 
         :param from_name: The from_name of this RenameRule.
@@ -158,7 +158,7 @@ class RenameRule(ProjectionRule):
     def to_name(self):
         """
         Gets the to_name of this RenameRule.
-        toName
+        The new attribute name.
 
 
         :return: The to_name of this RenameRule.
@@ -170,7 +170,7 @@ class RenameRule(ProjectionRule):
     def to_name(self, to_name):
         """
         Sets the to_name of this RenameRule.
-        toName
+        The new attribute name.
 
 
         :param to_name: The to_name of this RenameRule.

--- a/src/oci/data_integration/models/resource_configuration.py
+++ b/src/oci/data_integration/models/resource_configuration.py
@@ -1,0 +1,163 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ResourceConfiguration(object):
+    """
+    Properties related to a resource.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ResourceConfiguration object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param spark_version:
+            The value to assign to the spark_version property of this ResourceConfiguration.
+        :type spark_version: str
+
+        :param driver_shape:
+            The value to assign to the driver_shape property of this ResourceConfiguration.
+        :type driver_shape: str
+
+        :param executor_shape:
+            The value to assign to the executor_shape property of this ResourceConfiguration.
+        :type executor_shape: str
+
+        :param total_executors:
+            The value to assign to the total_executors property of this ResourceConfiguration.
+        :type total_executors: int
+
+        """
+        self.swagger_types = {
+            'spark_version': 'str',
+            'driver_shape': 'str',
+            'executor_shape': 'str',
+            'total_executors': 'int'
+        }
+
+        self.attribute_map = {
+            'spark_version': 'sparkVersion',
+            'driver_shape': 'driverShape',
+            'executor_shape': 'executorShape',
+            'total_executors': 'totalExecutors'
+        }
+
+        self._spark_version = None
+        self._driver_shape = None
+        self._executor_shape = None
+        self._total_executors = None
+
+    @property
+    def spark_version(self):
+        """
+        **[Required]** Gets the spark_version of this ResourceConfiguration.
+        The version of the spark used while creating an Oracle Cloud Infrastructure Data Flow application.
+
+
+        :return: The spark_version of this ResourceConfiguration.
+        :rtype: str
+        """
+        return self._spark_version
+
+    @spark_version.setter
+    def spark_version(self, spark_version):
+        """
+        Sets the spark_version of this ResourceConfiguration.
+        The version of the spark used while creating an Oracle Cloud Infrastructure Data Flow application.
+
+
+        :param spark_version: The spark_version of this ResourceConfiguration.
+        :type: str
+        """
+        self._spark_version = spark_version
+
+    @property
+    def driver_shape(self):
+        """
+        **[Required]** Gets the driver_shape of this ResourceConfiguration.
+        The VM shape of the driver used while creating an Oracle Cloud Infrastructure Data Flow application. It sets the driver cores and memory.
+
+
+        :return: The driver_shape of this ResourceConfiguration.
+        :rtype: str
+        """
+        return self._driver_shape
+
+    @driver_shape.setter
+    def driver_shape(self, driver_shape):
+        """
+        Sets the driver_shape of this ResourceConfiguration.
+        The VM shape of the driver used while creating an Oracle Cloud Infrastructure Data Flow application. It sets the driver cores and memory.
+
+
+        :param driver_shape: The driver_shape of this ResourceConfiguration.
+        :type: str
+        """
+        self._driver_shape = driver_shape
+
+    @property
+    def executor_shape(self):
+        """
+        **[Required]** Gets the executor_shape of this ResourceConfiguration.
+        The shape of the executor used while creating an Oracle Cloud Infrastructure Data Flow application. It sets the executor cores and memory.
+
+
+        :return: The executor_shape of this ResourceConfiguration.
+        :rtype: str
+        """
+        return self._executor_shape
+
+    @executor_shape.setter
+    def executor_shape(self, executor_shape):
+        """
+        Sets the executor_shape of this ResourceConfiguration.
+        The shape of the executor used while creating an Oracle Cloud Infrastructure Data Flow application. It sets the executor cores and memory.
+
+
+        :param executor_shape: The executor_shape of this ResourceConfiguration.
+        :type: str
+        """
+        self._executor_shape = executor_shape
+
+    @property
+    def total_executors(self):
+        """
+        **[Required]** Gets the total_executors of this ResourceConfiguration.
+        Number of executor VMs requested while creating an Oracle Cloud Infrastructure Data Flow application.
+
+
+        :return: The total_executors of this ResourceConfiguration.
+        :rtype: int
+        """
+        return self._total_executors
+
+    @total_executors.setter
+    def total_executors(self, total_executors):
+        """
+        Sets the total_executors of this ResourceConfiguration.
+        Number of executor VMs requested while creating an Oracle Cloud Infrastructure Data Flow application.
+
+
+        :param total_executors: The total_executors of this ResourceConfiguration.
+        :type: int
+        """
+        self._total_executors = total_executors
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/rule_based_field_map.py
+++ b/src/oci/data_integration/models/rule_based_field_map.py
@@ -139,7 +139,7 @@ class RuleBasedFieldMap(FieldMap):
     def key(self):
         """
         Gets the key of this RuleBasedFieldMap.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this RuleBasedFieldMap.
@@ -151,7 +151,7 @@ class RuleBasedFieldMap(FieldMap):
     def key(self, key):
         """
         Sets the key of this RuleBasedFieldMap.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this RuleBasedFieldMap.
@@ -163,7 +163,7 @@ class RuleBasedFieldMap(FieldMap):
     def model_version(self):
         """
         Gets the model_version of this RuleBasedFieldMap.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this RuleBasedFieldMap.
@@ -175,7 +175,7 @@ class RuleBasedFieldMap(FieldMap):
     def model_version(self, model_version):
         """
         Sets the model_version of this RuleBasedFieldMap.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this RuleBasedFieldMap.

--- a/src/oci/data_integration/models/rule_type_config.py
+++ b/src/oci/data_integration/models/rule_type_config.py
@@ -165,7 +165,7 @@ class RuleTypeConfig(DynamicTypeHandler):
     def scope(self):
         """
         Gets the scope of this RuleTypeConfig.
-        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a `TypedObject` or a full `TypedObject` definition.
 
 
         :return: The scope of this RuleTypeConfig.
@@ -177,7 +177,7 @@ class RuleTypeConfig(DynamicTypeHandler):
     def scope(self, scope):
         """
         Sets the scope of this RuleTypeConfig.
-        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a `TypedObject` or a full `TypedObject` definition.
 
 
         :param scope: The scope of this RuleTypeConfig.
@@ -189,7 +189,7 @@ class RuleTypeConfig(DynamicTypeHandler):
     def is_order_by_rule(self):
         """
         Gets the is_order_by_rule of this RuleTypeConfig.
-        orderByRule
+        Specifies whether it is ordered by rule.
 
 
         :return: The is_order_by_rule of this RuleTypeConfig.
@@ -201,7 +201,7 @@ class RuleTypeConfig(DynamicTypeHandler):
     def is_order_by_rule(self, is_order_by_rule):
         """
         Sets the is_order_by_rule of this RuleTypeConfig.
-        orderByRule
+        Specifies whether it is ordered by rule.
 
 
         :param is_order_by_rule: The is_order_by_rule of this RuleTypeConfig.
@@ -213,7 +213,7 @@ class RuleTypeConfig(DynamicTypeHandler):
     def projection_rules(self):
         """
         Gets the projection_rules of this RuleTypeConfig.
-        projectionRules
+        The projection rules.
 
 
         :return: The projection_rules of this RuleTypeConfig.
@@ -225,7 +225,7 @@ class RuleTypeConfig(DynamicTypeHandler):
     def projection_rules(self, projection_rules):
         """
         Sets the projection_rules of this RuleTypeConfig.
-        projectionRules
+        The projection rules.
 
 
         :param projection_rules: The projection_rules of this RuleTypeConfig.

--- a/src/oci/data_integration/models/schema.py
+++ b/src/oci/data_integration/models/schema.py
@@ -38,6 +38,10 @@ class Schema(object):
             The value to assign to the name property of this Schema.
         :type name: str
 
+        :param resource_name:
+            The value to assign to the resource_name property of this Schema.
+        :type resource_name: str
+
         :param description:
             The value to assign to the description property of this Schema.
         :type description: str
@@ -77,6 +81,7 @@ class Schema(object):
             'model_version': 'str',
             'parent_ref': 'ParentReference',
             'name': 'str',
+            'resource_name': 'str',
             'description': 'str',
             'object_version': 'int',
             'external_key': 'str',
@@ -93,6 +98,7 @@ class Schema(object):
             'model_version': 'modelVersion',
             'parent_ref': 'parentRef',
             'name': 'name',
+            'resource_name': 'resourceName',
             'description': 'description',
             'object_version': 'objectVersion',
             'external_key': 'externalKey',
@@ -108,6 +114,7 @@ class Schema(object):
         self._model_version = None
         self._parent_ref = None
         self._name = None
+        self._resource_name = None
         self._description = None
         self._object_version = None
         self._external_key = None
@@ -121,7 +128,7 @@ class Schema(object):
     def key(self):
         """
         Gets the key of this Schema.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this Schema.
@@ -133,7 +140,7 @@ class Schema(object):
     def key(self, key):
         """
         Sets the key of this Schema.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this Schema.
@@ -145,7 +152,7 @@ class Schema(object):
     def model_type(self):
         """
         Gets the model_type of this Schema.
-        The type of the object.
+        The object's type.
 
 
         :return: The model_type of this Schema.
@@ -157,7 +164,7 @@ class Schema(object):
     def model_type(self, model_type):
         """
         Sets the model_type of this Schema.
-        The type of the object.
+        The object's type.
 
 
         :param model_type: The model_type of this Schema.
@@ -169,7 +176,7 @@ class Schema(object):
     def model_version(self):
         """
         Gets the model_version of this Schema.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this Schema.
@@ -181,7 +188,7 @@ class Schema(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this Schema.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this Schema.
@@ -213,7 +220,7 @@ class Schema(object):
     def name(self):
         """
         Gets the name of this Schema.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this Schema.
@@ -225,7 +232,7 @@ class Schema(object):
     def name(self, name):
         """
         Sets the name of this Schema.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this Schema.
@@ -234,10 +241,34 @@ class Schema(object):
         self._name = name
 
     @property
+    def resource_name(self):
+        """
+        Gets the resource_name of this Schema.
+        A resource name can have letters, numbers, and special characters. The value is editable and is restricted to 4000 characters.
+
+
+        :return: The resource_name of this Schema.
+        :rtype: str
+        """
+        return self._resource_name
+
+    @resource_name.setter
+    def resource_name(self, resource_name):
+        """
+        Sets the resource_name of this Schema.
+        A resource name can have letters, numbers, and special characters. The value is editable and is restricted to 4000 characters.
+
+
+        :param resource_name: The resource_name of this Schema.
+        :type: str
+        """
+        self._resource_name = resource_name
+
+    @property
     def description(self):
         """
         Gets the description of this Schema.
-        Detailed description for the object.
+        User-defined description for the schema.
 
 
         :return: The description of this Schema.
@@ -249,7 +280,7 @@ class Schema(object):
     def description(self, description):
         """
         Sets the description of this Schema.
-        Detailed description for the object.
+        User-defined description for the schema.
 
 
         :param description: The description of this Schema.
@@ -309,7 +340,7 @@ class Schema(object):
     def is_has_containers(self):
         """
         Gets the is_has_containers of this Schema.
-        hasContainers
+        Specifies whether the schema has containers.
 
 
         :return: The is_has_containers of this Schema.
@@ -321,7 +352,7 @@ class Schema(object):
     def is_has_containers(self, is_has_containers):
         """
         Sets the is_has_containers of this Schema.
-        hasContainers
+        Specifies whether the schema has containers.
 
 
         :param is_has_containers: The is_has_containers of this Schema.
@@ -333,7 +364,7 @@ class Schema(object):
     def default_connection(self):
         """
         Gets the default_connection of this Schema.
-        Connection key which is the default.
+        The default connection key.
 
 
         :return: The default_connection of this Schema.
@@ -345,7 +376,7 @@ class Schema(object):
     def default_connection(self, default_connection):
         """
         Sets the default_connection of this Schema.
-        Connection key which is the default.
+        The default connection key.
 
 
         :param default_connection: The default_connection of this Schema.
@@ -381,7 +412,7 @@ class Schema(object):
     def identifier(self):
         """
         Gets the identifier of this Schema.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this Schema.
@@ -393,7 +424,7 @@ class Schema(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this Schema.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this Schema.

--- a/src/oci/data_integration/models/schema_summary.py
+++ b/src/oci/data_integration/models/schema_summary.py
@@ -38,6 +38,10 @@ class SchemaSummary(object):
             The value to assign to the name property of this SchemaSummary.
         :type name: str
 
+        :param resource_name:
+            The value to assign to the resource_name property of this SchemaSummary.
+        :type resource_name: str
+
         :param description:
             The value to assign to the description property of this SchemaSummary.
         :type description: str
@@ -77,6 +81,7 @@ class SchemaSummary(object):
             'model_version': 'str',
             'parent_ref': 'ParentReference',
             'name': 'str',
+            'resource_name': 'str',
             'description': 'str',
             'object_version': 'int',
             'external_key': 'str',
@@ -93,6 +98,7 @@ class SchemaSummary(object):
             'model_version': 'modelVersion',
             'parent_ref': 'parentRef',
             'name': 'name',
+            'resource_name': 'resourceName',
             'description': 'description',
             'object_version': 'objectVersion',
             'external_key': 'externalKey',
@@ -108,6 +114,7 @@ class SchemaSummary(object):
         self._model_version = None
         self._parent_ref = None
         self._name = None
+        self._resource_name = None
         self._description = None
         self._object_version = None
         self._external_key = None
@@ -121,7 +128,7 @@ class SchemaSummary(object):
     def key(self):
         """
         Gets the key of this SchemaSummary.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this SchemaSummary.
@@ -133,7 +140,7 @@ class SchemaSummary(object):
     def key(self, key):
         """
         Sets the key of this SchemaSummary.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this SchemaSummary.
@@ -145,7 +152,7 @@ class SchemaSummary(object):
     def model_type(self):
         """
         Gets the model_type of this SchemaSummary.
-        The type of the object.
+        The object's type.
 
 
         :return: The model_type of this SchemaSummary.
@@ -157,7 +164,7 @@ class SchemaSummary(object):
     def model_type(self, model_type):
         """
         Sets the model_type of this SchemaSummary.
-        The type of the object.
+        The object's type.
 
 
         :param model_type: The model_type of this SchemaSummary.
@@ -169,7 +176,7 @@ class SchemaSummary(object):
     def model_version(self):
         """
         Gets the model_version of this SchemaSummary.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this SchemaSummary.
@@ -181,7 +188,7 @@ class SchemaSummary(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this SchemaSummary.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this SchemaSummary.
@@ -213,7 +220,7 @@ class SchemaSummary(object):
     def name(self):
         """
         Gets the name of this SchemaSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this SchemaSummary.
@@ -225,7 +232,7 @@ class SchemaSummary(object):
     def name(self, name):
         """
         Sets the name of this SchemaSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this SchemaSummary.
@@ -234,10 +241,34 @@ class SchemaSummary(object):
         self._name = name
 
     @property
+    def resource_name(self):
+        """
+        Gets the resource_name of this SchemaSummary.
+        A resource name can have letters, numbers, and special characters. The value is editable and is restricted to 4000 characters.
+
+
+        :return: The resource_name of this SchemaSummary.
+        :rtype: str
+        """
+        return self._resource_name
+
+    @resource_name.setter
+    def resource_name(self, resource_name):
+        """
+        Sets the resource_name of this SchemaSummary.
+        A resource name can have letters, numbers, and special characters. The value is editable and is restricted to 4000 characters.
+
+
+        :param resource_name: The resource_name of this SchemaSummary.
+        :type: str
+        """
+        self._resource_name = resource_name
+
+    @property
     def description(self):
         """
         Gets the description of this SchemaSummary.
-        Detailed description for the object.
+        User-defined description for the schema.
 
 
         :return: The description of this SchemaSummary.
@@ -249,7 +280,7 @@ class SchemaSummary(object):
     def description(self, description):
         """
         Sets the description of this SchemaSummary.
-        Detailed description for the object.
+        User-defined description for the schema.
 
 
         :param description: The description of this SchemaSummary.
@@ -309,7 +340,7 @@ class SchemaSummary(object):
     def is_has_containers(self):
         """
         Gets the is_has_containers of this SchemaSummary.
-        hasContainers
+        Specifies whether the schema has containers.
 
 
         :return: The is_has_containers of this SchemaSummary.
@@ -321,7 +352,7 @@ class SchemaSummary(object):
     def is_has_containers(self, is_has_containers):
         """
         Sets the is_has_containers of this SchemaSummary.
-        hasContainers
+        Specifies whether the schema has containers.
 
 
         :param is_has_containers: The is_has_containers of this SchemaSummary.
@@ -333,7 +364,7 @@ class SchemaSummary(object):
     def default_connection(self):
         """
         Gets the default_connection of this SchemaSummary.
-        Connection key which is the default.
+        The default connection key.
 
 
         :return: The default_connection of this SchemaSummary.
@@ -345,7 +376,7 @@ class SchemaSummary(object):
     def default_connection(self, default_connection):
         """
         Sets the default_connection of this SchemaSummary.
-        Connection key which is the default.
+        The default connection key.
 
 
         :param default_connection: The default_connection of this SchemaSummary.
@@ -381,7 +412,7 @@ class SchemaSummary(object):
     def identifier(self):
         """
         Gets the identifier of this SchemaSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this SchemaSummary.
@@ -393,7 +424,7 @@ class SchemaSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this SchemaSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this SchemaSummary.

--- a/src/oci/data_integration/models/schema_summary_collection.py
+++ b/src/oci/data_integration/models/schema_summary_collection.py
@@ -37,7 +37,7 @@ class SchemaSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this SchemaSummaryCollection.
-        The array of Schema summaries
+        The array of schema summaries.
 
 
         :return: The items of this SchemaSummaryCollection.
@@ -49,7 +49,7 @@ class SchemaSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this SchemaSummaryCollection.
-        The array of Schema summaries
+        The array of schema summaries.
 
 
         :param items: The items of this SchemaSummaryCollection.

--- a/src/oci/data_integration/models/shape.py
+++ b/src/oci/data_integration/models/shape.py
@@ -21,7 +21,7 @@ class Shape(TypedObject):
 
         :param model_type:
             The value to assign to the model_type property of this Shape.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 

--- a/src/oci/data_integration/models/shape_field.py
+++ b/src/oci/data_integration/models/shape_field.py
@@ -21,7 +21,7 @@ class ShapeField(TypedObject):
 
         :param model_type:
             The value to assign to the model_type property of this ShapeField.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/sort_key.py
+++ b/src/oci/data_integration/models/sort_key.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SortKey(object):
+    """
+    Sort key contains a set of sort key rules defining sorting algorithm.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SortKey object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param sort_rules:
+            The value to assign to the sort_rules property of this SortKey.
+        :type sort_rules: list[SortKeyRule]
+
+        """
+        self.swagger_types = {
+            'sort_rules': 'list[SortKeyRule]'
+        }
+
+        self.attribute_map = {
+            'sort_rules': 'sortRules'
+        }
+
+        self._sort_rules = None
+
+    @property
+    def sort_rules(self):
+        """
+        Gets the sort_rules of this SortKey.
+        The list of sort key rules.
+
+
+        :return: The sort_rules of this SortKey.
+        :rtype: list[SortKeyRule]
+        """
+        return self._sort_rules
+
+    @sort_rules.setter
+    def sort_rules(self, sort_rules):
+        """
+        Sets the sort_rules of this SortKey.
+        The list of sort key rules.
+
+
+        :param sort_rules: The sort_rules of this SortKey.
+        :type: list[SortKeyRule]
+        """
+        self._sort_rules = sort_rules
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/sort_key_rule.py
+++ b/src/oci/data_integration/models/sort_key_rule.py
@@ -1,0 +1,97 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SortKeyRule(object):
+    """
+    A rule to define the set of fields to sort by, and whether to sort by ascending or descending values.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SortKeyRule object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param wrapped_rule:
+            The value to assign to the wrapped_rule property of this SortKeyRule.
+        :type wrapped_rule: ProjectionRule
+
+        :param is_ascending:
+            The value to assign to the is_ascending property of this SortKeyRule.
+        :type is_ascending: bool
+
+        """
+        self.swagger_types = {
+            'wrapped_rule': 'ProjectionRule',
+            'is_ascending': 'bool'
+        }
+
+        self.attribute_map = {
+            'wrapped_rule': 'wrappedRule',
+            'is_ascending': 'isAscending'
+        }
+
+        self._wrapped_rule = None
+        self._is_ascending = None
+
+    @property
+    def wrapped_rule(self):
+        """
+        Gets the wrapped_rule of this SortKeyRule.
+
+        :return: The wrapped_rule of this SortKeyRule.
+        :rtype: ProjectionRule
+        """
+        return self._wrapped_rule
+
+    @wrapped_rule.setter
+    def wrapped_rule(self, wrapped_rule):
+        """
+        Sets the wrapped_rule of this SortKeyRule.
+
+        :param wrapped_rule: The wrapped_rule of this SortKeyRule.
+        :type: ProjectionRule
+        """
+        self._wrapped_rule = wrapped_rule
+
+    @property
+    def is_ascending(self):
+        """
+        Gets the is_ascending of this SortKeyRule.
+        Specifies if the sort key has ascending order.
+
+
+        :return: The is_ascending of this SortKeyRule.
+        :rtype: bool
+        """
+        return self._is_ascending
+
+    @is_ascending.setter
+    def is_ascending(self, is_ascending):
+        """
+        Sets the is_ascending of this SortKeyRule.
+        Specifies if the sort key has ascending order.
+
+
+        :param is_ascending: The is_ascending of this SortKeyRule.
+        :type: bool
+        """
+        self._is_ascending = is_ascending
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/sort_oper.py
+++ b/src/oci/data_integration/models/sort_oper.py
@@ -1,0 +1,160 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .operator import Operator
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SortOper(Operator):
+    """
+    The information about the sort operator.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SortOper object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.SortOper.model_type` attribute
+        of this class is ``SORT_OPERATOR`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this SortOper.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this SortOper.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this SortOper.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this SortOper.
+        :type parent_ref: ParentReference
+
+        :param name:
+            The value to assign to the name property of this SortOper.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this SortOper.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this SortOper.
+        :type object_version: int
+
+        :param input_ports:
+            The value to assign to the input_ports property of this SortOper.
+        :type input_ports: list[InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this SortOper.
+        :type output_ports: list[OutputPort]
+
+        :param object_status:
+            The value to assign to the object_status property of this SortOper.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this SortOper.
+        :type identifier: str
+
+        :param parameters:
+            The value to assign to the parameters property of this SortOper.
+        :type parameters: list[Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this SortOper.
+        :type op_config_values: ConfigValues
+
+        :param sort_key:
+            The value to assign to the sort_key property of this SortOper.
+        :type sort_key: SortKey
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'object_status': 'int',
+            'identifier': 'str',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'sort_key': 'SortKey'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'sort_key': 'sortKey'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._input_ports = None
+        self._output_ports = None
+        self._object_status = None
+        self._identifier = None
+        self._parameters = None
+        self._op_config_values = None
+        self._sort_key = None
+        self._model_type = 'SORT_OPERATOR'
+
+    @property
+    def sort_key(self):
+        """
+        Gets the sort_key of this SortOper.
+
+        :return: The sort_key of this SortOper.
+        :rtype: SortKey
+        """
+        return self._sort_key
+
+    @sort_key.setter
+    def sort_key(self, sort_key):
+        """
+        Sets the sort_key of this SortOper.
+
+        :param sort_key: The sort_key of this SortOper.
+        :type: SortKey
+        """
+        self._sort_key = sort_key
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/source.py
+++ b/src/oci/data_integration/models/source.py
@@ -21,7 +21,7 @@ class Source(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this Source.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 

--- a/src/oci/data_integration/models/source_application_info.py
+++ b/src/oci/data_integration/models/source_application_info.py
@@ -1,0 +1,163 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SourceApplicationInfo(object):
+    """
+    The information about the application.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SourceApplicationInfo object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param workspace_id:
+            The value to assign to the workspace_id property of this SourceApplicationInfo.
+        :type workspace_id: str
+
+        :param application_key:
+            The value to assign to the application_key property of this SourceApplicationInfo.
+        :type application_key: str
+
+        :param application_version:
+            The value to assign to the application_version property of this SourceApplicationInfo.
+        :type application_version: str
+
+        :param last_patch_key:
+            The value to assign to the last_patch_key property of this SourceApplicationInfo.
+        :type last_patch_key: str
+
+        """
+        self.swagger_types = {
+            'workspace_id': 'str',
+            'application_key': 'str',
+            'application_version': 'str',
+            'last_patch_key': 'str'
+        }
+
+        self.attribute_map = {
+            'workspace_id': 'workspaceId',
+            'application_key': 'applicationKey',
+            'application_version': 'applicationVersion',
+            'last_patch_key': 'lastPatchKey'
+        }
+
+        self._workspace_id = None
+        self._application_key = None
+        self._application_version = None
+        self._last_patch_key = None
+
+    @property
+    def workspace_id(self):
+        """
+        Gets the workspace_id of this SourceApplicationInfo.
+        The OCID of the workspace containing the application. This allows cross workspace deployment to publish an application from a different workspace into the current workspace specified in this operation.
+
+
+        :return: The workspace_id of this SourceApplicationInfo.
+        :rtype: str
+        """
+        return self._workspace_id
+
+    @workspace_id.setter
+    def workspace_id(self, workspace_id):
+        """
+        Sets the workspace_id of this SourceApplicationInfo.
+        The OCID of the workspace containing the application. This allows cross workspace deployment to publish an application from a different workspace into the current workspace specified in this operation.
+
+
+        :param workspace_id: The workspace_id of this SourceApplicationInfo.
+        :type: str
+        """
+        self._workspace_id = workspace_id
+
+    @property
+    def application_key(self):
+        """
+        Gets the application_key of this SourceApplicationInfo.
+        The source application key to use when creating the application.
+
+
+        :return: The application_key of this SourceApplicationInfo.
+        :rtype: str
+        """
+        return self._application_key
+
+    @application_key.setter
+    def application_key(self, application_key):
+        """
+        Sets the application_key of this SourceApplicationInfo.
+        The source application key to use when creating the application.
+
+
+        :param application_key: The application_key of this SourceApplicationInfo.
+        :type: str
+        """
+        self._application_key = application_key
+
+    @property
+    def application_version(self):
+        """
+        Gets the application_version of this SourceApplicationInfo.
+        The source application version of the application.
+
+
+        :return: The application_version of this SourceApplicationInfo.
+        :rtype: str
+        """
+        return self._application_version
+
+    @application_version.setter
+    def application_version(self, application_version):
+        """
+        Sets the application_version of this SourceApplicationInfo.
+        The source application version of the application.
+
+
+        :param application_version: The application_version of this SourceApplicationInfo.
+        :type: str
+        """
+        self._application_version = application_version
+
+    @property
+    def last_patch_key(self):
+        """
+        Gets the last_patch_key of this SourceApplicationInfo.
+        The last patch key for the application.
+
+
+        :return: The last_patch_key of this SourceApplicationInfo.
+        :rtype: str
+        """
+        return self._last_patch_key
+
+    @last_patch_key.setter
+    def last_patch_key(self, last_patch_key):
+        """
+        Sets the last_patch_key of this SourceApplicationInfo.
+        The last patch key for the application.
+
+
+        :param last_patch_key: The last_patch_key of this SourceApplicationInfo.
+        :type: str
+        """
+        self._last_patch_key = last_patch_key
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/structured_type.py
+++ b/src/oci/data_integration/models/structured_type.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class StructuredType(object):
     """
-    A StructuredType object represents a data type that exists in a physical data asset object such as a table column, but is more complex, for example an Oracle database OBJECT type.   It can be composed of multiple DataType objects.
+    A `StructuredType` object represents a data type that exists in a physical data asset object such as a table column, but is more complex. For example, an Oracle database `OBJECT` type. It can be composed of multiple `DataType` objects.
     """
 
     #: A constant which can be used with the dt_type property of a StructuredType.
@@ -87,7 +87,7 @@ class StructuredType(object):
     def dt_type(self):
         """
         Gets the dt_type of this StructuredType.
-        dtType
+        The data type.
 
         Allowed values for this property are: "PRIMITIVE", "STRUCTURED"
 
@@ -101,7 +101,7 @@ class StructuredType(object):
     def dt_type(self, dt_type):
         """
         Sets the dt_type of this StructuredType.
-        dtType
+        The data type.
 
 
         :param dt_type: The dt_type of this StructuredType.
@@ -119,7 +119,7 @@ class StructuredType(object):
     def type_system_name(self):
         """
         Gets the type_system_name of this StructuredType.
-        typeSystemName
+        The data type system name.
 
 
         :return: The type_system_name of this StructuredType.
@@ -131,7 +131,7 @@ class StructuredType(object):
     def type_system_name(self, type_system_name):
         """
         Sets the type_system_name of this StructuredType.
-        typeSystemName
+        The data type system name.
 
 
         :param type_system_name: The type_system_name of this StructuredType.

--- a/src/oci/data_integration/models/target.py
+++ b/src/oci/data_integration/models/target.py
@@ -45,7 +45,7 @@ class Target(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this Target.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 

--- a/src/oci/data_integration/models/task.py
+++ b/src/oci/data_integration/models/task.py
@@ -227,7 +227,7 @@ class Task(object):
     def model_version(self):
         """
         Gets the model_version of this Task.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this Task.
@@ -239,7 +239,7 @@ class Task(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this Task.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this Task.
@@ -271,7 +271,7 @@ class Task(object):
     def name(self):
         """
         Gets the name of this Task.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this Task.
@@ -283,7 +283,7 @@ class Task(object):
     def name(self, name):
         """
         Sets the name of this Task.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this Task.
@@ -367,7 +367,7 @@ class Task(object):
     def identifier(self):
         """
         Gets the identifier of this Task.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this Task.
@@ -379,7 +379,7 @@ class Task(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this Task.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this Task.
@@ -523,7 +523,7 @@ class Task(object):
     def key_map(self):
         """
         Gets the key_map of this Task.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this Task.
@@ -535,7 +535,7 @@ class Task(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this Task.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this Task.

--- a/src/oci/data_integration/models/task_run.py
+++ b/src/oci/data_integration/models/task_run.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class TaskRun(object):
     """
-    The information about TaskRun.
+    The information about a task run.
     """
 
     #: A constant which can be used with the status property of a TaskRun.
@@ -309,7 +309,7 @@ class TaskRun(object):
     def name(self):
         """
         Gets the name of this TaskRun.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this TaskRun.
@@ -321,7 +321,7 @@ class TaskRun(object):
     def name(self, name):
         """
         Sets the name of this TaskRun.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this TaskRun.
@@ -401,7 +401,7 @@ class TaskRun(object):
     def status(self):
         """
         Gets the status of this TaskRun.
-        status
+        The status of the task run.
 
         Allowed values for this property are: "NOT_STARTED", "QUEUED", "RUNNING", "TERMINATING", "TERMINATED", "SUCCESS", "ERROR", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -416,7 +416,7 @@ class TaskRun(object):
     def status(self, status):
         """
         Sets the status of this TaskRun.
-        status
+        The status of the task run.
 
 
         :param status: The status of this TaskRun.
@@ -431,7 +431,7 @@ class TaskRun(object):
     def start_time_millis(self):
         """
         Gets the start_time_millis of this TaskRun.
-        startTimeMillis
+        The start time.
 
 
         :return: The start_time_millis of this TaskRun.
@@ -443,7 +443,7 @@ class TaskRun(object):
     def start_time_millis(self, start_time_millis):
         """
         Sets the start_time_millis of this TaskRun.
-        startTimeMillis
+        The start time.
 
 
         :param start_time_millis: The start_time_millis of this TaskRun.
@@ -455,7 +455,7 @@ class TaskRun(object):
     def end_time_millis(self):
         """
         Gets the end_time_millis of this TaskRun.
-        endTimeMillis
+        The end time.
 
 
         :return: The end_time_millis of this TaskRun.
@@ -467,7 +467,7 @@ class TaskRun(object):
     def end_time_millis(self, end_time_millis):
         """
         Sets the end_time_millis of this TaskRun.
-        endTimeMillis
+        The end time.
 
 
         :param end_time_millis: The end_time_millis of this TaskRun.
@@ -479,7 +479,7 @@ class TaskRun(object):
     def last_updated(self):
         """
         Gets the last_updated of this TaskRun.
-        lastUpdated
+        The date and time the object was last updated.
 
 
         :return: The last_updated of this TaskRun.
@@ -491,7 +491,7 @@ class TaskRun(object):
     def last_updated(self, last_updated):
         """
         Sets the last_updated of this TaskRun.
-        lastUpdated
+        The date and time the object was last updated.
 
 
         :param last_updated: The last_updated of this TaskRun.
@@ -503,7 +503,7 @@ class TaskRun(object):
     def records_written(self):
         """
         Gets the records_written of this TaskRun.
-        Number of records processed in task run.
+        The number of records processed in the task run.
 
 
         :return: The records_written of this TaskRun.
@@ -515,7 +515,7 @@ class TaskRun(object):
     def records_written(self, records_written):
         """
         Sets the records_written of this TaskRun.
-        Number of records processed in task run.
+        The number of records processed in the task run.
 
 
         :param records_written: The records_written of this TaskRun.
@@ -527,7 +527,7 @@ class TaskRun(object):
     def bytes_processed(self):
         """
         Gets the bytes_processed of this TaskRun.
-        Number of bytes processed in task run.
+        The number of bytes processed in the task run.
 
 
         :return: The bytes_processed of this TaskRun.
@@ -539,7 +539,7 @@ class TaskRun(object):
     def bytes_processed(self, bytes_processed):
         """
         Sets the bytes_processed of this TaskRun.
-        Number of bytes processed in task run.
+        The number of bytes processed in the task run.
 
 
         :param bytes_processed: The bytes_processed of this TaskRun.
@@ -551,7 +551,7 @@ class TaskRun(object):
     def error_message(self):
         """
         Gets the error_message of this TaskRun.
-        Error message if status is ERROR
+        Contains an error message if status is `ERROR`.
 
 
         :return: The error_message of this TaskRun.
@@ -563,7 +563,7 @@ class TaskRun(object):
     def error_message(self, error_message):
         """
         Sets the error_message of this TaskRun.
-        Error message if status is ERROR
+        Contains an error message if status is `ERROR`.
 
 
         :param error_message: The error_message of this TaskRun.
@@ -575,7 +575,7 @@ class TaskRun(object):
     def opc_request_id(self):
         """
         Gets the opc_request_id of this TaskRun.
-        Opc request id of execution of task run
+        The OPC request ID of execution of the task run.
 
 
         :return: The opc_request_id of this TaskRun.
@@ -587,7 +587,7 @@ class TaskRun(object):
     def opc_request_id(self, opc_request_id):
         """
         Sets the opc_request_id of this TaskRun.
-        Opc request id of execution of task run
+        The OPC request ID of execution of the task run.
 
 
         :param opc_request_id: The opc_request_id of this TaskRun.
@@ -623,7 +623,7 @@ class TaskRun(object):
     def task_type(self):
         """
         Gets the task_type of this TaskRun.
-        The type of the task for the run.
+        The type of task run.
 
         Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -638,7 +638,7 @@ class TaskRun(object):
     def task_type(self, task_type):
         """
         Sets the task_type of this TaskRun.
-        The type of the task for the run.
+        The type of task run.
 
 
         :param task_type: The task_type of this TaskRun.
@@ -653,7 +653,7 @@ class TaskRun(object):
     def identifier(self):
         """
         Gets the identifier of this TaskRun.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this TaskRun.
@@ -665,7 +665,7 @@ class TaskRun(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this TaskRun.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this TaskRun.
@@ -697,7 +697,7 @@ class TaskRun(object):
     def key_map(self):
         """
         Gets the key_map of this TaskRun.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this TaskRun.
@@ -709,7 +709,7 @@ class TaskRun(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this TaskRun.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this TaskRun.

--- a/src/oci/data_integration/models/task_run_details.py
+++ b/src/oci/data_integration/models/task_run_details.py
@@ -189,7 +189,7 @@ class TaskRunDetails(object):
     def key(self):
         """
         Gets the key of this TaskRunDetails.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this TaskRunDetails.
@@ -201,7 +201,7 @@ class TaskRunDetails(object):
     def key(self, key):
         """
         Sets the key of this TaskRunDetails.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this TaskRunDetails.
@@ -213,7 +213,7 @@ class TaskRunDetails(object):
     def model_type(self):
         """
         Gets the model_type of this TaskRunDetails.
-        The type of the object.
+        The object type.
 
 
         :return: The model_type of this TaskRunDetails.
@@ -225,7 +225,7 @@ class TaskRunDetails(object):
     def model_type(self, model_type):
         """
         Sets the model_type of this TaskRunDetails.
-        The type of the object.
+        The object type.
 
 
         :param model_type: The model_type of this TaskRunDetails.
@@ -237,7 +237,7 @@ class TaskRunDetails(object):
     def model_version(self):
         """
         Gets the model_version of this TaskRunDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this TaskRunDetails.
@@ -249,7 +249,7 @@ class TaskRunDetails(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this TaskRunDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this TaskRunDetails.
@@ -281,7 +281,7 @@ class TaskRunDetails(object):
     def name(self):
         """
         Gets the name of this TaskRunDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this TaskRunDetails.
@@ -293,7 +293,7 @@ class TaskRunDetails(object):
     def name(self, name):
         """
         Sets the name of this TaskRunDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this TaskRunDetails.
@@ -383,7 +383,7 @@ class TaskRunDetails(object):
     def start_time_millis(self):
         """
         Gets the start_time_millis of this TaskRunDetails.
-        startTimeMillis
+        The task run start time.
 
 
         :return: The start_time_millis of this TaskRunDetails.
@@ -395,7 +395,7 @@ class TaskRunDetails(object):
     def start_time_millis(self, start_time_millis):
         """
         Sets the start_time_millis of this TaskRunDetails.
-        startTimeMillis
+        The task run start time.
 
 
         :param start_time_millis: The start_time_millis of this TaskRunDetails.
@@ -407,7 +407,7 @@ class TaskRunDetails(object):
     def end_time_millis(self):
         """
         Gets the end_time_millis of this TaskRunDetails.
-        endTimeMillis
+        The task run end time.
 
 
         :return: The end_time_millis of this TaskRunDetails.
@@ -419,7 +419,7 @@ class TaskRunDetails(object):
     def end_time_millis(self, end_time_millis):
         """
         Sets the end_time_millis of this TaskRunDetails.
-        endTimeMillis
+        The task run end time.
 
 
         :param end_time_millis: The end_time_millis of this TaskRunDetails.
@@ -431,7 +431,7 @@ class TaskRunDetails(object):
     def last_updated(self):
         """
         Gets the last_updated of this TaskRunDetails.
-        lastUpdated
+        The date and time the task run was last updated.
 
 
         :return: The last_updated of this TaskRunDetails.
@@ -443,7 +443,7 @@ class TaskRunDetails(object):
     def last_updated(self, last_updated):
         """
         Sets the last_updated of this TaskRunDetails.
-        lastUpdated
+        The date and time the task run was last updated.
 
 
         :param last_updated: The last_updated of this TaskRunDetails.
@@ -557,7 +557,7 @@ class TaskRunDetails(object):
     def identifier(self):
         """
         Gets the identifier of this TaskRunDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this TaskRunDetails.
@@ -569,7 +569,7 @@ class TaskRunDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this TaskRunDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this TaskRunDetails.

--- a/src/oci/data_integration/models/task_run_log_summary.py
+++ b/src/oci/data_integration/models/task_run_log_summary.py
@@ -37,7 +37,7 @@ class TaskRunLogSummary(object):
     def message(self):
         """
         Gets the message of this TaskRunLogSummary.
-        Human-readable log message.
+        A user-friendly log message.
 
 
         :return: The message of this TaskRunLogSummary.
@@ -49,7 +49,7 @@ class TaskRunLogSummary(object):
     def message(self, message):
         """
         Sets the message of this TaskRunLogSummary.
-        Human-readable log message.
+        A user-friendly log message.
 
 
         :param message: The message of this TaskRunLogSummary.

--- a/src/oci/data_integration/models/task_run_summary.py
+++ b/src/oci/data_integration/models/task_run_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class TaskRunSummary(object):
     """
-    The information about TaskRun.
+    The information about a task run.
     """
 
     #: A constant which can be used with the status property of a TaskRunSummary.
@@ -189,7 +189,7 @@ class TaskRunSummary(object):
     def key(self):
         """
         Gets the key of this TaskRunSummary.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this TaskRunSummary.
@@ -201,7 +201,7 @@ class TaskRunSummary(object):
     def key(self, key):
         """
         Sets the key of this TaskRunSummary.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this TaskRunSummary.
@@ -213,7 +213,7 @@ class TaskRunSummary(object):
     def model_type(self):
         """
         Gets the model_type of this TaskRunSummary.
-        The type of the object.
+        The object type.
 
 
         :return: The model_type of this TaskRunSummary.
@@ -225,7 +225,7 @@ class TaskRunSummary(object):
     def model_type(self, model_type):
         """
         Sets the model_type of this TaskRunSummary.
-        The type of the object.
+        The object type.
 
 
         :param model_type: The model_type of this TaskRunSummary.
@@ -237,7 +237,7 @@ class TaskRunSummary(object):
     def model_version(self):
         """
         Gets the model_version of this TaskRunSummary.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this TaskRunSummary.
@@ -249,7 +249,7 @@ class TaskRunSummary(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this TaskRunSummary.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this TaskRunSummary.
@@ -281,7 +281,7 @@ class TaskRunSummary(object):
     def name(self):
         """
         Gets the name of this TaskRunSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this TaskRunSummary.
@@ -293,7 +293,7 @@ class TaskRunSummary(object):
     def name(self, name):
         """
         Sets the name of this TaskRunSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this TaskRunSummary.
@@ -383,7 +383,7 @@ class TaskRunSummary(object):
     def start_time_millis(self):
         """
         Gets the start_time_millis of this TaskRunSummary.
-        startTimeMillis
+        The task run start time.
 
 
         :return: The start_time_millis of this TaskRunSummary.
@@ -395,7 +395,7 @@ class TaskRunSummary(object):
     def start_time_millis(self, start_time_millis):
         """
         Sets the start_time_millis of this TaskRunSummary.
-        startTimeMillis
+        The task run start time.
 
 
         :param start_time_millis: The start_time_millis of this TaskRunSummary.
@@ -407,7 +407,7 @@ class TaskRunSummary(object):
     def end_time_millis(self):
         """
         Gets the end_time_millis of this TaskRunSummary.
-        endTimeMillis
+        The task run end time.
 
 
         :return: The end_time_millis of this TaskRunSummary.
@@ -419,7 +419,7 @@ class TaskRunSummary(object):
     def end_time_millis(self, end_time_millis):
         """
         Sets the end_time_millis of this TaskRunSummary.
-        endTimeMillis
+        The task run end time.
 
 
         :param end_time_millis: The end_time_millis of this TaskRunSummary.
@@ -431,7 +431,7 @@ class TaskRunSummary(object):
     def last_updated(self):
         """
         Gets the last_updated of this TaskRunSummary.
-        lastUpdated
+        The date and time the task run was last updated.
 
 
         :return: The last_updated of this TaskRunSummary.
@@ -443,7 +443,7 @@ class TaskRunSummary(object):
     def last_updated(self, last_updated):
         """
         Sets the last_updated of this TaskRunSummary.
-        lastUpdated
+        The date and time the task run was last updated.
 
 
         :param last_updated: The last_updated of this TaskRunSummary.
@@ -557,7 +557,7 @@ class TaskRunSummary(object):
     def identifier(self):
         """
         Gets the identifier of this TaskRunSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this TaskRunSummary.
@@ -569,7 +569,7 @@ class TaskRunSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this TaskRunSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this TaskRunSummary.

--- a/src/oci/data_integration/models/task_run_summary_collection.py
+++ b/src/oci/data_integration/models/task_run_summary_collection.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class TaskRunSummaryCollection(object):
     """
-    List of taskRun summaries
+    A list of task run summaries.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +37,7 @@ class TaskRunSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this TaskRunSummaryCollection.
-        The array of taskRun summaries
+        The array of task run summaries.
 
 
         :return: The items of this TaskRunSummaryCollection.
@@ -49,7 +49,7 @@ class TaskRunSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this TaskRunSummaryCollection.
-        The array of taskRun summaries
+        The array of task run summaries.
 
 
         :param items: The items of this TaskRunSummaryCollection.

--- a/src/oci/data_integration/models/task_summary.py
+++ b/src/oci/data_integration/models/task_summary.py
@@ -227,7 +227,7 @@ class TaskSummary(object):
     def model_version(self):
         """
         Gets the model_version of this TaskSummary.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this TaskSummary.
@@ -239,7 +239,7 @@ class TaskSummary(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this TaskSummary.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this TaskSummary.
@@ -271,7 +271,7 @@ class TaskSummary(object):
     def name(self):
         """
         Gets the name of this TaskSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this TaskSummary.
@@ -283,7 +283,7 @@ class TaskSummary(object):
     def name(self, name):
         """
         Sets the name of this TaskSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this TaskSummary.
@@ -367,7 +367,7 @@ class TaskSummary(object):
     def identifier(self):
         """
         Gets the identifier of this TaskSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this TaskSummary.
@@ -379,7 +379,7 @@ class TaskSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this TaskSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this TaskSummary.
@@ -523,7 +523,7 @@ class TaskSummary(object):
     def key_map(self):
         """
         Gets the key_map of this TaskSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :return: The key_map of this TaskSummary.
@@ -535,7 +535,7 @@ class TaskSummary(object):
     def key_map(self, key_map):
         """
         Sets the key_map of this TaskSummary.
-        A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+        A key map. If provided, key is replaced with generated key. This structure provides mapping between user provided key and generated key.
 
 
         :param key_map: The key_map of this TaskSummary.

--- a/src/oci/data_integration/models/task_summary_collection.py
+++ b/src/oci/data_integration/models/task_summary_collection.py
@@ -37,7 +37,7 @@ class TaskSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this TaskSummaryCollection.
-        The array of Task summaries.
+        The array of task summaries.
 
 
         :return: The items of this TaskSummaryCollection.
@@ -49,7 +49,7 @@ class TaskSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this TaskSummaryCollection.
-        The array of Task summaries.
+        The array of task summaries.
 
 
         :param items: The items of this TaskSummaryCollection.

--- a/src/oci/data_integration/models/task_validation.py
+++ b/src/oci/data_integration/models/task_validation.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class TaskValidation(object):
     """
-    The information about task validation
+    The information about task validation.
     """
 
     def __init__(self, **kwargs):
@@ -135,7 +135,7 @@ class TaskValidation(object):
     def total_message_count(self):
         """
         Gets the total_message_count of this TaskValidation.
-        Total number of validation messages
+        Total number of validation messages.
 
 
         :return: The total_message_count of this TaskValidation.
@@ -147,7 +147,7 @@ class TaskValidation(object):
     def total_message_count(self, total_message_count):
         """
         Sets the total_message_count of this TaskValidation.
-        Total number of validation messages
+        Total number of validation messages.
 
 
         :param total_message_count: The total_message_count of this TaskValidation.
@@ -159,7 +159,7 @@ class TaskValidation(object):
     def error_message_count(self):
         """
         Gets the error_message_count of this TaskValidation.
-        Total number of validation error messages
+        Total number of validation error messages.
 
 
         :return: The error_message_count of this TaskValidation.
@@ -171,7 +171,7 @@ class TaskValidation(object):
     def error_message_count(self, error_message_count):
         """
         Sets the error_message_count of this TaskValidation.
-        Total number of validation error messages
+        Total number of validation error messages.
 
 
         :param error_message_count: The error_message_count of this TaskValidation.
@@ -183,7 +183,7 @@ class TaskValidation(object):
     def warn_message_count(self):
         """
         Gets the warn_message_count of this TaskValidation.
-        Total number of validation warning messages
+        Total number of validation warning messages.
 
 
         :return: The warn_message_count of this TaskValidation.
@@ -195,7 +195,7 @@ class TaskValidation(object):
     def warn_message_count(self, warn_message_count):
         """
         Sets the warn_message_count of this TaskValidation.
-        Total number of validation warning messages
+        Total number of validation warning messages.
 
 
         :param warn_message_count: The warn_message_count of this TaskValidation.
@@ -207,7 +207,7 @@ class TaskValidation(object):
     def info_message_count(self):
         """
         Gets the info_message_count of this TaskValidation.
-        Total number of validation information messages
+        Total number of validation information messages.
 
 
         :return: The info_message_count of this TaskValidation.
@@ -219,7 +219,7 @@ class TaskValidation(object):
     def info_message_count(self, info_message_count):
         """
         Sets the info_message_count of this TaskValidation.
-        Total number of validation information messages
+        Total number of validation information messages.
 
 
         :param info_message_count: The info_message_count of this TaskValidation.
@@ -231,7 +231,7 @@ class TaskValidation(object):
     def validation_messages(self):
         """
         Gets the validation_messages of this TaskValidation.
-        Detailed information of the DataFlow object validation.
+        Detailed information of the data flow object validation.
 
 
         :return: The validation_messages of this TaskValidation.
@@ -243,7 +243,7 @@ class TaskValidation(object):
     def validation_messages(self, validation_messages):
         """
         Sets the validation_messages of this TaskValidation.
-        Detailed information of the DataFlow object validation.
+        Detailed information of the data flow object validation.
 
 
         :param validation_messages: The validation_messages of this TaskValidation.
@@ -255,7 +255,7 @@ class TaskValidation(object):
     def key(self):
         """
         Gets the key of this TaskValidation.
-        Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+        Objects use a 36 character key as unique ID. It is system generated and cannot be modified.
 
 
         :return: The key of this TaskValidation.
@@ -267,7 +267,7 @@ class TaskValidation(object):
     def key(self, key):
         """
         Sets the key of this TaskValidation.
-        Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+        Objects use a 36 character key as unique ID. It is system generated and cannot be modified.
 
 
         :param key: The key of this TaskValidation.
@@ -347,7 +347,7 @@ class TaskValidation(object):
     def name(self):
         """
         Gets the name of this TaskValidation.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this TaskValidation.
@@ -359,7 +359,7 @@ class TaskValidation(object):
     def name(self, name):
         """
         Sets the name of this TaskValidation.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this TaskValidation.
@@ -443,7 +443,7 @@ class TaskValidation(object):
     def identifier(self):
         """
         Gets the identifier of this TaskValidation.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this TaskValidation.
@@ -455,7 +455,7 @@ class TaskValidation(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this TaskValidation.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this TaskValidation.

--- a/src/oci/data_integration/models/task_validation_summary.py
+++ b/src/oci/data_integration/models/task_validation_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class TaskValidationSummary(object):
     """
-    The information about task validation
+    The information about task validation.
     """
 
     def __init__(self, **kwargs):
@@ -135,7 +135,7 @@ class TaskValidationSummary(object):
     def total_message_count(self):
         """
         Gets the total_message_count of this TaskValidationSummary.
-        Total number of validation messages
+        Total number of validation messages.
 
 
         :return: The total_message_count of this TaskValidationSummary.
@@ -147,7 +147,7 @@ class TaskValidationSummary(object):
     def total_message_count(self, total_message_count):
         """
         Sets the total_message_count of this TaskValidationSummary.
-        Total number of validation messages
+        Total number of validation messages.
 
 
         :param total_message_count: The total_message_count of this TaskValidationSummary.
@@ -159,7 +159,7 @@ class TaskValidationSummary(object):
     def error_message_count(self):
         """
         Gets the error_message_count of this TaskValidationSummary.
-        Total number of validation error messages
+        Total number of validation error messages.
 
 
         :return: The error_message_count of this TaskValidationSummary.
@@ -171,7 +171,7 @@ class TaskValidationSummary(object):
     def error_message_count(self, error_message_count):
         """
         Sets the error_message_count of this TaskValidationSummary.
-        Total number of validation error messages
+        Total number of validation error messages.
 
 
         :param error_message_count: The error_message_count of this TaskValidationSummary.
@@ -183,7 +183,7 @@ class TaskValidationSummary(object):
     def warn_message_count(self):
         """
         Gets the warn_message_count of this TaskValidationSummary.
-        Total number of validation warning messages
+        Total number of validation warning messages.
 
 
         :return: The warn_message_count of this TaskValidationSummary.
@@ -195,7 +195,7 @@ class TaskValidationSummary(object):
     def warn_message_count(self, warn_message_count):
         """
         Sets the warn_message_count of this TaskValidationSummary.
-        Total number of validation warning messages
+        Total number of validation warning messages.
 
 
         :param warn_message_count: The warn_message_count of this TaskValidationSummary.
@@ -207,7 +207,7 @@ class TaskValidationSummary(object):
     def info_message_count(self):
         """
         Gets the info_message_count of this TaskValidationSummary.
-        Total number of validation information messages
+        Total number of validation information messages.
 
 
         :return: The info_message_count of this TaskValidationSummary.
@@ -219,7 +219,7 @@ class TaskValidationSummary(object):
     def info_message_count(self, info_message_count):
         """
         Sets the info_message_count of this TaskValidationSummary.
-        Total number of validation information messages
+        Total number of validation information messages.
 
 
         :param info_message_count: The info_message_count of this TaskValidationSummary.
@@ -231,7 +231,7 @@ class TaskValidationSummary(object):
     def validation_messages(self):
         """
         Gets the validation_messages of this TaskValidationSummary.
-        Detailed information of the DataFlow object validation.
+        Detailed information of the data flow object validation.
 
 
         :return: The validation_messages of this TaskValidationSummary.
@@ -243,7 +243,7 @@ class TaskValidationSummary(object):
     def validation_messages(self, validation_messages):
         """
         Sets the validation_messages of this TaskValidationSummary.
-        Detailed information of the DataFlow object validation.
+        Detailed information of the data flow object validation.
 
 
         :param validation_messages: The validation_messages of this TaskValidationSummary.
@@ -255,7 +255,7 @@ class TaskValidationSummary(object):
     def key(self):
         """
         Gets the key of this TaskValidationSummary.
-        Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+        Objects use a 36 character key as unique ID. It is system generated and cannot be modified.
 
 
         :return: The key of this TaskValidationSummary.
@@ -267,7 +267,7 @@ class TaskValidationSummary(object):
     def key(self, key):
         """
         Sets the key of this TaskValidationSummary.
-        Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+        Objects use a 36 character key as unique ID. It is system generated and cannot be modified.
 
 
         :param key: The key of this TaskValidationSummary.
@@ -347,7 +347,7 @@ class TaskValidationSummary(object):
     def name(self):
         """
         Gets the name of this TaskValidationSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this TaskValidationSummary.
@@ -359,7 +359,7 @@ class TaskValidationSummary(object):
     def name(self, name):
         """
         Sets the name of this TaskValidationSummary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this TaskValidationSummary.
@@ -443,7 +443,7 @@ class TaskValidationSummary(object):
     def identifier(self):
         """
         Gets the identifier of this TaskValidationSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this TaskValidationSummary.
@@ -455,7 +455,7 @@ class TaskValidationSummary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this TaskValidationSummary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this TaskValidationSummary.

--- a/src/oci/data_integration/models/task_validation_summary_collection.py
+++ b/src/oci/data_integration/models/task_validation_summary_collection.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class TaskValidationSummaryCollection(object):
     """
-    List of task validation summaries
+    A list of task validation summaries.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +37,7 @@ class TaskValidationSummaryCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this TaskValidationSummaryCollection.
-        The array of validation summaries
+        An array of validation summaries.
 
 
         :return: The items of this TaskValidationSummaryCollection.
@@ -49,7 +49,7 @@ class TaskValidationSummaryCollection(object):
     def items(self, items):
         """
         Sets the items of this TaskValidationSummaryCollection.
-        The array of validation summaries
+        An array of validation summaries.
 
 
         :param items: The items of this TaskValidationSummaryCollection.

--- a/src/oci/data_integration/models/type_library.py
+++ b/src/oci/data_integration/models/type_library.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class TypeLibrary(object):
     """
-    The DIS type library container type.
+    The Data Integration type library container type.
     """
 
     def __init__(self, **kwargs):
@@ -192,7 +192,7 @@ class TypeLibrary(object):
     def name(self):
         """
         Gets the name of this TypeLibrary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this TypeLibrary.
@@ -204,7 +204,7 @@ class TypeLibrary(object):
     def name(self, name):
         """
         Sets the name of this TypeLibrary.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this TypeLibrary.
@@ -216,7 +216,7 @@ class TypeLibrary(object):
     def description(self):
         """
         Gets the description of this TypeLibrary.
-        Detailed description for the object.
+        A user defined description for the object.
 
 
         :return: The description of this TypeLibrary.
@@ -228,7 +228,7 @@ class TypeLibrary(object):
     def description(self, description):
         """
         Sets the description of this TypeLibrary.
-        Detailed description for the object.
+        A user defined description for the object.
 
 
         :param description: The description of this TypeLibrary.
@@ -312,7 +312,7 @@ class TypeLibrary(object):
     def identifier(self):
         """
         Gets the identifier of this TypeLibrary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this TypeLibrary.
@@ -324,7 +324,7 @@ class TypeLibrary(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this TypeLibrary.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this TypeLibrary.

--- a/src/oci/data_integration/models/type_list_rule.py
+++ b/src/oci/data_integration/models/type_list_rule.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class TypeListRule(ProjectionRule):
     """
-    The type list rule which defines how fields are projected.
+    The type list rule that defines how fields are projected.
     """
 
     #: A constant which can be used with the matching_strategy property of a TypeListRule.
@@ -103,7 +103,7 @@ class TypeListRule(ProjectionRule):
 
         :param types:
             The value to assign to the types property of this TypeListRule.
-        :type types: list[BaseType]
+        :type types: list[object]
 
         """
         self.swagger_types = {
@@ -121,7 +121,7 @@ class TypeListRule(ProjectionRule):
             'matching_strategy': 'str',
             'is_case_sensitive': 'bool',
             'rule_type': 'str',
-            'types': 'list[BaseType]'
+            'types': 'list[object]'
         }
 
         self.attribute_map = {
@@ -163,7 +163,7 @@ class TypeListRule(ProjectionRule):
     def is_skip_remaining_rules_on_match(self):
         """
         Gets the is_skip_remaining_rules_on_match of this TypeListRule.
-        skipRemainingRulesOnMatch
+        Specifies whether to skip remaining rules when a match is found.
 
 
         :return: The is_skip_remaining_rules_on_match of this TypeListRule.
@@ -175,7 +175,7 @@ class TypeListRule(ProjectionRule):
     def is_skip_remaining_rules_on_match(self, is_skip_remaining_rules_on_match):
         """
         Sets the is_skip_remaining_rules_on_match of this TypeListRule.
-        skipRemainingRulesOnMatch
+        Specifies whether to skip remaining rules when a match is found.
 
 
         :param is_skip_remaining_rules_on_match: The is_skip_remaining_rules_on_match of this TypeListRule.
@@ -187,7 +187,7 @@ class TypeListRule(ProjectionRule):
     def scope(self):
         """
         Gets the scope of this TypeListRule.
-        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+        Reference to a typed object. This can be either a key value to an object within the document, a shall referenced to a `TypedObject`, or a full `TypedObject` definition.
 
 
         :return: The scope of this TypeListRule.
@@ -199,7 +199,7 @@ class TypeListRule(ProjectionRule):
     def scope(self, scope):
         """
         Sets the scope of this TypeListRule.
-        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+        Reference to a typed object. This can be either a key value to an object within the document, a shall referenced to a `TypedObject`, or a full `TypedObject` definition.
 
 
         :param scope: The scope of this TypeListRule.
@@ -211,7 +211,7 @@ class TypeListRule(ProjectionRule):
     def is_cascade(self):
         """
         Gets the is_cascade of this TypeListRule.
-        cascade
+        Specifies whether to cascade or not.
 
 
         :return: The is_cascade of this TypeListRule.
@@ -223,7 +223,7 @@ class TypeListRule(ProjectionRule):
     def is_cascade(self, is_cascade):
         """
         Sets the is_cascade of this TypeListRule.
-        cascade
+        Specifies whether to cascade or not.
 
 
         :param is_cascade: The is_cascade of this TypeListRule.
@@ -235,7 +235,7 @@ class TypeListRule(ProjectionRule):
     def matching_strategy(self):
         """
         Gets the matching_strategy of this TypeListRule.
-        matchingStrategy
+        The pattern matching strategy.
 
         Allowed values for this property are: "NAME_OR_TAGS", "TAGS_ONLY", "NAME_ONLY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -250,7 +250,7 @@ class TypeListRule(ProjectionRule):
     def matching_strategy(self, matching_strategy):
         """
         Sets the matching_strategy of this TypeListRule.
-        matchingStrategy
+        The pattern matching strategy.
 
 
         :param matching_strategy: The matching_strategy of this TypeListRule.
@@ -265,7 +265,7 @@ class TypeListRule(ProjectionRule):
     def is_case_sensitive(self):
         """
         Gets the is_case_sensitive of this TypeListRule.
-        caseSensitive
+        Specifies if the rule is case sensitive.
 
 
         :return: The is_case_sensitive of this TypeListRule.
@@ -277,7 +277,7 @@ class TypeListRule(ProjectionRule):
     def is_case_sensitive(self, is_case_sensitive):
         """
         Sets the is_case_sensitive of this TypeListRule.
-        caseSensitive
+        Specifies if the rule is case sensitive.
 
 
         :param is_case_sensitive: The is_case_sensitive of this TypeListRule.
@@ -289,7 +289,7 @@ class TypeListRule(ProjectionRule):
     def rule_type(self):
         """
         Gets the rule_type of this TypeListRule.
-        ruleType
+        The rule type.
 
         Allowed values for this property are: "INCLUDE", "EXCLUDE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -304,7 +304,7 @@ class TypeListRule(ProjectionRule):
     def rule_type(self, rule_type):
         """
         Sets the rule_type of this TypeListRule.
-        ruleType
+        The rule type.
 
 
         :param rule_type: The rule_type of this TypeListRule.
@@ -319,11 +319,11 @@ class TypeListRule(ProjectionRule):
     def types(self):
         """
         Gets the types of this TypeListRule.
-        types
+        An arry of types.
 
 
         :return: The types of this TypeListRule.
-        :rtype: list[BaseType]
+        :rtype: list[object]
         """
         return self._types
 
@@ -331,11 +331,11 @@ class TypeListRule(ProjectionRule):
     def types(self, types):
         """
         Sets the types of this TypeListRule.
-        types
+        An arry of types.
 
 
         :param types: The types of this TypeListRule.
-        :type: list[BaseType]
+        :type: list[object]
         """
         self._types = types
 

--- a/src/oci/data_integration/models/type_system.py
+++ b/src/oci/data_integration/models/type_system.py
@@ -206,7 +206,7 @@ class TypeSystem(object):
     def name(self):
         """
         Gets the name of this TypeSystem.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this TypeSystem.
@@ -218,7 +218,7 @@ class TypeSystem(object):
     def name(self, name):
         """
         Sets the name of this TypeSystem.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this TypeSystem.
@@ -230,7 +230,7 @@ class TypeSystem(object):
     def description(self):
         """
         Gets the description of this TypeSystem.
-        Detailed description for the object.
+        A user defined description for the object.
 
 
         :return: The description of this TypeSystem.
@@ -242,7 +242,7 @@ class TypeSystem(object):
     def description(self, description):
         """
         Sets the description of this TypeSystem.
-        Detailed description for the object.
+        A user defined description for the object.
 
 
         :param description: The description of this TypeSystem.
@@ -278,7 +278,7 @@ class TypeSystem(object):
     def type_mapping_to(self):
         """
         Gets the type_mapping_to of this TypeSystem.
-        typeMappingTo
+        The type system to map to.
 
 
         :return: The type_mapping_to of this TypeSystem.
@@ -290,7 +290,7 @@ class TypeSystem(object):
     def type_mapping_to(self, type_mapping_to):
         """
         Sets the type_mapping_to of this TypeSystem.
-        typeMappingTo
+        The type system to map to.
 
 
         :param type_mapping_to: The type_mapping_to of this TypeSystem.
@@ -302,7 +302,7 @@ class TypeSystem(object):
     def type_mapping_from(self):
         """
         Gets the type_mapping_from of this TypeSystem.
-        typeMappingFrom
+        The type system to map from.
 
 
         :return: The type_mapping_from of this TypeSystem.
@@ -314,7 +314,7 @@ class TypeSystem(object):
     def type_mapping_from(self, type_mapping_from):
         """
         Sets the type_mapping_from of this TypeSystem.
-        typeMappingFrom
+        The type system to map from.
 
 
         :param type_mapping_from: The type_mapping_from of this TypeSystem.
@@ -350,7 +350,7 @@ class TypeSystem(object):
     def identifier(self):
         """
         Gets the identifier of this TypeSystem.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this TypeSystem.
@@ -362,7 +362,7 @@ class TypeSystem(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this TypeSystem.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this TypeSystem.
@@ -374,7 +374,7 @@ class TypeSystem(object):
     def types(self):
         """
         Gets the types of this TypeSystem.
-        types
+        An array of types.
 
 
         :return: The types of this TypeSystem.
@@ -386,7 +386,7 @@ class TypeSystem(object):
     def types(self, types):
         """
         Sets the types of this TypeSystem.
-        types
+        An array of types.
 
 
         :param types: The types of this TypeSystem.

--- a/src/oci/data_integration/models/typed_name_pattern_rule.py
+++ b/src/oci/data_integration/models/typed_name_pattern_rule.py
@@ -75,7 +75,7 @@ class TypedNamePatternRule(ProjectionRule):
 
         :param types:
             The value to assign to the types property of this TypedNamePatternRule.
-        :type types: list[BaseType]
+        :type types: list[object]
 
         :param is_skip_remaining_rules_on_match:
             The value to assign to the is_skip_remaining_rules_on_match property of this TypedNamePatternRule.
@@ -105,6 +105,10 @@ class TypedNamePatternRule(ProjectionRule):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type rule_type: str
 
+        :param pattern:
+            The value to assign to the pattern property of this TypedNamePatternRule.
+        :type pattern: str
+
         :param names:
             The value to assign to the names property of this TypedNamePatternRule.
         :type names: list[str]
@@ -119,13 +123,14 @@ class TypedNamePatternRule(ProjectionRule):
             'config_values': 'ConfigValues',
             'object_status': 'int',
             'description': 'str',
-            'types': 'list[BaseType]',
+            'types': 'list[object]',
             'is_skip_remaining_rules_on_match': 'bool',
             'scope': 'object',
             'is_cascade': 'bool',
             'matching_strategy': 'str',
             'is_case_sensitive': 'bool',
             'rule_type': 'str',
+            'pattern': 'str',
             'names': 'list[str]'
         }
 
@@ -145,6 +150,7 @@ class TypedNamePatternRule(ProjectionRule):
             'matching_strategy': 'matchingStrategy',
             'is_case_sensitive': 'isCaseSensitive',
             'rule_type': 'ruleType',
+            'pattern': 'pattern',
             'names': 'names'
         }
 
@@ -163,6 +169,7 @@ class TypedNamePatternRule(ProjectionRule):
         self._matching_strategy = None
         self._is_case_sensitive = None
         self._rule_type = None
+        self._pattern = None
         self._names = None
         self._model_type = 'TYPED_NAME_PATTERN_RULE'
 
@@ -170,11 +177,11 @@ class TypedNamePatternRule(ProjectionRule):
     def types(self):
         """
         Gets the types of this TypedNamePatternRule.
-        types
+        An array of types.
 
 
         :return: The types of this TypedNamePatternRule.
-        :rtype: list[BaseType]
+        :rtype: list[object]
         """
         return self._types
 
@@ -182,11 +189,11 @@ class TypedNamePatternRule(ProjectionRule):
     def types(self, types):
         """
         Sets the types of this TypedNamePatternRule.
-        types
+        An array of types.
 
 
         :param types: The types of this TypedNamePatternRule.
-        :type: list[BaseType]
+        :type: list[object]
         """
         self._types = types
 
@@ -194,7 +201,7 @@ class TypedNamePatternRule(ProjectionRule):
     def is_skip_remaining_rules_on_match(self):
         """
         Gets the is_skip_remaining_rules_on_match of this TypedNamePatternRule.
-        skipRemainingRulesOnMatch
+        Specifies whether to skip remaining rules when a match is found.
 
 
         :return: The is_skip_remaining_rules_on_match of this TypedNamePatternRule.
@@ -206,7 +213,7 @@ class TypedNamePatternRule(ProjectionRule):
     def is_skip_remaining_rules_on_match(self, is_skip_remaining_rules_on_match):
         """
         Sets the is_skip_remaining_rules_on_match of this TypedNamePatternRule.
-        skipRemainingRulesOnMatch
+        Specifies whether to skip remaining rules when a match is found.
 
 
         :param is_skip_remaining_rules_on_match: The is_skip_remaining_rules_on_match of this TypedNamePatternRule.
@@ -218,7 +225,7 @@ class TypedNamePatternRule(ProjectionRule):
     def scope(self):
         """
         Gets the scope of this TypedNamePatternRule.
-        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+        Reference to a typed object. This can be either a key value to an object within the document, a shall referenced to a `TypedObject`, or a full `TypedObject` definition.
 
 
         :return: The scope of this TypedNamePatternRule.
@@ -230,7 +237,7 @@ class TypedNamePatternRule(ProjectionRule):
     def scope(self, scope):
         """
         Sets the scope of this TypedNamePatternRule.
-        Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+        Reference to a typed object. This can be either a key value to an object within the document, a shall referenced to a `TypedObject`, or a full `TypedObject` definition.
 
 
         :param scope: The scope of this TypedNamePatternRule.
@@ -242,7 +249,7 @@ class TypedNamePatternRule(ProjectionRule):
     def is_cascade(self):
         """
         Gets the is_cascade of this TypedNamePatternRule.
-        cascade
+        Specifies whether to cascade or not.
 
 
         :return: The is_cascade of this TypedNamePatternRule.
@@ -254,7 +261,7 @@ class TypedNamePatternRule(ProjectionRule):
     def is_cascade(self, is_cascade):
         """
         Sets the is_cascade of this TypedNamePatternRule.
-        cascade
+        Specifies whether to cascade or not.
 
 
         :param is_cascade: The is_cascade of this TypedNamePatternRule.
@@ -266,7 +273,7 @@ class TypedNamePatternRule(ProjectionRule):
     def matching_strategy(self):
         """
         Gets the matching_strategy of this TypedNamePatternRule.
-        matchingStrategy
+        The pattern matching strategy.
 
         Allowed values for this property are: "NAME_OR_TAGS", "TAGS_ONLY", "NAME_ONLY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -281,7 +288,7 @@ class TypedNamePatternRule(ProjectionRule):
     def matching_strategy(self, matching_strategy):
         """
         Sets the matching_strategy of this TypedNamePatternRule.
-        matchingStrategy
+        The pattern matching strategy.
 
 
         :param matching_strategy: The matching_strategy of this TypedNamePatternRule.
@@ -296,7 +303,7 @@ class TypedNamePatternRule(ProjectionRule):
     def is_case_sensitive(self):
         """
         Gets the is_case_sensitive of this TypedNamePatternRule.
-        caseSensitive
+        Specifies if the rule is case sensitive.
 
 
         :return: The is_case_sensitive of this TypedNamePatternRule.
@@ -308,7 +315,7 @@ class TypedNamePatternRule(ProjectionRule):
     def is_case_sensitive(self, is_case_sensitive):
         """
         Sets the is_case_sensitive of this TypedNamePatternRule.
-        caseSensitive
+        Specifies if the rule is case sensitive.
 
 
         :param is_case_sensitive: The is_case_sensitive of this TypedNamePatternRule.
@@ -320,7 +327,7 @@ class TypedNamePatternRule(ProjectionRule):
     def rule_type(self):
         """
         Gets the rule_type of this TypedNamePatternRule.
-        ruleType
+        The rule type.
 
         Allowed values for this property are: "INCLUDE", "EXCLUDE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -335,7 +342,7 @@ class TypedNamePatternRule(ProjectionRule):
     def rule_type(self, rule_type):
         """
         Sets the rule_type of this TypedNamePatternRule.
-        ruleType
+        The rule type.
 
 
         :param rule_type: The rule_type of this TypedNamePatternRule.
@@ -347,10 +354,34 @@ class TypedNamePatternRule(ProjectionRule):
         self._rule_type = rule_type
 
     @property
+    def pattern(self):
+        """
+        Gets the pattern of this TypedNamePatternRule.
+        The rule pattern.
+
+
+        :return: The pattern of this TypedNamePatternRule.
+        :rtype: str
+        """
+        return self._pattern
+
+    @pattern.setter
+    def pattern(self, pattern):
+        """
+        Sets the pattern of this TypedNamePatternRule.
+        The rule pattern.
+
+
+        :param pattern: The pattern of this TypedNamePatternRule.
+        :type: str
+        """
+        self._pattern = pattern
+
+    @property
     def names(self):
         """
         Gets the names of this TypedNamePatternRule.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The names of this TypedNamePatternRule.
@@ -362,7 +393,7 @@ class TypedNamePatternRule(ProjectionRule):
     def names(self, names):
         """
         Sets the names of this TypedNamePatternRule.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param names: The names of this TypedNamePatternRule.

--- a/src/oci/data_integration/models/typed_object.py
+++ b/src/oci/data_integration/models/typed_object.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class TypedObject(object):
     """
-    The TypedObject class is a base class for any model object that has a type.
+    The `TypedObject` class is a base class for any model object that has a type.
     """
 
     #: A constant which can be used with the model_type property of a TypedObject.
@@ -32,6 +32,10 @@ class TypedObject(object):
     #: A constant which can be used with the model_type property of a TypedObject.
     #: This constant has a value of "DERIVED_FIELD"
     MODEL_TYPE_DERIVED_FIELD = "DERIVED_FIELD"
+
+    #: A constant which can be used with the model_type property of a TypedObject.
+    #: This constant has a value of "MACRO_FIELD"
+    MODEL_TYPE_MACRO_FIELD = "MACRO_FIELD"
 
     #: A constant which can be used with the model_type property of a TypedObject.
     #: This constant has a value of "OUTPUT_FIELD"
@@ -73,6 +77,7 @@ class TypedObject(object):
         * :class:`~oci.data_integration.models.ShapeField`
         * :class:`~oci.data_integration.models.Parameter`
         * :class:`~oci.data_integration.models.OutputField`
+        * :class:`~oci.data_integration.models.MacroField`
         * :class:`~oci.data_integration.models.DerivedField`
         * :class:`~oci.data_integration.models.FlowPort`
 
@@ -80,8 +85,7 @@ class TypedObject(object):
 
         :param model_type:
             The value to assign to the model_type property of this TypedObject.
-            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER", 'UNKNOWN_ENUM_VALUE'.
-            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
         :type model_type: str
 
         :param key:
@@ -185,6 +189,9 @@ class TypedObject(object):
         if type == 'OUTPUT_FIELD':
             return 'OutputField'
 
+        if type == 'MACRO_FIELD':
+            return 'MacroField'
+
         if type == 'DERIVED_FIELD':
             return 'DerivedField'
 
@@ -199,8 +206,7 @@ class TypedObject(object):
         **[Required]** Gets the model_type of this TypedObject.
         The type of the types object.
 
-        Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER", 'UNKNOWN_ENUM_VALUE'.
-        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"
 
 
         :return: The model_type of this TypedObject.
@@ -218,9 +224,12 @@ class TypedObject(object):
         :param model_type: The model_type of this TypedObject.
         :type: str
         """
-        allowed_values = ["SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"]
+        allowed_values = ["SHAPE", "INPUT_PORT", "SHAPE_FIELD", "INPUT_FIELD", "DERIVED_FIELD", "MACRO_FIELD", "OUTPUT_FIELD", "DYNAMIC_PROXY_FIELD", "OUTPUT_PORT", "DYNAMIC_INPUT_FIELD", "PROXY_FIELD", "PARAMETER"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
-            model_type = 'UNKNOWN_ENUM_VALUE'
+            raise ValueError(
+                "Invalid value for `model_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
         self._model_type = model_type
 
     @property
@@ -339,7 +348,7 @@ class TypedObject(object):
     def name(self):
         """
         Gets the name of this TypedObject.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this TypedObject.
@@ -351,7 +360,7 @@ class TypedObject(object):
     def name(self, name):
         """
         Sets the name of this TypedObject.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this TypedObject.

--- a/src/oci/data_integration/models/ui_properties.py
+++ b/src/oci/data_integration/models/ui_properties.py
@@ -44,7 +44,7 @@ class UIProperties(object):
     def coordinate_x(self):
         """
         Gets the coordinate_x of this UIProperties.
-        coordinateX
+        The X coordinate of the object.
 
 
         :return: The coordinate_x of this UIProperties.
@@ -56,7 +56,7 @@ class UIProperties(object):
     def coordinate_x(self, coordinate_x):
         """
         Sets the coordinate_x of this UIProperties.
-        coordinateX
+        The X coordinate of the object.
 
 
         :param coordinate_x: The coordinate_x of this UIProperties.
@@ -68,7 +68,7 @@ class UIProperties(object):
     def coordinate_y(self):
         """
         Gets the coordinate_y of this UIProperties.
-        coordinateY
+        The Y coordinate of the object.
 
 
         :return: The coordinate_y of this UIProperties.
@@ -80,7 +80,7 @@ class UIProperties(object):
     def coordinate_y(self, coordinate_y):
         """
         Sets the coordinate_y of this UIProperties.
-        coordinateY
+        The Y coordinate of the object.
 
 
         :param coordinate_y: The coordinate_y of this UIProperties.

--- a/src/oci/data_integration/models/unique_key.py
+++ b/src/oci/data_integration/models/unique_key.py
@@ -83,7 +83,7 @@ class UniqueKey(Key):
     def key(self):
         """
         Gets the key of this UniqueKey.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this UniqueKey.
@@ -95,7 +95,7 @@ class UniqueKey(Key):
     def key(self, key):
         """
         Sets the key of this UniqueKey.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this UniqueKey.
@@ -107,7 +107,7 @@ class UniqueKey(Key):
     def model_version(self):
         """
         Gets the model_version of this UniqueKey.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this UniqueKey.
@@ -119,7 +119,7 @@ class UniqueKey(Key):
     def model_version(self, model_version):
         """
         Sets the model_version of this UniqueKey.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this UniqueKey.
@@ -151,7 +151,7 @@ class UniqueKey(Key):
     def name(self):
         """
         Gets the name of this UniqueKey.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this UniqueKey.
@@ -163,7 +163,7 @@ class UniqueKey(Key):
     def name(self, name):
         """
         Sets the name of this UniqueKey.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this UniqueKey.
@@ -175,7 +175,7 @@ class UniqueKey(Key):
     def attribute_refs(self):
         """
         Gets the attribute_refs of this UniqueKey.
-        attributeRefs
+        An array of attribute references.
 
 
         :return: The attribute_refs of this UniqueKey.
@@ -187,7 +187,7 @@ class UniqueKey(Key):
     def attribute_refs(self, attribute_refs):
         """
         Sets the attribute_refs of this UniqueKey.
-        attributeRefs
+        An array of attribute references.
 
 
         :param attribute_refs: The attribute_refs of this UniqueKey.

--- a/src/oci/data_integration/models/update_application_details.py
+++ b/src/oci/data_integration/models/update_application_details.py
@@ -131,7 +131,7 @@ class UpdateApplicationDetails(object):
     def model_type(self):
         """
         **[Required]** Gets the model_type of this UpdateApplicationDetails.
-        The type of the object.
+        The object type.
 
 
         :return: The model_type of this UpdateApplicationDetails.
@@ -143,7 +143,7 @@ class UpdateApplicationDetails(object):
     def model_type(self, model_type):
         """
         Sets the model_type of this UpdateApplicationDetails.
-        The type of the object.
+        The object type.
 
 
         :param model_type: The model_type of this UpdateApplicationDetails.
@@ -155,7 +155,7 @@ class UpdateApplicationDetails(object):
     def model_version(self):
         """
         Gets the model_version of this UpdateApplicationDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this UpdateApplicationDetails.
@@ -167,7 +167,7 @@ class UpdateApplicationDetails(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this UpdateApplicationDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this UpdateApplicationDetails.
@@ -179,7 +179,7 @@ class UpdateApplicationDetails(object):
     def name(self):
         """
         Gets the name of this UpdateApplicationDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this UpdateApplicationDetails.
@@ -191,7 +191,7 @@ class UpdateApplicationDetails(object):
     def name(self, name):
         """
         Sets the name of this UpdateApplicationDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this UpdateApplicationDetails.
@@ -275,7 +275,7 @@ class UpdateApplicationDetails(object):
     def identifier(self):
         """
         Gets the identifier of this UpdateApplicationDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this UpdateApplicationDetails.
@@ -287,7 +287,7 @@ class UpdateApplicationDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this UpdateApplicationDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this UpdateApplicationDetails.

--- a/src/oci/data_integration/models/update_connection_details.py
+++ b/src/oci/data_integration/models/update_connection_details.py
@@ -29,21 +29,31 @@ class UpdateConnectionDetails(object):
     #: This constant has a value of "ORACLEDB_CONNECTION"
     MODEL_TYPE_ORACLEDB_CONNECTION = "ORACLEDB_CONNECTION"
 
+    #: A constant which can be used with the model_type property of a UpdateConnectionDetails.
+    #: This constant has a value of "MYSQL_CONNECTION"
+    MODEL_TYPE_MYSQL_CONNECTION = "MYSQL_CONNECTION"
+
+    #: A constant which can be used with the model_type property of a UpdateConnectionDetails.
+    #: This constant has a value of "GENERIC_JDBC_CONNECTION"
+    MODEL_TYPE_GENERIC_JDBC_CONNECTION = "GENERIC_JDBC_CONNECTION"
+
     def __init__(self, **kwargs):
         """
         Initializes a new UpdateConnectionDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.data_integration.models.UpdateConnectionFromJdbc`
         * :class:`~oci.data_integration.models.UpdateConnectionFromObjectStorage`
         * :class:`~oci.data_integration.models.UpdateConnectionFromAtp`
         * :class:`~oci.data_integration.models.UpdateConnectionFromOracle`
         * :class:`~oci.data_integration.models.UpdateConnectionFromAdwc`
+        * :class:`~oci.data_integration.models.UpdateConnectionFromMySQL`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param model_type:
             The value to assign to the model_type property of this UpdateConnectionDetails.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:
@@ -135,6 +145,9 @@ class UpdateConnectionDetails(object):
         """
         type = object_dictionary['modelType']
 
+        if type == 'GENERIC_JDBC_CONNECTION':
+            return 'UpdateConnectionFromJdbc'
+
         if type == 'ORACLE_OBJECT_STORAGE_CONNECTION':
             return 'UpdateConnectionFromObjectStorage'
 
@@ -146,6 +159,9 @@ class UpdateConnectionDetails(object):
 
         if type == 'ORACLE_ADWC_CONNECTION':
             return 'UpdateConnectionFromAdwc'
+
+        if type == 'MYSQL_CONNECTION':
+            return 'UpdateConnectionFromMySQL'
         else:
             return 'UpdateConnectionDetails'
 
@@ -155,7 +171,7 @@ class UpdateConnectionDetails(object):
         **[Required]** Gets the model_type of this UpdateConnectionDetails.
         The type of the connection.
 
-        Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+        Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
 
 
         :return: The model_type of this UpdateConnectionDetails.
@@ -173,7 +189,7 @@ class UpdateConnectionDetails(object):
         :param model_type: The model_type of this UpdateConnectionDetails.
         :type: str
         """
-        allowed_values = ["ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"]
+        allowed_values = ["ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             raise ValueError(
                 "Invalid value for `model_type`, must be None or one of {0}"
@@ -253,7 +269,7 @@ class UpdateConnectionDetails(object):
     def name(self):
         """
         Gets the name of this UpdateConnectionDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this UpdateConnectionDetails.
@@ -265,7 +281,7 @@ class UpdateConnectionDetails(object):
     def name(self, name):
         """
         Sets the name of this UpdateConnectionDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this UpdateConnectionDetails.
@@ -277,7 +293,7 @@ class UpdateConnectionDetails(object):
     def description(self):
         """
         Gets the description of this UpdateConnectionDetails.
-        Detailed description for the object.
+        User-defined description for the connection.
 
 
         :return: The description of this UpdateConnectionDetails.
@@ -289,7 +305,7 @@ class UpdateConnectionDetails(object):
     def description(self, description):
         """
         Sets the description of this UpdateConnectionDetails.
-        Detailed description for the object.
+        User-defined description for the connection.
 
 
         :param description: The description of this UpdateConnectionDetails.
@@ -349,7 +365,7 @@ class UpdateConnectionDetails(object):
     def identifier(self):
         """
         Gets the identifier of this UpdateConnectionDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this UpdateConnectionDetails.
@@ -361,7 +377,7 @@ class UpdateConnectionDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this UpdateConnectionDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this UpdateConnectionDetails.

--- a/src/oci/data_integration/models/update_connection_from_adwc.py
+++ b/src/oci/data_integration/models/update_connection_from_adwc.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateConnectionFromAdwc(UpdateConnectionDetails):
     """
-    The ADWC connection details object.
+    The details to update an Autonomous Data Warehouse data asset connection.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class UpdateConnectionFromAdwc(UpdateConnectionDetails):
 
         :param model_type:
             The value to assign to the model_type property of this UpdateConnectionFromAdwc.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/update_connection_from_atp.py
+++ b/src/oci/data_integration/models/update_connection_from_atp.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateConnectionFromAtp(UpdateConnectionDetails):
     """
-    The ATP connection details.
+    The details to update an Autonomous Transaction Processing data asset connection.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class UpdateConnectionFromAtp(UpdateConnectionDetails):
 
         :param model_type:
             The value to assign to the model_type property of this UpdateConnectionFromAtp.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/update_connection_from_jdbc.py
+++ b/src/oci/data_integration/models/update_connection_from_jdbc.py
@@ -1,0 +1,181 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .update_connection_details import UpdateConnectionDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateConnectionFromJdbc(UpdateConnectionDetails):
+    """
+    The details to update a generic JDBC data asset connection.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateConnectionFromJdbc object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.UpdateConnectionFromJdbc.model_type` attribute
+        of this class is ``GENERIC_JDBC_CONNECTION`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this UpdateConnectionFromJdbc.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this UpdateConnectionFromJdbc.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this UpdateConnectionFromJdbc.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this UpdateConnectionFromJdbc.
+        :type parent_ref: ParentReference
+
+        :param name:
+            The value to assign to the name property of this UpdateConnectionFromJdbc.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this UpdateConnectionFromJdbc.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this UpdateConnectionFromJdbc.
+        :type object_status: int
+
+        :param object_version:
+            The value to assign to the object_version property of this UpdateConnectionFromJdbc.
+        :type object_version: int
+
+        :param identifier:
+            The value to assign to the identifier property of this UpdateConnectionFromJdbc.
+        :type identifier: str
+
+        :param connection_properties:
+            The value to assign to the connection_properties property of this UpdateConnectionFromJdbc.
+        :type connection_properties: list[ConnectionProperty]
+
+        :param registry_metadata:
+            The value to assign to the registry_metadata property of this UpdateConnectionFromJdbc.
+        :type registry_metadata: RegistryMetadata
+
+        :param username:
+            The value to assign to the username property of this UpdateConnectionFromJdbc.
+        :type username: str
+
+        :param password:
+            The value to assign to the password property of this UpdateConnectionFromJdbc.
+        :type password: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'object_version': 'int',
+            'identifier': 'str',
+            'connection_properties': 'list[ConnectionProperty]',
+            'registry_metadata': 'RegistryMetadata',
+            'username': 'str',
+            'password': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'object_version': 'objectVersion',
+            'identifier': 'identifier',
+            'connection_properties': 'connectionProperties',
+            'registry_metadata': 'registryMetadata',
+            'username': 'username',
+            'password': 'password'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._object_version = None
+        self._identifier = None
+        self._connection_properties = None
+        self._registry_metadata = None
+        self._username = None
+        self._password = None
+        self._model_type = 'GENERIC_JDBC_CONNECTION'
+
+    @property
+    def username(self):
+        """
+        Gets the username of this UpdateConnectionFromJdbc.
+        The user name for the connection.
+
+
+        :return: The username of this UpdateConnectionFromJdbc.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this UpdateConnectionFromJdbc.
+        The user name for the connection.
+
+
+        :param username: The username of this UpdateConnectionFromJdbc.
+        :type: str
+        """
+        self._username = username
+
+    @property
+    def password(self):
+        """
+        Gets the password of this UpdateConnectionFromJdbc.
+        The password for the connection.
+
+
+        :return: The password of this UpdateConnectionFromJdbc.
+        :rtype: str
+        """
+        return self._password
+
+    @password.setter
+    def password(self, password):
+        """
+        Sets the password of this UpdateConnectionFromJdbc.
+        The password for the connection.
+
+
+        :param password: The password of this UpdateConnectionFromJdbc.
+        :type: str
+        """
+        self._password = password
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/update_connection_from_my_sql.py
+++ b/src/oci/data_integration/models/update_connection_from_my_sql.py
@@ -1,0 +1,181 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .update_connection_details import UpdateConnectionDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateConnectionFromMySQL(UpdateConnectionDetails):
+    """
+    The details to update a MYSQL data asset connection.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateConnectionFromMySQL object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.UpdateConnectionFromMySQL.model_type` attribute
+        of this class is ``MYSQL_CONNECTION`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this UpdateConnectionFromMySQL.
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this UpdateConnectionFromMySQL.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this UpdateConnectionFromMySQL.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this UpdateConnectionFromMySQL.
+        :type parent_ref: ParentReference
+
+        :param name:
+            The value to assign to the name property of this UpdateConnectionFromMySQL.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this UpdateConnectionFromMySQL.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this UpdateConnectionFromMySQL.
+        :type object_status: int
+
+        :param object_version:
+            The value to assign to the object_version property of this UpdateConnectionFromMySQL.
+        :type object_version: int
+
+        :param identifier:
+            The value to assign to the identifier property of this UpdateConnectionFromMySQL.
+        :type identifier: str
+
+        :param connection_properties:
+            The value to assign to the connection_properties property of this UpdateConnectionFromMySQL.
+        :type connection_properties: list[ConnectionProperty]
+
+        :param registry_metadata:
+            The value to assign to the registry_metadata property of this UpdateConnectionFromMySQL.
+        :type registry_metadata: RegistryMetadata
+
+        :param username:
+            The value to assign to the username property of this UpdateConnectionFromMySQL.
+        :type username: str
+
+        :param password:
+            The value to assign to the password property of this UpdateConnectionFromMySQL.
+        :type password: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'object_version': 'int',
+            'identifier': 'str',
+            'connection_properties': 'list[ConnectionProperty]',
+            'registry_metadata': 'RegistryMetadata',
+            'username': 'str',
+            'password': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'object_version': 'objectVersion',
+            'identifier': 'identifier',
+            'connection_properties': 'connectionProperties',
+            'registry_metadata': 'registryMetadata',
+            'username': 'username',
+            'password': 'password'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._object_version = None
+        self._identifier = None
+        self._connection_properties = None
+        self._registry_metadata = None
+        self._username = None
+        self._password = None
+        self._model_type = 'MYSQL_CONNECTION'
+
+    @property
+    def username(self):
+        """
+        Gets the username of this UpdateConnectionFromMySQL.
+        The user name for the connection.
+
+
+        :return: The username of this UpdateConnectionFromMySQL.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this UpdateConnectionFromMySQL.
+        The user name for the connection.
+
+
+        :param username: The username of this UpdateConnectionFromMySQL.
+        :type: str
+        """
+        self._username = username
+
+    @property
+    def password(self):
+        """
+        Gets the password of this UpdateConnectionFromMySQL.
+        The password for the connection.
+
+
+        :return: The password of this UpdateConnectionFromMySQL.
+        :rtype: str
+        """
+        return self._password
+
+    @password.setter
+    def password(self, password):
+        """
+        Sets the password of this UpdateConnectionFromMySQL.
+        The password for the connection.
+
+
+        :param password: The password of this UpdateConnectionFromMySQL.
+        :type: str
+        """
+        self._password = password
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/update_connection_from_object_storage.py
+++ b/src/oci/data_integration/models/update_connection_from_object_storage.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateConnectionFromObjectStorage(UpdateConnectionDetails):
     """
-    The Object Storage connection details.
+    The details to update an Oracle Object Storage data asset connection.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class UpdateConnectionFromObjectStorage(UpdateConnectionDetails):
 
         :param model_type:
             The value to assign to the model_type property of this UpdateConnectionFromObjectStorage.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:
@@ -138,7 +138,7 @@ class UpdateConnectionFromObjectStorage(UpdateConnectionDetails):
     def credential_file_content(self):
         """
         Gets the credential_file_content of this UpdateConnectionFromObjectStorage.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Oracle Object Storage wallet.
 
 
         :return: The credential_file_content of this UpdateConnectionFromObjectStorage.
@@ -150,7 +150,7 @@ class UpdateConnectionFromObjectStorage(UpdateConnectionDetails):
     def credential_file_content(self, credential_file_content):
         """
         Sets the credential_file_content of this UpdateConnectionFromObjectStorage.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Oracle Object Storage wallet.
 
 
         :param credential_file_content: The credential_file_content of this UpdateConnectionFromObjectStorage.
@@ -186,7 +186,7 @@ class UpdateConnectionFromObjectStorage(UpdateConnectionDetails):
     def finger_print(self):
         """
         Gets the finger_print of this UpdateConnectionFromObjectStorage.
-        The fingeprint for the user.
+        The fingerprint for the user.
 
 
         :return: The finger_print of this UpdateConnectionFromObjectStorage.
@@ -198,7 +198,7 @@ class UpdateConnectionFromObjectStorage(UpdateConnectionDetails):
     def finger_print(self, finger_print):
         """
         Sets the finger_print of this UpdateConnectionFromObjectStorage.
-        The fingeprint for the user.
+        The fingerprint for the user.
 
 
         :param finger_print: The finger_print of this UpdateConnectionFromObjectStorage.
@@ -210,7 +210,7 @@ class UpdateConnectionFromObjectStorage(UpdateConnectionDetails):
     def pass_phrase(self):
         """
         Gets the pass_phrase of this UpdateConnectionFromObjectStorage.
-        The pass phrase for the connection.
+        The passphrase for the connection.
 
 
         :return: The pass_phrase of this UpdateConnectionFromObjectStorage.
@@ -222,7 +222,7 @@ class UpdateConnectionFromObjectStorage(UpdateConnectionDetails):
     def pass_phrase(self, pass_phrase):
         """
         Sets the pass_phrase of this UpdateConnectionFromObjectStorage.
-        The pass phrase for the connection.
+        The passphrase for the connection.
 
 
         :param pass_phrase: The pass_phrase of this UpdateConnectionFromObjectStorage.

--- a/src/oci/data_integration/models/update_connection_from_oracle.py
+++ b/src/oci/data_integration/models/update_connection_from_oracle.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateConnectionFromOracle(UpdateConnectionDetails):
     """
-    The Oracle connection details object.
+    The details to update an Oracle Database data asset connection.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class UpdateConnectionFromOracle(UpdateConnectionDetails):
 
         :param model_type:
             The value to assign to the model_type property of this UpdateConnectionFromOracle.
-            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION"
+            Allowed values for this property are: "ORACLE_ADWC_CONNECTION", "ORACLE_ATP_CONNECTION", "ORACLE_OBJECT_STORAGE_CONNECTION", "ORACLEDB_CONNECTION", "MYSQL_CONNECTION", "GENERIC_JDBC_CONNECTION"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/update_data_asset_details.py
+++ b/src/oci/data_integration/models/update_data_asset_details.py
@@ -29,6 +29,14 @@ class UpdateDataAssetDetails(object):
     #: This constant has a value of "ORACLE_ADWC_DATA_ASSET"
     MODEL_TYPE_ORACLE_ADWC_DATA_ASSET = "ORACLE_ADWC_DATA_ASSET"
 
+    #: A constant which can be used with the model_type property of a UpdateDataAssetDetails.
+    #: This constant has a value of "MYSQL_DATA_ASSET"
+    MODEL_TYPE_MYSQL_DATA_ASSET = "MYSQL_DATA_ASSET"
+
+    #: A constant which can be used with the model_type property of a UpdateDataAssetDetails.
+    #: This constant has a value of "GENERIC_JDBC_DATA_ASSET"
+    MODEL_TYPE_GENERIC_JDBC_DATA_ASSET = "GENERIC_JDBC_DATA_ASSET"
+
     def __init__(self, **kwargs):
         """
         Initializes a new UpdateDataAssetDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
@@ -36,14 +44,16 @@ class UpdateDataAssetDetails(object):
 
         * :class:`~oci.data_integration.models.UpdateDataAssetFromAtp`
         * :class:`~oci.data_integration.models.UpdateDataAssetFromAdwc`
+        * :class:`~oci.data_integration.models.UpdateDataAssetFromJdbc`
         * :class:`~oci.data_integration.models.UpdateDataAssetFromObjectStorage`
+        * :class:`~oci.data_integration.models.UpdateDataAssetFromMySQL`
         * :class:`~oci.data_integration.models.UpdateDataAssetFromOracle`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param model_type:
             The value to assign to the model_type property of this UpdateDataAssetDetails.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -141,8 +151,14 @@ class UpdateDataAssetDetails(object):
         if type == 'ORACLE_ADWC_DATA_ASSET':
             return 'UpdateDataAssetFromAdwc'
 
+        if type == 'GENERIC_JDBC_DATA_ASSET':
+            return 'UpdateDataAssetFromJdbc'
+
         if type == 'ORACLE_OBJECT_STORAGE_DATA_ASSET':
             return 'UpdateDataAssetFromObjectStorage'
+
+        if type == 'MYSQL_DATA_ASSET':
+            return 'UpdateDataAssetFromMySQL'
 
         if type == 'ORACLE_DATA_ASSET':
             return 'UpdateDataAssetFromOracle'
@@ -155,7 +171,7 @@ class UpdateDataAssetDetails(object):
         **[Required]** Gets the model_type of this UpdateDataAssetDetails.
         The type of the data asset.
 
-        Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+        Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
 
 
         :return: The model_type of this UpdateDataAssetDetails.
@@ -173,7 +189,7 @@ class UpdateDataAssetDetails(object):
         :param model_type: The model_type of this UpdateDataAssetDetails.
         :type: str
         """
-        allowed_values = ["ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"]
+        allowed_values = ["ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             raise ValueError(
                 "Invalid value for `model_type`, must be None or one of {0}"
@@ -233,7 +249,7 @@ class UpdateDataAssetDetails(object):
     def name(self):
         """
         Gets the name of this UpdateDataAssetDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this UpdateDataAssetDetails.
@@ -245,7 +261,7 @@ class UpdateDataAssetDetails(object):
     def name(self, name):
         """
         Sets the name of this UpdateDataAssetDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this UpdateDataAssetDetails.
@@ -257,7 +273,7 @@ class UpdateDataAssetDetails(object):
     def description(self):
         """
         Gets the description of this UpdateDataAssetDetails.
-        Detailed description for the object.
+        The user-defined description of the data asset.
 
 
         :return: The description of this UpdateDataAssetDetails.
@@ -269,7 +285,7 @@ class UpdateDataAssetDetails(object):
     def description(self, description):
         """
         Sets the description of this UpdateDataAssetDetails.
-        Detailed description for the object.
+        The user-defined description of the data asset.
 
 
         :param description: The description of this UpdateDataAssetDetails.
@@ -329,7 +345,7 @@ class UpdateDataAssetDetails(object):
     def identifier(self):
         """
         Gets the identifier of this UpdateDataAssetDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this UpdateDataAssetDetails.
@@ -341,7 +357,7 @@ class UpdateDataAssetDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this UpdateDataAssetDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this UpdateDataAssetDetails.
@@ -353,7 +369,7 @@ class UpdateDataAssetDetails(object):
     def external_key(self):
         """
         Gets the external_key of this UpdateDataAssetDetails.
-        The external key for the object
+        The external key for the object.
 
 
         :return: The external_key of this UpdateDataAssetDetails.
@@ -365,7 +381,7 @@ class UpdateDataAssetDetails(object):
     def external_key(self, external_key):
         """
         Sets the external_key of this UpdateDataAssetDetails.
-        The external key for the object
+        The external key for the object.
 
 
         :param external_key: The external_key of this UpdateDataAssetDetails.
@@ -377,7 +393,7 @@ class UpdateDataAssetDetails(object):
     def asset_properties(self):
         """
         Gets the asset_properties of this UpdateDataAssetDetails.
-        assetProperties
+        Additional properties for the data asset.
 
 
         :return: The asset_properties of this UpdateDataAssetDetails.
@@ -389,7 +405,7 @@ class UpdateDataAssetDetails(object):
     def asset_properties(self, asset_properties):
         """
         Sets the asset_properties of this UpdateDataAssetDetails.
-        assetProperties
+        Additional properties for the data asset.
 
 
         :param asset_properties: The asset_properties of this UpdateDataAssetDetails.

--- a/src/oci/data_integration/models/update_data_asset_from_adwc.py
+++ b/src/oci/data_integration/models/update_data_asset_from_adwc.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateDataAssetFromAdwc(UpdateDataAssetDetails):
     """
-    The Oracle data asset details.
+    Details for the Autonomous Data Warehouse data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class UpdateDataAssetFromAdwc(UpdateDataAssetDetails):
 
         :param model_type:
             The value to assign to the model_type property of this UpdateDataAssetFromAdwc.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -138,7 +138,7 @@ class UpdateDataAssetFromAdwc(UpdateDataAssetDetails):
     def service_name(self):
         """
         Gets the service_name of this UpdateDataAssetFromAdwc.
-        The service name for the data asset.
+        The Autonomous Data Warehouse instance service name.
 
 
         :return: The service_name of this UpdateDataAssetFromAdwc.
@@ -150,7 +150,7 @@ class UpdateDataAssetFromAdwc(UpdateDataAssetDetails):
     def service_name(self, service_name):
         """
         Sets the service_name of this UpdateDataAssetFromAdwc.
-        The service name for the data asset.
+        The Autonomous Data Warehouse instance service name.
 
 
         :param service_name: The service_name of this UpdateDataAssetFromAdwc.
@@ -162,7 +162,7 @@ class UpdateDataAssetFromAdwc(UpdateDataAssetDetails):
     def driver_class(self):
         """
         Gets the driver_class of this UpdateDataAssetFromAdwc.
-        The driver class for the data asset.
+        The Autonomous Data Warehouse driver class.
 
 
         :return: The driver_class of this UpdateDataAssetFromAdwc.
@@ -174,7 +174,7 @@ class UpdateDataAssetFromAdwc(UpdateDataAssetDetails):
     def driver_class(self, driver_class):
         """
         Sets the driver_class of this UpdateDataAssetFromAdwc.
-        The driver class for the data asset.
+        The Autonomous Data Warehouse driver class.
 
 
         :param driver_class: The driver_class of this UpdateDataAssetFromAdwc.
@@ -186,7 +186,7 @@ class UpdateDataAssetFromAdwc(UpdateDataAssetDetails):
     def credential_file_content(self):
         """
         Gets the credential_file_content of this UpdateDataAssetFromAdwc.
-        The credential file content from a wallet for the data asset.
+        The credential file content from a Autonomous Data Warehouse wallet.
 
 
         :return: The credential_file_content of this UpdateDataAssetFromAdwc.
@@ -198,7 +198,7 @@ class UpdateDataAssetFromAdwc(UpdateDataAssetDetails):
     def credential_file_content(self, credential_file_content):
         """
         Sets the credential_file_content of this UpdateDataAssetFromAdwc.
-        The credential file content from a wallet for the data asset.
+        The credential file content from a Autonomous Data Warehouse wallet.
 
 
         :param credential_file_content: The credential_file_content of this UpdateDataAssetFromAdwc.

--- a/src/oci/data_integration/models/update_data_asset_from_atp.py
+++ b/src/oci/data_integration/models/update_data_asset_from_atp.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateDataAssetFromAtp(UpdateDataAssetDetails):
     """
-    The Oracle data asset details.
+    Details for the Autonomous Transaction Processing data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class UpdateDataAssetFromAtp(UpdateDataAssetDetails):
 
         :param model_type:
             The value to assign to the model_type property of this UpdateDataAssetFromAtp.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -138,7 +138,7 @@ class UpdateDataAssetFromAtp(UpdateDataAssetDetails):
     def service_name(self):
         """
         Gets the service_name of this UpdateDataAssetFromAtp.
-        The service name for the data asset.
+        The Autonomous Transaction Processing instance service name.
 
 
         :return: The service_name of this UpdateDataAssetFromAtp.
@@ -150,7 +150,7 @@ class UpdateDataAssetFromAtp(UpdateDataAssetDetails):
     def service_name(self, service_name):
         """
         Sets the service_name of this UpdateDataAssetFromAtp.
-        The service name for the data asset.
+        The Autonomous Transaction Processing instance service name.
 
 
         :param service_name: The service_name of this UpdateDataAssetFromAtp.
@@ -162,7 +162,7 @@ class UpdateDataAssetFromAtp(UpdateDataAssetDetails):
     def driver_class(self):
         """
         Gets the driver_class of this UpdateDataAssetFromAtp.
-        The driver class for the data asset.
+        The Autonomous Transaction Processing driver class
 
 
         :return: The driver_class of this UpdateDataAssetFromAtp.
@@ -174,7 +174,7 @@ class UpdateDataAssetFromAtp(UpdateDataAssetDetails):
     def driver_class(self, driver_class):
         """
         Sets the driver_class of this UpdateDataAssetFromAtp.
-        The driver class for the data asset.
+        The Autonomous Transaction Processing driver class
 
 
         :param driver_class: The driver_class of this UpdateDataAssetFromAtp.
@@ -186,7 +186,7 @@ class UpdateDataAssetFromAtp(UpdateDataAssetDetails):
     def credential_file_content(self):
         """
         Gets the credential_file_content of this UpdateDataAssetFromAtp.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Autonomous Transaction Processing wallet.
 
 
         :return: The credential_file_content of this UpdateDataAssetFromAtp.
@@ -198,7 +198,7 @@ class UpdateDataAssetFromAtp(UpdateDataAssetDetails):
     def credential_file_content(self, credential_file_content):
         """
         Sets the credential_file_content of this UpdateDataAssetFromAtp.
-        The credential file content from a wallet for the data asset.
+        The credential file content from an Autonomous Transaction Processing wallet.
 
 
         :param credential_file_content: The credential_file_content of this UpdateDataAssetFromAtp.

--- a/src/oci/data_integration/models/update_data_asset_from_jdbc.py
+++ b/src/oci/data_integration/models/update_data_asset_from_jdbc.py
@@ -1,0 +1,239 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .update_data_asset_details import UpdateDataAssetDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateDataAssetFromJdbc(UpdateDataAssetDetails):
+    """
+    Details for the Autonomous Transaction Processing data asset type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateDataAssetFromJdbc object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.UpdateDataAssetFromJdbc.model_type` attribute
+        of this class is ``GENERIC_JDBC_DATA_ASSET`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this UpdateDataAssetFromJdbc.
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this UpdateDataAssetFromJdbc.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this UpdateDataAssetFromJdbc.
+        :type model_version: str
+
+        :param name:
+            The value to assign to the name property of this UpdateDataAssetFromJdbc.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this UpdateDataAssetFromJdbc.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this UpdateDataAssetFromJdbc.
+        :type object_status: int
+
+        :param object_version:
+            The value to assign to the object_version property of this UpdateDataAssetFromJdbc.
+        :type object_version: int
+
+        :param identifier:
+            The value to assign to the identifier property of this UpdateDataAssetFromJdbc.
+        :type identifier: str
+
+        :param external_key:
+            The value to assign to the external_key property of this UpdateDataAssetFromJdbc.
+        :type external_key: str
+
+        :param asset_properties:
+            The value to assign to the asset_properties property of this UpdateDataAssetFromJdbc.
+        :type asset_properties: dict(str, str)
+
+        :param registry_metadata:
+            The value to assign to the registry_metadata property of this UpdateDataAssetFromJdbc.
+        :type registry_metadata: RegistryMetadata
+
+        :param host:
+            The value to assign to the host property of this UpdateDataAssetFromJdbc.
+        :type host: str
+
+        :param port:
+            The value to assign to the port property of this UpdateDataAssetFromJdbc.
+        :type port: str
+
+        :param data_asset_type:
+            The value to assign to the data_asset_type property of this UpdateDataAssetFromJdbc.
+        :type data_asset_type: str
+
+        :param default_connection:
+            The value to assign to the default_connection property of this UpdateDataAssetFromJdbc.
+        :type default_connection: UpdateConnectionFromJdbc
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'object_version': 'int',
+            'identifier': 'str',
+            'external_key': 'str',
+            'asset_properties': 'dict(str, str)',
+            'registry_metadata': 'RegistryMetadata',
+            'host': 'str',
+            'port': 'str',
+            'data_asset_type': 'str',
+            'default_connection': 'UpdateConnectionFromJdbc'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'object_version': 'objectVersion',
+            'identifier': 'identifier',
+            'external_key': 'externalKey',
+            'asset_properties': 'assetProperties',
+            'registry_metadata': 'registryMetadata',
+            'host': 'host',
+            'port': 'port',
+            'data_asset_type': 'dataAssetType',
+            'default_connection': 'defaultConnection'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._object_version = None
+        self._identifier = None
+        self._external_key = None
+        self._asset_properties = None
+        self._registry_metadata = None
+        self._host = None
+        self._port = None
+        self._data_asset_type = None
+        self._default_connection = None
+        self._model_type = 'GENERIC_JDBC_DATA_ASSET'
+
+    @property
+    def host(self):
+        """
+        Gets the host of this UpdateDataAssetFromJdbc.
+        The generic JDBC host name.
+
+
+        :return: The host of this UpdateDataAssetFromJdbc.
+        :rtype: str
+        """
+        return self._host
+
+    @host.setter
+    def host(self, host):
+        """
+        Sets the host of this UpdateDataAssetFromJdbc.
+        The generic JDBC host name.
+
+
+        :param host: The host of this UpdateDataAssetFromJdbc.
+        :type: str
+        """
+        self._host = host
+
+    @property
+    def port(self):
+        """
+        Gets the port of this UpdateDataAssetFromJdbc.
+        The generic JDBC port number.
+
+
+        :return: The port of this UpdateDataAssetFromJdbc.
+        :rtype: str
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this UpdateDataAssetFromJdbc.
+        The generic JDBC port number.
+
+
+        :param port: The port of this UpdateDataAssetFromJdbc.
+        :type: str
+        """
+        self._port = port
+
+    @property
+    def data_asset_type(self):
+        """
+        Gets the data_asset_type of this UpdateDataAssetFromJdbc.
+        The data asset type for the generic JDBC data asset.
+
+
+        :return: The data_asset_type of this UpdateDataAssetFromJdbc.
+        :rtype: str
+        """
+        return self._data_asset_type
+
+    @data_asset_type.setter
+    def data_asset_type(self, data_asset_type):
+        """
+        Sets the data_asset_type of this UpdateDataAssetFromJdbc.
+        The data asset type for the generic JDBC data asset.
+
+
+        :param data_asset_type: The data_asset_type of this UpdateDataAssetFromJdbc.
+        :type: str
+        """
+        self._data_asset_type = data_asset_type
+
+    @property
+    def default_connection(self):
+        """
+        Gets the default_connection of this UpdateDataAssetFromJdbc.
+
+        :return: The default_connection of this UpdateDataAssetFromJdbc.
+        :rtype: UpdateConnectionFromJdbc
+        """
+        return self._default_connection
+
+    @default_connection.setter
+    def default_connection(self, default_connection):
+        """
+        Sets the default_connection of this UpdateDataAssetFromJdbc.
+
+        :param default_connection: The default_connection of this UpdateDataAssetFromJdbc.
+        :type: UpdateConnectionFromJdbc
+        """
+        self._default_connection = default_connection
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/update_data_asset_from_my_sql.py
+++ b/src/oci/data_integration/models/update_data_asset_from_my_sql.py
@@ -1,0 +1,239 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .update_data_asset_details import UpdateDataAssetDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateDataAssetFromMySQL(UpdateDataAssetDetails):
+    """
+    Details for the MYSQL data asset type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateDataAssetFromMySQL object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.UpdateDataAssetFromMySQL.model_type` attribute
+        of this class is ``MYSQL_DATA_ASSET`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this UpdateDataAssetFromMySQL.
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this UpdateDataAssetFromMySQL.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this UpdateDataAssetFromMySQL.
+        :type model_version: str
+
+        :param name:
+            The value to assign to the name property of this UpdateDataAssetFromMySQL.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this UpdateDataAssetFromMySQL.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this UpdateDataAssetFromMySQL.
+        :type object_status: int
+
+        :param object_version:
+            The value to assign to the object_version property of this UpdateDataAssetFromMySQL.
+        :type object_version: int
+
+        :param identifier:
+            The value to assign to the identifier property of this UpdateDataAssetFromMySQL.
+        :type identifier: str
+
+        :param external_key:
+            The value to assign to the external_key property of this UpdateDataAssetFromMySQL.
+        :type external_key: str
+
+        :param asset_properties:
+            The value to assign to the asset_properties property of this UpdateDataAssetFromMySQL.
+        :type asset_properties: dict(str, str)
+
+        :param registry_metadata:
+            The value to assign to the registry_metadata property of this UpdateDataAssetFromMySQL.
+        :type registry_metadata: RegistryMetadata
+
+        :param host:
+            The value to assign to the host property of this UpdateDataAssetFromMySQL.
+        :type host: str
+
+        :param port:
+            The value to assign to the port property of this UpdateDataAssetFromMySQL.
+        :type port: str
+
+        :param service_name:
+            The value to assign to the service_name property of this UpdateDataAssetFromMySQL.
+        :type service_name: str
+
+        :param default_connection:
+            The value to assign to the default_connection property of this UpdateDataAssetFromMySQL.
+        :type default_connection: UpdateConnectionFromMySQL
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'object_version': 'int',
+            'identifier': 'str',
+            'external_key': 'str',
+            'asset_properties': 'dict(str, str)',
+            'registry_metadata': 'RegistryMetadata',
+            'host': 'str',
+            'port': 'str',
+            'service_name': 'str',
+            'default_connection': 'UpdateConnectionFromMySQL'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'object_version': 'objectVersion',
+            'identifier': 'identifier',
+            'external_key': 'externalKey',
+            'asset_properties': 'assetProperties',
+            'registry_metadata': 'registryMetadata',
+            'host': 'host',
+            'port': 'port',
+            'service_name': 'serviceName',
+            'default_connection': 'defaultConnection'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._object_version = None
+        self._identifier = None
+        self._external_key = None
+        self._asset_properties = None
+        self._registry_metadata = None
+        self._host = None
+        self._port = None
+        self._service_name = None
+        self._default_connection = None
+        self._model_type = 'MYSQL_DATA_ASSET'
+
+    @property
+    def host(self):
+        """
+        Gets the host of this UpdateDataAssetFromMySQL.
+        The generic JDBC host name.
+
+
+        :return: The host of this UpdateDataAssetFromMySQL.
+        :rtype: str
+        """
+        return self._host
+
+    @host.setter
+    def host(self, host):
+        """
+        Sets the host of this UpdateDataAssetFromMySQL.
+        The generic JDBC host name.
+
+
+        :param host: The host of this UpdateDataAssetFromMySQL.
+        :type: str
+        """
+        self._host = host
+
+    @property
+    def port(self):
+        """
+        Gets the port of this UpdateDataAssetFromMySQL.
+        The generic JDBC port number.
+
+
+        :return: The port of this UpdateDataAssetFromMySQL.
+        :rtype: str
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this UpdateDataAssetFromMySQL.
+        The generic JDBC port number.
+
+
+        :param port: The port of this UpdateDataAssetFromMySQL.
+        :type: str
+        """
+        self._port = port
+
+    @property
+    def service_name(self):
+        """
+        Gets the service_name of this UpdateDataAssetFromMySQL.
+        The generic JDBC service name for the database.
+
+
+        :return: The service_name of this UpdateDataAssetFromMySQL.
+        :rtype: str
+        """
+        return self._service_name
+
+    @service_name.setter
+    def service_name(self, service_name):
+        """
+        Sets the service_name of this UpdateDataAssetFromMySQL.
+        The generic JDBC service name for the database.
+
+
+        :param service_name: The service_name of this UpdateDataAssetFromMySQL.
+        :type: str
+        """
+        self._service_name = service_name
+
+    @property
+    def default_connection(self):
+        """
+        Gets the default_connection of this UpdateDataAssetFromMySQL.
+
+        :return: The default_connection of this UpdateDataAssetFromMySQL.
+        :rtype: UpdateConnectionFromMySQL
+        """
+        return self._default_connection
+
+    @default_connection.setter
+    def default_connection(self, default_connection):
+        """
+        Sets the default_connection of this UpdateDataAssetFromMySQL.
+
+        :param default_connection: The default_connection of this UpdateDataAssetFromMySQL.
+        :type: UpdateConnectionFromMySQL
+        """
+        self._default_connection = default_connection
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/update_data_asset_from_object_storage.py
+++ b/src/oci/data_integration/models/update_data_asset_from_object_storage.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateDataAssetFromObjectStorage(UpdateDataAssetDetails):
     """
-    The Oracle data asset details.
+    Details for the Oracle Object storage data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class UpdateDataAssetFromObjectStorage(UpdateDataAssetDetails):
 
         :param model_type:
             The value to assign to the model_type property of this UpdateDataAssetFromObjectStorage.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -138,7 +138,7 @@ class UpdateDataAssetFromObjectStorage(UpdateDataAssetDetails):
     def url(self):
         """
         Gets the url of this UpdateDataAssetFromObjectStorage.
-        url
+        The Oracle Object storage URL.
 
 
         :return: The url of this UpdateDataAssetFromObjectStorage.
@@ -150,7 +150,7 @@ class UpdateDataAssetFromObjectStorage(UpdateDataAssetDetails):
     def url(self, url):
         """
         Sets the url of this UpdateDataAssetFromObjectStorage.
-        url
+        The Oracle Object storage URL.
 
 
         :param url: The url of this UpdateDataAssetFromObjectStorage.
@@ -186,7 +186,7 @@ class UpdateDataAssetFromObjectStorage(UpdateDataAssetDetails):
     def namespace(self):
         """
         Gets the namespace of this UpdateDataAssetFromObjectStorage.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        The namespace for the specified Oracle Object storage resource. You can find the namespace under Object Storage Settings in the Console.
 
 
         :return: The namespace of this UpdateDataAssetFromObjectStorage.
@@ -198,7 +198,7 @@ class UpdateDataAssetFromObjectStorage(UpdateDataAssetDetails):
     def namespace(self, namespace):
         """
         Sets the namespace of this UpdateDataAssetFromObjectStorage.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        The namespace for the specified Oracle Object storage resource. You can find the namespace under Object Storage Settings in the Console.
 
 
         :param namespace: The namespace of this UpdateDataAssetFromObjectStorage.

--- a/src/oci/data_integration/models/update_data_asset_from_oracle.py
+++ b/src/oci/data_integration/models/update_data_asset_from_oracle.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
     """
-    The Oracle data asset details.
+    Details for the Oracle Database data asset type.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
 
         :param model_type:
             The value to assign to the model_type property of this UpdateDataAssetFromOracle.
-            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET"
+            Allowed values for this property are: "ORACLE_DATA_ASSET", "ORACLE_OBJECT_STORAGE_DATA_ASSET", "ORACLE_ATP_DATA_ASSET", "ORACLE_ADWC_DATA_ASSET", "MYSQL_DATA_ASSET", "GENERIC_JDBC_DATA_ASSET"
         :type model_type: str
 
         :param key:
@@ -159,7 +159,7 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
     def host(self):
         """
         Gets the host of this UpdateDataAssetFromOracle.
-        The host details for the data asset.
+        The Oracle Database hostname.
 
 
         :return: The host of this UpdateDataAssetFromOracle.
@@ -171,7 +171,7 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
     def host(self, host):
         """
         Sets the host of this UpdateDataAssetFromOracle.
-        The host details for the data asset.
+        The Oracle Database hostname.
 
 
         :param host: The host of this UpdateDataAssetFromOracle.
@@ -183,7 +183,7 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
     def port(self):
         """
         Gets the port of this UpdateDataAssetFromOracle.
-        The port details for the data asset.
+        The Oracle Database port.
 
 
         :return: The port of this UpdateDataAssetFromOracle.
@@ -195,7 +195,7 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
     def port(self, port):
         """
         Sets the port of this UpdateDataAssetFromOracle.
-        The port details for the data asset.
+        The Oracle Database port.
 
 
         :param port: The port of this UpdateDataAssetFromOracle.
@@ -207,7 +207,7 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
     def service_name(self):
         """
         Gets the service_name of this UpdateDataAssetFromOracle.
-        The service name for the data asset.
+        The Oracle Database service name.
 
 
         :return: The service_name of this UpdateDataAssetFromOracle.
@@ -219,7 +219,7 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
     def service_name(self, service_name):
         """
         Sets the service_name of this UpdateDataAssetFromOracle.
-        The service name for the data asset.
+        The Oracle Database service name.
 
 
         :param service_name: The service_name of this UpdateDataAssetFromOracle.
@@ -231,7 +231,7 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
     def driver_class(self):
         """
         Gets the driver_class of this UpdateDataAssetFromOracle.
-        The driver class for the data asset.
+        The Oracle Database driver class.
 
 
         :return: The driver_class of this UpdateDataAssetFromOracle.
@@ -243,7 +243,7 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
     def driver_class(self, driver_class):
         """
         Sets the driver_class of this UpdateDataAssetFromOracle.
-        The driver class for the data asset.
+        The Oracle Database driver class.
 
 
         :param driver_class: The driver_class of this UpdateDataAssetFromOracle.
@@ -255,7 +255,7 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
     def sid(self):
         """
         Gets the sid of this UpdateDataAssetFromOracle.
-        sid
+        The Oracle Database SID.
 
 
         :return: The sid of this UpdateDataAssetFromOracle.
@@ -267,7 +267,7 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
     def sid(self, sid):
         """
         Sets the sid of this UpdateDataAssetFromOracle.
-        sid
+        The Oracle Database SID.
 
 
         :param sid: The sid of this UpdateDataAssetFromOracle.

--- a/src/oci/data_integration/models/update_data_flow_details.py
+++ b/src/oci/data_integration/models/update_data_flow_details.py
@@ -213,7 +213,7 @@ class UpdateDataFlowDetails(object):
     def name(self):
         """
         Gets the name of this UpdateDataFlowDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this UpdateDataFlowDetails.
@@ -225,7 +225,7 @@ class UpdateDataFlowDetails(object):
     def name(self, name):
         """
         Sets the name of this UpdateDataFlowDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this UpdateDataFlowDetails.
@@ -237,7 +237,7 @@ class UpdateDataFlowDetails(object):
     def identifier(self):
         """
         Gets the identifier of this UpdateDataFlowDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this UpdateDataFlowDetails.
@@ -249,7 +249,7 @@ class UpdateDataFlowDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this UpdateDataFlowDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this UpdateDataFlowDetails.

--- a/src/oci/data_integration/models/update_external_publication_details.py
+++ b/src/oci/data_integration/models/update_external_publication_details.py
@@ -1,0 +1,217 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateExternalPublicationDetails(object):
+    """
+    Properties used to update a published Oracle Cloud Infrastructure Data Flow object.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateExternalPublicationDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param application_id:
+            The value to assign to the application_id property of this UpdateExternalPublicationDetails.
+        :type application_id: str
+
+        :param application_compartment_id:
+            The value to assign to the application_compartment_id property of this UpdateExternalPublicationDetails.
+        :type application_compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateExternalPublicationDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this UpdateExternalPublicationDetails.
+        :type description: str
+
+        :param resource_configuration:
+            The value to assign to the resource_configuration property of this UpdateExternalPublicationDetails.
+        :type resource_configuration: ResourceConfiguration
+
+        :param configuration_details:
+            The value to assign to the configuration_details property of this UpdateExternalPublicationDetails.
+        :type configuration_details: ConfigurationDetails
+
+        """
+        self.swagger_types = {
+            'application_id': 'str',
+            'application_compartment_id': 'str',
+            'display_name': 'str',
+            'description': 'str',
+            'resource_configuration': 'ResourceConfiguration',
+            'configuration_details': 'ConfigurationDetails'
+        }
+
+        self.attribute_map = {
+            'application_id': 'applicationId',
+            'application_compartment_id': 'applicationCompartmentId',
+            'display_name': 'displayName',
+            'description': 'description',
+            'resource_configuration': 'resourceConfiguration',
+            'configuration_details': 'configurationDetails'
+        }
+
+        self._application_id = None
+        self._application_compartment_id = None
+        self._display_name = None
+        self._description = None
+        self._resource_configuration = None
+        self._configuration_details = None
+
+    @property
+    def application_id(self):
+        """
+        Gets the application_id of this UpdateExternalPublicationDetails.
+        The unique OCID of the identifier that is returned after creating the Oracle Cloud Infrastructure Data Flow application.
+
+
+        :return: The application_id of this UpdateExternalPublicationDetails.
+        :rtype: str
+        """
+        return self._application_id
+
+    @application_id.setter
+    def application_id(self, application_id):
+        """
+        Sets the application_id of this UpdateExternalPublicationDetails.
+        The unique OCID of the identifier that is returned after creating the Oracle Cloud Infrastructure Data Flow application.
+
+
+        :param application_id: The application_id of this UpdateExternalPublicationDetails.
+        :type: str
+        """
+        self._application_id = application_id
+
+    @property
+    def application_compartment_id(self):
+        """
+        **[Required]** Gets the application_compartment_id of this UpdateExternalPublicationDetails.
+        The OCID of the compartment where the application is created in the Oracle Cloud Infrastructure Data Flow Service.
+
+
+        :return: The application_compartment_id of this UpdateExternalPublicationDetails.
+        :rtype: str
+        """
+        return self._application_compartment_id
+
+    @application_compartment_id.setter
+    def application_compartment_id(self, application_compartment_id):
+        """
+        Sets the application_compartment_id of this UpdateExternalPublicationDetails.
+        The OCID of the compartment where the application is created in the Oracle Cloud Infrastructure Data Flow Service.
+
+
+        :param application_compartment_id: The application_compartment_id of this UpdateExternalPublicationDetails.
+        :type: str
+        """
+        self._application_compartment_id = application_compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this UpdateExternalPublicationDetails.
+        The name of the application.
+
+
+        :return: The display_name of this UpdateExternalPublicationDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateExternalPublicationDetails.
+        The name of the application.
+
+
+        :param display_name: The display_name of this UpdateExternalPublicationDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this UpdateExternalPublicationDetails.
+        The details of the data flow or the application.
+
+
+        :return: The description of this UpdateExternalPublicationDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this UpdateExternalPublicationDetails.
+        The details of the data flow or the application.
+
+
+        :param description: The description of this UpdateExternalPublicationDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def resource_configuration(self):
+        """
+        Gets the resource_configuration of this UpdateExternalPublicationDetails.
+
+        :return: The resource_configuration of this UpdateExternalPublicationDetails.
+        :rtype: ResourceConfiguration
+        """
+        return self._resource_configuration
+
+    @resource_configuration.setter
+    def resource_configuration(self, resource_configuration):
+        """
+        Sets the resource_configuration of this UpdateExternalPublicationDetails.
+
+        :param resource_configuration: The resource_configuration of this UpdateExternalPublicationDetails.
+        :type: ResourceConfiguration
+        """
+        self._resource_configuration = resource_configuration
+
+    @property
+    def configuration_details(self):
+        """
+        Gets the configuration_details of this UpdateExternalPublicationDetails.
+
+        :return: The configuration_details of this UpdateExternalPublicationDetails.
+        :rtype: ConfigurationDetails
+        """
+        return self._configuration_details
+
+    @configuration_details.setter
+    def configuration_details(self, configuration_details):
+        """
+        Sets the configuration_details of this UpdateExternalPublicationDetails.
+
+        :param configuration_details: The configuration_details of this UpdateExternalPublicationDetails.
+        :type: ConfigurationDetails
+        """
+        self._configuration_details = configuration_details
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/update_folder_details.py
+++ b/src/oci/data_integration/models/update_folder_details.py
@@ -179,7 +179,7 @@ class UpdateFolderDetails(object):
     def name(self):
         """
         Gets the name of this UpdateFolderDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this UpdateFolderDetails.
@@ -191,7 +191,7 @@ class UpdateFolderDetails(object):
     def name(self, name):
         """
         Sets the name of this UpdateFolderDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this UpdateFolderDetails.
@@ -203,7 +203,7 @@ class UpdateFolderDetails(object):
     def description(self):
         """
         Gets the description of this UpdateFolderDetails.
-        Detailed description for the object.
+        A user defined description for the folder.
 
 
         :return: The description of this UpdateFolderDetails.
@@ -215,7 +215,7 @@ class UpdateFolderDetails(object):
     def description(self, description):
         """
         Sets the description of this UpdateFolderDetails.
-        Detailed description for the object.
+        A user defined description for the folder.
 
 
         :param description: The description of this UpdateFolderDetails.
@@ -227,7 +227,7 @@ class UpdateFolderDetails(object):
     def category_name(self):
         """
         Gets the category_name of this UpdateFolderDetails.
-        categoryName
+        The category name.
 
 
         :return: The category_name of this UpdateFolderDetails.
@@ -239,7 +239,7 @@ class UpdateFolderDetails(object):
     def category_name(self, category_name):
         """
         Sets the category_name of this UpdateFolderDetails.
-        categoryName
+        The category name.
 
 
         :param category_name: The category_name of this UpdateFolderDetails.
@@ -275,7 +275,7 @@ class UpdateFolderDetails(object):
     def identifier(self):
         """
         Gets the identifier of this UpdateFolderDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this UpdateFolderDetails.
@@ -287,7 +287,7 @@ class UpdateFolderDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this UpdateFolderDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this UpdateFolderDetails.

--- a/src/oci/data_integration/models/update_project_details.py
+++ b/src/oci/data_integration/models/update_project_details.py
@@ -172,7 +172,7 @@ class UpdateProjectDetails(object):
     def name(self):
         """
         Gets the name of this UpdateProjectDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this UpdateProjectDetails.
@@ -184,7 +184,7 @@ class UpdateProjectDetails(object):
     def name(self, name):
         """
         Sets the name of this UpdateProjectDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this UpdateProjectDetails.
@@ -196,7 +196,7 @@ class UpdateProjectDetails(object):
     def description(self):
         """
         Gets the description of this UpdateProjectDetails.
-        Detailed description for the object.
+        A user defined description for the project.
 
 
         :return: The description of this UpdateProjectDetails.
@@ -208,7 +208,7 @@ class UpdateProjectDetails(object):
     def description(self, description):
         """
         Sets the description of this UpdateProjectDetails.
-        Detailed description for the object.
+        A user defined description for the project.
 
 
         :param description: The description of this UpdateProjectDetails.
@@ -244,7 +244,7 @@ class UpdateProjectDetails(object):
     def identifier(self):
         """
         Gets the identifier of this UpdateProjectDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this UpdateProjectDetails.
@@ -256,7 +256,7 @@ class UpdateProjectDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this UpdateProjectDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this UpdateProjectDetails.

--- a/src/oci/data_integration/models/update_reference_details.py
+++ b/src/oci/data_integration/models/update_reference_details.py
@@ -1,0 +1,132 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateReferenceDetails(object):
+    """
+    Application references that need to be updated.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateReferenceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param options:
+            The value to assign to the options property of this UpdateReferenceDetails.
+        :type options: dict(str, str)
+
+        :param target_object:
+            The value to assign to the target_object property of this UpdateReferenceDetails.
+        :type target_object: object
+
+        :param child_references:
+            The value to assign to the child_references property of this UpdateReferenceDetails.
+        :type child_references: list[ChildReferenceDetail]
+
+        """
+        self.swagger_types = {
+            'options': 'dict(str, str)',
+            'target_object': 'object',
+            'child_references': 'list[ChildReferenceDetail]'
+        }
+
+        self.attribute_map = {
+            'options': 'options',
+            'target_object': 'targetObject',
+            'child_references': 'childReferences'
+        }
+
+        self._options = None
+        self._target_object = None
+        self._child_references = None
+
+    @property
+    def options(self):
+        """
+        Gets the options of this UpdateReferenceDetails.
+        A list of options such as `ignoreObjectOnError`.
+
+
+        :return: The options of this UpdateReferenceDetails.
+        :rtype: dict(str, str)
+        """
+        return self._options
+
+    @options.setter
+    def options(self, options):
+        """
+        Sets the options of this UpdateReferenceDetails.
+        A list of options such as `ignoreObjectOnError`.
+
+
+        :param options: The options of this UpdateReferenceDetails.
+        :type: dict(str, str)
+        """
+        self._options = options
+
+    @property
+    def target_object(self):
+        """
+        Gets the target_object of this UpdateReferenceDetails.
+        The new target object to reference. This should be of type `DataAsset`. The child references can be of type `Connection`.
+
+
+        :return: The target_object of this UpdateReferenceDetails.
+        :rtype: object
+        """
+        return self._target_object
+
+    @target_object.setter
+    def target_object(self, target_object):
+        """
+        Sets the target_object of this UpdateReferenceDetails.
+        The new target object to reference. This should be of type `DataAsset`. The child references can be of type `Connection`.
+
+
+        :param target_object: The target_object of this UpdateReferenceDetails.
+        :type: object
+        """
+        self._target_object = target_object
+
+    @property
+    def child_references(self):
+        """
+        Gets the child_references of this UpdateReferenceDetails.
+        The list of child references that also need to be updated.
+
+
+        :return: The child_references of this UpdateReferenceDetails.
+        :rtype: list[ChildReferenceDetail]
+        """
+        return self._child_references
+
+    @child_references.setter
+    def child_references(self, child_references):
+        """
+        Sets the child_references of this UpdateReferenceDetails.
+        The list of child references that also need to be updated.
+
+
+        :param child_references: The child_references of this UpdateReferenceDetails.
+        :type: list[ChildReferenceDetail]
+        """
+        self._child_references = child_references
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/update_task_details.py
+++ b/src/oci/data_integration/models/update_task_details.py
@@ -221,7 +221,7 @@ class UpdateTaskDetails(object):
     def model_version(self):
         """
         Gets the model_version of this UpdateTaskDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this UpdateTaskDetails.
@@ -233,7 +233,7 @@ class UpdateTaskDetails(object):
     def model_version(self, model_version):
         """
         Sets the model_version of this UpdateTaskDetails.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this UpdateTaskDetails.
@@ -265,7 +265,7 @@ class UpdateTaskDetails(object):
     def name(self):
         """
         Gets the name of this UpdateTaskDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this UpdateTaskDetails.
@@ -277,7 +277,7 @@ class UpdateTaskDetails(object):
     def name(self, name):
         """
         Sets the name of this UpdateTaskDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this UpdateTaskDetails.
@@ -361,7 +361,7 @@ class UpdateTaskDetails(object):
     def identifier(self):
         """
         Gets the identifier of this UpdateTaskDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :return: The identifier of this UpdateTaskDetails.
@@ -373,7 +373,7 @@ class UpdateTaskDetails(object):
     def identifier(self, identifier):
         """
         Sets the identifier of this UpdateTaskDetails.
-        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+        Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be modified.
 
 
         :param identifier: The identifier of this UpdateTaskDetails.

--- a/src/oci/data_integration/models/update_task_run_details.py
+++ b/src/oci/data_integration/models/update_task_run_details.py
@@ -115,7 +115,7 @@ class UpdateTaskRunDetails(object):
     def status(self):
         """
         Gets the status of this UpdateTaskRunDetails.
-        status
+        The status of the object.
 
         Allowed values for this property are: "TERMINATING"
 
@@ -129,7 +129,7 @@ class UpdateTaskRunDetails(object):
     def status(self, status):
         """
         Sets the status of this UpdateTaskRunDetails.
-        status
+        The status of the object.
 
 
         :param status: The status of this UpdateTaskRunDetails.
@@ -195,7 +195,7 @@ class UpdateTaskRunDetails(object):
     def name(self):
         """
         Gets the name of this UpdateTaskRunDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :return: The name of this UpdateTaskRunDetails.
@@ -207,7 +207,7 @@ class UpdateTaskRunDetails(object):
     def name(self, name):
         """
         Sets the name of this UpdateTaskRunDetails.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
 
 
         :param name: The name of this UpdateTaskRunDetails.

--- a/src/oci/data_integration/models/update_workspace_details.py
+++ b/src/oci/data_integration/models/update_workspace_details.py
@@ -118,7 +118,7 @@ class UpdateWorkspaceDetails(object):
     def description(self):
         """
         Gets the description of this UpdateWorkspaceDetails.
-        A detailed description for the workspace.
+        A user defined description for the workspace.
 
 
         :return: The description of this UpdateWorkspaceDetails.
@@ -130,7 +130,7 @@ class UpdateWorkspaceDetails(object):
     def description(self, description):
         """
         Sets the description of this UpdateWorkspaceDetails.
-        A detailed description for the workspace.
+        A user defined description for the workspace.
 
 
         :param description: The description of this UpdateWorkspaceDetails.

--- a/src/oci/data_integration/models/validation_message.py
+++ b/src/oci/data_integration/models/validation_message.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ValidationMessage(object):
     """
-    The level, message key and validation message.
+    The level, message key, and validation message.
     """
 
     def __init__(self, **kwargs):
@@ -51,7 +51,7 @@ class ValidationMessage(object):
     def level(self):
         """
         Gets the level of this ValidationMessage.
-        Total number of validation messages
+        The total number of validation messages.
 
 
         :return: The level of this ValidationMessage.
@@ -63,7 +63,7 @@ class ValidationMessage(object):
     def level(self, level):
         """
         Sets the level of this ValidationMessage.
-        Total number of validation messages
+        The total number of validation messages.
 
 
         :param level: The level of this ValidationMessage.
@@ -75,7 +75,7 @@ class ValidationMessage(object):
     def message_key(self):
         """
         Gets the message_key of this ValidationMessage.
-        The key.
+        The validation message key.
 
 
         :return: The message_key of this ValidationMessage.
@@ -87,7 +87,7 @@ class ValidationMessage(object):
     def message_key(self, message_key):
         """
         Sets the message_key of this ValidationMessage.
-        The key.
+        The validation message key.
 
 
         :param message_key: The message_key of this ValidationMessage.
@@ -99,7 +99,7 @@ class ValidationMessage(object):
     def validation_message(self):
         """
         Gets the validation_message of this ValidationMessage.
-        The message itself.
+        The validation message.
 
 
         :return: The validation_message of this ValidationMessage.
@@ -111,7 +111,7 @@ class ValidationMessage(object):
     def validation_message(self, validation_message):
         """
         Sets the validation_message of this ValidationMessage.
-        The message itself.
+        The validation message.
 
 
         :param validation_message: The validation_message of this ValidationMessage.

--- a/src/oci/data_integration/models/work_request.py
+++ b/src/oci/data_integration/models/work_request.py
@@ -197,7 +197,7 @@ class WorkRequest(object):
     def id(self):
         """
         **[Required]** Gets the id of this WorkRequest.
-        The id of the work request.
+        The ID of the work request.
 
 
         :return: The id of this WorkRequest.
@@ -209,7 +209,7 @@ class WorkRequest(object):
     def id(self, id):
         """
         Sets the id of this WorkRequest.
-        The id of the work request.
+        The ID of the work request.
 
 
         :param id: The id of this WorkRequest.
@@ -221,7 +221,7 @@ class WorkRequest(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this WorkRequest.
-        The ocid of the compartment that contains this work request. Work requests should be scoped to
+        The OCID of the compartment that contains this work request. Work requests should be scoped to
         the same compartment as the resource the work request affects. If the work request affects multiple resources that are not in the same compartment, then the system picks a primary
         resource whose compartment should be used.
 
@@ -235,7 +235,7 @@ class WorkRequest(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this WorkRequest.
-        The ocid of the compartment that contains this work request. Work requests should be scoped to
+        The OCID of the compartment that contains this work request. Work requests should be scoped to
         the same compartment as the resource the work request affects. If the work request affects multiple resources that are not in the same compartment, then the system picks a primary
         resource whose compartment should be used.
 

--- a/src/oci/data_integration/models/work_request_resource.py
+++ b/src/oci/data_integration/models/work_request_resource.py
@@ -117,9 +117,9 @@ class WorkRequestResource(object):
         """
         **[Required]** Gets the action_type of this WorkRequestResource.
         The way in which this resource is affected by the work tracked in the work request.
-        A resource being created, updated, or deleted will remain in the IN_PROGRESS state until
-        work is complete for that resource at which point it will transition to CREATED, UPDATED,
-        or DELETED, respectively.
+        A resource being created, updated, or deleted will remain in the `IN_PROGRESS` state until
+        work is complete for that resource at which point it will transition to `CREATED`, `UPDATED`,
+        or `DELETED`, respectively.
 
         Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "MOVED", "IN_PROGRESS", "FAILED", "STOPPED", "STARTED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -135,9 +135,9 @@ class WorkRequestResource(object):
         """
         Sets the action_type of this WorkRequestResource.
         The way in which this resource is affected by the work tracked in the work request.
-        A resource being created, updated, or deleted will remain in the IN_PROGRESS state until
-        work is complete for that resource at which point it will transition to CREATED, UPDATED,
-        or DELETED, respectively.
+        A resource being created, updated, or deleted will remain in the `IN_PROGRESS` state until
+        work is complete for that resource at which point it will transition to `CREATED`, `UPDATED`,
+        or `DELETED`, respectively.
 
 
         :param action_type: The action_type of this WorkRequestResource.

--- a/src/oci/data_integration/models/work_request_summary.py
+++ b/src/oci/data_integration/models/work_request_summary.py
@@ -197,7 +197,7 @@ class WorkRequestSummary(object):
     def id(self):
         """
         **[Required]** Gets the id of this WorkRequestSummary.
-        The id of the work request.
+        The ID of the work request.
 
 
         :return: The id of this WorkRequestSummary.
@@ -209,7 +209,7 @@ class WorkRequestSummary(object):
     def id(self, id):
         """
         Sets the id of this WorkRequestSummary.
-        The id of the work request.
+        The ID of the work request.
 
 
         :param id: The id of this WorkRequestSummary.
@@ -221,7 +221,7 @@ class WorkRequestSummary(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this WorkRequestSummary.
-        The ocid of the compartment that contains this work request. Work requests should be scoped to
+        The OCID of the compartment that contains this work request. Work requests should be scoped to
         the same compartment as the resource the work request affects. If the work request affects multiple resources that are not in the same compartment, then the system picks a primary
         resource whose compartment should be used.
 
@@ -235,7 +235,7 @@ class WorkRequestSummary(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this WorkRequestSummary.
-        The ocid of the compartment that contains this work request. Work requests should be scoped to
+        The OCID of the compartment that contains this work request. Work requests should be scoped to
         the same compartment as the resource the work request affects. If the work request affects multiple resources that are not in the same compartment, then the system picks a primary
         resource whose compartment should be used.
 

--- a/src/oci/data_integration/models/workspace.py
+++ b/src/oci/data_integration/models/workspace.py
@@ -273,7 +273,7 @@ class Workspace(object):
     def is_private_network_enabled(self):
         """
         Gets the is_private_network_enabled of this Workspace.
-        Whether the private network connection is enabled or disabled.
+        Specifies whether the private network connection is enabled or disabled.
 
 
         :return: The is_private_network_enabled of this Workspace.
@@ -285,7 +285,7 @@ class Workspace(object):
     def is_private_network_enabled(self, is_private_network_enabled):
         """
         Sets the is_private_network_enabled of this Workspace.
-        Whether the private network connection is enabled or disabled.
+        Specifies whether the private network connection is enabled or disabled.
 
 
         :param is_private_network_enabled: The is_private_network_enabled of this Workspace.
@@ -533,7 +533,7 @@ class Workspace(object):
     def state_message(self):
         """
         Gets the state_message of this Workspace.
-        A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+        A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in failed state.
 
 
         :return: The state_message of this Workspace.
@@ -545,7 +545,7 @@ class Workspace(object):
     def state_message(self, state_message):
         """
         Sets the state_message of this Workspace.
-        A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+        A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in failed state.
 
 
         :param state_message: The state_message of this Workspace.
@@ -557,7 +557,7 @@ class Workspace(object):
     def id(self):
         """
         **[Required]** Gets the id of this Workspace.
-        Unique identifier that is immutable on creation
+        A system-generated and immutable identifier assigned to the workspace upon creation.
 
 
         :return: The id of this Workspace.
@@ -569,7 +569,7 @@ class Workspace(object):
     def id(self, id):
         """
         Sets the id of this Workspace.
-        Unique identifier that is immutable on creation
+        A system-generated and immutable identifier assigned to the workspace upon creation.
 
 
         :param id: The id of this Workspace.

--- a/src/oci/data_integration/models/workspace_summary.py
+++ b/src/oci/data_integration/models/workspace_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class WorkspaceSummary(object):
     """
-    Summary of a Workspace.
+    Summary details of a workspace.
     """
 
     #: A constant which can be used with the lifecycle_state property of a WorkspaceSummary.
@@ -142,7 +142,7 @@ class WorkspaceSummary(object):
     def id(self):
         """
         Gets the id of this WorkspaceSummary.
-        Unique identifier that is immutable.
+        A system-generated and immutable identifier assigned to the workspace upon creation.
 
 
         :return: The id of this WorkspaceSummary.
@@ -154,7 +154,7 @@ class WorkspaceSummary(object):
     def id(self, id):
         """
         Sets the id of this WorkspaceSummary.
-        Unique identifier that is immutable.
+        A system-generated and immutable identifier assigned to the workspace upon creation.
 
 
         :param id: The id of this WorkspaceSummary.
@@ -166,7 +166,7 @@ class WorkspaceSummary(object):
     def description(self):
         """
         Gets the description of this WorkspaceSummary.
-        A detailed description of the workspace.
+        A user defined description for the workspace.
 
 
         :return: The description of this WorkspaceSummary.
@@ -178,7 +178,7 @@ class WorkspaceSummary(object):
     def description(self, description):
         """
         Sets the description of this WorkspaceSummary.
-        A detailed description of the workspace.
+        A user defined description for the workspace.
 
 
         :param description: The description of this WorkspaceSummary.

--- a/src/oci/data_integration/models/write_operation_config.py
+++ b/src/oci/data_integration/models/write_operation_config.py
@@ -75,6 +75,10 @@ class WriteOperationConfig(AbstractDataOperationConfig):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type write_mode: str
 
+        :param merge_key:
+            The value to assign to the merge_key property of this WriteOperationConfig.
+        :type merge_key: UniqueKey
+
         :param object_status:
             The value to assign to the object_status property of this WriteOperationConfig.
         :type object_status: int
@@ -90,6 +94,7 @@ class WriteOperationConfig(AbstractDataOperationConfig):
             'partition_config': 'PartitionConfig',
             'write_attribute': 'AbstractWriteAttribute',
             'write_mode': 'str',
+            'merge_key': 'UniqueKey',
             'object_status': 'int'
         }
 
@@ -103,6 +108,7 @@ class WriteOperationConfig(AbstractDataOperationConfig):
             'partition_config': 'partitionConfig',
             'write_attribute': 'writeAttribute',
             'write_mode': 'writeMode',
+            'merge_key': 'mergeKey',
             'object_status': 'objectStatus'
         }
 
@@ -115,6 +121,7 @@ class WriteOperationConfig(AbstractDataOperationConfig):
         self._partition_config = None
         self._write_attribute = None
         self._write_mode = None
+        self._merge_key = None
         self._object_status = None
         self._model_type = 'WRITE_OPERATION_CONFIG'
 
@@ -122,7 +129,7 @@ class WriteOperationConfig(AbstractDataOperationConfig):
     def key(self):
         """
         Gets the key of this WriteOperationConfig.
-        The key of the object.
+        The object key.
 
 
         :return: The key of this WriteOperationConfig.
@@ -134,7 +141,7 @@ class WriteOperationConfig(AbstractDataOperationConfig):
     def key(self, key):
         """
         Sets the key of this WriteOperationConfig.
-        The key of the object.
+        The object key.
 
 
         :param key: The key of this WriteOperationConfig.
@@ -146,7 +153,7 @@ class WriteOperationConfig(AbstractDataOperationConfig):
     def model_version(self):
         """
         Gets the model_version of this WriteOperationConfig.
-        The model version of an object.
+        The object's model version.
 
 
         :return: The model_version of this WriteOperationConfig.
@@ -158,7 +165,7 @@ class WriteOperationConfig(AbstractDataOperationConfig):
     def model_version(self, model_version):
         """
         Sets the model_version of this WriteOperationConfig.
-        The model version of an object.
+        The object's model version.
 
 
         :param model_version: The model_version of this WriteOperationConfig.
@@ -299,6 +306,26 @@ class WriteOperationConfig(AbstractDataOperationConfig):
         if not value_allowed_none_or_none_sentinel(write_mode, allowed_values):
             write_mode = 'UNKNOWN_ENUM_VALUE'
         self._write_mode = write_mode
+
+    @property
+    def merge_key(self):
+        """
+        Gets the merge_key of this WriteOperationConfig.
+
+        :return: The merge_key of this WriteOperationConfig.
+        :rtype: UniqueKey
+        """
+        return self._merge_key
+
+    @merge_key.setter
+    def merge_key(self, merge_key):
+        """
+        Sets the merge_key of this WriteOperationConfig.
+
+        :param merge_key: The merge_key of this WriteOperationConfig.
+        :type: UniqueKey
+        """
+        self._merge_key = merge_key
 
     @property
     def object_status(self):

--- a/src/oci/database/database_client.py
+++ b/src/oci/database/database_client.py
@@ -89,7 +89,7 @@ class DatabaseClient(object):
 
     def activate_exadata_infrastructure(self, exadata_infrastructure_id, activate_exadata_infrastructure_details, **kwargs):
         """
-        Activates the specified Exadata infrastructure.
+        Activates the specified Exadata Cloud@Customer infrastructure.
 
 
         :param str exadata_infrastructure_id: (required)
@@ -474,15 +474,15 @@ class DatabaseClient(object):
 
     def change_autonomous_exadata_infrastructure_compartment(self, change_compartment_details, autonomous_exadata_infrastructure_id, **kwargs):
         """
-        Move the Autonomous Exadata Infrastructure and its dependent resources to the specified compartment.
-        For more information about moving Autonomous Exadata Infrastructures, see
+        Moves the Autonomous Exadata Infrastructure resource and its dependent resources to the specified compartment.
+        For more information, see
         `Moving Database Resources to a Different Compartment`__.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes
 
 
         :param ChangeCompartmentDetails change_compartment_details: (required)
-            Request to move Autonomous Exadata Infrastructure to a different compartment
+            Request to move an Autonomous Exadata Infrastructure resource to a different compartment.
 
         :param str autonomous_exadata_infrastructure_id: (required)
             The Autonomous Exadata Infrastructure  `OCID`__.
@@ -670,14 +670,14 @@ class DatabaseClient(object):
     def change_backup_destination_compartment(self, change_compartment_details, backup_destination_id, **kwargs):
         """
         Move the backup destination and its dependent resources to the specified compartment.
-        For more information about moving backup destinations, see
+        For more information, see
         `Moving Database Resources to a Different Compartment`__.
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes
 
 
         :param ChangeCompartmentDetails change_compartment_details: (required)
-            Request to move backup destination to a different compartment
+            Request to move backup destination to a different compartment.
 
         :param str backup_destination_id: (required)
             The `OCID`__ of the backup destination.
@@ -765,6 +765,198 @@ class DatabaseClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 body=change_compartment_details)
+
+    def change_cloud_exadata_infrastructure_compartment(self, change_cloud_exadata_infrastructure_compartment_details, cloud_exadata_infrastructure_id, **kwargs):
+        """
+        To move a cloud Exadata infrastructure resource and its dependent resources to another compartment, use the
+        :func:`change_cloud_exadata_infrastructure_compartment` operation.
+
+
+        :param ChangeCloudExadataInfrastructureCompartmentDetails change_cloud_exadata_infrastructure_compartment_details: (required)
+            Request to move cloud Exadata infrastructure resource to a different compartment.
+
+        :param str cloud_exadata_infrastructure_id: (required)
+            The cloud Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudExadataInfrastructures/{cloudExadataInfrastructureId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_cloud_exadata_infrastructure_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudExadataInfrastructureId": cloud_exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_cloud_exadata_infrastructure_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_cloud_exadata_infrastructure_compartment_details)
+
+    def change_cloud_vm_cluster_compartment(self, change_cloud_vm_cluster_compartment_details, cloud_vm_cluster_id, **kwargs):
+        """
+        To move a cloud VM cluster and its dependent resources to another compartment, use the
+        :func:`change_cloud_vm_cluster_compartment` operation.
+
+
+        :param ChangeCloudVmClusterCompartmentDetails change_cloud_vm_cluster_compartment_details: (required)
+            Request to move cloud VM cluster to a different compartment
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudVmClusters/{cloudVmClusterId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_cloud_vm_cluster_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudVmClusterId": cloud_vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_cloud_vm_cluster_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_cloud_vm_cluster_compartment_details)
 
     def change_database_software_image_compartment(self, change_compartment_details, database_software_image_id, **kwargs):
         """
@@ -875,7 +1067,7 @@ class DatabaseClient(object):
 
 
         :param ChangeCompartmentDetails change_compartment_details: (required)
-            Request to move Db System to a different compartment
+            Request to move the DB system to a different compartment.
 
         :param str db_system_id: (required)
             The DB system `OCID`__.
@@ -966,7 +1158,7 @@ class DatabaseClient(object):
 
     def change_exadata_infrastructure_compartment(self, change_exadata_infrastructure_compartment_details, exadata_infrastructure_id, **kwargs):
         """
-        To move an Exadata infrastructure and its dependent resources to another compartment, use the
+        To move an Exadata Cloud@Customer infrastructure resource and its dependent resources to another compartment, use the
         :func:`change_exadata_infrastructure_compartment` operation.
 
 
@@ -1062,12 +1254,12 @@ class DatabaseClient(object):
 
     def change_vm_cluster_compartment(self, change_vm_cluster_compartment_details, vm_cluster_id, **kwargs):
         """
-        To move a VM cluster and its dependent resources to another compartment, use the
+        To move an Exadata Cloud@Customer VM cluster and its dependent resources to another compartment, use the
         :func:`change_vm_cluster_compartment` operation.
 
 
         :param ChangeVmClusterCompartmentDetails change_vm_cluster_compartment_details: (required)
-            Request to move VM cluster to a different compartment
+            Request to move the Exadata Cloud@Customer VM cluster to a different compartment.
 
         :param str vm_cluster_id: (required)
             The VM cluster `OCID`__.
@@ -1254,7 +1446,7 @@ class DatabaseClient(object):
 
     def create_autonomous_container_database(self, create_autonomous_container_database_details, **kwargs):
         """
-        Create a new Autonomous Container Database in the specified Autonomous Exadata Infrastructure.
+        Creates an Autonomous Container Database in the specified Autonomous Exadata Infrastructure.
 
 
         :param CreateAutonomousContainerDatabaseDetails create_autonomous_container_database_details: (required)
@@ -1604,7 +1796,7 @@ class DatabaseClient(object):
 
     def create_autonomous_vm_cluster(self, create_autonomous_vm_cluster_details, **kwargs):
         """
-        Creates an Autonomous VM cluster.
+        Creates an Autonomous VM cluster for Exadata Cloud@Customer.
 
 
         :param CreateAutonomousVmClusterDetails create_autonomous_vm_cluster_details: (required)
@@ -1745,7 +1937,7 @@ class DatabaseClient(object):
 
     def create_backup_destination(self, create_backup_destination_details, **kwargs):
         """
-        Creates a backup destination.
+        Creates a backup destination in an Exadata Cloud@Customer system.
 
 
         :param CreateBackupDestinationDetails create_backup_destination_details: (required)
@@ -1816,9 +2008,155 @@ class DatabaseClient(object):
                 body=create_backup_destination_details,
                 response_type="BackupDestination")
 
+    def create_cloud_exadata_infrastructure(self, create_cloud_exadata_infrastructure_details, **kwargs):
+        """
+        Creates a cloud Exadata infrastructure resource.
+
+
+        :param CreateCloudExadataInfrastructureDetails create_cloud_exadata_infrastructure_details: (required)
+            Request to create cloud Exadata infrastructure.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.CloudExadataInfrastructure`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudExadataInfrastructures"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_cloud_exadata_infrastructure got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_cloud_exadata_infrastructure_details,
+                response_type="CloudExadataInfrastructure")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_cloud_exadata_infrastructure_details,
+                response_type="CloudExadataInfrastructure")
+
+    def create_cloud_vm_cluster(self, create_cloud_vm_cluster_details, **kwargs):
+        """
+        Creates a cloud VM cluster.
+
+
+        :param CreateCloudVmClusterDetails create_cloud_vm_cluster_details: (required)
+            Request to create a cloud VM cluster.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.CloudVmCluster`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudVmClusters"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_cloud_vm_cluster got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_cloud_vm_cluster_details,
+                response_type="CloudVmCluster")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_cloud_vm_cluster_details,
+                response_type="CloudVmCluster")
+
     def create_console_connection(self, create_console_connection_details, db_node_id, **kwargs):
         """
-        Creates a new console connection to the specified dbNode.
+        Creates a new console connection to the specified database node.
         After the console connection has been created and is available,
         you connect to the console using SSH.
 
@@ -2000,7 +2338,7 @@ class DatabaseClient(object):
 
     def create_database(self, create_new_database_details, **kwargs):
         """
-        Creates a new database in the specified Database Home. If the database version is provided, it must match the version of the Database Home. Applies to Exadata DB systems and Exadata Cloud at Customer.
+        Creates a new database in the specified Database Home. If the database version is provided, it must match the version of the Database Home. Applies to Exadata and Exadata Cloud@Customer systems.
 
 
         :param CreateDatabaseBase create_new_database_details: (required)
@@ -2141,7 +2479,7 @@ class DatabaseClient(object):
 
     def create_db_home(self, create_db_home_with_db_system_id_details, **kwargs):
         """
-        Creates a new Database Home in the specified DB system based on the request parameters you provide. Applies to bare metal DB systems, Exadata DB systems, and Exadata Cloud at Customer systems.
+        Creates a new Database Home in the specified database system based on the request parameters you provide. Applies to bare metal DB systems, Exadata systems, and Exadata Cloud@Customer systems.
 
 
         :param CreateDbHomeBase create_db_home_with_db_system_id_details: (required)
@@ -2209,11 +2547,11 @@ class DatabaseClient(object):
 
     def create_exadata_infrastructure(self, create_exadata_infrastructure_details, **kwargs):
         """
-        Create Exadata infrastructure.
+        Creates Exadata Cloud@Customer infrastructure.
 
 
         :param CreateExadataInfrastructureDetails create_exadata_infrastructure_details: (required)
-            Request to create Exadata infrastructure.
+            Request to create Exadata Cloud@Customer infrastructure.
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or
@@ -2354,11 +2692,11 @@ class DatabaseClient(object):
 
     def create_vm_cluster(self, create_vm_cluster_details, **kwargs):
         """
-        Creates a VM cluster.
+        Creates an Exadata Cloud@Customer VM cluster.
 
 
         :param CreateVmClusterDetails create_vm_cluster_details: (required)
-            Request to create a VM cluster.
+            Request to create an Exadata Cloud@Customer VM cluster.
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or
@@ -2427,7 +2765,7 @@ class DatabaseClient(object):
 
     def create_vm_cluster_network(self, exadata_infrastructure_id, vm_cluster_network_details, **kwargs):
         """
-        Creates the VM cluster network.
+        Creates the Exadata Cloud@Customer VM cluster network.
 
 
         :param str exadata_infrastructure_id: (required)
@@ -2436,7 +2774,7 @@ class DatabaseClient(object):
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param VmClusterNetworkDetails vm_cluster_network_details: (required)
-            Request to create the VM cluster network.
+            Request to create the Cloud@Customer VM cluster network.
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or
@@ -2524,7 +2862,7 @@ class DatabaseClient(object):
         - reset - power off and power on
 
         **Note:** Stopping a node affects billing differently, depending on the type of DB system:
-        *Bare metal and Exadata DB systems* - The _stop_ state has no effect on the resources you consume.
+        *Bare metal and Exadata systems* - The _stop_ state has no effect on the resources you consume.
         Billing continues for DB nodes that you stop, and related resources continue
         to apply against any relevant quotas. You must terminate the DB system
         (:func:`terminate_db_system`)
@@ -2781,7 +3119,7 @@ class DatabaseClient(object):
 
     def delete_autonomous_vm_cluster(self, autonomous_vm_cluster_id, **kwargs):
         """
-        Deletes the specified Autonomous VM cluster.
+        Deletes the specified Autonomous VM cluster in an Exadata Cloud@Customer system.
 
 
         :param str autonomous_vm_cluster_id: (required)
@@ -2934,7 +3272,7 @@ class DatabaseClient(object):
 
     def delete_backup_destination(self, backup_destination_id, **kwargs):
         """
-        Deletes a backup destination.
+        Deletes a backup destination in an Exadata Cloud@Customer system.
 
 
         :param str backup_destination_id: (required)
@@ -3011,9 +3349,178 @@ class DatabaseClient(object):
                 path_params=path_params,
                 header_params=header_params)
 
+    def delete_cloud_exadata_infrastructure(self, cloud_exadata_infrastructure_id, **kwargs):
+        """
+        Deletes the cloud Exadata infrastructure resource.
+
+
+        :param str cloud_exadata_infrastructure_id: (required)
+            The cloud Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param bool is_delete_vm_clusters: (optional)
+            If `true`, forces the deletion the specified cloud Exadata infrastructure resource as well as all associated VM clusters. If `false`, the cloud Exadata infrastructure resource can be deleted only if it has no associated VM clusters. Default value is `false`.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudExadataInfrastructures/{cloudExadataInfrastructureId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "is_delete_vm_clusters",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_cloud_exadata_infrastructure got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudExadataInfrastructureId": cloud_exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "isDeleteVmClusters": kwargs.get("is_delete_vm_clusters", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+
+    def delete_cloud_vm_cluster(self, cloud_vm_cluster_id, **kwargs):
+        """
+        Deletes the specified cloud VM cluster.
+
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudVmClusters/{cloudVmClusterId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_cloud_vm_cluster got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudVmClusterId": cloud_vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
     def delete_console_connection(self, db_node_id, console_connection_id, **kwargs):
         """
-        Deletes the specified Db node console connection.
+        Deletes the specified database node console connection.
 
 
         :param str db_node_id: (required)
@@ -3091,9 +3598,9 @@ class DatabaseClient(object):
 
     def delete_database(self, database_id, **kwargs):
         """
-        Deletes the database. Applies only to Exadata DB systems.
+        Deletes the specified database. Applies only to Exadata systems.
 
-        The data in this database is local to the DB system and will be lost when the database is deleted. Oracle recommends that you back up any data in the DB system prior to deleting it. You can use the `performFinalBackup` parameter to have the Exadata DB system database backed up before it is deleted.
+        The data in this database is local to the Exadata system and will be lost when the database is deleted. Oracle recommends that you back up any data in the Exadata system prior to deleting it. You can use the `performFinalBackup` parameter to have the Exadata system database backed up before it is deleted.
 
 
         :param str database_id: (required)
@@ -3261,9 +3768,9 @@ class DatabaseClient(object):
 
     def delete_db_home(self, db_home_id, **kwargs):
         """
-        Deletes a Database Home. Applies to bare metal DB systems, Exadata DB systems, and Exadata Cloud at Customer systems.
+        Deletes a Database Home. Applies to bare metal DB systems, Exadata Cloud Service, and Exadata Cloud@Customer systems.
 
-        Oracle recommends that you use the `performFinalBackup` parameter to back up any data on a bare metal DB system before you delete a Database Home. On an Exadata Cloud at Customer system or an Exadata DB system, you can delete a Database Home only when there are no databases in it and therefore you cannot use the `performFinalBackup` parameter to back up data.
+        Oracle recommends that you use the `performFinalBackup` parameter to back up any data on a bare metal DB system before you delete a Database Home. On an Exadata Cloud@Customer system or an Exadata Cloud Service system, you can delete a Database Home only when there are no databases in it and therefore you cannot use the `performFinalBackup` parameter to back up data.
 
 
         :param str db_home_id: (required)
@@ -3352,7 +3859,7 @@ class DatabaseClient(object):
 
     def delete_exadata_infrastructure(self, exadata_infrastructure_id, **kwargs):
         """
-        Deletes the Exadata infrastructure.
+        Deletes the Exadata Cloud@Customer infrastructure.
 
 
         :param str exadata_infrastructure_id: (required)
@@ -3431,7 +3938,7 @@ class DatabaseClient(object):
 
     def delete_vm_cluster(self, vm_cluster_id, **kwargs):
         """
-        Deletes the specified VM cluster.
+        Deletes the specified Exadata Cloud@Customer VM cluster.
 
 
         :param str vm_cluster_id: (required)
@@ -3510,7 +4017,7 @@ class DatabaseClient(object):
 
     def delete_vm_cluster_network(self, exadata_infrastructure_id, vm_cluster_network_id, **kwargs):
         """
-        Deletes the specified VM cluster network.
+        Deletes the specified Exadata Cloud@Customer VM cluster network.
 
 
         :param str exadata_infrastructure_id: (required)
@@ -3673,7 +4180,7 @@ class DatabaseClient(object):
 
     def download_exadata_infrastructure_config_file(self, exadata_infrastructure_id, **kwargs):
         """
-        Downloads the configuration file for the specified Exadata infrastructure.
+        Downloads the configuration file for the specified Exadata Cloud@Customer infrastructure.
 
 
         :param str exadata_infrastructure_id: (required)
@@ -3758,7 +4265,7 @@ class DatabaseClient(object):
 
     def download_vm_cluster_network_config_file(self, exadata_infrastructure_id, vm_cluster_network_id, **kwargs):
         """
-        Downloads the configuration file for the specified VM Cluster Network.
+        Downloads the configuration file for the specified Exadata Cloud@Customer VM cluster network.
 
 
         :param str exadata_infrastructure_id: (required)
@@ -4212,7 +4719,7 @@ class DatabaseClient(object):
 
     def generate_recommended_vm_cluster_network(self, exadata_infrastructure_id, generate_recommended_network_details, **kwargs):
         """
-        Generates a recommended VM cluster network configuration.
+        Generates a recommended Cloud@Customer VM cluster network configuration.
 
 
         :param str exadata_infrastructure_id: (required)
@@ -4221,7 +4728,7 @@ class DatabaseClient(object):
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param GenerateRecommendedNetworkDetails generate_recommended_network_details: (required)
-            Request to generate a recommended VM cluster network configuration.
+            Request to generate a recommended Cloud@Customer VM cluster network configuration.
 
         :param str opc_request_id: (optional)
             Unique identifier for the request.
@@ -4776,7 +5283,7 @@ class DatabaseClient(object):
 
     def get_autonomous_exadata_infrastructure(self, autonomous_exadata_infrastructure_id, **kwargs):
         """
-        Gets information about the specified Autonomous Exadata Infrastructure.
+        Gets information about the specified Autonomous Exadata Infrastructure resource.
 
 
         :param str autonomous_exadata_infrastructure_id: (required)
@@ -4841,11 +5348,11 @@ class DatabaseClient(object):
 
     def get_autonomous_patch(self, autonomous_patch_id, **kwargs):
         """
-        Gets information about the specified Autonomous Patch.
+        Gets information about a specific autonomous patch.
 
 
         :param str autonomous_patch_id: (required)
-            The Autonomous Patch `OCID`__.
+            The autonomous patch `OCID`__.
 
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -4906,7 +5413,7 @@ class DatabaseClient(object):
 
     def get_autonomous_vm_cluster(self, autonomous_vm_cluster_id, **kwargs):
         """
-        Gets information about the specified Autonomous VM cluster.
+        Gets information about the specified Autonomous VM cluster for an Exadata Cloud@Customer system.
 
 
         :param str autonomous_vm_cluster_id: (required)
@@ -5045,7 +5552,7 @@ class DatabaseClient(object):
 
     def get_backup_destination(self, backup_destination_id, **kwargs):
         """
-        Gets information about the specified backup destination.
+        Gets information about the specified backup destination in an Exadata Cloud@Customer system.
 
 
         :param str backup_destination_id: (required)
@@ -5117,9 +5624,392 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="BackupDestination")
 
+    def get_cloud_exadata_infrastructure(self, cloud_exadata_infrastructure_id, **kwargs):
+        """
+        Gets information about the specified cloud Exadata infrastructure resource.
+
+
+        :param str cloud_exadata_infrastructure_id: (required)
+            The cloud Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.CloudExadataInfrastructure`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudExadataInfrastructures/{cloudExadataInfrastructureId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_cloud_exadata_infrastructure got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudExadataInfrastructureId": cloud_exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="CloudExadataInfrastructure")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="CloudExadataInfrastructure")
+
+    def get_cloud_vm_cluster(self, cloud_vm_cluster_id, **kwargs):
+        """
+        Gets information about the specified cloud VM cluster.
+
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.CloudVmCluster`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudVmClusters/{cloudVmClusterId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_cloud_vm_cluster got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudVmClusterId": cloud_vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="CloudVmCluster")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="CloudVmCluster")
+
+    def get_cloud_vm_cluster_iorm_config(self, cloud_vm_cluster_id, **kwargs):
+        """
+        Gets the IORM configuration for the specified cloud VM cluster.
+        If you have not specified an IORM configuration, the default configuration is returned.
+
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExadataIormConfig`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudVmClusters/{cloudVmClusterId}/CloudVmClusterIormConfig"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_cloud_vm_cluster_iorm_config got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudVmClusterId": cloud_vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExadataIormConfig")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExadataIormConfig")
+
+    def get_cloud_vm_cluster_update(self, cloud_vm_cluster_id, update_id, **kwargs):
+        """
+        Gets information about a specified maintenance update package.
+
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str update_id: (required)
+            The `OCID`__ of the maintenance update.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.Update`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudVmClusters/{cloudVmClusterId}/updates/{updateId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_cloud_vm_cluster_update got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudVmClusterId": cloud_vm_cluster_id,
+            "updateId": update_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Update")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Update")
+
+    def get_cloud_vm_cluster_update_history_entry(self, cloud_vm_cluster_id, update_history_entry_id, **kwargs):
+        """
+        Gets the maintenance update history details for the specified update history entry.
+
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str update_history_entry_id: (required)
+            The `OCID`__ of the maintenance update history entry.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.UpdateHistoryEntry`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudVmClusters/{cloudVmClusterId}/updateHistoryEntries/{updateHistoryEntryId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_cloud_vm_cluster_update_history_entry got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudVmClusterId": cloud_vm_cluster_id,
+            "updateHistoryEntryId": update_history_entry_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="UpdateHistoryEntry")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="UpdateHistoryEntry")
+
     def get_console_connection(self, db_node_id, console_connection_id, **kwargs):
         """
-        Gets the specified Db node console connection's information.
+        Gets the specified database node console connection's information.
 
 
         :param str db_node_id: (required)
@@ -5259,7 +6149,7 @@ class DatabaseClient(object):
 
     def get_database(self, database_id, **kwargs):
         """
-        Gets information about a specific database.
+        Gets information about the specified database.
 
 
         :param str database_id: (required)
@@ -5726,7 +6616,7 @@ class DatabaseClient(object):
 
     def get_db_system_patch(self, db_system_id, patch_id, **kwargs):
         """
-        Gets information about a specified patch package.
+        Gets information the specified patch.
 
 
         :param str db_system_id: (required)
@@ -5797,7 +6687,7 @@ class DatabaseClient(object):
 
     def get_db_system_patch_history_entry(self, db_system_id, patch_history_entry_id, **kwargs):
         """
-        Gets the patch history details for the specified patchHistoryEntryId.
+        Gets the details of the specified patch operation on the specified DB system.
 
 
         :param str db_system_id: (required)
@@ -5868,7 +6758,7 @@ class DatabaseClient(object):
 
     def get_exadata_infrastructure(self, exadata_infrastructure_id, **kwargs):
         """
-        Gets information about the specified Exadata infrastructure.
+        Gets information about the specified Exadata Cloud@Customer infrastructure.
 
 
         :param str exadata_infrastructure_id: (required)
@@ -5942,7 +6832,7 @@ class DatabaseClient(object):
 
     def get_exadata_infrastructure_ocpus(self, autonomous_exadata_infrastructure_id, **kwargs):
         """
-        Gets details of the available and consumed OCPUs for the specified Autonomous Exadata Infrastructure instance.
+        Gets details of the available and consumed OCPUs for the specified Autonomous Exadata Infrastructure resource.
 
 
         :param str autonomous_exadata_infrastructure_id: (required)
@@ -6016,8 +6906,8 @@ class DatabaseClient(object):
 
     def get_exadata_iorm_config(self, db_system_id, **kwargs):
         """
-        Gets `IORM` Setting for the requested Exadata DB System.
-        The default IORM Settings is pre-created in all the Exadata DB System.
+        Gets the IORM configuration settings for the specified cloud Exadata system.
+        All Exadata service instances have default IORM settings.
 
 
         :param str db_system_id: (required)
@@ -6223,7 +7113,7 @@ class DatabaseClient(object):
 
     def get_vm_cluster(self, vm_cluster_id, **kwargs):
         """
-        Gets information about the specified VM cluster.
+        Gets information about the specified Exadata Cloud@Customer VM cluster.
 
 
         :param str vm_cluster_id: (required)
@@ -6297,7 +7187,7 @@ class DatabaseClient(object):
 
     def get_vm_cluster_network(self, exadata_infrastructure_id, vm_cluster_network_id, **kwargs):
         """
-        Gets information about the specified VM cluster network.
+        Gets information about the specified Exadata Cloud@Customer VM cluster network.
 
 
         :param str exadata_infrastructure_id: (required)
@@ -6448,7 +7338,7 @@ class DatabaseClient(object):
 
     def get_vm_cluster_patch_history_entry(self, vm_cluster_id, patch_history_entry_id, **kwargs):
         """
-        Gets the patch history details for the specified patchHistoryEntryId.
+        Gets the patch history details for the specified patch history entry.
 
 
         :param str vm_cluster_id: (required)
@@ -6519,11 +7409,11 @@ class DatabaseClient(object):
 
     def launch_autonomous_exadata_infrastructure(self, launch_autonomous_exadata_infrastructure_details, **kwargs):
         """
-        Launches a new Autonomous Exadata Infrastructure in the specified compartment and availability domain.
+        Creates a new Autonomous Exadata Infrastructure in the specified compartment and availability domain.
 
 
         :param LaunchAutonomousExadataInfrastructureDetails launch_autonomous_exadata_infrastructure_details: (required)
-            Request to launch a Autonomous Exadata Infrastructure.
+            Request to create an Autonomous Exadata Infrastructure resource.
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or
@@ -7208,7 +8098,7 @@ class DatabaseClient(object):
 
     def list_autonomous_database_clones(self, compartment_id, autonomous_database_id, **kwargs):
         """
-        Gets a list of the Autonomous Database clones for the specified Autonomous Database.
+        Lists the Autonomous Database clones for the specified Autonomous Database.
 
 
         :param str compartment_id: (required)
@@ -7367,7 +8257,7 @@ class DatabaseClient(object):
 
     def list_autonomous_databases(self, compartment_id, **kwargs):
         """
-        Gets a list of Autonomous Databases.
+        Gets a list of Autonomous Databases based on the query parameters specified.
 
 
         :param str compartment_id: (required)
@@ -7771,7 +8661,7 @@ class DatabaseClient(object):
 
     def list_autonomous_exadata_infrastructure_shapes(self, availability_domain, compartment_id, **kwargs):
         """
-        Gets a list of the shapes that can be used to launch a new Autonomous Exadata Infrastructure DB system. The shape determines resources to allocate to the DB system (CPU cores, memory and storage).
+        Gets a list of the shapes that can be used to launch a new Autonomous Exadata Infrastructure resource. The shape determines resources to allocate (CPU cores, memory and storage).
 
 
         :param str availability_domain: (required)
@@ -7981,7 +8871,7 @@ class DatabaseClient(object):
 
     def list_autonomous_vm_clusters(self, compartment_id, **kwargs):
         """
-        Gets a list of Autonomous VM clusters in the specified compartment.
+        Gets a list of Exadata Cloud@Customer Autonomous VM clusters in the specified compartment.
 
 
         :param str compartment_id: (required)
@@ -8196,7 +9086,7 @@ class DatabaseClient(object):
 
     def list_backups(self, **kwargs):
         """
-        Gets a list of backups based on the databaseId or compartmentId specified. Either one of the query parameters must be provided.
+        Gets a list of backups based on the `databaseId` or `compartmentId` specified. Either one of these query parameters must be provided.
 
 
         :param str database_id: (optional)
@@ -8275,9 +9165,474 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="list[BackupSummary]")
 
+    def list_cloud_exadata_infrastructures(self, compartment_id, **kwargs):
+        """
+        Gets a list of the cloud Exadata infrastructure in the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the given lifecycle state exactly.
+
+            Allowed values are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.CloudExadataInfrastructureSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudExadataInfrastructures"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "opc_request_id",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state",
+            "display_name"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_cloud_exadata_infrastructures got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[CloudExadataInfrastructureSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[CloudExadataInfrastructureSummary]")
+
+    def list_cloud_vm_cluster_update_history_entries(self, cloud_vm_cluster_id, **kwargs):
+        """
+        Gets the history of the maintenance update actions performed on the specified cloud VM cluster.
+
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str update_type: (optional)
+            A filter to return only resources that match the given update type exactly.
+
+            Allowed values are: "GI_PATCH"
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.UpdateHistoryEntrySummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudVmClusters/{cloudVmClusterId}/updateHistoryEntries"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "update_type",
+            "limit",
+            "page",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_cloud_vm_cluster_update_history_entries got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudVmClusterId": cloud_vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'update_type' in kwargs:
+            update_type_allowed_values = ["GI_PATCH"]
+            if kwargs['update_type'] not in update_type_allowed_values:
+                raise ValueError(
+                    "Invalid value for `update_type`, must be one of {0}".format(update_type_allowed_values)
+                )
+
+        query_params = {
+            "updateType": kwargs.get("update_type", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[UpdateHistoryEntrySummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[UpdateHistoryEntrySummary]")
+
+    def list_cloud_vm_cluster_updates(self, cloud_vm_cluster_id, **kwargs):
+        """
+        Lists the maintenance updates that can be applied to the requested cloud VM cluster.
+
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str update_type: (optional)
+            A filter to return only resources that match the given update type exactly.
+
+            Allowed values are: "GI_PATCH"
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.UpdateSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudVmClusters/{cloudVmClusterId}/updates"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "update_type",
+            "limit",
+            "page",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_cloud_vm_cluster_updates got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudVmClusterId": cloud_vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'update_type' in kwargs:
+            update_type_allowed_values = ["GI_PATCH"]
+            if kwargs['update_type'] not in update_type_allowed_values:
+                raise ValueError(
+                    "Invalid value for `update_type`, must be one of {0}".format(update_type_allowed_values)
+                )
+
+        query_params = {
+            "updateType": kwargs.get("update_type", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[UpdateSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[UpdateSummary]")
+
+    def list_cloud_vm_clusters(self, compartment_id, **kwargs):
+        """
+        Gets a list of the cloud VM clusters in the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str cloud_exadata_infrastructure_id: (optional)
+            If provided, filters the results for the specified cloud Exadata infrastructure.
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str sort_by: (optional)
+            The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to return only cloud VM clusters that match the given lifecycle state exactly.
+
+            Allowed values are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.CloudVmClusterSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudVmClusters"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "cloud_exadata_infrastructure_id",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state",
+            "display_name",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_cloud_vm_clusters got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "cloudExadataInfrastructureId": kwargs.get("cloud_exadata_infrastructure_id", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[CloudVmClusterSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[CloudVmClusterSummary]")
+
     def list_console_connections(self, db_node_id, **kwargs):
         """
-        Lists the console connections for the specified Db node.
+        Lists the console connections for the specified database node.
 
 
         :param str db_node_id: (required)
@@ -8543,7 +9898,7 @@ class DatabaseClient(object):
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the given lifecycle state exactly.
 
-            Allowed values are: "PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "UPDATING"
+            Allowed values are: "PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "TERMINATING", "TERMINATED", "UPDATING"
 
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
@@ -8604,7 +9959,7 @@ class DatabaseClient(object):
                 )
 
         if 'lifecycle_state' in kwargs:
-            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "UPDATING"]
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "TERMINATING", "TERMINATED", "UPDATING"]
             if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
                 raise ValueError(
                     "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
@@ -8798,7 +10153,7 @@ class DatabaseClient(object):
 
     def list_db_home_patch_history_entries(self, db_home_id, **kwargs):
         """
-        Gets history of the actions taken for patches for the specified Database Home.
+        Lists the history of patch operations on the specified Database Home.
 
 
         :param str db_home_id: (required)
@@ -8966,7 +10321,7 @@ class DatabaseClient(object):
 
     def list_db_homes(self, compartment_id, **kwargs):
         """
-        Gets a list of Database Homes in the specified DB system and compartment. A Database Home is a directory where Oracle Database software is installed.
+        Lists the Database Homes in the specified DB system and compartment. A Database Home is a directory where Oracle Database software is installed.
 
 
         :param str compartment_id: (required)
@@ -9107,7 +10462,7 @@ class DatabaseClient(object):
 
     def list_db_nodes(self, compartment_id, **kwargs):
         """
-        Gets a list of database nodes in the specified DB system and compartment. A database node is a server running database software.
+        Lists the database nodes in the specified DB system and compartment. A database node is a server running database software.
 
 
         :param str compartment_id: (required)
@@ -9320,7 +10675,7 @@ class DatabaseClient(object):
 
     def list_db_system_patches(self, db_system_id, **kwargs):
         """
-        Lists the patches applicable to the requested DB system.
+        Lists the patches applicable to the specified DB system.
 
 
         :param str db_system_id: (required)
@@ -9482,7 +10837,7 @@ class DatabaseClient(object):
 
     def list_db_systems(self, compartment_id, **kwargs):
         """
-        Gets a list of the DB systems in the specified compartment. You can specify a backupId to list only the DB systems that support creating a database using this backup in this compartment.
+        Lists the DB systems in the specified compartment. You can specify a `backupId` to list only the DB systems that support creating a database using this backup in this compartment.
 
 
         :param str compartment_id: (required)
@@ -9516,7 +10871,7 @@ class DatabaseClient(object):
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the given lifecycle state exactly.
 
-            Allowed values are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"
+            Allowed values are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MIGRATED", "MAINTENANCE_IN_PROGRESS"
 
         :param str availability_domain: (optional)
             A filter to return only resources that match the given availability domain exactly.
@@ -9570,7 +10925,7 @@ class DatabaseClient(object):
                 )
 
         if 'lifecycle_state' in kwargs:
-            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MIGRATED", "MAINTENANCE_IN_PROGRESS"]
             if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
                 raise ValueError(
                     "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
@@ -9717,7 +11072,7 @@ class DatabaseClient(object):
 
     def list_exadata_infrastructures(self, compartment_id, **kwargs):
         """
-        Gets a list of the Exadata infrastructure in the specified compartment.
+        Gets a list of the Exadata Cloud@Customer infrastructure resources in the specified compartment.
 
 
         :param str compartment_id: (required)
@@ -9843,7 +11198,7 @@ class DatabaseClient(object):
 
     def list_gi_versions(self, compartment_id, **kwargs):
         """
-        Gets a list of supported GI versions for VM Cluster.
+        Gets a list of supported GI versions for the Exadata Cloud@Customer VM cluster.
 
 
         :param str compartment_id: (required)
@@ -9949,7 +11304,7 @@ class DatabaseClient(object):
         :param str target_resource_type: (optional)
             The type of the target resource.
 
-            Allowed values are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM"
+            Allowed values are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", "CLOUD_EXADATA_INFRASTRUCTURE"
 
         :param str maintenance_type: (optional)
             The maintenance type.
@@ -10015,7 +11370,7 @@ class DatabaseClient(object):
                 "list_maintenance_runs got unknown kwargs: {!r}".format(extra_kwargs))
 
         if 'target_resource_type' in kwargs:
-            target_resource_type_allowed_values = ["AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM"]
+            target_resource_type_allowed_values = ["AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", "CLOUD_EXADATA_INFRASTRUCTURE"]
             if kwargs['target_resource_type'] not in target_resource_type_allowed_values:
                 raise ValueError(
                     "Invalid value for `target_resource_type`, must be one of {0}".format(target_resource_type_allowed_values)
@@ -10090,7 +11445,7 @@ class DatabaseClient(object):
 
     def list_vm_cluster_networks(self, exadata_infrastructure_id, compartment_id, **kwargs):
         """
-        Gets a list of the VM cluster networks in the specified compartment.
+        Gets a list of the Exadata Cloud@Customer VM cluster networks in the specified compartment.
 
 
         :param str exadata_infrastructure_id: (required)
@@ -10233,7 +11588,7 @@ class DatabaseClient(object):
 
     def list_vm_cluster_patch_history_entries(self, vm_cluster_id, **kwargs):
         """
-        Gets the history of the patch actions performed on the specified Vm cluster.
+        Gets the history of the patch actions performed on the specified VM cluster in an Exadata Cloud@Customer system.
 
 
         :param str vm_cluster_id: (required)
@@ -10317,7 +11672,7 @@ class DatabaseClient(object):
 
     def list_vm_cluster_patches(self, vm_cluster_id, **kwargs):
         """
-        Lists the patches applicable to the requested Vm cluster.
+        Lists the patches applicable to the specified VM cluster in an Exadata Cloud@Customer system.
 
 
         :param str vm_cluster_id: (required)
@@ -10401,7 +11756,7 @@ class DatabaseClient(object):
 
     def list_vm_clusters(self, compartment_id, **kwargs):
         """
-        Gets a list of the VM clusters in the specified compartment.
+        Gets a list of the Exadata Cloud@Customer VM clusters in the specified compartment.
 
 
         :param str compartment_id: (required)
@@ -10529,6 +11884,98 @@ class DatabaseClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="list[VmClusterSummary]")
+
+    def migrate_exadata_db_system_resource_model(self, db_system_id, **kwargs):
+        """
+        Migrates the Exadata DB system to the cloud Exadata infrastructure model. All related resources will be migrated.
+
+
+        :param str db_system_id: (required)
+            The DB system `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExadataDbSystemMigration`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/dbSystems/{dbSystemId}/actions/migration"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "migrate_exadata_db_system_resource_model got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "dbSystemId": db_system_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExadataDbSystemMigration")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExadataDbSystemMigration")
 
     def register_autonomous_database_data_safe(self, autonomous_database_id, **kwargs):
         """
@@ -11094,6 +12541,194 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=restore_database_details,
                 response_type="Database")
+
+    def rotate_autonomous_container_database_encryption_key(self, autonomous_container_database_id, **kwargs):
+        """
+        Creates a new version of an existing `Vault service`__ key.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/KeyManagement/Concepts/keyoverview.htm
+
+
+        :param str autonomous_container_database_id: (required)
+            The Autonomous Container Database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.AutonomousContainerDatabase`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousContainerDatabases/{autonomousContainerDatabaseId}/actions/rotateKey"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "rotate_autonomous_container_database_encryption_key got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "autonomousContainerDatabaseId": autonomous_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="AutonomousContainerDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="AutonomousContainerDatabase")
+
+    def rotate_autonomous_database_encryption_key(self, autonomous_database_id, **kwargs):
+        """
+        Rotate existing AutonomousDatabase `Vault service`__ key.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/KeyManagement/Concepts/keyoverview.htm
+
+
+        :param str autonomous_database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.AutonomousDatabase`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/autonomousDatabases/{autonomousDatabaseId}/actions/rotateKey"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "rotate_autonomous_database_encryption_key got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "autonomousDatabaseId": autonomous_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="AutonomousDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="AutonomousDatabase")
 
     def start_autonomous_data_warehouse(self, autonomous_data_warehouse_id, **kwargs):
         """
@@ -11662,7 +13297,7 @@ class DatabaseClient(object):
 
     def terminate_autonomous_exadata_infrastructure(self, autonomous_exadata_infrastructure_id, **kwargs):
         """
-        Terminates an Autonomous Exadata Infrastructure, which permanently deletes the Exadata Infrastructure and any container databases and databases contained in the Exadata Infrastructure. The database data is local to the Autonomous Exadata Infrastructure and will be lost when the system is terminated. Oracle recommends that you back up any data in the Autonomous Exadata Infrastructure prior to terminating it.
+        Terminates an Autonomous Exadata Infrastructure, which permanently deletes the infrastructure resource and any container databases and databases contained in the resource. The database data is local to the Autonomous Exadata Infrastructure and will be lost when the system is terminated. Oracle recommends that you back up any data in the Autonomous Exadata Infrastructure prior to terminating it.
 
 
         :param str autonomous_exadata_infrastructure_id: (required)
@@ -12276,7 +13911,7 @@ class DatabaseClient(object):
 
     def update_autonomous_vm_cluster(self, autonomous_vm_cluster_id, update_autonomous_vm_cluster_details, **kwargs):
         """
-        Updates the specified Autonomous VM cluster.
+        Updates the specified Autonomous VM cluster for the Exadata Cloud@Customer system.
 
 
         :param str autonomous_vm_cluster_id: (required)
@@ -12449,9 +14084,267 @@ class DatabaseClient(object):
                 body=update_backup_destination_details,
                 response_type="BackupDestination")
 
+    def update_cloud_exadata_infrastructure(self, cloud_exadata_infrastructure_id, update_cloud_exadata_infrastructure_details, **kwargs):
+        """
+        Updates the Cloud Exadata infrastructure resource.
+
+
+        :param str cloud_exadata_infrastructure_id: (required)
+            The cloud Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateCloudExadataInfrastructureDetails update_cloud_exadata_infrastructure_details: (required)
+            Request to update the properties of an cloud Exadata infrastructure resource.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.CloudExadataInfrastructure`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudExadataInfrastructures/{cloudExadataInfrastructureId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_cloud_exadata_infrastructure got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudExadataInfrastructureId": cloud_exadata_infrastructure_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_cloud_exadata_infrastructure_details,
+                response_type="CloudExadataInfrastructure")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_cloud_exadata_infrastructure_details,
+                response_type="CloudExadataInfrastructure")
+
+    def update_cloud_vm_cluster(self, cloud_vm_cluster_id, update_cloud_vm_cluster_details, **kwargs):
+        """
+        Updates the specified cloud VM cluster.
+
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateCloudVmClusterDetails update_cloud_vm_cluster_details: (required)
+            Request to update the attributes of a cloud VM cluster.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.CloudVmCluster`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudVmClusters/{cloudVmClusterId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_cloud_vm_cluster got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudVmClusterId": cloud_vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_cloud_vm_cluster_details,
+                response_type="CloudVmCluster")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_cloud_vm_cluster_details,
+                response_type="CloudVmCluster")
+
+    def update_cloud_vm_cluster_iorm_config(self, cloud_vm_cluster_id, cloud_vm_cluster_iorm_config_update_details, **kwargs):
+        """
+        Updates the IORM settings for the specified cloud VM cluster.
+
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param ExadataIormConfigUpdateDetails cloud_vm_cluster_iorm_config_update_details: (required)
+            Request to perform database update.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExadataIormConfig`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/cloudVmClusters/{cloudVmClusterId}/CloudVmClusterIormConfig"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_cloud_vm_cluster_iorm_config got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "cloudVmClusterId": cloud_vm_cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=cloud_vm_cluster_iorm_config_update_details,
+                response_type="ExadataIormConfig")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=cloud_vm_cluster_iorm_config_update_details,
+                response_type="ExadataIormConfig")
+
     def update_database(self, database_id, update_database_details, **kwargs):
         """
-        Update a Database based on the request parameters you provide.
+        Update the specified database based on the request parameters provided.
 
 
         :param str database_id: (required)
@@ -12613,7 +14506,7 @@ class DatabaseClient(object):
 
     def update_db_home(self, db_home_id, update_db_home_details, **kwargs):
         """
-        Patches the specified dbHome.
+        Patches the specified Database Home.
 
 
         :param str db_home_id: (required)
@@ -12622,7 +14515,7 @@ class DatabaseClient(object):
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param UpdateDbHomeDetails update_db_home_details: (required)
-            Request to update the properties of a DB Home.
+            Request to update the properties of a Database Home.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
@@ -12694,7 +14587,7 @@ class DatabaseClient(object):
 
     def update_db_system(self, db_system_id, update_db_system_details, **kwargs):
         """
-        Updates the properties of a DB system, such as the CPU core count.
+        Updates the properties of the specified DB system.
 
 
         :param str db_system_id: (required)
@@ -12775,7 +14668,7 @@ class DatabaseClient(object):
 
     def update_exadata_infrastructure(self, exadata_infrastructure_id, update_exadata_infrastructure_details, **kwargs):
         """
-        Updates the Exadata infrastructure.
+        Updates the Exadata Cloud@Customer infrastructure.
 
 
         :param str exadata_infrastructure_id: (required)
@@ -12784,7 +14677,7 @@ class DatabaseClient(object):
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param UpdateExadataInfrastructureDetails update_exadata_infrastructure_details: (required)
-            Request to update the properties of an Exadata infrastructure
+            Request to update the properties of an Exadata Cloud@Customer infrastructure.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
@@ -12861,7 +14754,7 @@ class DatabaseClient(object):
 
     def update_exadata_iorm_config(self, db_system_id, exadata_iorm_config_update_details, **kwargs):
         """
-        Update `IORM` Settings for the requested Exadata DB System.
+        Updates IORM settings for the specified Exadata system.
 
 
         :param str db_system_id: (required)
@@ -13026,7 +14919,7 @@ class DatabaseClient(object):
 
     def update_vm_cluster(self, vm_cluster_id, update_vm_cluster_details, **kwargs):
         """
-        Updates the specified VM cluster.
+        Updates the specified Exadata Cloud@Customer VM cluster.
 
 
         :param str vm_cluster_id: (required)
@@ -13112,7 +15005,7 @@ class DatabaseClient(object):
 
     def update_vm_cluster_network(self, exadata_infrastructure_id, vm_cluster_network_id, update_vm_cluster_network_details, **kwargs):
         """
-        Updates the specified VM cluster network.
+        Updates the specified Exadata Cloud@Customer VM cluster network.
 
 
         :param str exadata_infrastructure_id: (required)
@@ -13204,7 +15097,7 @@ class DatabaseClient(object):
 
     def validate_vm_cluster_network(self, exadata_infrastructure_id, vm_cluster_network_id, **kwargs):
         """
-        Validates the specified VM cluster network.
+        Validates the specified Exadata Cloud@Customer VM cluster network.
 
 
         :param str exadata_infrastructure_id: (required)

--- a/src/oci/database/database_client_composite_operations.py
+++ b/src/oci/database/database_client_composite_operations.py
@@ -279,7 +279,7 @@ class DatabaseClientCompositeOperations(object):
         to enter the given state(s).
 
         :param ChangeCompartmentDetails change_compartment_details: (required)
-            Request to move Autonomous Exadata Infrastructure to a different compartment
+            Request to move an Autonomous Exadata Infrastructure resource to a different compartment.
 
         :param str autonomous_exadata_infrastructure_id: (required)
             The Autonomous Exadata Infrastructure  `OCID`__.
@@ -359,7 +359,7 @@ class DatabaseClientCompositeOperations(object):
         to enter the given state(s).
 
         :param ChangeCompartmentDetails change_compartment_details: (required)
-            Request to move backup destination to a different compartment
+            Request to move backup destination to a different compartment.
 
         :param str backup_destination_id: (required)
             The `OCID`__ of the backup destination.
@@ -378,6 +378,86 @@ class DatabaseClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         operation_result = self.client.change_backup_destination_compartment(change_compartment_details, backup_destination_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def change_cloud_exadata_infrastructure_compartment_and_wait_for_work_request(self, change_cloud_exadata_infrastructure_compartment_details, cloud_exadata_infrastructure_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.change_cloud_exadata_infrastructure_compartment` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param ChangeCloudExadataInfrastructureCompartmentDetails change_cloud_exadata_infrastructure_compartment_details: (required)
+            Request to move cloud Exadata infrastructure resource to a different compartment.
+
+        :param str cloud_exadata_infrastructure_id: (required)
+            The cloud Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.change_cloud_exadata_infrastructure_compartment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.change_cloud_exadata_infrastructure_compartment(change_cloud_exadata_infrastructure_compartment_details, cloud_exadata_infrastructure_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def change_cloud_vm_cluster_compartment_and_wait_for_work_request(self, change_cloud_vm_cluster_compartment_details, cloud_vm_cluster_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.change_cloud_vm_cluster_compartment` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param ChangeCloudVmClusterCompartmentDetails change_cloud_vm_cluster_compartment_details: (required)
+            Request to move cloud VM cluster to a different compartment
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.change_cloud_vm_cluster_compartment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.change_cloud_vm_cluster_compartment(change_cloud_vm_cluster_compartment_details, cloud_vm_cluster_id, **operation_kwargs)
         work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
         lowered_work_request_states = [w.lower() for w in work_request_states]
         work_request_id = operation_result.headers['opc-work-request-id']
@@ -439,7 +519,7 @@ class DatabaseClientCompositeOperations(object):
         to enter the given state(s).
 
         :param ChangeCompartmentDetails change_compartment_details: (required)
-            Request to move Db System to a different compartment
+            Request to move the DB system to a different compartment.
 
         :param str db_system_id: (required)
             The DB system `OCID`__.
@@ -519,7 +599,7 @@ class DatabaseClientCompositeOperations(object):
         to enter the given state(s).
 
         :param ChangeVmClusterCompartmentDetails change_vm_cluster_compartment_details: (required)
-            Request to move VM cluster to a different compartment
+            Request to move the Exadata Cloud@Customer VM cluster to a different compartment.
 
         :param str vm_cluster_id: (required)
             The VM cluster `OCID`__.
@@ -1072,6 +1152,152 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def create_cloud_exadata_infrastructure_and_wait_for_work_request(self, create_cloud_exadata_infrastructure_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_cloud_exadata_infrastructure` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param CreateCloudExadataInfrastructureDetails create_cloud_exadata_infrastructure_details: (required)
+            Request to create cloud Exadata infrastructure.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_cloud_exadata_infrastructure`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_cloud_exadata_infrastructure(create_cloud_exadata_infrastructure_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_cloud_exadata_infrastructure_and_wait_for_state(self, create_cloud_exadata_infrastructure_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_cloud_exadata_infrastructure` and waits for the :py:class:`~oci.database.models.CloudExadataInfrastructure` acted upon
+        to enter the given state(s).
+
+        :param CreateCloudExadataInfrastructureDetails create_cloud_exadata_infrastructure_details: (required)
+            Request to create cloud Exadata infrastructure.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.CloudExadataInfrastructure.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_cloud_exadata_infrastructure`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_cloud_exadata_infrastructure(create_cloud_exadata_infrastructure_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_cloud_exadata_infrastructure(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_cloud_vm_cluster_and_wait_for_work_request(self, create_cloud_vm_cluster_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_cloud_vm_cluster` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param CreateCloudVmClusterDetails create_cloud_vm_cluster_details: (required)
+            Request to create a cloud VM cluster.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_cloud_vm_cluster`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_cloud_vm_cluster(create_cloud_vm_cluster_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_cloud_vm_cluster_and_wait_for_state(self, create_cloud_vm_cluster_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_cloud_vm_cluster` and waits for the :py:class:`~oci.database.models.CloudVmCluster` acted upon
+        to enter the given state(s).
+
+        :param CreateCloudVmClusterDetails create_cloud_vm_cluster_details: (required)
+            Request to create a cloud VM cluster.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.CloudVmCluster.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_cloud_vm_cluster`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_cloud_vm_cluster(create_cloud_vm_cluster_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_cloud_vm_cluster(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_console_connection_and_wait_for_state(self, create_console_connection_details, db_node_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.create_console_connection` and waits for the :py:class:`~oci.database.models.ConsoleConnection` acted upon
@@ -1423,7 +1649,7 @@ class DatabaseClientCompositeOperations(object):
         to enter the given state(s).
 
         :param CreateExadataInfrastructureDetails create_exadata_infrastructure_details: (required)
-            Request to create Exadata infrastructure.
+            Request to create Exadata Cloud@Customer infrastructure.
 
         :param list[str] work_request_states: (optional)
             An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
@@ -1458,7 +1684,7 @@ class DatabaseClientCompositeOperations(object):
         to enter the given state(s).
 
         :param CreateExadataInfrastructureDetails create_exadata_infrastructure_details: (required)
-            Request to create Exadata infrastructure.
+            Request to create Exadata Cloud@Customer infrastructure.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.ExadataInfrastructure.lifecycle_state`
@@ -1531,7 +1757,7 @@ class DatabaseClientCompositeOperations(object):
         to enter the given state(s).
 
         :param CreateVmClusterDetails create_vm_cluster_details: (required)
-            Request to create a VM cluster.
+            Request to create an Exadata Cloud@Customer VM cluster.
 
         :param list[str] work_request_states: (optional)
             An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
@@ -1566,7 +1792,7 @@ class DatabaseClientCompositeOperations(object):
         to enter the given state(s).
 
         :param CreateVmClusterDetails create_vm_cluster_details: (required)
-            Request to create a VM cluster.
+            Request to create an Exadata Cloud@Customer VM cluster.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.VmCluster.lifecycle_state`
@@ -1609,7 +1835,7 @@ class DatabaseClientCompositeOperations(object):
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param VmClusterNetworkDetails vm_cluster_network_details: (required)
-            Request to create the VM cluster network.
+            Request to create the Cloud@Customer VM cluster network.
 
         :param list[str] work_request_states: (optional)
             An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
@@ -1649,7 +1875,7 @@ class DatabaseClientCompositeOperations(object):
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param VmClusterNetworkDetails vm_cluster_network_details: (required)
-            Request to create the VM cluster network.
+            Request to create the Cloud@Customer VM cluster network.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.VmClusterNetwork.lifecycle_state`
@@ -1974,6 +2200,80 @@ class DatabaseClientCompositeOperations(object):
             result_to_return = waiter_result
 
             return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_cloud_exadata_infrastructure_and_wait_for_work_request(self, cloud_exadata_infrastructure_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.delete_cloud_exadata_infrastructure` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str cloud_exadata_infrastructure_id: (required)
+            The cloud Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.delete_cloud_exadata_infrastructure`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.delete_cloud_exadata_infrastructure(cloud_exadata_infrastructure_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_cloud_vm_cluster_and_wait_for_work_request(self, cloud_vm_cluster_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.delete_cloud_vm_cluster` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.delete_cloud_vm_cluster`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.delete_cloud_vm_cluster(cloud_vm_cluster_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -2417,7 +2717,7 @@ class DatabaseClientCompositeOperations(object):
         to enter the given state(s).
 
         :param LaunchAutonomousExadataInfrastructureDetails launch_autonomous_exadata_infrastructure_details: (required)
-            Request to launch a Autonomous Exadata Infrastructure.
+            Request to create an Autonomous Exadata Infrastructure resource.
 
         :param list[str] work_request_states: (optional)
             An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
@@ -2452,7 +2752,7 @@ class DatabaseClientCompositeOperations(object):
         to enter the given state(s).
 
         :param LaunchAutonomousExadataInfrastructureDetails launch_autonomous_exadata_infrastructure_details: (required)
-            Request to launch a Autonomous Exadata Infrastructure.
+            Request to create an Autonomous Exadata Infrastructure resource.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.AutonomousExadataInfrastructure.lifecycle_state`
@@ -2554,6 +2854,43 @@ class DatabaseClientCompositeOperations(object):
             result_to_return = waiter_result
 
             return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def migrate_exadata_db_system_resource_model_and_wait_for_work_request(self, db_system_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.migrate_exadata_db_system_resource_model` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str db_system_id: (required)
+            The DB system `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.migrate_exadata_db_system_resource_model`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.migrate_exadata_db_system_resource_model(db_system_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -3041,6 +3378,160 @@ class DatabaseClientCompositeOperations(object):
             waiter_result = oci.wait_until(
                 self.client,
                 self.client.get_database(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def rotate_autonomous_container_database_encryption_key_and_wait_for_work_request(self, autonomous_container_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.rotate_autonomous_container_database_encryption_key` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str autonomous_container_database_id: (required)
+            The Autonomous Container Database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.rotate_autonomous_container_database_encryption_key`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.rotate_autonomous_container_database_encryption_key(autonomous_container_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def rotate_autonomous_container_database_encryption_key_and_wait_for_state(self, autonomous_container_database_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.rotate_autonomous_container_database_encryption_key` and waits for the :py:class:`~oci.database.models.AutonomousContainerDatabase` acted upon
+        to enter the given state(s).
+
+        :param str autonomous_container_database_id: (required)
+            The Autonomous Container Database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.AutonomousContainerDatabase.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.rotate_autonomous_container_database_encryption_key`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.rotate_autonomous_container_database_encryption_key(autonomous_container_database_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_autonomous_container_database(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def rotate_autonomous_database_encryption_key_and_wait_for_work_request(self, autonomous_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.rotate_autonomous_database_encryption_key` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str autonomous_database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.rotate_autonomous_database_encryption_key`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.rotate_autonomous_database_encryption_key(autonomous_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def rotate_autonomous_database_encryption_key_and_wait_for_state(self, autonomous_database_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.rotate_autonomous_database_encryption_key` and waits for the :py:class:`~oci.database.models.AutonomousDatabase` acted upon
+        to enter the given state(s).
+
+        :param str autonomous_database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.AutonomousDatabase.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.rotate_autonomous_database_encryption_key`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.rotate_autonomous_database_encryption_key(autonomous_database_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_autonomous_database(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )
@@ -4059,6 +4550,212 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def update_cloud_exadata_infrastructure_and_wait_for_work_request(self, cloud_exadata_infrastructure_id, update_cloud_exadata_infrastructure_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_cloud_exadata_infrastructure` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str cloud_exadata_infrastructure_id: (required)
+            The cloud Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateCloudExadataInfrastructureDetails update_cloud_exadata_infrastructure_details: (required)
+            Request to update the properties of an cloud Exadata infrastructure resource.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_cloud_exadata_infrastructure`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_cloud_exadata_infrastructure(cloud_exadata_infrastructure_id, update_cloud_exadata_infrastructure_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_cloud_exadata_infrastructure_and_wait_for_state(self, cloud_exadata_infrastructure_id, update_cloud_exadata_infrastructure_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_cloud_exadata_infrastructure` and waits for the :py:class:`~oci.database.models.CloudExadataInfrastructure` acted upon
+        to enter the given state(s).
+
+        :param str cloud_exadata_infrastructure_id: (required)
+            The cloud Exadata infrastructure `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateCloudExadataInfrastructureDetails update_cloud_exadata_infrastructure_details: (required)
+            Request to update the properties of an cloud Exadata infrastructure resource.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.CloudExadataInfrastructure.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_cloud_exadata_infrastructure`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_cloud_exadata_infrastructure(cloud_exadata_infrastructure_id, update_cloud_exadata_infrastructure_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_cloud_exadata_infrastructure(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_cloud_vm_cluster_and_wait_for_work_request(self, cloud_vm_cluster_id, update_cloud_vm_cluster_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_cloud_vm_cluster` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateCloudVmClusterDetails update_cloud_vm_cluster_details: (required)
+            Request to update the attributes of a cloud VM cluster.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_cloud_vm_cluster`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_cloud_vm_cluster(cloud_vm_cluster_id, update_cloud_vm_cluster_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_cloud_vm_cluster_and_wait_for_state(self, cloud_vm_cluster_id, update_cloud_vm_cluster_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_cloud_vm_cluster` and waits for the :py:class:`~oci.database.models.CloudVmCluster` acted upon
+        to enter the given state(s).
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateCloudVmClusterDetails update_cloud_vm_cluster_details: (required)
+            Request to update the attributes of a cloud VM cluster.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.CloudVmCluster.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_cloud_vm_cluster`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_cloud_vm_cluster(cloud_vm_cluster_id, update_cloud_vm_cluster_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_cloud_vm_cluster(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_cloud_vm_cluster_iorm_config_and_wait_for_work_request(self, cloud_vm_cluster_id, cloud_vm_cluster_iorm_config_update_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_cloud_vm_cluster_iorm_config` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str cloud_vm_cluster_id: (required)
+            The cloud VM cluster `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param ExadataIormConfigUpdateDetails cloud_vm_cluster_iorm_config_update_details: (required)
+            Request to perform database update.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_cloud_vm_cluster_iorm_config`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_cloud_vm_cluster_iorm_config(cloud_vm_cluster_id, cloud_vm_cluster_iorm_config_update_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def update_database_and_wait_for_work_request(self, database_id, update_database_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.update_database` and waits for the oci.work_requests.models.WorkRequest
@@ -4196,7 +4893,7 @@ class DatabaseClientCompositeOperations(object):
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param UpdateDbHomeDetails update_db_home_details: (required)
-            Request to update the properties of a DB Home.
+            Request to update the properties of a Database Home.
 
         :param list[str] work_request_states: (optional)
             An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
@@ -4236,7 +4933,7 @@ class DatabaseClientCompositeOperations(object):
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param UpdateDbHomeDetails update_db_home_details: (required)
-            Request to update the properties of a DB Home.
+            Request to update the properties of a Database Home.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.DbHome.lifecycle_state`
@@ -4362,7 +5059,7 @@ class DatabaseClientCompositeOperations(object):
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param UpdateExadataInfrastructureDetails update_exadata_infrastructure_details: (required)
-            Request to update the properties of an Exadata infrastructure
+            Request to update the properties of an Exadata Cloud@Customer infrastructure.
 
         :param list[str] work_request_states: (optional)
             An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
@@ -4402,7 +5099,7 @@ class DatabaseClientCompositeOperations(object):
             __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param UpdateExadataInfrastructureDetails update_exadata_infrastructure_details: (required)
-            Request to update the properties of an Exadata infrastructure
+            Request to update the properties of an Exadata Cloud@Customer infrastructure.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.ExadataInfrastructure.lifecycle_state`

--- a/src/oci/database/models/__init__.py
+++ b/src/oci/database/models/__init__.py
@@ -41,9 +41,15 @@ from .backup_destination_details import BackupDestinationDetails
 from .backup_destination_summary import BackupDestinationSummary
 from .backup_summary import BackupSummary
 from .change_autonomous_vm_cluster_compartment_details import ChangeAutonomousVmClusterCompartmentDetails
+from .change_cloud_exadata_infrastructure_compartment_details import ChangeCloudExadataInfrastructureCompartmentDetails
+from .change_cloud_vm_cluster_compartment_details import ChangeCloudVmClusterCompartmentDetails
 from .change_compartment_details import ChangeCompartmentDetails
 from .change_exadata_infrastructure_compartment_details import ChangeExadataInfrastructureCompartmentDetails
 from .change_vm_cluster_compartment_details import ChangeVmClusterCompartmentDetails
+from .cloud_exadata_infrastructure import CloudExadataInfrastructure
+from .cloud_exadata_infrastructure_summary import CloudExadataInfrastructureSummary
+from .cloud_vm_cluster import CloudVmCluster
+from .cloud_vm_cluster_summary import CloudVmClusterSummary
 from .complete_external_backup_job_details import CompleteExternalBackupJobDetails
 from .console_connection import ConsoleConnection
 from .console_connection_summary import ConsoleConnectionSummary
@@ -59,6 +65,8 @@ from .create_autonomous_database_from_backup_timestamp_details import CreateAuto
 from .create_autonomous_vm_cluster_details import CreateAutonomousVmClusterDetails
 from .create_backup_destination_details import CreateBackupDestinationDetails
 from .create_backup_details import CreateBackupDetails
+from .create_cloud_exadata_infrastructure_details import CreateCloudExadataInfrastructureDetails
+from .create_cloud_vm_cluster_details import CreateCloudVmClusterDetails
 from .create_console_connection_details import CreateConsoleConnectionDetails
 from .create_data_guard_association_details import CreateDataGuardAssociationDetails
 from .create_data_guard_association_to_existing_db_system_details import CreateDataGuardAssociationToExistingDbSystemDetails
@@ -80,6 +88,7 @@ from .create_db_home_with_db_system_id_details import CreateDbHomeWithDbSystemId
 from .create_db_home_with_db_system_id_from_backup_details import CreateDbHomeWithDbSystemIdFromBackupDetails
 from .create_db_home_with_db_system_id_from_database_details import CreateDbHomeWithDbSystemIdFromDatabaseDetails
 from .create_db_home_with_vm_cluster_id_details import CreateDbHomeWithVmClusterIdDetails
+from .create_db_home_with_vm_cluster_id_from_backup_details import CreateDbHomeWithVmClusterIdFromBackupDetails
 from .create_exadata_infrastructure_details import CreateExadataInfrastructureDetails
 from .create_external_backup_job_details import CreateExternalBackupJobDetails
 from .create_nfs_backup_destination_details import CreateNFSBackupDestinationDetails
@@ -108,6 +117,8 @@ from .db_system_shape_summary import DbSystemShapeSummary
 from .db_system_summary import DbSystemSummary
 from .db_version_summary import DbVersionSummary
 from .deregister_autonomous_database_data_safe_details import DeregisterAutonomousDatabaseDataSafeDetails
+from .exadata_db_system_migration import ExadataDbSystemMigration
+from .exadata_db_system_migration_summary import ExadataDbSystemMigrationSummary
 from .exadata_infrastructure import ExadataInfrastructure
 from .exadata_infrastructure_contact import ExadataInfrastructureContact
 from .exadata_infrastructure_summary import ExadataInfrastructureSummary
@@ -146,6 +157,7 @@ from .restore_database_details import RestoreDatabaseDetails
 from .scan_details import ScanDetails
 from .self_mount_details import SelfMountDetails
 from .switchover_data_guard_association_details import SwitchoverDataGuardAssociationDetails
+from .update import Update
 from .update_autonomous_container_database_details import UpdateAutonomousContainerDatabaseDetails
 from .update_autonomous_data_warehouse_details import UpdateAutonomousDataWarehouseDetails
 from .update_autonomous_database_details import UpdateAutonomousDatabaseDetails
@@ -153,12 +165,18 @@ from .update_autonomous_database_wallet_details import UpdateAutonomousDatabaseW
 from .update_autonomous_exadata_infrastructure_details import UpdateAutonomousExadataInfrastructureDetails
 from .update_autonomous_vm_cluster_details import UpdateAutonomousVmClusterDetails
 from .update_backup_destination_details import UpdateBackupDestinationDetails
+from .update_cloud_exadata_infrastructure_details import UpdateCloudExadataInfrastructureDetails
+from .update_cloud_vm_cluster_details import UpdateCloudVmClusterDetails
 from .update_database_details import UpdateDatabaseDetails
 from .update_database_software_image_details import UpdateDatabaseSoftwareImageDetails
 from .update_db_home_details import UpdateDbHomeDetails
 from .update_db_system_details import UpdateDbSystemDetails
+from .update_details import UpdateDetails
 from .update_exadata_infrastructure_details import UpdateExadataInfrastructureDetails
+from .update_history_entry import UpdateHistoryEntry
+from .update_history_entry_summary import UpdateHistoryEntrySummary
 from .update_maintenance_run_details import UpdateMaintenanceRunDetails
+from .update_summary import UpdateSummary
 from .update_vm_cluster_details import UpdateVmClusterDetails
 from .update_vm_cluster_network_details import UpdateVmClusterNetworkDetails
 from .vm_cluster import VmCluster
@@ -208,9 +226,15 @@ database_type_mapping = {
     "BackupDestinationSummary": BackupDestinationSummary,
     "BackupSummary": BackupSummary,
     "ChangeAutonomousVmClusterCompartmentDetails": ChangeAutonomousVmClusterCompartmentDetails,
+    "ChangeCloudExadataInfrastructureCompartmentDetails": ChangeCloudExadataInfrastructureCompartmentDetails,
+    "ChangeCloudVmClusterCompartmentDetails": ChangeCloudVmClusterCompartmentDetails,
     "ChangeCompartmentDetails": ChangeCompartmentDetails,
     "ChangeExadataInfrastructureCompartmentDetails": ChangeExadataInfrastructureCompartmentDetails,
     "ChangeVmClusterCompartmentDetails": ChangeVmClusterCompartmentDetails,
+    "CloudExadataInfrastructure": CloudExadataInfrastructure,
+    "CloudExadataInfrastructureSummary": CloudExadataInfrastructureSummary,
+    "CloudVmCluster": CloudVmCluster,
+    "CloudVmClusterSummary": CloudVmClusterSummary,
     "CompleteExternalBackupJobDetails": CompleteExternalBackupJobDetails,
     "ConsoleConnection": ConsoleConnection,
     "ConsoleConnectionSummary": ConsoleConnectionSummary,
@@ -226,6 +250,8 @@ database_type_mapping = {
     "CreateAutonomousVmClusterDetails": CreateAutonomousVmClusterDetails,
     "CreateBackupDestinationDetails": CreateBackupDestinationDetails,
     "CreateBackupDetails": CreateBackupDetails,
+    "CreateCloudExadataInfrastructureDetails": CreateCloudExadataInfrastructureDetails,
+    "CreateCloudVmClusterDetails": CreateCloudVmClusterDetails,
     "CreateConsoleConnectionDetails": CreateConsoleConnectionDetails,
     "CreateDataGuardAssociationDetails": CreateDataGuardAssociationDetails,
     "CreateDataGuardAssociationToExistingDbSystemDetails": CreateDataGuardAssociationToExistingDbSystemDetails,
@@ -247,6 +273,7 @@ database_type_mapping = {
     "CreateDbHomeWithDbSystemIdFromBackupDetails": CreateDbHomeWithDbSystemIdFromBackupDetails,
     "CreateDbHomeWithDbSystemIdFromDatabaseDetails": CreateDbHomeWithDbSystemIdFromDatabaseDetails,
     "CreateDbHomeWithVmClusterIdDetails": CreateDbHomeWithVmClusterIdDetails,
+    "CreateDbHomeWithVmClusterIdFromBackupDetails": CreateDbHomeWithVmClusterIdFromBackupDetails,
     "CreateExadataInfrastructureDetails": CreateExadataInfrastructureDetails,
     "CreateExternalBackupJobDetails": CreateExternalBackupJobDetails,
     "CreateNFSBackupDestinationDetails": CreateNFSBackupDestinationDetails,
@@ -275,6 +302,8 @@ database_type_mapping = {
     "DbSystemSummary": DbSystemSummary,
     "DbVersionSummary": DbVersionSummary,
     "DeregisterAutonomousDatabaseDataSafeDetails": DeregisterAutonomousDatabaseDataSafeDetails,
+    "ExadataDbSystemMigration": ExadataDbSystemMigration,
+    "ExadataDbSystemMigrationSummary": ExadataDbSystemMigrationSummary,
     "ExadataInfrastructure": ExadataInfrastructure,
     "ExadataInfrastructureContact": ExadataInfrastructureContact,
     "ExadataInfrastructureSummary": ExadataInfrastructureSummary,
@@ -313,6 +342,7 @@ database_type_mapping = {
     "ScanDetails": ScanDetails,
     "SelfMountDetails": SelfMountDetails,
     "SwitchoverDataGuardAssociationDetails": SwitchoverDataGuardAssociationDetails,
+    "Update": Update,
     "UpdateAutonomousContainerDatabaseDetails": UpdateAutonomousContainerDatabaseDetails,
     "UpdateAutonomousDataWarehouseDetails": UpdateAutonomousDataWarehouseDetails,
     "UpdateAutonomousDatabaseDetails": UpdateAutonomousDatabaseDetails,
@@ -320,12 +350,18 @@ database_type_mapping = {
     "UpdateAutonomousExadataInfrastructureDetails": UpdateAutonomousExadataInfrastructureDetails,
     "UpdateAutonomousVmClusterDetails": UpdateAutonomousVmClusterDetails,
     "UpdateBackupDestinationDetails": UpdateBackupDestinationDetails,
+    "UpdateCloudExadataInfrastructureDetails": UpdateCloudExadataInfrastructureDetails,
+    "UpdateCloudVmClusterDetails": UpdateCloudVmClusterDetails,
     "UpdateDatabaseDetails": UpdateDatabaseDetails,
     "UpdateDatabaseSoftwareImageDetails": UpdateDatabaseSoftwareImageDetails,
     "UpdateDbHomeDetails": UpdateDbHomeDetails,
     "UpdateDbSystemDetails": UpdateDbSystemDetails,
+    "UpdateDetails": UpdateDetails,
     "UpdateExadataInfrastructureDetails": UpdateExadataInfrastructureDetails,
+    "UpdateHistoryEntry": UpdateHistoryEntry,
+    "UpdateHistoryEntrySummary": UpdateHistoryEntrySummary,
     "UpdateMaintenanceRunDetails": UpdateMaintenanceRunDetails,
+    "UpdateSummary": UpdateSummary,
     "UpdateVmClusterDetails": UpdateVmClusterDetails,
     "UpdateVmClusterNetworkDetails": UpdateVmClusterNetworkDetails,
     "VmCluster": VmCluster,

--- a/src/oci/database/models/activate_exadata_infrastructure_details.py
+++ b/src/oci/database/models/activate_exadata_infrastructure_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ActivateExadataInfrastructureDetails(object):
     """
-    The activation details for the Exadata infrastructure.
+    The activation details for the Exadata Cloud@Customer infrastructure.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/database/models/autonomous_container_database.py
+++ b/src/oci/database/models/autonomous_container_database.py
@@ -122,6 +122,14 @@ class AutonomousContainerDatabase(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type infrastructure_type: str
 
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this AutonomousContainerDatabase.
+        :type kms_key_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this AutonomousContainerDatabase.
+        :type vault_id: str
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this AutonomousContainerDatabase.
             Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "BACKUP_IN_PROGRESS", "RESTORING", "RESTORE_FAILED", "RESTARTING", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
@@ -188,6 +196,8 @@ class AutonomousContainerDatabase(object):
             'autonomous_exadata_infrastructure_id': 'str',
             'autonomous_vm_cluster_id': 'str',
             'infrastructure_type': 'str',
+            'kms_key_id': 'str',
+            'vault_id': 'str',
             'lifecycle_state': 'str',
             'lifecycle_details': 'str',
             'time_created': 'datetime',
@@ -212,6 +222,8 @@ class AutonomousContainerDatabase(object):
             'autonomous_exadata_infrastructure_id': 'autonomousExadataInfrastructureId',
             'autonomous_vm_cluster_id': 'autonomousVmClusterId',
             'infrastructure_type': 'infrastructureType',
+            'kms_key_id': 'kmsKeyId',
+            'vault_id': 'vaultId',
             'lifecycle_state': 'lifecycleState',
             'lifecycle_details': 'lifecycleDetails',
             'time_created': 'timeCreated',
@@ -235,6 +247,8 @@ class AutonomousContainerDatabase(object):
         self._autonomous_exadata_infrastructure_id = None
         self._autonomous_vm_cluster_id = None
         self._infrastructure_type = None
+        self._kms_key_id = None
+        self._vault_id = None
         self._lifecycle_state = None
         self._lifecycle_details = None
         self._time_created = None
@@ -452,6 +466,60 @@ class AutonomousContainerDatabase(object):
         if not value_allowed_none_or_none_sentinel(infrastructure_type, allowed_values):
             infrastructure_type = 'UNKNOWN_ENUM_VALUE'
         self._infrastructure_type = infrastructure_type
+
+    @property
+    def kms_key_id(self):
+        """
+        Gets the kms_key_id of this AutonomousContainerDatabase.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :return: The kms_key_id of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._kms_key_id
+
+    @kms_key_id.setter
+    def kms_key_id(self, kms_key_id):
+        """
+        Sets the kms_key_id of this AutonomousContainerDatabase.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :param kms_key_id: The kms_key_id of this AutonomousContainerDatabase.
+        :type: str
+        """
+        self._kms_key_id = kms_key_id
+
+    @property
+    def vault_id(self):
+        """
+        Gets the vault_id of this AutonomousContainerDatabase.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :return: The vault_id of this AutonomousContainerDatabase.
+        :rtype: str
+        """
+        return self._vault_id
+
+    @vault_id.setter
+    def vault_id(self, vault_id):
+        """
+        Sets the vault_id of this AutonomousContainerDatabase.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :param vault_id: The vault_id of this AutonomousContainerDatabase.
+        :type: str
+        """
+        self._vault_id = vault_id
 
     @property
     def lifecycle_state(self):
@@ -757,7 +825,7 @@ class AutonomousContainerDatabase(object):
     def db_version(self):
         """
         Gets the db_version of this AutonomousContainerDatabase.
-        Oracle Database version of the Autonomous Container Database
+        Oracle Database version of the Autonomous Container Database.
 
 
         :return: The db_version of this AutonomousContainerDatabase.
@@ -769,7 +837,7 @@ class AutonomousContainerDatabase(object):
     def db_version(self, db_version):
         """
         Sets the db_version of this AutonomousContainerDatabase.
-        Oracle Database version of the Autonomous Container Database
+        Oracle Database version of the Autonomous Container Database.
 
 
         :param db_version: The db_version of this AutonomousContainerDatabase.

--- a/src/oci/database/models/autonomous_container_database_summary.py
+++ b/src/oci/database/models/autonomous_container_database_summary.py
@@ -122,6 +122,14 @@ class AutonomousContainerDatabaseSummary(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type infrastructure_type: str
 
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this AutonomousContainerDatabaseSummary.
+        :type kms_key_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this AutonomousContainerDatabaseSummary.
+        :type vault_id: str
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this AutonomousContainerDatabaseSummary.
             Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "BACKUP_IN_PROGRESS", "RESTORING", "RESTORE_FAILED", "RESTARTING", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
@@ -188,6 +196,8 @@ class AutonomousContainerDatabaseSummary(object):
             'autonomous_exadata_infrastructure_id': 'str',
             'autonomous_vm_cluster_id': 'str',
             'infrastructure_type': 'str',
+            'kms_key_id': 'str',
+            'vault_id': 'str',
             'lifecycle_state': 'str',
             'lifecycle_details': 'str',
             'time_created': 'datetime',
@@ -212,6 +222,8 @@ class AutonomousContainerDatabaseSummary(object):
             'autonomous_exadata_infrastructure_id': 'autonomousExadataInfrastructureId',
             'autonomous_vm_cluster_id': 'autonomousVmClusterId',
             'infrastructure_type': 'infrastructureType',
+            'kms_key_id': 'kmsKeyId',
+            'vault_id': 'vaultId',
             'lifecycle_state': 'lifecycleState',
             'lifecycle_details': 'lifecycleDetails',
             'time_created': 'timeCreated',
@@ -235,6 +247,8 @@ class AutonomousContainerDatabaseSummary(object):
         self._autonomous_exadata_infrastructure_id = None
         self._autonomous_vm_cluster_id = None
         self._infrastructure_type = None
+        self._kms_key_id = None
+        self._vault_id = None
         self._lifecycle_state = None
         self._lifecycle_details = None
         self._time_created = None
@@ -452,6 +466,60 @@ class AutonomousContainerDatabaseSummary(object):
         if not value_allowed_none_or_none_sentinel(infrastructure_type, allowed_values):
             infrastructure_type = 'UNKNOWN_ENUM_VALUE'
         self._infrastructure_type = infrastructure_type
+
+    @property
+    def kms_key_id(self):
+        """
+        Gets the kms_key_id of this AutonomousContainerDatabaseSummary.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :return: The kms_key_id of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._kms_key_id
+
+    @kms_key_id.setter
+    def kms_key_id(self, kms_key_id):
+        """
+        Sets the kms_key_id of this AutonomousContainerDatabaseSummary.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :param kms_key_id: The kms_key_id of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        self._kms_key_id = kms_key_id
+
+    @property
+    def vault_id(self):
+        """
+        Gets the vault_id of this AutonomousContainerDatabaseSummary.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :return: The vault_id of this AutonomousContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._vault_id
+
+    @vault_id.setter
+    def vault_id(self, vault_id):
+        """
+        Sets the vault_id of this AutonomousContainerDatabaseSummary.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :param vault_id: The vault_id of this AutonomousContainerDatabaseSummary.
+        :type: str
+        """
+        self._vault_id = vault_id
 
     @property
     def lifecycle_state(self):
@@ -757,7 +825,7 @@ class AutonomousContainerDatabaseSummary(object):
     def db_version(self):
         """
         Gets the db_version of this AutonomousContainerDatabaseSummary.
-        Oracle Database version of the Autonomous Container Database
+        Oracle Database version of the Autonomous Container Database.
 
 
         :return: The db_version of this AutonomousContainerDatabaseSummary.
@@ -769,7 +837,7 @@ class AutonomousContainerDatabaseSummary(object):
     def db_version(self, db_version):
         """
         Sets the db_version of this AutonomousContainerDatabaseSummary.
-        Oracle Database version of the Autonomous Container Database
+        Oracle Database version of the Autonomous Container Database.
 
 
         :param db_version: The db_version of this AutonomousContainerDatabaseSummary.

--- a/src/oci/database/models/autonomous_database.py
+++ b/src/oci/database/models/autonomous_database.py
@@ -1177,7 +1177,7 @@ class AutonomousDatabase(object):
 
         **Subnet Restrictions:**
         - For bare metal DB systems and for single node virtual machine DB systems, do not use a subnet that overlaps with 192.168.16.16/28.
-        - For Exadata and virtual machine 2-node RAC DB systems, do not use a subnet that overlaps with 192.168.128.0/20.
+        - For Exadata and virtual machine 2-node RAC systems, do not use a subnet that overlaps with 192.168.128.0/20.
         - For Autonomous Database, setting this will disable public secure access to the database.
 
         These subnets are used by the Oracle Clusterware private interconnect on the database instance.
@@ -1200,7 +1200,7 @@ class AutonomousDatabase(object):
 
         **Subnet Restrictions:**
         - For bare metal DB systems and for single node virtual machine DB systems, do not use a subnet that overlaps with 192.168.16.16/28.
-        - For Exadata and virtual machine 2-node RAC DB systems, do not use a subnet that overlaps with 192.168.128.0/20.
+        - For Exadata and virtual machine 2-node RAC systems, do not use a subnet that overlaps with 192.168.128.0/20.
         - For Autonomous Database, setting this will disable public secure access to the database.
 
         These subnets are used by the Oracle Clusterware private interconnect on the database instance.
@@ -1415,8 +1415,8 @@ class AutonomousDatabase(object):
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
 
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
-        For update operation, if you wish to delete all the existing whitelisted IP\u2019s, use an array with a single empty string entry.
-        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
+        For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
+        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.<unique_id>\",\"ocid1.vcn.oc1.sea.<unique_id1>;1.1.1.1\",\"ocid1.vcn.oc1.sea.<unique_id2>;1.1.0.0/16\"]`
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -1434,8 +1434,8 @@ class AutonomousDatabase(object):
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
 
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
-        For update operation, if you wish to delete all the existing whitelisted IP\u2019s, use an array with a single empty string entry.
-        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
+        For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
+        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.<unique_id>\",\"ocid1.vcn.oc1.sea.<unique_id1>;1.1.1.1\",\"ocid1.vcn.oc1.sea.<unique_id2>;1.1.0.0/16\"]`
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 

--- a/src/oci/database/models/autonomous_database_summary.py
+++ b/src/oci/database/models/autonomous_database_summary.py
@@ -1179,7 +1179,7 @@ class AutonomousDatabaseSummary(object):
 
         **Subnet Restrictions:**
         - For bare metal DB systems and for single node virtual machine DB systems, do not use a subnet that overlaps with 192.168.16.16/28.
-        - For Exadata and virtual machine 2-node RAC DB systems, do not use a subnet that overlaps with 192.168.128.0/20.
+        - For Exadata and virtual machine 2-node RAC systems, do not use a subnet that overlaps with 192.168.128.0/20.
         - For Autonomous Database, setting this will disable public secure access to the database.
 
         These subnets are used by the Oracle Clusterware private interconnect on the database instance.
@@ -1202,7 +1202,7 @@ class AutonomousDatabaseSummary(object):
 
         **Subnet Restrictions:**
         - For bare metal DB systems and for single node virtual machine DB systems, do not use a subnet that overlaps with 192.168.16.16/28.
-        - For Exadata and virtual machine 2-node RAC DB systems, do not use a subnet that overlaps with 192.168.128.0/20.
+        - For Exadata and virtual machine 2-node RAC systems, do not use a subnet that overlaps with 192.168.128.0/20.
         - For Autonomous Database, setting this will disable public secure access to the database.
 
         These subnets are used by the Oracle Clusterware private interconnect on the database instance.
@@ -1417,8 +1417,8 @@ class AutonomousDatabaseSummary(object):
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
 
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
-        For update operation, if you wish to delete all the existing whitelisted IP\u2019s, use an array with a single empty string entry.
-        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
+        For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
+        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.<unique_id>\",\"ocid1.vcn.oc1.sea.<unique_id1>;1.1.1.1\",\"ocid1.vcn.oc1.sea.<unique_id2>;1.1.0.0/16\"]`
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -1436,8 +1436,8 @@ class AutonomousDatabaseSummary(object):
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
 
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
-        For update operation, if you wish to delete all the existing whitelisted IP\u2019s, use an array with a single empty string entry.
-        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
+        For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
+        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.<unique_id>\",\"ocid1.vcn.oc1.sea.<unique_id1>;1.1.1.1\",\"ocid1.vcn.oc1.sea.<unique_id2>;1.1.0.0/16\"]`
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 

--- a/src/oci/database/models/change_cloud_exadata_infrastructure_compartment_details.py
+++ b/src/oci/database/models/change_cloud_exadata_infrastructure_compartment_details.py
@@ -1,0 +1,74 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeCloudExadataInfrastructureCompartmentDetails(object):
+    """
+    The configuration details for moving the resource.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeCloudExadataInfrastructureCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeCloudExadataInfrastructureCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeCloudExadataInfrastructureCompartmentDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeCloudExadataInfrastructureCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeCloudExadataInfrastructureCompartmentDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeCloudExadataInfrastructureCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/change_cloud_vm_cluster_compartment_details.py
+++ b/src/oci/database/models/change_cloud_vm_cluster_compartment_details.py
@@ -1,0 +1,74 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeCloudVmClusterCompartmentDetails(object):
+    """
+    The configuration details for moving the cloud VM cluster to another compartment.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeCloudVmClusterCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeCloudVmClusterCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeCloudVmClusterCompartmentDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeCloudVmClusterCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeCloudVmClusterCompartmentDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeCloudVmClusterCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/cloud_exadata_infrastructure.py
+++ b/src/oci/database/models/cloud_exadata_infrastructure.py
@@ -1,0 +1,630 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CloudExadataInfrastructure(object):
+    """
+    Details of the cloud Exadata infrastructure resource.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructure.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructure.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructure.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructure.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructure.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructure.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructure.
+    #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
+    LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CloudExadataInfrastructure object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this CloudExadataInfrastructure.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CloudExadataInfrastructure.
+        :type compartment_id: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this CloudExadataInfrastructure.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CloudExadataInfrastructure.
+        :type display_name: str
+
+        :param shape:
+            The value to assign to the shape property of this CloudExadataInfrastructure.
+        :type shape: str
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this CloudExadataInfrastructure.
+        :type availability_domain: str
+
+        :param compute_count:
+            The value to assign to the compute_count property of this CloudExadataInfrastructure.
+        :type compute_count: int
+
+        :param storage_count:
+            The value to assign to the storage_count property of this CloudExadataInfrastructure.
+        :type storage_count: int
+
+        :param total_storage_size_in_gbs:
+            The value to assign to the total_storage_size_in_gbs property of this CloudExadataInfrastructure.
+        :type total_storage_size_in_gbs: int
+
+        :param available_storage_size_in_gbs:
+            The value to assign to the available_storage_size_in_gbs property of this CloudExadataInfrastructure.
+        :type available_storage_size_in_gbs: int
+
+        :param time_created:
+            The value to assign to the time_created property of this CloudExadataInfrastructure.
+        :type time_created: datetime
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this CloudExadataInfrastructure.
+        :type lifecycle_details: str
+
+        :param maintenance_window:
+            The value to assign to the maintenance_window property of this CloudExadataInfrastructure.
+        :type maintenance_window: MaintenanceWindow
+
+        :param last_maintenance_run_id:
+            The value to assign to the last_maintenance_run_id property of this CloudExadataInfrastructure.
+        :type last_maintenance_run_id: str
+
+        :param next_maintenance_run_id:
+            The value to assign to the next_maintenance_run_id property of this CloudExadataInfrastructure.
+        :type next_maintenance_run_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CloudExadataInfrastructure.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CloudExadataInfrastructure.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'lifecycle_state': 'str',
+            'display_name': 'str',
+            'shape': 'str',
+            'availability_domain': 'str',
+            'compute_count': 'int',
+            'storage_count': 'int',
+            'total_storage_size_in_gbs': 'int',
+            'available_storage_size_in_gbs': 'int',
+            'time_created': 'datetime',
+            'lifecycle_details': 'str',
+            'maintenance_window': 'MaintenanceWindow',
+            'last_maintenance_run_id': 'str',
+            'next_maintenance_run_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'lifecycle_state': 'lifecycleState',
+            'display_name': 'displayName',
+            'shape': 'shape',
+            'availability_domain': 'availabilityDomain',
+            'compute_count': 'computeCount',
+            'storage_count': 'storageCount',
+            'total_storage_size_in_gbs': 'totalStorageSizeInGBs',
+            'available_storage_size_in_gbs': 'availableStorageSizeInGBs',
+            'time_created': 'timeCreated',
+            'lifecycle_details': 'lifecycleDetails',
+            'maintenance_window': 'maintenanceWindow',
+            'last_maintenance_run_id': 'lastMaintenanceRunId',
+            'next_maintenance_run_id': 'nextMaintenanceRunId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._lifecycle_state = None
+        self._display_name = None
+        self._shape = None
+        self._availability_domain = None
+        self._compute_count = None
+        self._storage_count = None
+        self._total_storage_size_in_gbs = None
+        self._available_storage_size_in_gbs = None
+        self._time_created = None
+        self._lifecycle_details = None
+        self._maintenance_window = None
+        self._last_maintenance_run_id = None
+        self._next_maintenance_run_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this CloudExadataInfrastructure.
+        The `OCID`__ of the cloud Exadata infrastructure resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this CloudExadataInfrastructure.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this CloudExadataInfrastructure.
+        The `OCID`__ of the cloud Exadata infrastructure resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this CloudExadataInfrastructure.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CloudExadataInfrastructure.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CloudExadataInfrastructure.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CloudExadataInfrastructure.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CloudExadataInfrastructure.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this CloudExadataInfrastructure.
+        The current lifecycle state of the cloud Exadata infrastructure resource.
+
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this CloudExadataInfrastructure.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this CloudExadataInfrastructure.
+        The current lifecycle state of the cloud Exadata infrastructure resource.
+
+
+        :param lifecycle_state: The lifecycle_state of this CloudExadataInfrastructure.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CloudExadataInfrastructure.
+        The user-friendly name for the cloud Exadata infrastructure resource. The name does not need to be unique.
+
+
+        :return: The display_name of this CloudExadataInfrastructure.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CloudExadataInfrastructure.
+        The user-friendly name for the cloud Exadata infrastructure resource. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this CloudExadataInfrastructure.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def shape(self):
+        """
+        **[Required]** Gets the shape of this CloudExadataInfrastructure.
+        The model name of the cloud Exadata infrastructure resource.
+
+
+        :return: The shape of this CloudExadataInfrastructure.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this CloudExadataInfrastructure.
+        The model name of the cloud Exadata infrastructure resource.
+
+
+        :param shape: The shape of this CloudExadataInfrastructure.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def availability_domain(self):
+        """
+        **[Required]** Gets the availability_domain of this CloudExadataInfrastructure.
+        The name of the availability domain that the cloud Exadata infrastructure resource is located in.
+
+
+        :return: The availability_domain of this CloudExadataInfrastructure.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this CloudExadataInfrastructure.
+        The name of the availability domain that the cloud Exadata infrastructure resource is located in.
+
+
+        :param availability_domain: The availability_domain of this CloudExadataInfrastructure.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def compute_count(self):
+        """
+        Gets the compute_count of this CloudExadataInfrastructure.
+        The number of compute servers for the cloud Exadata infrastructure.
+
+
+        :return: The compute_count of this CloudExadataInfrastructure.
+        :rtype: int
+        """
+        return self._compute_count
+
+    @compute_count.setter
+    def compute_count(self, compute_count):
+        """
+        Sets the compute_count of this CloudExadataInfrastructure.
+        The number of compute servers for the cloud Exadata infrastructure.
+
+
+        :param compute_count: The compute_count of this CloudExadataInfrastructure.
+        :type: int
+        """
+        self._compute_count = compute_count
+
+    @property
+    def storage_count(self):
+        """
+        Gets the storage_count of this CloudExadataInfrastructure.
+        The number of storage servers for the cloud Exadata infrastructure.
+
+
+        :return: The storage_count of this CloudExadataInfrastructure.
+        :rtype: int
+        """
+        return self._storage_count
+
+    @storage_count.setter
+    def storage_count(self, storage_count):
+        """
+        Sets the storage_count of this CloudExadataInfrastructure.
+        The number of storage servers for the cloud Exadata infrastructure.
+
+
+        :param storage_count: The storage_count of this CloudExadataInfrastructure.
+        :type: int
+        """
+        self._storage_count = storage_count
+
+    @property
+    def total_storage_size_in_gbs(self):
+        """
+        Gets the total_storage_size_in_gbs of this CloudExadataInfrastructure.
+        The total storage allocated to the cloud Exadata infrastructure resource, in gigabytes (GB).
+
+
+        :return: The total_storage_size_in_gbs of this CloudExadataInfrastructure.
+        :rtype: int
+        """
+        return self._total_storage_size_in_gbs
+
+    @total_storage_size_in_gbs.setter
+    def total_storage_size_in_gbs(self, total_storage_size_in_gbs):
+        """
+        Sets the total_storage_size_in_gbs of this CloudExadataInfrastructure.
+        The total storage allocated to the cloud Exadata infrastructure resource, in gigabytes (GB).
+
+
+        :param total_storage_size_in_gbs: The total_storage_size_in_gbs of this CloudExadataInfrastructure.
+        :type: int
+        """
+        self._total_storage_size_in_gbs = total_storage_size_in_gbs
+
+    @property
+    def available_storage_size_in_gbs(self):
+        """
+        Gets the available_storage_size_in_gbs of this CloudExadataInfrastructure.
+        The available storage can be allocated to the cloud Exadata infrastructure resource, in gigabytes (GB).
+
+
+        :return: The available_storage_size_in_gbs of this CloudExadataInfrastructure.
+        :rtype: int
+        """
+        return self._available_storage_size_in_gbs
+
+    @available_storage_size_in_gbs.setter
+    def available_storage_size_in_gbs(self, available_storage_size_in_gbs):
+        """
+        Sets the available_storage_size_in_gbs of this CloudExadataInfrastructure.
+        The available storage can be allocated to the cloud Exadata infrastructure resource, in gigabytes (GB).
+
+
+        :param available_storage_size_in_gbs: The available_storage_size_in_gbs of this CloudExadataInfrastructure.
+        :type: int
+        """
+        self._available_storage_size_in_gbs = available_storage_size_in_gbs
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this CloudExadataInfrastructure.
+        The date and time the cloud Exadata infrastructure resource was created.
+
+
+        :return: The time_created of this CloudExadataInfrastructure.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this CloudExadataInfrastructure.
+        The date and time the cloud Exadata infrastructure resource was created.
+
+
+        :param time_created: The time_created of this CloudExadataInfrastructure.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this CloudExadataInfrastructure.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this CloudExadataInfrastructure.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this CloudExadataInfrastructure.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this CloudExadataInfrastructure.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def maintenance_window(self):
+        """
+        Gets the maintenance_window of this CloudExadataInfrastructure.
+
+        :return: The maintenance_window of this CloudExadataInfrastructure.
+        :rtype: MaintenanceWindow
+        """
+        return self._maintenance_window
+
+    @maintenance_window.setter
+    def maintenance_window(self, maintenance_window):
+        """
+        Sets the maintenance_window of this CloudExadataInfrastructure.
+
+        :param maintenance_window: The maintenance_window of this CloudExadataInfrastructure.
+        :type: MaintenanceWindow
+        """
+        self._maintenance_window = maintenance_window
+
+    @property
+    def last_maintenance_run_id(self):
+        """
+        Gets the last_maintenance_run_id of this CloudExadataInfrastructure.
+        The `OCID`__ of the last maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The last_maintenance_run_id of this CloudExadataInfrastructure.
+        :rtype: str
+        """
+        return self._last_maintenance_run_id
+
+    @last_maintenance_run_id.setter
+    def last_maintenance_run_id(self, last_maintenance_run_id):
+        """
+        Sets the last_maintenance_run_id of this CloudExadataInfrastructure.
+        The `OCID`__ of the last maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param last_maintenance_run_id: The last_maintenance_run_id of this CloudExadataInfrastructure.
+        :type: str
+        """
+        self._last_maintenance_run_id = last_maintenance_run_id
+
+    @property
+    def next_maintenance_run_id(self):
+        """
+        Gets the next_maintenance_run_id of this CloudExadataInfrastructure.
+        The `OCID`__ of the next maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The next_maintenance_run_id of this CloudExadataInfrastructure.
+        :rtype: str
+        """
+        return self._next_maintenance_run_id
+
+    @next_maintenance_run_id.setter
+    def next_maintenance_run_id(self, next_maintenance_run_id):
+        """
+        Sets the next_maintenance_run_id of this CloudExadataInfrastructure.
+        The `OCID`__ of the next maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param next_maintenance_run_id: The next_maintenance_run_id of this CloudExadataInfrastructure.
+        :type: str
+        """
+        self._next_maintenance_run_id = next_maintenance_run_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CloudExadataInfrastructure.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CloudExadataInfrastructure.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CloudExadataInfrastructure.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CloudExadataInfrastructure.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CloudExadataInfrastructure.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CloudExadataInfrastructure.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CloudExadataInfrastructure.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CloudExadataInfrastructure.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/cloud_exadata_infrastructure_summary.py
+++ b/src/oci/database/models/cloud_exadata_infrastructure_summary.py
@@ -1,0 +1,630 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CloudExadataInfrastructureSummary(object):
+    """
+    Details of the cloud Exadata infrastructure resource.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructureSummary.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructureSummary.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructureSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructureSummary.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructureSummary.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructureSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudExadataInfrastructureSummary.
+    #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
+    LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CloudExadataInfrastructureSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this CloudExadataInfrastructureSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CloudExadataInfrastructureSummary.
+        :type compartment_id: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this CloudExadataInfrastructureSummary.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CloudExadataInfrastructureSummary.
+        :type display_name: str
+
+        :param shape:
+            The value to assign to the shape property of this CloudExadataInfrastructureSummary.
+        :type shape: str
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this CloudExadataInfrastructureSummary.
+        :type availability_domain: str
+
+        :param compute_count:
+            The value to assign to the compute_count property of this CloudExadataInfrastructureSummary.
+        :type compute_count: int
+
+        :param storage_count:
+            The value to assign to the storage_count property of this CloudExadataInfrastructureSummary.
+        :type storage_count: int
+
+        :param total_storage_size_in_gbs:
+            The value to assign to the total_storage_size_in_gbs property of this CloudExadataInfrastructureSummary.
+        :type total_storage_size_in_gbs: int
+
+        :param available_storage_size_in_gbs:
+            The value to assign to the available_storage_size_in_gbs property of this CloudExadataInfrastructureSummary.
+        :type available_storage_size_in_gbs: int
+
+        :param time_created:
+            The value to assign to the time_created property of this CloudExadataInfrastructureSummary.
+        :type time_created: datetime
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this CloudExadataInfrastructureSummary.
+        :type lifecycle_details: str
+
+        :param maintenance_window:
+            The value to assign to the maintenance_window property of this CloudExadataInfrastructureSummary.
+        :type maintenance_window: MaintenanceWindow
+
+        :param last_maintenance_run_id:
+            The value to assign to the last_maintenance_run_id property of this CloudExadataInfrastructureSummary.
+        :type last_maintenance_run_id: str
+
+        :param next_maintenance_run_id:
+            The value to assign to the next_maintenance_run_id property of this CloudExadataInfrastructureSummary.
+        :type next_maintenance_run_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CloudExadataInfrastructureSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CloudExadataInfrastructureSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'lifecycle_state': 'str',
+            'display_name': 'str',
+            'shape': 'str',
+            'availability_domain': 'str',
+            'compute_count': 'int',
+            'storage_count': 'int',
+            'total_storage_size_in_gbs': 'int',
+            'available_storage_size_in_gbs': 'int',
+            'time_created': 'datetime',
+            'lifecycle_details': 'str',
+            'maintenance_window': 'MaintenanceWindow',
+            'last_maintenance_run_id': 'str',
+            'next_maintenance_run_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'lifecycle_state': 'lifecycleState',
+            'display_name': 'displayName',
+            'shape': 'shape',
+            'availability_domain': 'availabilityDomain',
+            'compute_count': 'computeCount',
+            'storage_count': 'storageCount',
+            'total_storage_size_in_gbs': 'totalStorageSizeInGBs',
+            'available_storage_size_in_gbs': 'availableStorageSizeInGBs',
+            'time_created': 'timeCreated',
+            'lifecycle_details': 'lifecycleDetails',
+            'maintenance_window': 'maintenanceWindow',
+            'last_maintenance_run_id': 'lastMaintenanceRunId',
+            'next_maintenance_run_id': 'nextMaintenanceRunId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._lifecycle_state = None
+        self._display_name = None
+        self._shape = None
+        self._availability_domain = None
+        self._compute_count = None
+        self._storage_count = None
+        self._total_storage_size_in_gbs = None
+        self._available_storage_size_in_gbs = None
+        self._time_created = None
+        self._lifecycle_details = None
+        self._maintenance_window = None
+        self._last_maintenance_run_id = None
+        self._next_maintenance_run_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this CloudExadataInfrastructureSummary.
+        The `OCID`__ of the cloud Exadata infrastructure resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this CloudExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this CloudExadataInfrastructureSummary.
+        The `OCID`__ of the cloud Exadata infrastructure resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this CloudExadataInfrastructureSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CloudExadataInfrastructureSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CloudExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CloudExadataInfrastructureSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CloudExadataInfrastructureSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this CloudExadataInfrastructureSummary.
+        The current lifecycle state of the cloud Exadata infrastructure resource.
+
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this CloudExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this CloudExadataInfrastructureSummary.
+        The current lifecycle state of the cloud Exadata infrastructure resource.
+
+
+        :param lifecycle_state: The lifecycle_state of this CloudExadataInfrastructureSummary.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CloudExadataInfrastructureSummary.
+        The user-friendly name for the cloud Exadata infrastructure resource. The name does not need to be unique.
+
+
+        :return: The display_name of this CloudExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CloudExadataInfrastructureSummary.
+        The user-friendly name for the cloud Exadata infrastructure resource. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this CloudExadataInfrastructureSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def shape(self):
+        """
+        **[Required]** Gets the shape of this CloudExadataInfrastructureSummary.
+        The model name of the cloud Exadata infrastructure resource.
+
+
+        :return: The shape of this CloudExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this CloudExadataInfrastructureSummary.
+        The model name of the cloud Exadata infrastructure resource.
+
+
+        :param shape: The shape of this CloudExadataInfrastructureSummary.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def availability_domain(self):
+        """
+        **[Required]** Gets the availability_domain of this CloudExadataInfrastructureSummary.
+        The name of the availability domain that the cloud Exadata infrastructure resource is located in.
+
+
+        :return: The availability_domain of this CloudExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this CloudExadataInfrastructureSummary.
+        The name of the availability domain that the cloud Exadata infrastructure resource is located in.
+
+
+        :param availability_domain: The availability_domain of this CloudExadataInfrastructureSummary.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def compute_count(self):
+        """
+        Gets the compute_count of this CloudExadataInfrastructureSummary.
+        The number of compute servers for the cloud Exadata infrastructure.
+
+
+        :return: The compute_count of this CloudExadataInfrastructureSummary.
+        :rtype: int
+        """
+        return self._compute_count
+
+    @compute_count.setter
+    def compute_count(self, compute_count):
+        """
+        Sets the compute_count of this CloudExadataInfrastructureSummary.
+        The number of compute servers for the cloud Exadata infrastructure.
+
+
+        :param compute_count: The compute_count of this CloudExadataInfrastructureSummary.
+        :type: int
+        """
+        self._compute_count = compute_count
+
+    @property
+    def storage_count(self):
+        """
+        Gets the storage_count of this CloudExadataInfrastructureSummary.
+        The number of storage servers for the cloud Exadata infrastructure.
+
+
+        :return: The storage_count of this CloudExadataInfrastructureSummary.
+        :rtype: int
+        """
+        return self._storage_count
+
+    @storage_count.setter
+    def storage_count(self, storage_count):
+        """
+        Sets the storage_count of this CloudExadataInfrastructureSummary.
+        The number of storage servers for the cloud Exadata infrastructure.
+
+
+        :param storage_count: The storage_count of this CloudExadataInfrastructureSummary.
+        :type: int
+        """
+        self._storage_count = storage_count
+
+    @property
+    def total_storage_size_in_gbs(self):
+        """
+        Gets the total_storage_size_in_gbs of this CloudExadataInfrastructureSummary.
+        The total storage allocated to the cloud Exadata infrastructure resource, in gigabytes (GB).
+
+
+        :return: The total_storage_size_in_gbs of this CloudExadataInfrastructureSummary.
+        :rtype: int
+        """
+        return self._total_storage_size_in_gbs
+
+    @total_storage_size_in_gbs.setter
+    def total_storage_size_in_gbs(self, total_storage_size_in_gbs):
+        """
+        Sets the total_storage_size_in_gbs of this CloudExadataInfrastructureSummary.
+        The total storage allocated to the cloud Exadata infrastructure resource, in gigabytes (GB).
+
+
+        :param total_storage_size_in_gbs: The total_storage_size_in_gbs of this CloudExadataInfrastructureSummary.
+        :type: int
+        """
+        self._total_storage_size_in_gbs = total_storage_size_in_gbs
+
+    @property
+    def available_storage_size_in_gbs(self):
+        """
+        Gets the available_storage_size_in_gbs of this CloudExadataInfrastructureSummary.
+        The available storage can be allocated to the cloud Exadata infrastructure resource, in gigabytes (GB).
+
+
+        :return: The available_storage_size_in_gbs of this CloudExadataInfrastructureSummary.
+        :rtype: int
+        """
+        return self._available_storage_size_in_gbs
+
+    @available_storage_size_in_gbs.setter
+    def available_storage_size_in_gbs(self, available_storage_size_in_gbs):
+        """
+        Sets the available_storage_size_in_gbs of this CloudExadataInfrastructureSummary.
+        The available storage can be allocated to the cloud Exadata infrastructure resource, in gigabytes (GB).
+
+
+        :param available_storage_size_in_gbs: The available_storage_size_in_gbs of this CloudExadataInfrastructureSummary.
+        :type: int
+        """
+        self._available_storage_size_in_gbs = available_storage_size_in_gbs
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this CloudExadataInfrastructureSummary.
+        The date and time the cloud Exadata infrastructure resource was created.
+
+
+        :return: The time_created of this CloudExadataInfrastructureSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this CloudExadataInfrastructureSummary.
+        The date and time the cloud Exadata infrastructure resource was created.
+
+
+        :param time_created: The time_created of this CloudExadataInfrastructureSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this CloudExadataInfrastructureSummary.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this CloudExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this CloudExadataInfrastructureSummary.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this CloudExadataInfrastructureSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def maintenance_window(self):
+        """
+        Gets the maintenance_window of this CloudExadataInfrastructureSummary.
+
+        :return: The maintenance_window of this CloudExadataInfrastructureSummary.
+        :rtype: MaintenanceWindow
+        """
+        return self._maintenance_window
+
+    @maintenance_window.setter
+    def maintenance_window(self, maintenance_window):
+        """
+        Sets the maintenance_window of this CloudExadataInfrastructureSummary.
+
+        :param maintenance_window: The maintenance_window of this CloudExadataInfrastructureSummary.
+        :type: MaintenanceWindow
+        """
+        self._maintenance_window = maintenance_window
+
+    @property
+    def last_maintenance_run_id(self):
+        """
+        Gets the last_maintenance_run_id of this CloudExadataInfrastructureSummary.
+        The `OCID`__ of the last maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The last_maintenance_run_id of this CloudExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._last_maintenance_run_id
+
+    @last_maintenance_run_id.setter
+    def last_maintenance_run_id(self, last_maintenance_run_id):
+        """
+        Sets the last_maintenance_run_id of this CloudExadataInfrastructureSummary.
+        The `OCID`__ of the last maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param last_maintenance_run_id: The last_maintenance_run_id of this CloudExadataInfrastructureSummary.
+        :type: str
+        """
+        self._last_maintenance_run_id = last_maintenance_run_id
+
+    @property
+    def next_maintenance_run_id(self):
+        """
+        Gets the next_maintenance_run_id of this CloudExadataInfrastructureSummary.
+        The `OCID`__ of the next maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The next_maintenance_run_id of this CloudExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._next_maintenance_run_id
+
+    @next_maintenance_run_id.setter
+    def next_maintenance_run_id(self, next_maintenance_run_id):
+        """
+        Sets the next_maintenance_run_id of this CloudExadataInfrastructureSummary.
+        The `OCID`__ of the next maintenance run.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param next_maintenance_run_id: The next_maintenance_run_id of this CloudExadataInfrastructureSummary.
+        :type: str
+        """
+        self._next_maintenance_run_id = next_maintenance_run_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CloudExadataInfrastructureSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CloudExadataInfrastructureSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CloudExadataInfrastructureSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CloudExadataInfrastructureSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CloudExadataInfrastructureSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CloudExadataInfrastructureSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CloudExadataInfrastructureSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CloudExadataInfrastructureSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/cloud_vm_cluster.py
+++ b/src/oci/database/models/cloud_vm_cluster.py
@@ -1,0 +1,1335 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CloudVmCluster(object):
+    """
+    Details of the cloud VM cluster.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmCluster.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmCluster.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmCluster.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmCluster.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmCluster.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmCluster.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmCluster.
+    #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
+    LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
+
+    #: A constant which can be used with the license_model property of a CloudVmCluster.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a CloudVmCluster.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    #: A constant which can be used with the disk_redundancy property of a CloudVmCluster.
+    #: This constant has a value of "HIGH"
+    DISK_REDUNDANCY_HIGH = "HIGH"
+
+    #: A constant which can be used with the disk_redundancy property of a CloudVmCluster.
+    #: This constant has a value of "NORMAL"
+    DISK_REDUNDANCY_NORMAL = "NORMAL"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CloudVmCluster object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param iorm_config_cache:
+            The value to assign to the iorm_config_cache property of this CloudVmCluster.
+        :type iorm_config_cache: ExadataIormConfig
+
+        :param id:
+            The value to assign to the id property of this CloudVmCluster.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CloudVmCluster.
+        :type compartment_id: str
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this CloudVmCluster.
+        :type availability_domain: str
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this CloudVmCluster.
+        :type subnet_id: str
+
+        :param backup_subnet_id:
+            The value to assign to the backup_subnet_id property of this CloudVmCluster.
+        :type backup_subnet_id: str
+
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this CloudVmCluster.
+        :type nsg_ids: list[str]
+
+        :param backup_network_nsg_ids:
+            The value to assign to the backup_network_nsg_ids property of this CloudVmCluster.
+        :type backup_network_nsg_ids: list[str]
+
+        :param last_update_history_entry_id:
+            The value to assign to the last_update_history_entry_id property of this CloudVmCluster.
+        :type last_update_history_entry_id: str
+
+        :param shape:
+            The value to assign to the shape property of this CloudVmCluster.
+        :type shape: str
+
+        :param listener_port:
+            The value to assign to the listener_port property of this CloudVmCluster.
+        :type listener_port: int
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this CloudVmCluster.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param node_count:
+            The value to assign to the node_count property of this CloudVmCluster.
+        :type node_count: int
+
+        :param storage_size_in_gbs:
+            The value to assign to the storage_size_in_gbs property of this CloudVmCluster.
+        :type storage_size_in_gbs: int
+
+        :param display_name:
+            The value to assign to the display_name property of this CloudVmCluster.
+        :type display_name: str
+
+        :param time_created:
+            The value to assign to the time_created property of this CloudVmCluster.
+        :type time_created: datetime
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this CloudVmCluster.
+        :type lifecycle_details: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this CloudVmCluster.
+        :type time_zone: str
+
+        :param hostname:
+            The value to assign to the hostname property of this CloudVmCluster.
+        :type hostname: str
+
+        :param domain:
+            The value to assign to the domain property of this CloudVmCluster.
+        :type domain: str
+
+        :param cpu_core_count:
+            The value to assign to the cpu_core_count property of this CloudVmCluster.
+        :type cpu_core_count: int
+
+        :param cluster_name:
+            The value to assign to the cluster_name property of this CloudVmCluster.
+        :type cluster_name: str
+
+        :param data_storage_percentage:
+            The value to assign to the data_storage_percentage property of this CloudVmCluster.
+        :type data_storage_percentage: int
+
+        :param is_local_backup_enabled:
+            The value to assign to the is_local_backup_enabled property of this CloudVmCluster.
+        :type is_local_backup_enabled: bool
+
+        :param cloud_exadata_infrastructure_id:
+            The value to assign to the cloud_exadata_infrastructure_id property of this CloudVmCluster.
+        :type cloud_exadata_infrastructure_id: str
+
+        :param is_sparse_diskgroup_enabled:
+            The value to assign to the is_sparse_diskgroup_enabled property of this CloudVmCluster.
+        :type is_sparse_diskgroup_enabled: bool
+
+        :param gi_version:
+            The value to assign to the gi_version property of this CloudVmCluster.
+        :type gi_version: str
+
+        :param system_version:
+            The value to assign to the system_version property of this CloudVmCluster.
+        :type system_version: str
+
+        :param ssh_public_keys:
+            The value to assign to the ssh_public_keys property of this CloudVmCluster.
+        :type ssh_public_keys: list[str]
+
+        :param license_model:
+            The value to assign to the license_model property of this CloudVmCluster.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type license_model: str
+
+        :param disk_redundancy:
+            The value to assign to the disk_redundancy property of this CloudVmCluster.
+            Allowed values for this property are: "HIGH", "NORMAL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type disk_redundancy: str
+
+        :param scan_ip_ids:
+            The value to assign to the scan_ip_ids property of this CloudVmCluster.
+        :type scan_ip_ids: list[str]
+
+        :param vip_ids:
+            The value to assign to the vip_ids property of this CloudVmCluster.
+        :type vip_ids: list[str]
+
+        :param scan_dns_record_id:
+            The value to assign to the scan_dns_record_id property of this CloudVmCluster.
+        :type scan_dns_record_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CloudVmCluster.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CloudVmCluster.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'iorm_config_cache': 'ExadataIormConfig',
+            'id': 'str',
+            'compartment_id': 'str',
+            'availability_domain': 'str',
+            'subnet_id': 'str',
+            'backup_subnet_id': 'str',
+            'nsg_ids': 'list[str]',
+            'backup_network_nsg_ids': 'list[str]',
+            'last_update_history_entry_id': 'str',
+            'shape': 'str',
+            'listener_port': 'int',
+            'lifecycle_state': 'str',
+            'node_count': 'int',
+            'storage_size_in_gbs': 'int',
+            'display_name': 'str',
+            'time_created': 'datetime',
+            'lifecycle_details': 'str',
+            'time_zone': 'str',
+            'hostname': 'str',
+            'domain': 'str',
+            'cpu_core_count': 'int',
+            'cluster_name': 'str',
+            'data_storage_percentage': 'int',
+            'is_local_backup_enabled': 'bool',
+            'cloud_exadata_infrastructure_id': 'str',
+            'is_sparse_diskgroup_enabled': 'bool',
+            'gi_version': 'str',
+            'system_version': 'str',
+            'ssh_public_keys': 'list[str]',
+            'license_model': 'str',
+            'disk_redundancy': 'str',
+            'scan_ip_ids': 'list[str]',
+            'vip_ids': 'list[str]',
+            'scan_dns_record_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'iorm_config_cache': 'iormConfigCache',
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'availability_domain': 'availabilityDomain',
+            'subnet_id': 'subnetId',
+            'backup_subnet_id': 'backupSubnetId',
+            'nsg_ids': 'nsgIds',
+            'backup_network_nsg_ids': 'backupNetworkNsgIds',
+            'last_update_history_entry_id': 'lastUpdateHistoryEntryId',
+            'shape': 'shape',
+            'listener_port': 'listenerPort',
+            'lifecycle_state': 'lifecycleState',
+            'node_count': 'nodeCount',
+            'storage_size_in_gbs': 'storageSizeInGBs',
+            'display_name': 'displayName',
+            'time_created': 'timeCreated',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_zone': 'timeZone',
+            'hostname': 'hostname',
+            'domain': 'domain',
+            'cpu_core_count': 'cpuCoreCount',
+            'cluster_name': 'clusterName',
+            'data_storage_percentage': 'dataStoragePercentage',
+            'is_local_backup_enabled': 'isLocalBackupEnabled',
+            'cloud_exadata_infrastructure_id': 'cloudExadataInfrastructureId',
+            'is_sparse_diskgroup_enabled': 'isSparseDiskgroupEnabled',
+            'gi_version': 'giVersion',
+            'system_version': 'systemVersion',
+            'ssh_public_keys': 'sshPublicKeys',
+            'license_model': 'licenseModel',
+            'disk_redundancy': 'diskRedundancy',
+            'scan_ip_ids': 'scanIpIds',
+            'vip_ids': 'vipIds',
+            'scan_dns_record_id': 'scanDnsRecordId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._iorm_config_cache = None
+        self._id = None
+        self._compartment_id = None
+        self._availability_domain = None
+        self._subnet_id = None
+        self._backup_subnet_id = None
+        self._nsg_ids = None
+        self._backup_network_nsg_ids = None
+        self._last_update_history_entry_id = None
+        self._shape = None
+        self._listener_port = None
+        self._lifecycle_state = None
+        self._node_count = None
+        self._storage_size_in_gbs = None
+        self._display_name = None
+        self._time_created = None
+        self._lifecycle_details = None
+        self._time_zone = None
+        self._hostname = None
+        self._domain = None
+        self._cpu_core_count = None
+        self._cluster_name = None
+        self._data_storage_percentage = None
+        self._is_local_backup_enabled = None
+        self._cloud_exadata_infrastructure_id = None
+        self._is_sparse_diskgroup_enabled = None
+        self._gi_version = None
+        self._system_version = None
+        self._ssh_public_keys = None
+        self._license_model = None
+        self._disk_redundancy = None
+        self._scan_ip_ids = None
+        self._vip_ids = None
+        self._scan_dns_record_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def iorm_config_cache(self):
+        """
+        Gets the iorm_config_cache of this CloudVmCluster.
+
+        :return: The iorm_config_cache of this CloudVmCluster.
+        :rtype: ExadataIormConfig
+        """
+        return self._iorm_config_cache
+
+    @iorm_config_cache.setter
+    def iorm_config_cache(self, iorm_config_cache):
+        """
+        Sets the iorm_config_cache of this CloudVmCluster.
+
+        :param iorm_config_cache: The iorm_config_cache of this CloudVmCluster.
+        :type: ExadataIormConfig
+        """
+        self._iorm_config_cache = iorm_config_cache
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this CloudVmCluster.
+        The `OCID`__ of the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this CloudVmCluster.
+        The `OCID`__ of the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this CloudVmCluster.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CloudVmCluster.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CloudVmCluster.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CloudVmCluster.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def availability_domain(self):
+        """
+        **[Required]** Gets the availability_domain of this CloudVmCluster.
+        The name of the availability domain that the cloud Exadata infrastructure resource is located in.
+
+
+        :return: The availability_domain of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this CloudVmCluster.
+        The name of the availability domain that the cloud Exadata infrastructure resource is located in.
+
+
+        :param availability_domain: The availability_domain of this CloudVmCluster.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def subnet_id(self):
+        """
+        **[Required]** Gets the subnet_id of this CloudVmCluster.
+        The `OCID`__ of the subnet associated with the cloud VM cluster.
+
+        **Subnet Restrictions:**
+        - For Exadata and virtual machine 2-node RAC systems, do not use a subnet that overlaps with 192.168.128.0/20.
+
+        These subnets are used by the Oracle Clusterware private interconnect on the database instance.
+        Specifying an overlapping subnet will cause the private interconnect to malfunction.
+        This restriction applies to both the client subnet and backup subnet.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The subnet_id of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._subnet_id
+
+    @subnet_id.setter
+    def subnet_id(self, subnet_id):
+        """
+        Sets the subnet_id of this CloudVmCluster.
+        The `OCID`__ of the subnet associated with the cloud VM cluster.
+
+        **Subnet Restrictions:**
+        - For Exadata and virtual machine 2-node RAC systems, do not use a subnet that overlaps with 192.168.128.0/20.
+
+        These subnets are used by the Oracle Clusterware private interconnect on the database instance.
+        Specifying an overlapping subnet will cause the private interconnect to malfunction.
+        This restriction applies to both the client subnet and backup subnet.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param subnet_id: The subnet_id of this CloudVmCluster.
+        :type: str
+        """
+        self._subnet_id = subnet_id
+
+    @property
+    def backup_subnet_id(self):
+        """
+        Gets the backup_subnet_id of this CloudVmCluster.
+        The `OCID`__ of the backup network subnet associated with the cloud VM cluster.
+
+        **Subnet Restriction:** See the subnet restrictions information for **subnetId**.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The backup_subnet_id of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._backup_subnet_id
+
+    @backup_subnet_id.setter
+    def backup_subnet_id(self, backup_subnet_id):
+        """
+        Sets the backup_subnet_id of this CloudVmCluster.
+        The `OCID`__ of the backup network subnet associated with the cloud VM cluster.
+
+        **Subnet Restriction:** See the subnet restrictions information for **subnetId**.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param backup_subnet_id: The backup_subnet_id of this CloudVmCluster.
+        :type: str
+        """
+        self._backup_subnet_id = backup_subnet_id
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this CloudVmCluster.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+        **NsgIds restrictions:**
+        - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :return: The nsg_ids of this CloudVmCluster.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this CloudVmCluster.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+        **NsgIds restrictions:**
+        - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :param nsg_ids: The nsg_ids of this CloudVmCluster.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
+
+    @property
+    def backup_network_nsg_ids(self):
+        """
+        Gets the backup_network_nsg_ids of this CloudVmCluster.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :return: The backup_network_nsg_ids of this CloudVmCluster.
+        :rtype: list[str]
+        """
+        return self._backup_network_nsg_ids
+
+    @backup_network_nsg_ids.setter
+    def backup_network_nsg_ids(self, backup_network_nsg_ids):
+        """
+        Sets the backup_network_nsg_ids of this CloudVmCluster.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :param backup_network_nsg_ids: The backup_network_nsg_ids of this CloudVmCluster.
+        :type: list[str]
+        """
+        self._backup_network_nsg_ids = backup_network_nsg_ids
+
+    @property
+    def last_update_history_entry_id(self):
+        """
+        Gets the last_update_history_entry_id of this CloudVmCluster.
+        The `OCID`__ of the last maintenance update history entry. This value is updated when a maintenance update starts.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The last_update_history_entry_id of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._last_update_history_entry_id
+
+    @last_update_history_entry_id.setter
+    def last_update_history_entry_id(self, last_update_history_entry_id):
+        """
+        Sets the last_update_history_entry_id of this CloudVmCluster.
+        The `OCID`__ of the last maintenance update history entry. This value is updated when a maintenance update starts.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param last_update_history_entry_id: The last_update_history_entry_id of this CloudVmCluster.
+        :type: str
+        """
+        self._last_update_history_entry_id = last_update_history_entry_id
+
+    @property
+    def shape(self):
+        """
+        **[Required]** Gets the shape of this CloudVmCluster.
+        The model name of the Exadata hardware running the cloud VM cluster.
+
+
+        :return: The shape of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this CloudVmCluster.
+        The model name of the Exadata hardware running the cloud VM cluster.
+
+
+        :param shape: The shape of this CloudVmCluster.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def listener_port(self):
+        """
+        Gets the listener_port of this CloudVmCluster.
+        The port number configured for the listener on the cloud VM cluster.
+
+
+        :return: The listener_port of this CloudVmCluster.
+        :rtype: int
+        """
+        return self._listener_port
+
+    @listener_port.setter
+    def listener_port(self, listener_port):
+        """
+        Sets the listener_port of this CloudVmCluster.
+        The port number configured for the listener on the cloud VM cluster.
+
+
+        :param listener_port: The listener_port of this CloudVmCluster.
+        :type: int
+        """
+        self._listener_port = listener_port
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this CloudVmCluster.
+        The current state of the cloud VM cluster.
+
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this CloudVmCluster.
+        The current state of the cloud VM cluster.
+
+
+        :param lifecycle_state: The lifecycle_state of this CloudVmCluster.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def node_count(self):
+        """
+        Gets the node_count of this CloudVmCluster.
+        The number of nodes in the cloud VM cluster.
+
+
+        :return: The node_count of this CloudVmCluster.
+        :rtype: int
+        """
+        return self._node_count
+
+    @node_count.setter
+    def node_count(self, node_count):
+        """
+        Sets the node_count of this CloudVmCluster.
+        The number of nodes in the cloud VM cluster.
+
+
+        :param node_count: The node_count of this CloudVmCluster.
+        :type: int
+        """
+        self._node_count = node_count
+
+    @property
+    def storage_size_in_gbs(self):
+        """
+        Gets the storage_size_in_gbs of this CloudVmCluster.
+        The storage allocation for the disk group, in gigabytes (GB).
+
+
+        :return: The storage_size_in_gbs of this CloudVmCluster.
+        :rtype: int
+        """
+        return self._storage_size_in_gbs
+
+    @storage_size_in_gbs.setter
+    def storage_size_in_gbs(self, storage_size_in_gbs):
+        """
+        Sets the storage_size_in_gbs of this CloudVmCluster.
+        The storage allocation for the disk group, in gigabytes (GB).
+
+
+        :param storage_size_in_gbs: The storage_size_in_gbs of this CloudVmCluster.
+        :type: int
+        """
+        self._storage_size_in_gbs = storage_size_in_gbs
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CloudVmCluster.
+        The user-friendly name for the cloud VM cluster. The name does not need to be unique.
+
+
+        :return: The display_name of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CloudVmCluster.
+        The user-friendly name for the cloud VM cluster. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this CloudVmCluster.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this CloudVmCluster.
+        The date and time that the cloud VM cluster was created.
+
+
+        :return: The time_created of this CloudVmCluster.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this CloudVmCluster.
+        The date and time that the cloud VM cluster was created.
+
+
+        :param time_created: The time_created of this CloudVmCluster.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this CloudVmCluster.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this CloudVmCluster.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this CloudVmCluster.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this CloudVmCluster.
+        The time zone of the cloud VM cluster. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :return: The time_zone of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this CloudVmCluster.
+        The time zone of the cloud VM cluster. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :param time_zone: The time_zone of this CloudVmCluster.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def hostname(self):
+        """
+        **[Required]** Gets the hostname of this CloudVmCluster.
+        The hostname for the cloud VM cluster.
+
+
+        :return: The hostname of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, hostname):
+        """
+        Sets the hostname of this CloudVmCluster.
+        The hostname for the cloud VM cluster.
+
+
+        :param hostname: The hostname of this CloudVmCluster.
+        :type: str
+        """
+        self._hostname = hostname
+
+    @property
+    def domain(self):
+        """
+        **[Required]** Gets the domain of this CloudVmCluster.
+        The domain name for the cloud VM cluster.
+
+
+        :return: The domain of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._domain
+
+    @domain.setter
+    def domain(self, domain):
+        """
+        Sets the domain of this CloudVmCluster.
+        The domain name for the cloud VM cluster.
+
+
+        :param domain: The domain of this CloudVmCluster.
+        :type: str
+        """
+        self._domain = domain
+
+    @property
+    def cpu_core_count(self):
+        """
+        **[Required]** Gets the cpu_core_count of this CloudVmCluster.
+        The number of CPU cores enabled on the cloud VM cluster.
+
+
+        :return: The cpu_core_count of this CloudVmCluster.
+        :rtype: int
+        """
+        return self._cpu_core_count
+
+    @cpu_core_count.setter
+    def cpu_core_count(self, cpu_core_count):
+        """
+        Sets the cpu_core_count of this CloudVmCluster.
+        The number of CPU cores enabled on the cloud VM cluster.
+
+
+        :param cpu_core_count: The cpu_core_count of this CloudVmCluster.
+        :type: int
+        """
+        self._cpu_core_count = cpu_core_count
+
+    @property
+    def cluster_name(self):
+        """
+        Gets the cluster_name of this CloudVmCluster.
+        The cluster name for cloud VM cluster. The cluster name must begin with an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
+
+
+        :return: The cluster_name of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._cluster_name
+
+    @cluster_name.setter
+    def cluster_name(self, cluster_name):
+        """
+        Sets the cluster_name of this CloudVmCluster.
+        The cluster name for cloud VM cluster. The cluster name must begin with an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
+
+
+        :param cluster_name: The cluster_name of this CloudVmCluster.
+        :type: str
+        """
+        self._cluster_name = cluster_name
+
+    @property
+    def data_storage_percentage(self):
+        """
+        Gets the data_storage_percentage of this CloudVmCluster.
+        The percentage assigned to DATA storage (user data and database files).
+        The remaining percentage is assigned to RECO storage (database redo logs, archive logs, and recovery manager backups). Accepted values are 35, 40, 60 and 80. The default is 80 percent assigned to DATA storage. See `Storage Configuration`__ in the Exadata documentation for details on the impact of the configuration settings on storage.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/exaoverview.htm#Exadata
+
+
+        :return: The data_storage_percentage of this CloudVmCluster.
+        :rtype: int
+        """
+        return self._data_storage_percentage
+
+    @data_storage_percentage.setter
+    def data_storage_percentage(self, data_storage_percentage):
+        """
+        Sets the data_storage_percentage of this CloudVmCluster.
+        The percentage assigned to DATA storage (user data and database files).
+        The remaining percentage is assigned to RECO storage (database redo logs, archive logs, and recovery manager backups). Accepted values are 35, 40, 60 and 80. The default is 80 percent assigned to DATA storage. See `Storage Configuration`__ in the Exadata documentation for details on the impact of the configuration settings on storage.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/exaoverview.htm#Exadata
+
+
+        :param data_storage_percentage: The data_storage_percentage of this CloudVmCluster.
+        :type: int
+        """
+        self._data_storage_percentage = data_storage_percentage
+
+    @property
+    def is_local_backup_enabled(self):
+        """
+        Gets the is_local_backup_enabled of this CloudVmCluster.
+        If true, database backup on local Exadata storage is configured for the cloud VM cluster. If false, database backup on local Exadata storage is not available in the cloud VM cluster.
+
+
+        :return: The is_local_backup_enabled of this CloudVmCluster.
+        :rtype: bool
+        """
+        return self._is_local_backup_enabled
+
+    @is_local_backup_enabled.setter
+    def is_local_backup_enabled(self, is_local_backup_enabled):
+        """
+        Sets the is_local_backup_enabled of this CloudVmCluster.
+        If true, database backup on local Exadata storage is configured for the cloud VM cluster. If false, database backup on local Exadata storage is not available in the cloud VM cluster.
+
+
+        :param is_local_backup_enabled: The is_local_backup_enabled of this CloudVmCluster.
+        :type: bool
+        """
+        self._is_local_backup_enabled = is_local_backup_enabled
+
+    @property
+    def cloud_exadata_infrastructure_id(self):
+        """
+        **[Required]** Gets the cloud_exadata_infrastructure_id of this CloudVmCluster.
+        The `OCID`__ of the cloud Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The cloud_exadata_infrastructure_id of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._cloud_exadata_infrastructure_id
+
+    @cloud_exadata_infrastructure_id.setter
+    def cloud_exadata_infrastructure_id(self, cloud_exadata_infrastructure_id):
+        """
+        Sets the cloud_exadata_infrastructure_id of this CloudVmCluster.
+        The `OCID`__ of the cloud Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param cloud_exadata_infrastructure_id: The cloud_exadata_infrastructure_id of this CloudVmCluster.
+        :type: str
+        """
+        self._cloud_exadata_infrastructure_id = cloud_exadata_infrastructure_id
+
+    @property
+    def is_sparse_diskgroup_enabled(self):
+        """
+        Gets the is_sparse_diskgroup_enabled of this CloudVmCluster.
+        If true, sparse disk group is configured for the cloud VM cluster. If false, sparse disk group is not created.
+
+
+        :return: The is_sparse_diskgroup_enabled of this CloudVmCluster.
+        :rtype: bool
+        """
+        return self._is_sparse_diskgroup_enabled
+
+    @is_sparse_diskgroup_enabled.setter
+    def is_sparse_diskgroup_enabled(self, is_sparse_diskgroup_enabled):
+        """
+        Sets the is_sparse_diskgroup_enabled of this CloudVmCluster.
+        If true, sparse disk group is configured for the cloud VM cluster. If false, sparse disk group is not created.
+
+
+        :param is_sparse_diskgroup_enabled: The is_sparse_diskgroup_enabled of this CloudVmCluster.
+        :type: bool
+        """
+        self._is_sparse_diskgroup_enabled = is_sparse_diskgroup_enabled
+
+    @property
+    def gi_version(self):
+        """
+        Gets the gi_version of this CloudVmCluster.
+        A valid Oracle Grid Infrastructure (GI) software version.
+
+
+        :return: The gi_version of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._gi_version
+
+    @gi_version.setter
+    def gi_version(self, gi_version):
+        """
+        Sets the gi_version of this CloudVmCluster.
+        A valid Oracle Grid Infrastructure (GI) software version.
+
+
+        :param gi_version: The gi_version of this CloudVmCluster.
+        :type: str
+        """
+        self._gi_version = gi_version
+
+    @property
+    def system_version(self):
+        """
+        Gets the system_version of this CloudVmCluster.
+        Operating system version of the image.
+
+
+        :return: The system_version of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._system_version
+
+    @system_version.setter
+    def system_version(self, system_version):
+        """
+        Sets the system_version of this CloudVmCluster.
+        Operating system version of the image.
+
+
+        :param system_version: The system_version of this CloudVmCluster.
+        :type: str
+        """
+        self._system_version = system_version
+
+    @property
+    def ssh_public_keys(self):
+        """
+        **[Required]** Gets the ssh_public_keys of this CloudVmCluster.
+        The public key portion of one or more key pairs used for SSH access to the cloud VM cluster.
+
+
+        :return: The ssh_public_keys of this CloudVmCluster.
+        :rtype: list[str]
+        """
+        return self._ssh_public_keys
+
+    @ssh_public_keys.setter
+    def ssh_public_keys(self, ssh_public_keys):
+        """
+        Sets the ssh_public_keys of this CloudVmCluster.
+        The public key portion of one or more key pairs used for SSH access to the cloud VM cluster.
+
+
+        :param ssh_public_keys: The ssh_public_keys of this CloudVmCluster.
+        :type: list[str]
+        """
+        self._ssh_public_keys = ssh_public_keys
+
+    @property
+    def license_model(self):
+        """
+        Gets the license_model of this CloudVmCluster.
+        The Oracle license model that applies to the cloud VM cluster. The default is LICENSE_INCLUDED.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The license_model of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this CloudVmCluster.
+        The Oracle license model that applies to the cloud VM cluster. The default is LICENSE_INCLUDED.
+
+
+        :param license_model: The license_model of this CloudVmCluster.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            license_model = 'UNKNOWN_ENUM_VALUE'
+        self._license_model = license_model
+
+    @property
+    def disk_redundancy(self):
+        """
+        Gets the disk_redundancy of this CloudVmCluster.
+        The type of redundancy configured for the cloud Vm cluster.
+        NORMAL is 2-way redundancy.
+        HIGH is 3-way redundancy.
+
+        Allowed values for this property are: "HIGH", "NORMAL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The disk_redundancy of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._disk_redundancy
+
+    @disk_redundancy.setter
+    def disk_redundancy(self, disk_redundancy):
+        """
+        Sets the disk_redundancy of this CloudVmCluster.
+        The type of redundancy configured for the cloud Vm cluster.
+        NORMAL is 2-way redundancy.
+        HIGH is 3-way redundancy.
+
+
+        :param disk_redundancy: The disk_redundancy of this CloudVmCluster.
+        :type: str
+        """
+        allowed_values = ["HIGH", "NORMAL"]
+        if not value_allowed_none_or_none_sentinel(disk_redundancy, allowed_values):
+            disk_redundancy = 'UNKNOWN_ENUM_VALUE'
+        self._disk_redundancy = disk_redundancy
+
+    @property
+    def scan_ip_ids(self):
+        """
+        Gets the scan_ip_ids of this CloudVmCluster.
+        The `OCID`__ of the Single Client Access Name (SCAN) IP addresses associated with the cloud VM cluster.
+        SCAN IP addresses are typically used for load balancing and are not assigned to any interface.
+        Oracle Clusterware directs the requests to the appropriate nodes in the cluster.
+
+        **Note:** For a single-node DB system, this list is empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The scan_ip_ids of this CloudVmCluster.
+        :rtype: list[str]
+        """
+        return self._scan_ip_ids
+
+    @scan_ip_ids.setter
+    def scan_ip_ids(self, scan_ip_ids):
+        """
+        Sets the scan_ip_ids of this CloudVmCluster.
+        The `OCID`__ of the Single Client Access Name (SCAN) IP addresses associated with the cloud VM cluster.
+        SCAN IP addresses are typically used for load balancing and are not assigned to any interface.
+        Oracle Clusterware directs the requests to the appropriate nodes in the cluster.
+
+        **Note:** For a single-node DB system, this list is empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param scan_ip_ids: The scan_ip_ids of this CloudVmCluster.
+        :type: list[str]
+        """
+        self._scan_ip_ids = scan_ip_ids
+
+    @property
+    def vip_ids(self):
+        """
+        Gets the vip_ids of this CloudVmCluster.
+        The `OCID`__ of the virtual IP (VIP) addresses associated with the cloud VM cluster.
+        The Cluster Ready Services (CRS) creates and maintains one VIP address for each node in the Exadata Cloud Service instance to
+        enable failover. If one node fails, the VIP is reassigned to another active node in the cluster.
+
+        **Note:** For a single-node DB system, this list is empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vip_ids of this CloudVmCluster.
+        :rtype: list[str]
+        """
+        return self._vip_ids
+
+    @vip_ids.setter
+    def vip_ids(self, vip_ids):
+        """
+        Sets the vip_ids of this CloudVmCluster.
+        The `OCID`__ of the virtual IP (VIP) addresses associated with the cloud VM cluster.
+        The Cluster Ready Services (CRS) creates and maintains one VIP address for each node in the Exadata Cloud Service instance to
+        enable failover. If one node fails, the VIP is reassigned to another active node in the cluster.
+
+        **Note:** For a single-node DB system, this list is empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vip_ids: The vip_ids of this CloudVmCluster.
+        :type: list[str]
+        """
+        self._vip_ids = vip_ids
+
+    @property
+    def scan_dns_record_id(self):
+        """
+        Gets the scan_dns_record_id of this CloudVmCluster.
+        The `OCID`__ of the DNS record for the SCAN IP addresses that are associated with the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The scan_dns_record_id of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._scan_dns_record_id
+
+    @scan_dns_record_id.setter
+    def scan_dns_record_id(self, scan_dns_record_id):
+        """
+        Sets the scan_dns_record_id of this CloudVmCluster.
+        The `OCID`__ of the DNS record for the SCAN IP addresses that are associated with the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param scan_dns_record_id: The scan_dns_record_id of this CloudVmCluster.
+        :type: str
+        """
+        self._scan_dns_record_id = scan_dns_record_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CloudVmCluster.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CloudVmCluster.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CloudVmCluster.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CloudVmCluster.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CloudVmCluster.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CloudVmCluster.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CloudVmCluster.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CloudVmCluster.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/cloud_vm_cluster_summary.py
+++ b/src/oci/database/models/cloud_vm_cluster_summary.py
@@ -1,0 +1,1308 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CloudVmClusterSummary(object):
+    """
+    Details of the cloud VM cluster.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmClusterSummary.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmClusterSummary.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmClusterSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmClusterSummary.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmClusterSummary.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmClusterSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a CloudVmClusterSummary.
+    #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
+    LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
+
+    #: A constant which can be used with the license_model property of a CloudVmClusterSummary.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a CloudVmClusterSummary.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    #: A constant which can be used with the disk_redundancy property of a CloudVmClusterSummary.
+    #: This constant has a value of "HIGH"
+    DISK_REDUNDANCY_HIGH = "HIGH"
+
+    #: A constant which can be used with the disk_redundancy property of a CloudVmClusterSummary.
+    #: This constant has a value of "NORMAL"
+    DISK_REDUNDANCY_NORMAL = "NORMAL"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CloudVmClusterSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this CloudVmClusterSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CloudVmClusterSummary.
+        :type compartment_id: str
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this CloudVmClusterSummary.
+        :type availability_domain: str
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this CloudVmClusterSummary.
+        :type subnet_id: str
+
+        :param backup_subnet_id:
+            The value to assign to the backup_subnet_id property of this CloudVmClusterSummary.
+        :type backup_subnet_id: str
+
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this CloudVmClusterSummary.
+        :type nsg_ids: list[str]
+
+        :param backup_network_nsg_ids:
+            The value to assign to the backup_network_nsg_ids property of this CloudVmClusterSummary.
+        :type backup_network_nsg_ids: list[str]
+
+        :param last_update_history_entry_id:
+            The value to assign to the last_update_history_entry_id property of this CloudVmClusterSummary.
+        :type last_update_history_entry_id: str
+
+        :param shape:
+            The value to assign to the shape property of this CloudVmClusterSummary.
+        :type shape: str
+
+        :param listener_port:
+            The value to assign to the listener_port property of this CloudVmClusterSummary.
+        :type listener_port: int
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this CloudVmClusterSummary.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param node_count:
+            The value to assign to the node_count property of this CloudVmClusterSummary.
+        :type node_count: int
+
+        :param storage_size_in_gbs:
+            The value to assign to the storage_size_in_gbs property of this CloudVmClusterSummary.
+        :type storage_size_in_gbs: int
+
+        :param display_name:
+            The value to assign to the display_name property of this CloudVmClusterSummary.
+        :type display_name: str
+
+        :param time_created:
+            The value to assign to the time_created property of this CloudVmClusterSummary.
+        :type time_created: datetime
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this CloudVmClusterSummary.
+        :type lifecycle_details: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this CloudVmClusterSummary.
+        :type time_zone: str
+
+        :param hostname:
+            The value to assign to the hostname property of this CloudVmClusterSummary.
+        :type hostname: str
+
+        :param domain:
+            The value to assign to the domain property of this CloudVmClusterSummary.
+        :type domain: str
+
+        :param cpu_core_count:
+            The value to assign to the cpu_core_count property of this CloudVmClusterSummary.
+        :type cpu_core_count: int
+
+        :param cluster_name:
+            The value to assign to the cluster_name property of this CloudVmClusterSummary.
+        :type cluster_name: str
+
+        :param data_storage_percentage:
+            The value to assign to the data_storage_percentage property of this CloudVmClusterSummary.
+        :type data_storage_percentage: int
+
+        :param is_local_backup_enabled:
+            The value to assign to the is_local_backup_enabled property of this CloudVmClusterSummary.
+        :type is_local_backup_enabled: bool
+
+        :param cloud_exadata_infrastructure_id:
+            The value to assign to the cloud_exadata_infrastructure_id property of this CloudVmClusterSummary.
+        :type cloud_exadata_infrastructure_id: str
+
+        :param is_sparse_diskgroup_enabled:
+            The value to assign to the is_sparse_diskgroup_enabled property of this CloudVmClusterSummary.
+        :type is_sparse_diskgroup_enabled: bool
+
+        :param gi_version:
+            The value to assign to the gi_version property of this CloudVmClusterSummary.
+        :type gi_version: str
+
+        :param system_version:
+            The value to assign to the system_version property of this CloudVmClusterSummary.
+        :type system_version: str
+
+        :param ssh_public_keys:
+            The value to assign to the ssh_public_keys property of this CloudVmClusterSummary.
+        :type ssh_public_keys: list[str]
+
+        :param license_model:
+            The value to assign to the license_model property of this CloudVmClusterSummary.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type license_model: str
+
+        :param disk_redundancy:
+            The value to assign to the disk_redundancy property of this CloudVmClusterSummary.
+            Allowed values for this property are: "HIGH", "NORMAL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type disk_redundancy: str
+
+        :param scan_ip_ids:
+            The value to assign to the scan_ip_ids property of this CloudVmClusterSummary.
+        :type scan_ip_ids: list[str]
+
+        :param vip_ids:
+            The value to assign to the vip_ids property of this CloudVmClusterSummary.
+        :type vip_ids: list[str]
+
+        :param scan_dns_record_id:
+            The value to assign to the scan_dns_record_id property of this CloudVmClusterSummary.
+        :type scan_dns_record_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CloudVmClusterSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CloudVmClusterSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'availability_domain': 'str',
+            'subnet_id': 'str',
+            'backup_subnet_id': 'str',
+            'nsg_ids': 'list[str]',
+            'backup_network_nsg_ids': 'list[str]',
+            'last_update_history_entry_id': 'str',
+            'shape': 'str',
+            'listener_port': 'int',
+            'lifecycle_state': 'str',
+            'node_count': 'int',
+            'storage_size_in_gbs': 'int',
+            'display_name': 'str',
+            'time_created': 'datetime',
+            'lifecycle_details': 'str',
+            'time_zone': 'str',
+            'hostname': 'str',
+            'domain': 'str',
+            'cpu_core_count': 'int',
+            'cluster_name': 'str',
+            'data_storage_percentage': 'int',
+            'is_local_backup_enabled': 'bool',
+            'cloud_exadata_infrastructure_id': 'str',
+            'is_sparse_diskgroup_enabled': 'bool',
+            'gi_version': 'str',
+            'system_version': 'str',
+            'ssh_public_keys': 'list[str]',
+            'license_model': 'str',
+            'disk_redundancy': 'str',
+            'scan_ip_ids': 'list[str]',
+            'vip_ids': 'list[str]',
+            'scan_dns_record_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'availability_domain': 'availabilityDomain',
+            'subnet_id': 'subnetId',
+            'backup_subnet_id': 'backupSubnetId',
+            'nsg_ids': 'nsgIds',
+            'backup_network_nsg_ids': 'backupNetworkNsgIds',
+            'last_update_history_entry_id': 'lastUpdateHistoryEntryId',
+            'shape': 'shape',
+            'listener_port': 'listenerPort',
+            'lifecycle_state': 'lifecycleState',
+            'node_count': 'nodeCount',
+            'storage_size_in_gbs': 'storageSizeInGBs',
+            'display_name': 'displayName',
+            'time_created': 'timeCreated',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_zone': 'timeZone',
+            'hostname': 'hostname',
+            'domain': 'domain',
+            'cpu_core_count': 'cpuCoreCount',
+            'cluster_name': 'clusterName',
+            'data_storage_percentage': 'dataStoragePercentage',
+            'is_local_backup_enabled': 'isLocalBackupEnabled',
+            'cloud_exadata_infrastructure_id': 'cloudExadataInfrastructureId',
+            'is_sparse_diskgroup_enabled': 'isSparseDiskgroupEnabled',
+            'gi_version': 'giVersion',
+            'system_version': 'systemVersion',
+            'ssh_public_keys': 'sshPublicKeys',
+            'license_model': 'licenseModel',
+            'disk_redundancy': 'diskRedundancy',
+            'scan_ip_ids': 'scanIpIds',
+            'vip_ids': 'vipIds',
+            'scan_dns_record_id': 'scanDnsRecordId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._availability_domain = None
+        self._subnet_id = None
+        self._backup_subnet_id = None
+        self._nsg_ids = None
+        self._backup_network_nsg_ids = None
+        self._last_update_history_entry_id = None
+        self._shape = None
+        self._listener_port = None
+        self._lifecycle_state = None
+        self._node_count = None
+        self._storage_size_in_gbs = None
+        self._display_name = None
+        self._time_created = None
+        self._lifecycle_details = None
+        self._time_zone = None
+        self._hostname = None
+        self._domain = None
+        self._cpu_core_count = None
+        self._cluster_name = None
+        self._data_storage_percentage = None
+        self._is_local_backup_enabled = None
+        self._cloud_exadata_infrastructure_id = None
+        self._is_sparse_diskgroup_enabled = None
+        self._gi_version = None
+        self._system_version = None
+        self._ssh_public_keys = None
+        self._license_model = None
+        self._disk_redundancy = None
+        self._scan_ip_ids = None
+        self._vip_ids = None
+        self._scan_dns_record_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this CloudVmClusterSummary.
+        The `OCID`__ of the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this CloudVmClusterSummary.
+        The `OCID`__ of the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CloudVmClusterSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CloudVmClusterSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def availability_domain(self):
+        """
+        **[Required]** Gets the availability_domain of this CloudVmClusterSummary.
+        The name of the availability domain that the cloud Exadata infrastructure resource is located in.
+
+
+        :return: The availability_domain of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this CloudVmClusterSummary.
+        The name of the availability domain that the cloud Exadata infrastructure resource is located in.
+
+
+        :param availability_domain: The availability_domain of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def subnet_id(self):
+        """
+        **[Required]** Gets the subnet_id of this CloudVmClusterSummary.
+        The `OCID`__ of the subnet associated with the cloud VM cluster.
+
+        **Subnet Restrictions:**
+        - For Exadata and virtual machine 2-node RAC systems, do not use a subnet that overlaps with 192.168.128.0/20.
+
+        These subnets are used by the Oracle Clusterware private interconnect on the database instance.
+        Specifying an overlapping subnet will cause the private interconnect to malfunction.
+        This restriction applies to both the client subnet and backup subnet.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The subnet_id of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._subnet_id
+
+    @subnet_id.setter
+    def subnet_id(self, subnet_id):
+        """
+        Sets the subnet_id of this CloudVmClusterSummary.
+        The `OCID`__ of the subnet associated with the cloud VM cluster.
+
+        **Subnet Restrictions:**
+        - For Exadata and virtual machine 2-node RAC systems, do not use a subnet that overlaps with 192.168.128.0/20.
+
+        These subnets are used by the Oracle Clusterware private interconnect on the database instance.
+        Specifying an overlapping subnet will cause the private interconnect to malfunction.
+        This restriction applies to both the client subnet and backup subnet.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param subnet_id: The subnet_id of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._subnet_id = subnet_id
+
+    @property
+    def backup_subnet_id(self):
+        """
+        Gets the backup_subnet_id of this CloudVmClusterSummary.
+        The `OCID`__ of the backup network subnet associated with the cloud VM cluster.
+
+        **Subnet Restriction:** See the subnet restrictions information for **subnetId**.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The backup_subnet_id of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._backup_subnet_id
+
+    @backup_subnet_id.setter
+    def backup_subnet_id(self, backup_subnet_id):
+        """
+        Sets the backup_subnet_id of this CloudVmClusterSummary.
+        The `OCID`__ of the backup network subnet associated with the cloud VM cluster.
+
+        **Subnet Restriction:** See the subnet restrictions information for **subnetId**.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param backup_subnet_id: The backup_subnet_id of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._backup_subnet_id = backup_subnet_id
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this CloudVmClusterSummary.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+        **NsgIds restrictions:**
+        - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :return: The nsg_ids of this CloudVmClusterSummary.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this CloudVmClusterSummary.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+        **NsgIds restrictions:**
+        - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :param nsg_ids: The nsg_ids of this CloudVmClusterSummary.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
+
+    @property
+    def backup_network_nsg_ids(self):
+        """
+        Gets the backup_network_nsg_ids of this CloudVmClusterSummary.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :return: The backup_network_nsg_ids of this CloudVmClusterSummary.
+        :rtype: list[str]
+        """
+        return self._backup_network_nsg_ids
+
+    @backup_network_nsg_ids.setter
+    def backup_network_nsg_ids(self, backup_network_nsg_ids):
+        """
+        Sets the backup_network_nsg_ids of this CloudVmClusterSummary.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :param backup_network_nsg_ids: The backup_network_nsg_ids of this CloudVmClusterSummary.
+        :type: list[str]
+        """
+        self._backup_network_nsg_ids = backup_network_nsg_ids
+
+    @property
+    def last_update_history_entry_id(self):
+        """
+        Gets the last_update_history_entry_id of this CloudVmClusterSummary.
+        The `OCID`__ of the last maintenance update history entry. This value is updated when a maintenance update starts.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The last_update_history_entry_id of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._last_update_history_entry_id
+
+    @last_update_history_entry_id.setter
+    def last_update_history_entry_id(self, last_update_history_entry_id):
+        """
+        Sets the last_update_history_entry_id of this CloudVmClusterSummary.
+        The `OCID`__ of the last maintenance update history entry. This value is updated when a maintenance update starts.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param last_update_history_entry_id: The last_update_history_entry_id of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._last_update_history_entry_id = last_update_history_entry_id
+
+    @property
+    def shape(self):
+        """
+        **[Required]** Gets the shape of this CloudVmClusterSummary.
+        The model name of the Exadata hardware running the cloud VM cluster.
+
+
+        :return: The shape of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this CloudVmClusterSummary.
+        The model name of the Exadata hardware running the cloud VM cluster.
+
+
+        :param shape: The shape of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def listener_port(self):
+        """
+        Gets the listener_port of this CloudVmClusterSummary.
+        The port number configured for the listener on the cloud VM cluster.
+
+
+        :return: The listener_port of this CloudVmClusterSummary.
+        :rtype: int
+        """
+        return self._listener_port
+
+    @listener_port.setter
+    def listener_port(self, listener_port):
+        """
+        Sets the listener_port of this CloudVmClusterSummary.
+        The port number configured for the listener on the cloud VM cluster.
+
+
+        :param listener_port: The listener_port of this CloudVmClusterSummary.
+        :type: int
+        """
+        self._listener_port = listener_port
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this CloudVmClusterSummary.
+        The current state of the cloud VM cluster.
+
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this CloudVmClusterSummary.
+        The current state of the cloud VM cluster.
+
+
+        :param lifecycle_state: The lifecycle_state of this CloudVmClusterSummary.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def node_count(self):
+        """
+        Gets the node_count of this CloudVmClusterSummary.
+        The number of nodes in the cloud VM cluster.
+
+
+        :return: The node_count of this CloudVmClusterSummary.
+        :rtype: int
+        """
+        return self._node_count
+
+    @node_count.setter
+    def node_count(self, node_count):
+        """
+        Sets the node_count of this CloudVmClusterSummary.
+        The number of nodes in the cloud VM cluster.
+
+
+        :param node_count: The node_count of this CloudVmClusterSummary.
+        :type: int
+        """
+        self._node_count = node_count
+
+    @property
+    def storage_size_in_gbs(self):
+        """
+        Gets the storage_size_in_gbs of this CloudVmClusterSummary.
+        The storage allocation for the disk group, in gigabytes (GB).
+
+
+        :return: The storage_size_in_gbs of this CloudVmClusterSummary.
+        :rtype: int
+        """
+        return self._storage_size_in_gbs
+
+    @storage_size_in_gbs.setter
+    def storage_size_in_gbs(self, storage_size_in_gbs):
+        """
+        Sets the storage_size_in_gbs of this CloudVmClusterSummary.
+        The storage allocation for the disk group, in gigabytes (GB).
+
+
+        :param storage_size_in_gbs: The storage_size_in_gbs of this CloudVmClusterSummary.
+        :type: int
+        """
+        self._storage_size_in_gbs = storage_size_in_gbs
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CloudVmClusterSummary.
+        The user-friendly name for the cloud VM cluster. The name does not need to be unique.
+
+
+        :return: The display_name of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CloudVmClusterSummary.
+        The user-friendly name for the cloud VM cluster. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this CloudVmClusterSummary.
+        The date and time that the cloud VM cluster was created.
+
+
+        :return: The time_created of this CloudVmClusterSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this CloudVmClusterSummary.
+        The date and time that the cloud VM cluster was created.
+
+
+        :param time_created: The time_created of this CloudVmClusterSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this CloudVmClusterSummary.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this CloudVmClusterSummary.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this CloudVmClusterSummary.
+        The time zone of the cloud VM cluster. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :return: The time_zone of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this CloudVmClusterSummary.
+        The time zone of the cloud VM cluster. For details, see `Exadata Infrastructure Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :param time_zone: The time_zone of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def hostname(self):
+        """
+        **[Required]** Gets the hostname of this CloudVmClusterSummary.
+        The hostname for the cloud VM cluster.
+
+
+        :return: The hostname of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, hostname):
+        """
+        Sets the hostname of this CloudVmClusterSummary.
+        The hostname for the cloud VM cluster.
+
+
+        :param hostname: The hostname of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._hostname = hostname
+
+    @property
+    def domain(self):
+        """
+        **[Required]** Gets the domain of this CloudVmClusterSummary.
+        The domain name for the cloud VM cluster.
+
+
+        :return: The domain of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._domain
+
+    @domain.setter
+    def domain(self, domain):
+        """
+        Sets the domain of this CloudVmClusterSummary.
+        The domain name for the cloud VM cluster.
+
+
+        :param domain: The domain of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._domain = domain
+
+    @property
+    def cpu_core_count(self):
+        """
+        **[Required]** Gets the cpu_core_count of this CloudVmClusterSummary.
+        The number of CPU cores enabled on the cloud VM cluster.
+
+
+        :return: The cpu_core_count of this CloudVmClusterSummary.
+        :rtype: int
+        """
+        return self._cpu_core_count
+
+    @cpu_core_count.setter
+    def cpu_core_count(self, cpu_core_count):
+        """
+        Sets the cpu_core_count of this CloudVmClusterSummary.
+        The number of CPU cores enabled on the cloud VM cluster.
+
+
+        :param cpu_core_count: The cpu_core_count of this CloudVmClusterSummary.
+        :type: int
+        """
+        self._cpu_core_count = cpu_core_count
+
+    @property
+    def cluster_name(self):
+        """
+        Gets the cluster_name of this CloudVmClusterSummary.
+        The cluster name for cloud VM cluster. The cluster name must begin with an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
+
+
+        :return: The cluster_name of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._cluster_name
+
+    @cluster_name.setter
+    def cluster_name(self, cluster_name):
+        """
+        Sets the cluster_name of this CloudVmClusterSummary.
+        The cluster name for cloud VM cluster. The cluster name must begin with an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
+
+
+        :param cluster_name: The cluster_name of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._cluster_name = cluster_name
+
+    @property
+    def data_storage_percentage(self):
+        """
+        Gets the data_storage_percentage of this CloudVmClusterSummary.
+        The percentage assigned to DATA storage (user data and database files).
+        The remaining percentage is assigned to RECO storage (database redo logs, archive logs, and recovery manager backups). Accepted values are 35, 40, 60 and 80. The default is 80 percent assigned to DATA storage. See `Storage Configuration`__ in the Exadata documentation for details on the impact of the configuration settings on storage.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/exaoverview.htm#Exadata
+
+
+        :return: The data_storage_percentage of this CloudVmClusterSummary.
+        :rtype: int
+        """
+        return self._data_storage_percentage
+
+    @data_storage_percentage.setter
+    def data_storage_percentage(self, data_storage_percentage):
+        """
+        Sets the data_storage_percentage of this CloudVmClusterSummary.
+        The percentage assigned to DATA storage (user data and database files).
+        The remaining percentage is assigned to RECO storage (database redo logs, archive logs, and recovery manager backups). Accepted values are 35, 40, 60 and 80. The default is 80 percent assigned to DATA storage. See `Storage Configuration`__ in the Exadata documentation for details on the impact of the configuration settings on storage.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/exaoverview.htm#Exadata
+
+
+        :param data_storage_percentage: The data_storage_percentage of this CloudVmClusterSummary.
+        :type: int
+        """
+        self._data_storage_percentage = data_storage_percentage
+
+    @property
+    def is_local_backup_enabled(self):
+        """
+        Gets the is_local_backup_enabled of this CloudVmClusterSummary.
+        If true, database backup on local Exadata storage is configured for the cloud VM cluster. If false, database backup on local Exadata storage is not available in the cloud VM cluster.
+
+
+        :return: The is_local_backup_enabled of this CloudVmClusterSummary.
+        :rtype: bool
+        """
+        return self._is_local_backup_enabled
+
+    @is_local_backup_enabled.setter
+    def is_local_backup_enabled(self, is_local_backup_enabled):
+        """
+        Sets the is_local_backup_enabled of this CloudVmClusterSummary.
+        If true, database backup on local Exadata storage is configured for the cloud VM cluster. If false, database backup on local Exadata storage is not available in the cloud VM cluster.
+
+
+        :param is_local_backup_enabled: The is_local_backup_enabled of this CloudVmClusterSummary.
+        :type: bool
+        """
+        self._is_local_backup_enabled = is_local_backup_enabled
+
+    @property
+    def cloud_exadata_infrastructure_id(self):
+        """
+        **[Required]** Gets the cloud_exadata_infrastructure_id of this CloudVmClusterSummary.
+        The `OCID`__ of the cloud Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The cloud_exadata_infrastructure_id of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._cloud_exadata_infrastructure_id
+
+    @cloud_exadata_infrastructure_id.setter
+    def cloud_exadata_infrastructure_id(self, cloud_exadata_infrastructure_id):
+        """
+        Sets the cloud_exadata_infrastructure_id of this CloudVmClusterSummary.
+        The `OCID`__ of the cloud Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param cloud_exadata_infrastructure_id: The cloud_exadata_infrastructure_id of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._cloud_exadata_infrastructure_id = cloud_exadata_infrastructure_id
+
+    @property
+    def is_sparse_diskgroup_enabled(self):
+        """
+        Gets the is_sparse_diskgroup_enabled of this CloudVmClusterSummary.
+        If true, sparse disk group is configured for the cloud VM cluster. If false, sparse disk group is not created.
+
+
+        :return: The is_sparse_diskgroup_enabled of this CloudVmClusterSummary.
+        :rtype: bool
+        """
+        return self._is_sparse_diskgroup_enabled
+
+    @is_sparse_diskgroup_enabled.setter
+    def is_sparse_diskgroup_enabled(self, is_sparse_diskgroup_enabled):
+        """
+        Sets the is_sparse_diskgroup_enabled of this CloudVmClusterSummary.
+        If true, sparse disk group is configured for the cloud VM cluster. If false, sparse disk group is not created.
+
+
+        :param is_sparse_diskgroup_enabled: The is_sparse_diskgroup_enabled of this CloudVmClusterSummary.
+        :type: bool
+        """
+        self._is_sparse_diskgroup_enabled = is_sparse_diskgroup_enabled
+
+    @property
+    def gi_version(self):
+        """
+        Gets the gi_version of this CloudVmClusterSummary.
+        A valid Oracle Grid Infrastructure (GI) software version.
+
+
+        :return: The gi_version of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._gi_version
+
+    @gi_version.setter
+    def gi_version(self, gi_version):
+        """
+        Sets the gi_version of this CloudVmClusterSummary.
+        A valid Oracle Grid Infrastructure (GI) software version.
+
+
+        :param gi_version: The gi_version of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._gi_version = gi_version
+
+    @property
+    def system_version(self):
+        """
+        Gets the system_version of this CloudVmClusterSummary.
+        Operating system version of the image.
+
+
+        :return: The system_version of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._system_version
+
+    @system_version.setter
+    def system_version(self, system_version):
+        """
+        Sets the system_version of this CloudVmClusterSummary.
+        Operating system version of the image.
+
+
+        :param system_version: The system_version of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._system_version = system_version
+
+    @property
+    def ssh_public_keys(self):
+        """
+        **[Required]** Gets the ssh_public_keys of this CloudVmClusterSummary.
+        The public key portion of one or more key pairs used for SSH access to the cloud VM cluster.
+
+
+        :return: The ssh_public_keys of this CloudVmClusterSummary.
+        :rtype: list[str]
+        """
+        return self._ssh_public_keys
+
+    @ssh_public_keys.setter
+    def ssh_public_keys(self, ssh_public_keys):
+        """
+        Sets the ssh_public_keys of this CloudVmClusterSummary.
+        The public key portion of one or more key pairs used for SSH access to the cloud VM cluster.
+
+
+        :param ssh_public_keys: The ssh_public_keys of this CloudVmClusterSummary.
+        :type: list[str]
+        """
+        self._ssh_public_keys = ssh_public_keys
+
+    @property
+    def license_model(self):
+        """
+        Gets the license_model of this CloudVmClusterSummary.
+        The Oracle license model that applies to the cloud VM cluster. The default is LICENSE_INCLUDED.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The license_model of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this CloudVmClusterSummary.
+        The Oracle license model that applies to the cloud VM cluster. The default is LICENSE_INCLUDED.
+
+
+        :param license_model: The license_model of this CloudVmClusterSummary.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            license_model = 'UNKNOWN_ENUM_VALUE'
+        self._license_model = license_model
+
+    @property
+    def disk_redundancy(self):
+        """
+        Gets the disk_redundancy of this CloudVmClusterSummary.
+        The type of redundancy configured for the cloud Vm cluster.
+        NORMAL is 2-way redundancy.
+        HIGH is 3-way redundancy.
+
+        Allowed values for this property are: "HIGH", "NORMAL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The disk_redundancy of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._disk_redundancy
+
+    @disk_redundancy.setter
+    def disk_redundancy(self, disk_redundancy):
+        """
+        Sets the disk_redundancy of this CloudVmClusterSummary.
+        The type of redundancy configured for the cloud Vm cluster.
+        NORMAL is 2-way redundancy.
+        HIGH is 3-way redundancy.
+
+
+        :param disk_redundancy: The disk_redundancy of this CloudVmClusterSummary.
+        :type: str
+        """
+        allowed_values = ["HIGH", "NORMAL"]
+        if not value_allowed_none_or_none_sentinel(disk_redundancy, allowed_values):
+            disk_redundancy = 'UNKNOWN_ENUM_VALUE'
+        self._disk_redundancy = disk_redundancy
+
+    @property
+    def scan_ip_ids(self):
+        """
+        Gets the scan_ip_ids of this CloudVmClusterSummary.
+        The `OCID`__ of the Single Client Access Name (SCAN) IP addresses associated with the cloud VM cluster.
+        SCAN IP addresses are typically used for load balancing and are not assigned to any interface.
+        Oracle Clusterware directs the requests to the appropriate nodes in the cluster.
+
+        **Note:** For a single-node DB system, this list is empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The scan_ip_ids of this CloudVmClusterSummary.
+        :rtype: list[str]
+        """
+        return self._scan_ip_ids
+
+    @scan_ip_ids.setter
+    def scan_ip_ids(self, scan_ip_ids):
+        """
+        Sets the scan_ip_ids of this CloudVmClusterSummary.
+        The `OCID`__ of the Single Client Access Name (SCAN) IP addresses associated with the cloud VM cluster.
+        SCAN IP addresses are typically used for load balancing and are not assigned to any interface.
+        Oracle Clusterware directs the requests to the appropriate nodes in the cluster.
+
+        **Note:** For a single-node DB system, this list is empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param scan_ip_ids: The scan_ip_ids of this CloudVmClusterSummary.
+        :type: list[str]
+        """
+        self._scan_ip_ids = scan_ip_ids
+
+    @property
+    def vip_ids(self):
+        """
+        Gets the vip_ids of this CloudVmClusterSummary.
+        The `OCID`__ of the virtual IP (VIP) addresses associated with the cloud VM cluster.
+        The Cluster Ready Services (CRS) creates and maintains one VIP address for each node in the Exadata Cloud Service instance to
+        enable failover. If one node fails, the VIP is reassigned to another active node in the cluster.
+
+        **Note:** For a single-node DB system, this list is empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vip_ids of this CloudVmClusterSummary.
+        :rtype: list[str]
+        """
+        return self._vip_ids
+
+    @vip_ids.setter
+    def vip_ids(self, vip_ids):
+        """
+        Sets the vip_ids of this CloudVmClusterSummary.
+        The `OCID`__ of the virtual IP (VIP) addresses associated with the cloud VM cluster.
+        The Cluster Ready Services (CRS) creates and maintains one VIP address for each node in the Exadata Cloud Service instance to
+        enable failover. If one node fails, the VIP is reassigned to another active node in the cluster.
+
+        **Note:** For a single-node DB system, this list is empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vip_ids: The vip_ids of this CloudVmClusterSummary.
+        :type: list[str]
+        """
+        self._vip_ids = vip_ids
+
+    @property
+    def scan_dns_record_id(self):
+        """
+        Gets the scan_dns_record_id of this CloudVmClusterSummary.
+        The `OCID`__ of the DNS record for the SCAN IP addresses that are associated with the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The scan_dns_record_id of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._scan_dns_record_id
+
+    @scan_dns_record_id.setter
+    def scan_dns_record_id(self, scan_dns_record_id):
+        """
+        Sets the scan_dns_record_id of this CloudVmClusterSummary.
+        The `OCID`__ of the DNS record for the SCAN IP addresses that are associated with the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param scan_dns_record_id: The scan_dns_record_id of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._scan_dns_record_id = scan_dns_record_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CloudVmClusterSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CloudVmClusterSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CloudVmClusterSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CloudVmClusterSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CloudVmClusterSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CloudVmClusterSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CloudVmClusterSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CloudVmClusterSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_autonomous_container_database_details.py
+++ b/src/oci/database/models/create_autonomous_container_database_details.py
@@ -76,6 +76,18 @@ class CreateAutonomousContainerDatabaseDetails(object):
             The value to assign to the backup_config property of this CreateAutonomousContainerDatabaseDetails.
         :type backup_config: AutonomousContainerDatabaseBackupConfig
 
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this CreateAutonomousContainerDatabaseDetails.
+        :type kms_key_id: str
+
+        :param kms_key_version_id:
+            The value to assign to the kms_key_version_id property of this CreateAutonomousContainerDatabaseDetails.
+        :type kms_key_version_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this CreateAutonomousContainerDatabaseDetails.
+        :type vault_id: str
+
         """
         self.swagger_types = {
             'display_name': 'str',
@@ -88,7 +100,10 @@ class CreateAutonomousContainerDatabaseDetails(object):
             'maintenance_window_details': 'MaintenanceWindow',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
-            'backup_config': 'AutonomousContainerDatabaseBackupConfig'
+            'backup_config': 'AutonomousContainerDatabaseBackupConfig',
+            'kms_key_id': 'str',
+            'kms_key_version_id': 'str',
+            'vault_id': 'str'
         }
 
         self.attribute_map = {
@@ -102,7 +117,10 @@ class CreateAutonomousContainerDatabaseDetails(object):
             'maintenance_window_details': 'maintenanceWindowDetails',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
-            'backup_config': 'backupConfig'
+            'backup_config': 'backupConfig',
+            'kms_key_id': 'kmsKeyId',
+            'kms_key_version_id': 'kmsKeyVersionId',
+            'vault_id': 'vaultId'
         }
 
         self._display_name = None
@@ -116,6 +134,9 @@ class CreateAutonomousContainerDatabaseDetails(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._backup_config = None
+        self._kms_key_id = None
+        self._kms_key_version_id = None
+        self._vault_id = None
 
     @property
     def display_name(self):
@@ -408,6 +429,84 @@ class CreateAutonomousContainerDatabaseDetails(object):
         :type: AutonomousContainerDatabaseBackupConfig
         """
         self._backup_config = backup_config
+
+    @property
+    def kms_key_id(self):
+        """
+        Gets the kms_key_id of this CreateAutonomousContainerDatabaseDetails.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :return: The kms_key_id of this CreateAutonomousContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._kms_key_id
+
+    @kms_key_id.setter
+    def kms_key_id(self, kms_key_id):
+        """
+        Sets the kms_key_id of this CreateAutonomousContainerDatabaseDetails.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :param kms_key_id: The kms_key_id of this CreateAutonomousContainerDatabaseDetails.
+        :type: str
+        """
+        self._kms_key_id = kms_key_id
+
+    @property
+    def kms_key_version_id(self):
+        """
+        Gets the kms_key_version_id of this CreateAutonomousContainerDatabaseDetails.
+        The OCID of the key container version that is used in database transparent data encryption (TDE) operations KMS Key can have multiple key versions. If none is specified, the current key version (latest) of the Key Id is used for the operation.
+
+
+        :return: The kms_key_version_id of this CreateAutonomousContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._kms_key_version_id
+
+    @kms_key_version_id.setter
+    def kms_key_version_id(self, kms_key_version_id):
+        """
+        Sets the kms_key_version_id of this CreateAutonomousContainerDatabaseDetails.
+        The OCID of the key container version that is used in database transparent data encryption (TDE) operations KMS Key can have multiple key versions. If none is specified, the current key version (latest) of the Key Id is used for the operation.
+
+
+        :param kms_key_version_id: The kms_key_version_id of this CreateAutonomousContainerDatabaseDetails.
+        :type: str
+        """
+        self._kms_key_version_id = kms_key_version_id
+
+    @property
+    def vault_id(self):
+        """
+        Gets the vault_id of this CreateAutonomousContainerDatabaseDetails.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :return: The vault_id of this CreateAutonomousContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._vault_id
+
+    @vault_id.setter
+    def vault_id(self, vault_id):
+        """
+        Sets the vault_id of this CreateAutonomousContainerDatabaseDetails.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :param vault_id: The vault_id of this CreateAutonomousContainerDatabaseDetails.
+        :type: str
+        """
+        self._vault_id = vault_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/create_autonomous_database_base.py
+++ b/src/oci/database/models/create_autonomous_database_base.py
@@ -626,8 +626,8 @@ class CreateAutonomousDatabaseBase(object):
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
 
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
-        For update operation, if you wish to delete all the existing whitelisted IP\u2019s, use an array with a single empty string entry.
-        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
+        For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
+        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.<unique_id>\",\"ocid1.vcn.oc1.sea.<unique_id1>;1.1.1.1\",\"ocid1.vcn.oc1.sea.<unique_id2>;1.1.0.0/16\"]`
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -645,8 +645,8 @@ class CreateAutonomousDatabaseBase(object):
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
 
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
-        For update operation, if you wish to delete all the existing whitelisted IP\u2019s, use an array with a single empty string entry.
-        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
+        For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
+        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.<unique_id>\",\"ocid1.vcn.oc1.sea.<unique_id1>;1.1.1.1\",\"ocid1.vcn.oc1.sea.<unique_id2>;1.1.0.0/16\"]`
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -688,7 +688,7 @@ class CreateAutonomousDatabaseBase(object):
 
         **Subnet Restrictions:**
         - For bare metal DB systems and for single node virtual machine DB systems, do not use a subnet that overlaps with 192.168.16.16/28.
-        - For Exadata and virtual machine 2-node RAC DB systems, do not use a subnet that overlaps with 192.168.128.0/20.
+        - For Exadata and virtual machine 2-node RAC systems, do not use a subnet that overlaps with 192.168.128.0/20.
         - For Autonomous Database, setting this will disable public secure access to the database.
 
         These subnets are used by the Oracle Clusterware private interconnect on the database instance.
@@ -711,7 +711,7 @@ class CreateAutonomousDatabaseBase(object):
 
         **Subnet Restrictions:**
         - For bare metal DB systems and for single node virtual machine DB systems, do not use a subnet that overlaps with 192.168.16.16/28.
-        - For Exadata and virtual machine 2-node RAC DB systems, do not use a subnet that overlaps with 192.168.128.0/20.
+        - For Exadata and virtual machine 2-node RAC systems, do not use a subnet that overlaps with 192.168.128.0/20.
         - For Autonomous Database, setting this will disable public secure access to the database.
 
         These subnets are used by the Oracle Clusterware private interconnect on the database instance.

--- a/src/oci/database/models/create_cloud_exadata_infrastructure_details.py
+++ b/src/oci/database/models/create_cloud_exadata_infrastructure_details.py
@@ -1,0 +1,334 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateCloudExadataInfrastructureDetails(object):
+    """
+    Request to create cloud Exadata infrastructure.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateCloudExadataInfrastructureDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this CreateCloudExadataInfrastructureDetails.
+        :type availability_domain: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateCloudExadataInfrastructureDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateCloudExadataInfrastructureDetails.
+        :type display_name: str
+
+        :param shape:
+            The value to assign to the shape property of this CreateCloudExadataInfrastructureDetails.
+        :type shape: str
+
+        :param compute_count:
+            The value to assign to the compute_count property of this CreateCloudExadataInfrastructureDetails.
+        :type compute_count: int
+
+        :param storage_count:
+            The value to assign to the storage_count property of this CreateCloudExadataInfrastructureDetails.
+        :type storage_count: int
+
+        :param maintenance_window:
+            The value to assign to the maintenance_window property of this CreateCloudExadataInfrastructureDetails.
+        :type maintenance_window: MaintenanceWindow
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateCloudExadataInfrastructureDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateCloudExadataInfrastructureDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'availability_domain': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'shape': 'str',
+            'compute_count': 'int',
+            'storage_count': 'int',
+            'maintenance_window': 'MaintenanceWindow',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'availability_domain': 'availabilityDomain',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'shape': 'shape',
+            'compute_count': 'computeCount',
+            'storage_count': 'storageCount',
+            'maintenance_window': 'maintenanceWindow',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._availability_domain = None
+        self._compartment_id = None
+        self._display_name = None
+        self._shape = None
+        self._compute_count = None
+        self._storage_count = None
+        self._maintenance_window = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def availability_domain(self):
+        """
+        **[Required]** Gets the availability_domain of this CreateCloudExadataInfrastructureDetails.
+        The availability domain where the cloud Exadata infrastructure is located.
+
+
+        :return: The availability_domain of this CreateCloudExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this CreateCloudExadataInfrastructureDetails.
+        The availability domain where the cloud Exadata infrastructure is located.
+
+
+        :param availability_domain: The availability_domain of this CreateCloudExadataInfrastructureDetails.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateCloudExadataInfrastructureDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateCloudExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateCloudExadataInfrastructureDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateCloudExadataInfrastructureDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateCloudExadataInfrastructureDetails.
+        The user-friendly name for the cloud Exadata infrastructure resource. The name does not need to be unique.
+
+
+        :return: The display_name of this CreateCloudExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateCloudExadataInfrastructureDetails.
+        The user-friendly name for the cloud Exadata infrastructure resource. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this CreateCloudExadataInfrastructureDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def shape(self):
+        """
+        **[Required]** Gets the shape of this CreateCloudExadataInfrastructureDetails.
+        The shape of the cloud Exadata infrastructure resource.
+
+
+        :return: The shape of this CreateCloudExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        """
+        Sets the shape of this CreateCloudExadataInfrastructureDetails.
+        The shape of the cloud Exadata infrastructure resource.
+
+
+        :param shape: The shape of this CreateCloudExadataInfrastructureDetails.
+        :type: str
+        """
+        self._shape = shape
+
+    @property
+    def compute_count(self):
+        """
+        Gets the compute_count of this CreateCloudExadataInfrastructureDetails.
+        The number of compute servers for the cloud Exadata infrastructure.
+
+
+        :return: The compute_count of this CreateCloudExadataInfrastructureDetails.
+        :rtype: int
+        """
+        return self._compute_count
+
+    @compute_count.setter
+    def compute_count(self, compute_count):
+        """
+        Sets the compute_count of this CreateCloudExadataInfrastructureDetails.
+        The number of compute servers for the cloud Exadata infrastructure.
+
+
+        :param compute_count: The compute_count of this CreateCloudExadataInfrastructureDetails.
+        :type: int
+        """
+        self._compute_count = compute_count
+
+    @property
+    def storage_count(self):
+        """
+        Gets the storage_count of this CreateCloudExadataInfrastructureDetails.
+        The number of storage servers for the cloud Exadata infrastructure.
+
+
+        :return: The storage_count of this CreateCloudExadataInfrastructureDetails.
+        :rtype: int
+        """
+        return self._storage_count
+
+    @storage_count.setter
+    def storage_count(self, storage_count):
+        """
+        Sets the storage_count of this CreateCloudExadataInfrastructureDetails.
+        The number of storage servers for the cloud Exadata infrastructure.
+
+
+        :param storage_count: The storage_count of this CreateCloudExadataInfrastructureDetails.
+        :type: int
+        """
+        self._storage_count = storage_count
+
+    @property
+    def maintenance_window(self):
+        """
+        Gets the maintenance_window of this CreateCloudExadataInfrastructureDetails.
+
+        :return: The maintenance_window of this CreateCloudExadataInfrastructureDetails.
+        :rtype: MaintenanceWindow
+        """
+        return self._maintenance_window
+
+    @maintenance_window.setter
+    def maintenance_window(self, maintenance_window):
+        """
+        Sets the maintenance_window of this CreateCloudExadataInfrastructureDetails.
+
+        :param maintenance_window: The maintenance_window of this CreateCloudExadataInfrastructureDetails.
+        :type: MaintenanceWindow
+        """
+        self._maintenance_window = maintenance_window
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateCloudExadataInfrastructureDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateCloudExadataInfrastructureDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateCloudExadataInfrastructureDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateCloudExadataInfrastructureDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateCloudExadataInfrastructureDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateCloudExadataInfrastructureDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateCloudExadataInfrastructureDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateCloudExadataInfrastructureDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_cloud_vm_cluster_details.py
+++ b/src/oci/database/models/create_cloud_vm_cluster_details.py
@@ -1,0 +1,766 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateCloudVmClusterDetails(object):
+    """
+    Details for the create cloud VM cluster operation.
+    """
+
+    #: A constant which can be used with the license_model property of a CreateCloudVmClusterDetails.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a CreateCloudVmClusterDetails.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateCloudVmClusterDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateCloudVmClusterDetails.
+        :type compartment_id: str
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this CreateCloudVmClusterDetails.
+        :type subnet_id: str
+
+        :param backup_subnet_id:
+            The value to assign to the backup_subnet_id property of this CreateCloudVmClusterDetails.
+        :type backup_subnet_id: str
+
+        :param cpu_core_count:
+            The value to assign to the cpu_core_count property of this CreateCloudVmClusterDetails.
+        :type cpu_core_count: int
+
+        :param cluster_name:
+            The value to assign to the cluster_name property of this CreateCloudVmClusterDetails.
+        :type cluster_name: str
+
+        :param data_storage_percentage:
+            The value to assign to the data_storage_percentage property of this CreateCloudVmClusterDetails.
+        :type data_storage_percentage: int
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateCloudVmClusterDetails.
+        :type display_name: str
+
+        :param cloud_exadata_infrastructure_id:
+            The value to assign to the cloud_exadata_infrastructure_id property of this CreateCloudVmClusterDetails.
+        :type cloud_exadata_infrastructure_id: str
+
+        :param hostname:
+            The value to assign to the hostname property of this CreateCloudVmClusterDetails.
+        :type hostname: str
+
+        :param domain:
+            The value to assign to the domain property of this CreateCloudVmClusterDetails.
+        :type domain: str
+
+        :param ssh_public_keys:
+            The value to assign to the ssh_public_keys property of this CreateCloudVmClusterDetails.
+        :type ssh_public_keys: list[str]
+
+        :param license_model:
+            The value to assign to the license_model property of this CreateCloudVmClusterDetails.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+        :type license_model: str
+
+        :param is_sparse_diskgroup_enabled:
+            The value to assign to the is_sparse_diskgroup_enabled property of this CreateCloudVmClusterDetails.
+        :type is_sparse_diskgroup_enabled: bool
+
+        :param is_local_backup_enabled:
+            The value to assign to the is_local_backup_enabled property of this CreateCloudVmClusterDetails.
+        :type is_local_backup_enabled: bool
+
+        :param time_zone:
+            The value to assign to the time_zone property of this CreateCloudVmClusterDetails.
+        :type time_zone: str
+
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this CreateCloudVmClusterDetails.
+        :type nsg_ids: list[str]
+
+        :param backup_network_nsg_ids:
+            The value to assign to the backup_network_nsg_ids property of this CreateCloudVmClusterDetails.
+        :type backup_network_nsg_ids: list[str]
+
+        :param gi_version:
+            The value to assign to the gi_version property of this CreateCloudVmClusterDetails.
+        :type gi_version: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateCloudVmClusterDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateCloudVmClusterDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'subnet_id': 'str',
+            'backup_subnet_id': 'str',
+            'cpu_core_count': 'int',
+            'cluster_name': 'str',
+            'data_storage_percentage': 'int',
+            'display_name': 'str',
+            'cloud_exadata_infrastructure_id': 'str',
+            'hostname': 'str',
+            'domain': 'str',
+            'ssh_public_keys': 'list[str]',
+            'license_model': 'str',
+            'is_sparse_diskgroup_enabled': 'bool',
+            'is_local_backup_enabled': 'bool',
+            'time_zone': 'str',
+            'nsg_ids': 'list[str]',
+            'backup_network_nsg_ids': 'list[str]',
+            'gi_version': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'subnet_id': 'subnetId',
+            'backup_subnet_id': 'backupSubnetId',
+            'cpu_core_count': 'cpuCoreCount',
+            'cluster_name': 'clusterName',
+            'data_storage_percentage': 'dataStoragePercentage',
+            'display_name': 'displayName',
+            'cloud_exadata_infrastructure_id': 'cloudExadataInfrastructureId',
+            'hostname': 'hostname',
+            'domain': 'domain',
+            'ssh_public_keys': 'sshPublicKeys',
+            'license_model': 'licenseModel',
+            'is_sparse_diskgroup_enabled': 'isSparseDiskgroupEnabled',
+            'is_local_backup_enabled': 'isLocalBackupEnabled',
+            'time_zone': 'timeZone',
+            'nsg_ids': 'nsgIds',
+            'backup_network_nsg_ids': 'backupNetworkNsgIds',
+            'gi_version': 'giVersion',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._subnet_id = None
+        self._backup_subnet_id = None
+        self._cpu_core_count = None
+        self._cluster_name = None
+        self._data_storage_percentage = None
+        self._display_name = None
+        self._cloud_exadata_infrastructure_id = None
+        self._hostname = None
+        self._domain = None
+        self._ssh_public_keys = None
+        self._license_model = None
+        self._is_sparse_diskgroup_enabled = None
+        self._is_local_backup_enabled = None
+        self._time_zone = None
+        self._nsg_ids = None
+        self._backup_network_nsg_ids = None
+        self._gi_version = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateCloudVmClusterDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateCloudVmClusterDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateCloudVmClusterDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateCloudVmClusterDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def subnet_id(self):
+        """
+        **[Required]** Gets the subnet_id of this CreateCloudVmClusterDetails.
+        The `OCID`__ of the subnet associated with the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The subnet_id of this CreateCloudVmClusterDetails.
+        :rtype: str
+        """
+        return self._subnet_id
+
+    @subnet_id.setter
+    def subnet_id(self, subnet_id):
+        """
+        Sets the subnet_id of this CreateCloudVmClusterDetails.
+        The `OCID`__ of the subnet associated with the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param subnet_id: The subnet_id of this CreateCloudVmClusterDetails.
+        :type: str
+        """
+        self._subnet_id = subnet_id
+
+    @property
+    def backup_subnet_id(self):
+        """
+        **[Required]** Gets the backup_subnet_id of this CreateCloudVmClusterDetails.
+        The `OCID`__ of the backup network subnet associated with the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The backup_subnet_id of this CreateCloudVmClusterDetails.
+        :rtype: str
+        """
+        return self._backup_subnet_id
+
+    @backup_subnet_id.setter
+    def backup_subnet_id(self, backup_subnet_id):
+        """
+        Sets the backup_subnet_id of this CreateCloudVmClusterDetails.
+        The `OCID`__ of the backup network subnet associated with the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param backup_subnet_id: The backup_subnet_id of this CreateCloudVmClusterDetails.
+        :type: str
+        """
+        self._backup_subnet_id = backup_subnet_id
+
+    @property
+    def cpu_core_count(self):
+        """
+        **[Required]** Gets the cpu_core_count of this CreateCloudVmClusterDetails.
+        The number of CPU cores to enable for a cloud VM cluster. Valid values depend on the specified shape:
+
+        - Exadata.Base.48 - Specify a multiple of 2, from 0 to 48.
+        - Exadata.Quarter1.84 - Specify a multiple of 2, from 22 to 84.
+        - Exadata.Half1.168 - Specify a multiple of 4, from 44 to 168.
+        - Exadata.Full1.336 - Specify a multiple of 8, from 88 to 336.
+        - Exadata.Quarter2.92 - Specify a multiple of 2, from 0 to 92.
+        - Exadata.Half2.184 - Specify a multiple of 4, from 0 to 184.
+        - Exadata.Full2.368 - Specify a multiple of 8, from 0 to 368.
+
+
+        :return: The cpu_core_count of this CreateCloudVmClusterDetails.
+        :rtype: int
+        """
+        return self._cpu_core_count
+
+    @cpu_core_count.setter
+    def cpu_core_count(self, cpu_core_count):
+        """
+        Sets the cpu_core_count of this CreateCloudVmClusterDetails.
+        The number of CPU cores to enable for a cloud VM cluster. Valid values depend on the specified shape:
+
+        - Exadata.Base.48 - Specify a multiple of 2, from 0 to 48.
+        - Exadata.Quarter1.84 - Specify a multiple of 2, from 22 to 84.
+        - Exadata.Half1.168 - Specify a multiple of 4, from 44 to 168.
+        - Exadata.Full1.336 - Specify a multiple of 8, from 88 to 336.
+        - Exadata.Quarter2.92 - Specify a multiple of 2, from 0 to 92.
+        - Exadata.Half2.184 - Specify a multiple of 4, from 0 to 184.
+        - Exadata.Full2.368 - Specify a multiple of 8, from 0 to 368.
+
+
+        :param cpu_core_count: The cpu_core_count of this CreateCloudVmClusterDetails.
+        :type: int
+        """
+        self._cpu_core_count = cpu_core_count
+
+    @property
+    def cluster_name(self):
+        """
+        Gets the cluster_name of this CreateCloudVmClusterDetails.
+        The cluster name for cloud VM cluster. The cluster name must begin with an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
+
+
+        :return: The cluster_name of this CreateCloudVmClusterDetails.
+        :rtype: str
+        """
+        return self._cluster_name
+
+    @cluster_name.setter
+    def cluster_name(self, cluster_name):
+        """
+        Sets the cluster_name of this CreateCloudVmClusterDetails.
+        The cluster name for cloud VM cluster. The cluster name must begin with an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
+
+
+        :param cluster_name: The cluster_name of this CreateCloudVmClusterDetails.
+        :type: str
+        """
+        self._cluster_name = cluster_name
+
+    @property
+    def data_storage_percentage(self):
+        """
+        Gets the data_storage_percentage of this CreateCloudVmClusterDetails.
+        The percentage assigned to DATA storage (user data and database files).
+        The remaining percentage is assigned to RECO storage (database redo logs, archive logs, and recovery manager backups). Accepted values are 35, 40, 60 and 80. The default is 80 percent assigned to DATA storage. See `Storage Configuration`__ in the Exadata documentation for details on the impact of the configuration settings on storage.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/exaoverview.htm#Exadata
+
+
+        :return: The data_storage_percentage of this CreateCloudVmClusterDetails.
+        :rtype: int
+        """
+        return self._data_storage_percentage
+
+    @data_storage_percentage.setter
+    def data_storage_percentage(self, data_storage_percentage):
+        """
+        Sets the data_storage_percentage of this CreateCloudVmClusterDetails.
+        The percentage assigned to DATA storage (user data and database files).
+        The remaining percentage is assigned to RECO storage (database redo logs, archive logs, and recovery manager backups). Accepted values are 35, 40, 60 and 80. The default is 80 percent assigned to DATA storage. See `Storage Configuration`__ in the Exadata documentation for details on the impact of the configuration settings on storage.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/exaoverview.htm#Exadata
+
+
+        :param data_storage_percentage: The data_storage_percentage of this CreateCloudVmClusterDetails.
+        :type: int
+        """
+        self._data_storage_percentage = data_storage_percentage
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateCloudVmClusterDetails.
+        The user-friendly name for the cloud VM cluster. The name does not need to be unique.
+
+
+        :return: The display_name of this CreateCloudVmClusterDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateCloudVmClusterDetails.
+        The user-friendly name for the cloud VM cluster. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this CreateCloudVmClusterDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def cloud_exadata_infrastructure_id(self):
+        """
+        **[Required]** Gets the cloud_exadata_infrastructure_id of this CreateCloudVmClusterDetails.
+        The `OCID`__ of the cloud Exadata infrastructure resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The cloud_exadata_infrastructure_id of this CreateCloudVmClusterDetails.
+        :rtype: str
+        """
+        return self._cloud_exadata_infrastructure_id
+
+    @cloud_exadata_infrastructure_id.setter
+    def cloud_exadata_infrastructure_id(self, cloud_exadata_infrastructure_id):
+        """
+        Sets the cloud_exadata_infrastructure_id of this CreateCloudVmClusterDetails.
+        The `OCID`__ of the cloud Exadata infrastructure resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param cloud_exadata_infrastructure_id: The cloud_exadata_infrastructure_id of this CreateCloudVmClusterDetails.
+        :type: str
+        """
+        self._cloud_exadata_infrastructure_id = cloud_exadata_infrastructure_id
+
+    @property
+    def hostname(self):
+        """
+        **[Required]** Gets the hostname of this CreateCloudVmClusterDetails.
+        The hostname for the cloud VM cluster. The hostname must begin with an alphabetic character, and
+        can contain alphanumeric characters and hyphens (-). The maximum length of the hostname is 16 characters for bare metal and virtual machine DB systems, and 12 characters for Exadata systems.
+
+        The maximum length of the combined hostname and domain is 63 characters.
+
+        **Note:** The hostname must be unique within the subnet. If it is not unique,
+        the cloud VM Cluster will fail to provision.
+
+
+        :return: The hostname of this CreateCloudVmClusterDetails.
+        :rtype: str
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, hostname):
+        """
+        Sets the hostname of this CreateCloudVmClusterDetails.
+        The hostname for the cloud VM cluster. The hostname must begin with an alphabetic character, and
+        can contain alphanumeric characters and hyphens (-). The maximum length of the hostname is 16 characters for bare metal and virtual machine DB systems, and 12 characters for Exadata systems.
+
+        The maximum length of the combined hostname and domain is 63 characters.
+
+        **Note:** The hostname must be unique within the subnet. If it is not unique,
+        the cloud VM Cluster will fail to provision.
+
+
+        :param hostname: The hostname of this CreateCloudVmClusterDetails.
+        :type: str
+        """
+        self._hostname = hostname
+
+    @property
+    def domain(self):
+        """
+        Gets the domain of this CreateCloudVmClusterDetails.
+        A domain name used for the cloud VM cluster. If the Oracle-provided internet and VCN
+        resolver is enabled for the specified subnet, the domain name for the subnet is used
+        (do not provide one). Otherwise, provide a valid DNS domain name. Hyphens (-) are not permitted.
+
+
+        :return: The domain of this CreateCloudVmClusterDetails.
+        :rtype: str
+        """
+        return self._domain
+
+    @domain.setter
+    def domain(self, domain):
+        """
+        Sets the domain of this CreateCloudVmClusterDetails.
+        A domain name used for the cloud VM cluster. If the Oracle-provided internet and VCN
+        resolver is enabled for the specified subnet, the domain name for the subnet is used
+        (do not provide one). Otherwise, provide a valid DNS domain name. Hyphens (-) are not permitted.
+
+
+        :param domain: The domain of this CreateCloudVmClusterDetails.
+        :type: str
+        """
+        self._domain = domain
+
+    @property
+    def ssh_public_keys(self):
+        """
+        **[Required]** Gets the ssh_public_keys of this CreateCloudVmClusterDetails.
+        The public key portion of one or more key pairs used for SSH access to the cloud VM cluster.
+
+
+        :return: The ssh_public_keys of this CreateCloudVmClusterDetails.
+        :rtype: list[str]
+        """
+        return self._ssh_public_keys
+
+    @ssh_public_keys.setter
+    def ssh_public_keys(self, ssh_public_keys):
+        """
+        Sets the ssh_public_keys of this CreateCloudVmClusterDetails.
+        The public key portion of one or more key pairs used for SSH access to the cloud VM cluster.
+
+
+        :param ssh_public_keys: The ssh_public_keys of this CreateCloudVmClusterDetails.
+        :type: list[str]
+        """
+        self._ssh_public_keys = ssh_public_keys
+
+    @property
+    def license_model(self):
+        """
+        Gets the license_model of this CreateCloudVmClusterDetails.
+        The Oracle license model that applies to the cloud VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+
+
+        :return: The license_model of this CreateCloudVmClusterDetails.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this CreateCloudVmClusterDetails.
+        The Oracle license model that applies to the cloud VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+
+
+        :param license_model: The license_model of this CreateCloudVmClusterDetails.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            raise ValueError(
+                "Invalid value for `license_model`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._license_model = license_model
+
+    @property
+    def is_sparse_diskgroup_enabled(self):
+        """
+        Gets the is_sparse_diskgroup_enabled of this CreateCloudVmClusterDetails.
+        If true, the sparse disk group is configured for the cloud VM cluster. If false, the sparse disk group is not created.
+
+
+        :return: The is_sparse_diskgroup_enabled of this CreateCloudVmClusterDetails.
+        :rtype: bool
+        """
+        return self._is_sparse_diskgroup_enabled
+
+    @is_sparse_diskgroup_enabled.setter
+    def is_sparse_diskgroup_enabled(self, is_sparse_diskgroup_enabled):
+        """
+        Sets the is_sparse_diskgroup_enabled of this CreateCloudVmClusterDetails.
+        If true, the sparse disk group is configured for the cloud VM cluster. If false, the sparse disk group is not created.
+
+
+        :param is_sparse_diskgroup_enabled: The is_sparse_diskgroup_enabled of this CreateCloudVmClusterDetails.
+        :type: bool
+        """
+        self._is_sparse_diskgroup_enabled = is_sparse_diskgroup_enabled
+
+    @property
+    def is_local_backup_enabled(self):
+        """
+        Gets the is_local_backup_enabled of this CreateCloudVmClusterDetails.
+        If true, database backup on local Exadata storage is configured for the cloud VM cluster. If false, database backup on local Exadata storage is not available in the cloud VM cluster.
+
+
+        :return: The is_local_backup_enabled of this CreateCloudVmClusterDetails.
+        :rtype: bool
+        """
+        return self._is_local_backup_enabled
+
+    @is_local_backup_enabled.setter
+    def is_local_backup_enabled(self, is_local_backup_enabled):
+        """
+        Sets the is_local_backup_enabled of this CreateCloudVmClusterDetails.
+        If true, database backup on local Exadata storage is configured for the cloud VM cluster. If false, database backup on local Exadata storage is not available in the cloud VM cluster.
+
+
+        :param is_local_backup_enabled: The is_local_backup_enabled of this CreateCloudVmClusterDetails.
+        :type: bool
+        """
+        self._is_local_backup_enabled = is_local_backup_enabled
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this CreateCloudVmClusterDetails.
+        The time zone to use for the cloud VM cluster. For details, see `Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :return: The time_zone of this CreateCloudVmClusterDetails.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this CreateCloudVmClusterDetails.
+        The time zone to use for the cloud VM cluster. For details, see `Time Zones`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/References/timezones.htm
+
+
+        :param time_zone: The time_zone of this CreateCloudVmClusterDetails.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this CreateCloudVmClusterDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+        **NsgIds restrictions:**
+        - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :return: The nsg_ids of this CreateCloudVmClusterDetails.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this CreateCloudVmClusterDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+        **NsgIds restrictions:**
+        - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :param nsg_ids: The nsg_ids of this CreateCloudVmClusterDetails.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
+
+    @property
+    def backup_network_nsg_ids(self):
+        """
+        Gets the backup_network_nsg_ids of this CreateCloudVmClusterDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :return: The backup_network_nsg_ids of this CreateCloudVmClusterDetails.
+        :rtype: list[str]
+        """
+        return self._backup_network_nsg_ids
+
+    @backup_network_nsg_ids.setter
+    def backup_network_nsg_ids(self, backup_network_nsg_ids):
+        """
+        Sets the backup_network_nsg_ids of this CreateCloudVmClusterDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :param backup_network_nsg_ids: The backup_network_nsg_ids of this CreateCloudVmClusterDetails.
+        :type: list[str]
+        """
+        self._backup_network_nsg_ids = backup_network_nsg_ids
+
+    @property
+    def gi_version(self):
+        """
+        **[Required]** Gets the gi_version of this CreateCloudVmClusterDetails.
+        A valid Oracle Grid Infrastructure (GI) software version.
+
+
+        :return: The gi_version of this CreateCloudVmClusterDetails.
+        :rtype: str
+        """
+        return self._gi_version
+
+    @gi_version.setter
+    def gi_version(self, gi_version):
+        """
+        Sets the gi_version of this CreateCloudVmClusterDetails.
+        A valid Oracle Grid Infrastructure (GI) software version.
+
+
+        :param gi_version: The gi_version of this CreateCloudVmClusterDetails.
+        :type: str
+        """
+        self._gi_version = gi_version
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateCloudVmClusterDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateCloudVmClusterDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateCloudVmClusterDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateCloudVmClusterDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateCloudVmClusterDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateCloudVmClusterDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateCloudVmClusterDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateCloudVmClusterDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_data_guard_association_with_new_db_system_details.py
+++ b/src/oci/database/models/create_data_guard_association_with_new_db_system_details.py
@@ -261,7 +261,7 @@ class CreateDataGuardAssociationWithNewDbSystemDetails(CreateDataGuardAssociatio
     def backup_network_nsg_ids(self):
         """
         Gets the backup_network_nsg_ids of this CreateDataGuardAssociationWithNewDbSystemDetails.
-        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata DB systems.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
         __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
@@ -276,7 +276,7 @@ class CreateDataGuardAssociationWithNewDbSystemDetails(CreateDataGuardAssociatio
     def backup_network_nsg_ids(self, backup_network_nsg_ids):
         """
         Sets the backup_network_nsg_ids of this CreateDataGuardAssociationWithNewDbSystemDetails.
-        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata DB systems.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
         __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm

--- a/src/oci/database/models/create_db_home_base.py
+++ b/src/oci/database/models/create_db_home_base.py
@@ -28,6 +28,10 @@ class CreateDbHomeBase(object):
     SOURCE_DATABASE = "DATABASE"
 
     #: A constant which can be used with the source property of a CreateDbHomeBase.
+    #: This constant has a value of "VM_CLUSTER_BACKUP"
+    SOURCE_VM_CLUSTER_BACKUP = "VM_CLUSTER_BACKUP"
+
+    #: A constant which can be used with the source property of a CreateDbHomeBase.
     #: This constant has a value of "VM_CLUSTER_NEW"
     SOURCE_VM_CLUSTER_NEW = "VM_CLUSTER_NEW"
 
@@ -38,6 +42,7 @@ class CreateDbHomeBase(object):
 
         * :class:`~oci.database.models.CreateDbHomeWithDbSystemIdFromDatabaseDetails`
         * :class:`~oci.database.models.CreateDbHomeWithDbSystemIdFromBackupDetails`
+        * :class:`~oci.database.models.CreateDbHomeWithVmClusterIdFromBackupDetails`
         * :class:`~oci.database.models.CreateDbHomeWithDbSystemIdDetails`
         * :class:`~oci.database.models.CreateDbHomeWithVmClusterIdDetails`
 
@@ -61,7 +66,7 @@ class CreateDbHomeBase(object):
 
         :param source:
             The value to assign to the source property of this CreateDbHomeBase.
-            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_NEW"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"
         :type source: str
 
         """
@@ -100,6 +105,9 @@ class CreateDbHomeBase(object):
 
         if type == 'DB_BACKUP':
             return 'CreateDbHomeWithDbSystemIdFromBackupDetails'
+
+        if type == 'VM_CLUSTER_BACKUP':
+            return 'CreateDbHomeWithVmClusterIdFromBackupDetails'
 
         if type == 'NONE':
             return 'CreateDbHomeWithDbSystemIdDetails'
@@ -231,7 +239,7 @@ class CreateDbHomeBase(object):
         Gets the source of this CreateDbHomeBase.
         The source of database: NONE for creating a new database. DB_BACKUP for creating a new database by restoring from a database backup.
 
-        Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_NEW"
+        Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"
 
 
         :return: The source of this CreateDbHomeBase.
@@ -249,7 +257,7 @@ class CreateDbHomeBase(object):
         :param source: The source of this CreateDbHomeBase.
         :type: str
         """
-        allowed_values = ["NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_NEW"]
+        allowed_values = ["NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"]
         if not value_allowed_none_or_none_sentinel(source, allowed_values):
             raise ValueError(
                 "Invalid value for `source`, must be None or one of {0}"

--- a/src/oci/database/models/create_db_home_with_db_system_id_details.py
+++ b/src/oci/database/models/create_db_home_with_db_system_id_details.py
@@ -37,7 +37,7 @@ class CreateDbHomeWithDbSystemIdDetails(CreateDbHomeBase):
 
         :param source:
             The value to assign to the source property of this CreateDbHomeWithDbSystemIdDetails.
-            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_NEW"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"
         :type source: str
 
         :param db_system_id:

--- a/src/oci/database/models/create_db_home_with_db_system_id_from_backup_details.py
+++ b/src/oci/database/models/create_db_home_with_db_system_id_from_backup_details.py
@@ -37,7 +37,7 @@ class CreateDbHomeWithDbSystemIdFromBackupDetails(CreateDbHomeBase):
 
         :param source:
             The value to assign to the source property of this CreateDbHomeWithDbSystemIdFromBackupDetails.
-            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_NEW"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"
         :type source: str
 
         :param db_system_id:

--- a/src/oci/database/models/create_db_home_with_db_system_id_from_database_details.py
+++ b/src/oci/database/models/create_db_home_with_db_system_id_from_database_details.py
@@ -37,7 +37,7 @@ class CreateDbHomeWithDbSystemIdFromDatabaseDetails(CreateDbHomeBase):
 
         :param source:
             The value to assign to the source property of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
-            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_NEW"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"
         :type source: str
 
         :param db_system_id:

--- a/src/oci/database/models/create_db_home_with_vm_cluster_id_details.py
+++ b/src/oci/database/models/create_db_home_with_vm_cluster_id_details.py
@@ -37,7 +37,7 @@ class CreateDbHomeWithVmClusterIdDetails(CreateDbHomeBase):
 
         :param source:
             The value to assign to the source property of this CreateDbHomeWithVmClusterIdDetails.
-            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_NEW"
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"
         :type source: str
 
         :param vm_cluster_id:

--- a/src/oci/database/models/create_db_home_with_vm_cluster_id_from_backup_details.py
+++ b/src/oci/database/models/create_db_home_with_vm_cluster_id_from_backup_details.py
@@ -1,0 +1,139 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_db_home_base import CreateDbHomeBase
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDbHomeWithVmClusterIdFromBackupDetails(CreateDbHomeBase):
+    """
+    Note that a valid `vmClusterId` value must be supplied for the `CreateDbHomeWithVmClusterIdFromBackup` API operation to successfully complete.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDbHomeWithVmClusterIdFromBackupDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.CreateDbHomeWithVmClusterIdFromBackupDetails.source` attribute
+        of this class is ``VM_CLUSTER_BACKUP`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type display_name: str
+
+        :param database_software_image_id:
+            The value to assign to the database_software_image_id property of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type database_software_image_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param source:
+            The value to assign to the source property of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+            Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"
+        :type source: str
+
+        :param vm_cluster_id:
+            The value to assign to the vm_cluster_id property of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type vm_cluster_id: str
+
+        :param database:
+            The value to assign to the database property of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type database: CreateDatabaseFromBackupDetails
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'database_software_image_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'source': 'str',
+            'vm_cluster_id': 'str',
+            'database': 'CreateDatabaseFromBackupDetails'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'database_software_image_id': 'databaseSoftwareImageId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'source': 'source',
+            'vm_cluster_id': 'vmClusterId',
+            'database': 'database'
+        }
+
+        self._display_name = None
+        self._database_software_image_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._source = None
+        self._vm_cluster_id = None
+        self._database = None
+        self._source = 'VM_CLUSTER_BACKUP'
+
+    @property
+    def vm_cluster_id(self):
+        """
+        **[Required]** Gets the vm_cluster_id of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vm_cluster_id of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :rtype: str
+        """
+        return self._vm_cluster_id
+
+    @vm_cluster_id.setter
+    def vm_cluster_id(self, vm_cluster_id):
+        """
+        Sets the vm_cluster_id of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        The `OCID`__ of the VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vm_cluster_id: The vm_cluster_id of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type: str
+        """
+        self._vm_cluster_id = vm_cluster_id
+
+    @property
+    def database(self):
+        """
+        **[Required]** Gets the database of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+
+        :return: The database of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :rtype: CreateDatabaseFromBackupDetails
+        """
+        return self._database
+
+    @database.setter
+    def database(self, database):
+        """
+        Sets the database of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+
+        :param database: The database of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type: CreateDatabaseFromBackupDetails
+        """
+        self._database = database
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_exadata_infrastructure_details.py
+++ b/src/oci/database/models/create_exadata_infrastructure_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateExadataInfrastructureDetails(object):
     """
-    Request to create Exadata infrastructure.
+    Request to create Exadata Cloud@Customer infrastructure resource.
     """
 
     def __init__(self, **kwargs):
@@ -416,7 +416,7 @@ class CreateExadataInfrastructureDetails(object):
     def contacts(self):
         """
         Gets the contacts of this CreateExadataInfrastructureDetails.
-        The list of contacts for the Exadata Infrastructure.
+        The list of contacts for the Exadata infrastructure.
 
 
         :return: The contacts of this CreateExadataInfrastructureDetails.
@@ -428,7 +428,7 @@ class CreateExadataInfrastructureDetails(object):
     def contacts(self, contacts):
         """
         Sets the contacts of this CreateExadataInfrastructureDetails.
-        The list of contacts for the Exadata Infrastructure.
+        The list of contacts for the Exadata infrastructure.
 
 
         :param contacts: The contacts of this CreateExadataInfrastructureDetails.

--- a/src/oci/database/models/create_vm_cluster_details.py
+++ b/src/oci/database/models/create_vm_cluster_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateVmClusterDetails(object):
     """
-    Details for the create VM cluster operation.
+    Details for the create Exadata Cloud@Customer VM cluster operation.
     """
 
     #: A constant which can be used with the license_model property of a CreateVmClusterDetails.

--- a/src/oci/database/models/database_software_image.py
+++ b/src/oci/database/models/database_software_image.py
@@ -34,6 +34,14 @@ class DatabaseSoftwareImage(object):
     LIFECYCLE_STATE_FAILED = "FAILED"
 
     #: A constant which can be used with the lifecycle_state property of a DatabaseSoftwareImage.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a DatabaseSoftwareImage.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a DatabaseSoftwareImage.
     #: This constant has a value of "UPDATING"
     LIFECYCLE_STATE_UPDATING = "UPDATING"
 
@@ -76,7 +84,7 @@ class DatabaseSoftwareImage(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this DatabaseSoftwareImage.
-            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "TERMINATING", "TERMINATED", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -294,7 +302,7 @@ class DatabaseSoftwareImage(object):
         **[Required]** Gets the lifecycle_state of this DatabaseSoftwareImage.
         The current state of the database software image.
 
-        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "TERMINATING", "TERMINATED", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -313,7 +321,7 @@ class DatabaseSoftwareImage(object):
         :param lifecycle_state: The lifecycle_state of this DatabaseSoftwareImage.
         :type: str
         """
-        allowed_values = ["PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "UPDATING"]
+        allowed_values = ["PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "TERMINATING", "TERMINATED", "UPDATING"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state

--- a/src/oci/database/models/database_software_image_summary.py
+++ b/src/oci/database/models/database_software_image_summary.py
@@ -44,6 +44,14 @@ class DatabaseSoftwareImageSummary(object):
     LIFECYCLE_STATE_FAILED = "FAILED"
 
     #: A constant which can be used with the lifecycle_state property of a DatabaseSoftwareImageSummary.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a DatabaseSoftwareImageSummary.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a DatabaseSoftwareImageSummary.
     #: This constant has a value of "UPDATING"
     LIFECYCLE_STATE_UPDATING = "UPDATING"
 
@@ -86,7 +94,7 @@ class DatabaseSoftwareImageSummary(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this DatabaseSoftwareImageSummary.
-            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "TERMINATING", "TERMINATED", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -304,7 +312,7 @@ class DatabaseSoftwareImageSummary(object):
         **[Required]** Gets the lifecycle_state of this DatabaseSoftwareImageSummary.
         The current state of the database software image.
 
-        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "TERMINATING", "TERMINATED", "UPDATING", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -323,7 +331,7 @@ class DatabaseSoftwareImageSummary(object):
         :param lifecycle_state: The lifecycle_state of this DatabaseSoftwareImageSummary.
         :type: str
         """
-        allowed_values = ["PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "UPDATING"]
+        allowed_values = ["PROVISIONING", "AVAILABLE", "DELETING", "DELETED", "FAILED", "TERMINATING", "TERMINATED", "UPDATING"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state

--- a/src/oci/database/models/db_iorm_config.py
+++ b/src/oci/database/models/db_iorm_config.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DbIormConfig(object):
     """
-    IORM Config setting response for this database
+    The IORM configuration settings for the database.
     """
 
     def __init__(self, **kwargs):
@@ -51,7 +51,7 @@ class DbIormConfig(object):
     def db_name(self):
         """
         Gets the db_name of this DbIormConfig.
-        Database Name. For default DbPlan, the dbName will always be `default`
+        The database name. For the default `DbPlan`, the `dbName` is `default`.
 
 
         :return: The db_name of this DbIormConfig.
@@ -63,7 +63,7 @@ class DbIormConfig(object):
     def db_name(self, db_name):
         """
         Sets the db_name of this DbIormConfig.
-        Database Name. For default DbPlan, the dbName will always be `default`
+        The database name. For the default `DbPlan`, the `dbName` is `default`.
 
 
         :param db_name: The db_name of this DbIormConfig.
@@ -75,7 +75,7 @@ class DbIormConfig(object):
     def share(self):
         """
         Gets the share of this DbIormConfig.
-        Relative priority of a database
+        The relative priority of this database.
 
 
         :return: The share of this DbIormConfig.
@@ -87,7 +87,7 @@ class DbIormConfig(object):
     def share(self, share):
         """
         Sets the share of this DbIormConfig.
-        Relative priority of a database
+        The relative priority of this database.
 
 
         :param share: The share of this DbIormConfig.
@@ -99,7 +99,7 @@ class DbIormConfig(object):
     def flash_cache_limit(self):
         """
         Gets the flash_cache_limit of this DbIormConfig.
-        Flash Cache limit, internally configured based on shares
+        The flash cache limit for this database. This value is internally configured based on the share value assigned to the database.
 
 
         :return: The flash_cache_limit of this DbIormConfig.
@@ -111,7 +111,7 @@ class DbIormConfig(object):
     def flash_cache_limit(self, flash_cache_limit):
         """
         Sets the flash_cache_limit of this DbIormConfig.
-        Flash Cache limit, internally configured based on shares
+        The flash cache limit for this database. This value is internally configured based on the share value assigned to the database.
 
 
         :param flash_cache_limit: The flash_cache_limit of this DbIormConfig.

--- a/src/oci/database/models/db_iorm_config_update_detail.py
+++ b/src/oci/database/models/db_iorm_config_update_detail.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DbIormConfigUpdateDetail(object):
     """
-    IORM Config setting request for this database
+    Details of the IORM configuration settings update request.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,7 @@ class DbIormConfigUpdateDetail(object):
     def db_name(self):
         """
         Gets the db_name of this DbIormConfigUpdateDetail.
-        Database Name. For updating default DbPlan, pass in dbName as `default`
+        The database name. For the default `DbPlan`, the `dbName` is `default`.
 
 
         :return: The db_name of this DbIormConfigUpdateDetail.
@@ -56,7 +56,7 @@ class DbIormConfigUpdateDetail(object):
     def db_name(self, db_name):
         """
         Sets the db_name of this DbIormConfigUpdateDetail.
-        Database Name. For updating default DbPlan, pass in dbName as `default`
+        The database name. For the default `DbPlan`, the `dbName` is `default`.
 
 
         :param db_name: The db_name of this DbIormConfigUpdateDetail.
@@ -68,7 +68,7 @@ class DbIormConfigUpdateDetail(object):
     def share(self):
         """
         Gets the share of this DbIormConfigUpdateDetail.
-        Relative priority of a database
+        The relative priority of this database.
 
 
         :return: The share of this DbIormConfigUpdateDetail.
@@ -80,7 +80,7 @@ class DbIormConfigUpdateDetail(object):
     def share(self, share):
         """
         Sets the share of this DbIormConfigUpdateDetail.
-        Relative priority of a database
+        The relative priority of this database.
 
 
         :param share: The share of this DbIormConfigUpdateDetail.

--- a/src/oci/database/models/db_system.py
+++ b/src/oci/database/models/db_system.py
@@ -54,6 +54,10 @@ class DbSystem(object):
     LIFECYCLE_STATE_FAILED = "FAILED"
 
     #: A constant which can be used with the lifecycle_state property of a DbSystem.
+    #: This constant has a value of "MIGRATED"
+    LIFECYCLE_STATE_MIGRATED = "MIGRATED"
+
+    #: A constant which can be used with the lifecycle_state property of a DbSystem.
     #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
     LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
 
@@ -174,7 +178,7 @@ class DbSystem(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this DbSystem.
-            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MIGRATED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -650,7 +654,7 @@ class DbSystem(object):
     def backup_network_nsg_ids(self):
         """
         Gets the backup_network_nsg_ids of this DbSystem.
-        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata DB systems.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
         __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
@@ -665,7 +669,7 @@ class DbSystem(object):
     def backup_network_nsg_ids(self, backup_network_nsg_ids):
         """
         Sets the backup_network_nsg_ids of this DbSystem.
-        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata DB systems.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
         __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
@@ -876,7 +880,7 @@ class DbSystem(object):
     def cluster_name(self):
         """
         Gets the cluster_name of this DbSystem.
-        The cluster name for Exadata and 2-node RAC virtual machine DB systems. The cluster name must begin with an an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
+        The cluster name for Exadata and 2-node RAC virtual machine DB systems. The cluster name must begin with an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
 
 
         :return: The cluster_name of this DbSystem.
@@ -888,7 +892,7 @@ class DbSystem(object):
     def cluster_name(self, cluster_name):
         """
         Sets the cluster_name of this DbSystem.
-        The cluster name for Exadata and 2-node RAC virtual machine DB systems. The cluster name must begin with an an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
+        The cluster name for Exadata and 2-node RAC virtual machine DB systems. The cluster name must begin with an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
 
 
         :param cluster_name: The cluster_name of this DbSystem.
@@ -1010,7 +1014,7 @@ class DbSystem(object):
         **[Required]** Gets the lifecycle_state of this DbSystem.
         The current state of the DB system.
 
-        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MIGRATED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -1029,7 +1033,7 @@ class DbSystem(object):
         :param lifecycle_state: The lifecycle_state of this DbSystem.
         :type: str
         """
-        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MIGRATED", "MAINTENANCE_IN_PROGRESS"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state

--- a/src/oci/database/models/db_system_shape_summary.py
+++ b/src/oci/database/models/db_system_shape_summary.py
@@ -84,6 +84,10 @@ class DbSystemShapeSummary(object):
             The value to assign to the maximum_node_count property of this DbSystemShapeSummary.
         :type maximum_node_count: int
 
+        :param available_core_count_per_node:
+            The value to assign to the available_core_count_per_node property of this DbSystemShapeSummary.
+        :type available_core_count_per_node: int
+
         """
         self.swagger_types = {
             'name': 'str',
@@ -100,7 +104,8 @@ class DbSystemShapeSummary(object):
             'available_data_storage_in_t_bs': 'int',
             'min_data_storage_in_t_bs': 'int',
             'minimum_node_count': 'int',
-            'maximum_node_count': 'int'
+            'maximum_node_count': 'int',
+            'available_core_count_per_node': 'int'
         }
 
         self.attribute_map = {
@@ -118,7 +123,8 @@ class DbSystemShapeSummary(object):
             'available_data_storage_in_t_bs': 'availableDataStorageInTBs',
             'min_data_storage_in_t_bs': 'minDataStorageInTBs',
             'minimum_node_count': 'minimumNodeCount',
-            'maximum_node_count': 'maximumNodeCount'
+            'maximum_node_count': 'maximumNodeCount',
+            'available_core_count_per_node': 'availableCoreCountPerNode'
         }
 
         self._name = None
@@ -136,6 +142,7 @@ class DbSystemShapeSummary(object):
         self._min_data_storage_in_t_bs = None
         self._minimum_node_count = None
         self._maximum_node_count = None
+        self._available_core_count_per_node = None
 
     @property
     def name(self):
@@ -496,6 +503,30 @@ class DbSystemShapeSummary(object):
         :type: int
         """
         self._maximum_node_count = maximum_node_count
+
+    @property
+    def available_core_count_per_node(self):
+        """
+        Gets the available_core_count_per_node of this DbSystemShapeSummary.
+        The maximum number of CPU cores per database node that can be enabled for this shape. Only applicable to the flex Exadata shape. Does not apply to X6, X7, and X8 fixed-shape systems.
+
+
+        :return: The available_core_count_per_node of this DbSystemShapeSummary.
+        :rtype: int
+        """
+        return self._available_core_count_per_node
+
+    @available_core_count_per_node.setter
+    def available_core_count_per_node(self, available_core_count_per_node):
+        """
+        Sets the available_core_count_per_node of this DbSystemShapeSummary.
+        The maximum number of CPU cores per database node that can be enabled for this shape. Only applicable to the flex Exadata shape. Does not apply to X6, X7, and X8 fixed-shape systems.
+
+
+        :param available_core_count_per_node: The available_core_count_per_node of this DbSystemShapeSummary.
+        :type: int
+        """
+        self._available_core_count_per_node = available_core_count_per_node
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/db_system_summary.py
+++ b/src/oci/database/models/db_system_summary.py
@@ -76,6 +76,10 @@ class DbSystemSummary(object):
     LIFECYCLE_STATE_FAILED = "FAILED"
 
     #: A constant which can be used with the lifecycle_state property of a DbSystemSummary.
+    #: This constant has a value of "MIGRATED"
+    LIFECYCLE_STATE_MIGRATED = "MIGRATED"
+
+    #: A constant which can be used with the lifecycle_state property of a DbSystemSummary.
     #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
     LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
 
@@ -192,7 +196,7 @@ class DbSystemSummary(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this DbSystemSummary.
-            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MIGRATED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -645,7 +649,7 @@ class DbSystemSummary(object):
     def backup_network_nsg_ids(self):
         """
         Gets the backup_network_nsg_ids of this DbSystemSummary.
-        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata DB systems.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
         __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
@@ -660,7 +664,7 @@ class DbSystemSummary(object):
     def backup_network_nsg_ids(self, backup_network_nsg_ids):
         """
         Sets the backup_network_nsg_ids of this DbSystemSummary.
-        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata DB systems.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
         __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
@@ -871,7 +875,7 @@ class DbSystemSummary(object):
     def cluster_name(self):
         """
         Gets the cluster_name of this DbSystemSummary.
-        The cluster name for Exadata and 2-node RAC virtual machine DB systems. The cluster name must begin with an an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
+        The cluster name for Exadata and 2-node RAC virtual machine DB systems. The cluster name must begin with an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
 
 
         :return: The cluster_name of this DbSystemSummary.
@@ -883,7 +887,7 @@ class DbSystemSummary(object):
     def cluster_name(self, cluster_name):
         """
         Sets the cluster_name of this DbSystemSummary.
-        The cluster name for Exadata and 2-node RAC virtual machine DB systems. The cluster name must begin with an an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
+        The cluster name for Exadata and 2-node RAC virtual machine DB systems. The cluster name must begin with an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
 
 
         :param cluster_name: The cluster_name of this DbSystemSummary.
@@ -1005,7 +1009,7 @@ class DbSystemSummary(object):
         **[Required]** Gets the lifecycle_state of this DbSystemSummary.
         The current state of the DB system.
 
-        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MIGRATED", "MAINTENANCE_IN_PROGRESS", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -1024,7 +1028,7 @@ class DbSystemSummary(object):
         :param lifecycle_state: The lifecycle_state of this DbSystemSummary.
         :type: str
         """
-        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MAINTENANCE_IN_PROGRESS"]
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", "MIGRATED", "MAINTENANCE_IN_PROGRESS"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state

--- a/src/oci/database/models/exadata_db_system_migration.py
+++ b/src/oci/database/models/exadata_db_system_migration.py
@@ -1,0 +1,175 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExadataDbSystemMigration(object):
+    """
+    Information about the Exadata DB system migration. The migration is used to move the system to the Exadata infrastructure resource model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExadataDbSystemMigration object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param db_system_id:
+            The value to assign to the db_system_id property of this ExadataDbSystemMigration.
+        :type db_system_id: str
+
+        :param cloud_vm_cluster_id:
+            The value to assign to the cloud_vm_cluster_id property of this ExadataDbSystemMigration.
+        :type cloud_vm_cluster_id: str
+
+        :param cloud_exadata_infrastructure_id:
+            The value to assign to the cloud_exadata_infrastructure_id property of this ExadataDbSystemMigration.
+        :type cloud_exadata_infrastructure_id: str
+
+        :param additional_migrations:
+            The value to assign to the additional_migrations property of this ExadataDbSystemMigration.
+        :type additional_migrations: list[ExadataDbSystemMigrationSummary]
+
+        """
+        self.swagger_types = {
+            'db_system_id': 'str',
+            'cloud_vm_cluster_id': 'str',
+            'cloud_exadata_infrastructure_id': 'str',
+            'additional_migrations': 'list[ExadataDbSystemMigrationSummary]'
+        }
+
+        self.attribute_map = {
+            'db_system_id': 'dbSystemId',
+            'cloud_vm_cluster_id': 'cloudVmClusterId',
+            'cloud_exadata_infrastructure_id': 'cloudExadataInfrastructureId',
+            'additional_migrations': 'additionalMigrations'
+        }
+
+        self._db_system_id = None
+        self._cloud_vm_cluster_id = None
+        self._cloud_exadata_infrastructure_id = None
+        self._additional_migrations = None
+
+    @property
+    def db_system_id(self):
+        """
+        **[Required]** Gets the db_system_id of this ExadataDbSystemMigration.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The db_system_id of this ExadataDbSystemMigration.
+        :rtype: str
+        """
+        return self._db_system_id
+
+    @db_system_id.setter
+    def db_system_id(self, db_system_id):
+        """
+        Sets the db_system_id of this ExadataDbSystemMigration.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param db_system_id: The db_system_id of this ExadataDbSystemMigration.
+        :type: str
+        """
+        self._db_system_id = db_system_id
+
+    @property
+    def cloud_vm_cluster_id(self):
+        """
+        **[Required]** Gets the cloud_vm_cluster_id of this ExadataDbSystemMigration.
+        The `OCID`__ of the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The cloud_vm_cluster_id of this ExadataDbSystemMigration.
+        :rtype: str
+        """
+        return self._cloud_vm_cluster_id
+
+    @cloud_vm_cluster_id.setter
+    def cloud_vm_cluster_id(self, cloud_vm_cluster_id):
+        """
+        Sets the cloud_vm_cluster_id of this ExadataDbSystemMigration.
+        The `OCID`__ of the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param cloud_vm_cluster_id: The cloud_vm_cluster_id of this ExadataDbSystemMigration.
+        :type: str
+        """
+        self._cloud_vm_cluster_id = cloud_vm_cluster_id
+
+    @property
+    def cloud_exadata_infrastructure_id(self):
+        """
+        **[Required]** Gets the cloud_exadata_infrastructure_id of this ExadataDbSystemMigration.
+        The `OCID`__ of the cloud Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The cloud_exadata_infrastructure_id of this ExadataDbSystemMigration.
+        :rtype: str
+        """
+        return self._cloud_exadata_infrastructure_id
+
+    @cloud_exadata_infrastructure_id.setter
+    def cloud_exadata_infrastructure_id(self, cloud_exadata_infrastructure_id):
+        """
+        Sets the cloud_exadata_infrastructure_id of this ExadataDbSystemMigration.
+        The `OCID`__ of the cloud Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param cloud_exadata_infrastructure_id: The cloud_exadata_infrastructure_id of this ExadataDbSystemMigration.
+        :type: str
+        """
+        self._cloud_exadata_infrastructure_id = cloud_exadata_infrastructure_id
+
+    @property
+    def additional_migrations(self):
+        """
+        Gets the additional_migrations of this ExadataDbSystemMigration.
+        The details of addtional resources related to the migration.
+
+
+        :return: The additional_migrations of this ExadataDbSystemMigration.
+        :rtype: list[ExadataDbSystemMigrationSummary]
+        """
+        return self._additional_migrations
+
+    @additional_migrations.setter
+    def additional_migrations(self, additional_migrations):
+        """
+        Sets the additional_migrations of this ExadataDbSystemMigration.
+        The details of addtional resources related to the migration.
+
+
+        :param additional_migrations: The additional_migrations of this ExadataDbSystemMigration.
+        :type: list[ExadataDbSystemMigrationSummary]
+        """
+        self._additional_migrations = additional_migrations
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/exadata_db_system_migration_summary.py
+++ b/src/oci/database/models/exadata_db_system_migration_summary.py
@@ -1,0 +1,144 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExadataDbSystemMigrationSummary(object):
+    """
+    Information about Exadata DB system migration. The migration is used to move the system to the Exadata infrastructure resource model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExadataDbSystemMigrationSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param db_system_id:
+            The value to assign to the db_system_id property of this ExadataDbSystemMigrationSummary.
+        :type db_system_id: str
+
+        :param cloud_vm_cluster_id:
+            The value to assign to the cloud_vm_cluster_id property of this ExadataDbSystemMigrationSummary.
+        :type cloud_vm_cluster_id: str
+
+        :param cloud_exadata_infrastructure_id:
+            The value to assign to the cloud_exadata_infrastructure_id property of this ExadataDbSystemMigrationSummary.
+        :type cloud_exadata_infrastructure_id: str
+
+        """
+        self.swagger_types = {
+            'db_system_id': 'str',
+            'cloud_vm_cluster_id': 'str',
+            'cloud_exadata_infrastructure_id': 'str'
+        }
+
+        self.attribute_map = {
+            'db_system_id': 'dbSystemId',
+            'cloud_vm_cluster_id': 'cloudVmClusterId',
+            'cloud_exadata_infrastructure_id': 'cloudExadataInfrastructureId'
+        }
+
+        self._db_system_id = None
+        self._cloud_vm_cluster_id = None
+        self._cloud_exadata_infrastructure_id = None
+
+    @property
+    def db_system_id(self):
+        """
+        **[Required]** Gets the db_system_id of this ExadataDbSystemMigrationSummary.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The db_system_id of this ExadataDbSystemMigrationSummary.
+        :rtype: str
+        """
+        return self._db_system_id
+
+    @db_system_id.setter
+    def db_system_id(self, db_system_id):
+        """
+        Sets the db_system_id of this ExadataDbSystemMigrationSummary.
+        The `OCID`__ of the DB system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param db_system_id: The db_system_id of this ExadataDbSystemMigrationSummary.
+        :type: str
+        """
+        self._db_system_id = db_system_id
+
+    @property
+    def cloud_vm_cluster_id(self):
+        """
+        **[Required]** Gets the cloud_vm_cluster_id of this ExadataDbSystemMigrationSummary.
+        The `OCID`__ of the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The cloud_vm_cluster_id of this ExadataDbSystemMigrationSummary.
+        :rtype: str
+        """
+        return self._cloud_vm_cluster_id
+
+    @cloud_vm_cluster_id.setter
+    def cloud_vm_cluster_id(self, cloud_vm_cluster_id):
+        """
+        Sets the cloud_vm_cluster_id of this ExadataDbSystemMigrationSummary.
+        The `OCID`__ of the cloud VM cluster.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param cloud_vm_cluster_id: The cloud_vm_cluster_id of this ExadataDbSystemMigrationSummary.
+        :type: str
+        """
+        self._cloud_vm_cluster_id = cloud_vm_cluster_id
+
+    @property
+    def cloud_exadata_infrastructure_id(self):
+        """
+        **[Required]** Gets the cloud_exadata_infrastructure_id of this ExadataDbSystemMigrationSummary.
+        The `OCID`__ of the cloud Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The cloud_exadata_infrastructure_id of this ExadataDbSystemMigrationSummary.
+        :rtype: str
+        """
+        return self._cloud_exadata_infrastructure_id
+
+    @cloud_exadata_infrastructure_id.setter
+    def cloud_exadata_infrastructure_id(self, cloud_exadata_infrastructure_id):
+        """
+        Sets the cloud_exadata_infrastructure_id of this ExadataDbSystemMigrationSummary.
+        The `OCID`__ of the cloud Exadata infrastructure.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param cloud_exadata_infrastructure_id: The cloud_exadata_infrastructure_id of this ExadataDbSystemMigrationSummary.
+        :type: str
+        """
+        self._cloud_exadata_infrastructure_id = cloud_exadata_infrastructure_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/exadata_infrastructure.py
+++ b/src/oci/database/models/exadata_infrastructure.py
@@ -361,7 +361,7 @@ class ExadataInfrastructure(object):
     def display_name(self):
         """
         **[Required]** Gets the display_name of this ExadataInfrastructure.
-        The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+        The user-friendly name for the Exadata Cloud@Customer infrastructure. The name does not need to be unique.
 
 
         :return: The display_name of this ExadataInfrastructure.
@@ -373,7 +373,7 @@ class ExadataInfrastructure(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this ExadataInfrastructure.
-        The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+        The user-friendly name for the Exadata Cloud@Customer infrastructure. The name does not need to be unique.
 
 
         :param display_name: The display_name of this ExadataInfrastructure.
@@ -893,7 +893,7 @@ class ExadataInfrastructure(object):
     def csi_number(self):
         """
         Gets the csi_number of this ExadataInfrastructure.
-        The CSI Number of the Exadata Infrastructure.
+        The CSI Number of the Exadata infrastructure.
 
 
         :return: The csi_number of this ExadataInfrastructure.
@@ -905,7 +905,7 @@ class ExadataInfrastructure(object):
     def csi_number(self, csi_number):
         """
         Sets the csi_number of this ExadataInfrastructure.
-        The CSI Number of the Exadata Infrastructure.
+        The CSI Number of the Exadata infrastructure.
 
 
         :param csi_number: The csi_number of this ExadataInfrastructure.
@@ -917,7 +917,7 @@ class ExadataInfrastructure(object):
     def contacts(self):
         """
         Gets the contacts of this ExadataInfrastructure.
-        The list of contacts for the Exadata Infrastructure.
+        The list of contacts for the Exadata infrastructure.
 
 
         :return: The contacts of this ExadataInfrastructure.
@@ -929,7 +929,7 @@ class ExadataInfrastructure(object):
     def contacts(self, contacts):
         """
         Sets the contacts of this ExadataInfrastructure.
-        The list of contacts for the Exadata Infrastructure.
+        The list of contacts for the Exadata infrastructure.
 
 
         :param contacts: The contacts of this ExadataInfrastructure.

--- a/src/oci/database/models/exadata_infrastructure_summary.py
+++ b/src/oci/database/models/exadata_infrastructure_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ExadataInfrastructureSummary(object):
     """
-    Details of the Exadata infrastructure.
+    Details of the Exadata Cloud@Customer infrastructure.
     """
 
     #: A constant which can be used with the lifecycle_state property of a ExadataInfrastructureSummary.
@@ -361,7 +361,7 @@ class ExadataInfrastructureSummary(object):
     def display_name(self):
         """
         **[Required]** Gets the display_name of this ExadataInfrastructureSummary.
-        The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+        The user-friendly name for the Exadata Cloud@Customer infrastructure. The name does not need to be unique.
 
 
         :return: The display_name of this ExadataInfrastructureSummary.
@@ -373,7 +373,7 @@ class ExadataInfrastructureSummary(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this ExadataInfrastructureSummary.
-        The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+        The user-friendly name for the Exadata Cloud@Customer infrastructure. The name does not need to be unique.
 
 
         :param display_name: The display_name of this ExadataInfrastructureSummary.
@@ -893,7 +893,7 @@ class ExadataInfrastructureSummary(object):
     def csi_number(self):
         """
         Gets the csi_number of this ExadataInfrastructureSummary.
-        The CSI Number of the Exadata Infrastructure.
+        The CSI Number of the Exadata infrastructure.
 
 
         :return: The csi_number of this ExadataInfrastructureSummary.
@@ -905,7 +905,7 @@ class ExadataInfrastructureSummary(object):
     def csi_number(self, csi_number):
         """
         Sets the csi_number of this ExadataInfrastructureSummary.
-        The CSI Number of the Exadata Infrastructure.
+        The CSI Number of the Exadata infrastructure.
 
 
         :param csi_number: The csi_number of this ExadataInfrastructureSummary.
@@ -917,7 +917,7 @@ class ExadataInfrastructureSummary(object):
     def contacts(self):
         """
         Gets the contacts of this ExadataInfrastructureSummary.
-        The list of contacts for the Exadata Infrastructure.
+        The list of contacts for the Exadata infrastructure.
 
 
         :return: The contacts of this ExadataInfrastructureSummary.
@@ -929,7 +929,7 @@ class ExadataInfrastructureSummary(object):
     def contacts(self, contacts):
         """
         Sets the contacts of this ExadataInfrastructureSummary.
-        The list of contacts for the Exadata Infrastructure.
+        The list of contacts for the Exadata infrastructure.
 
 
         :param contacts: The contacts of this ExadataInfrastructureSummary.

--- a/src/oci/database/models/exadata_iorm_config.py
+++ b/src/oci/database/models/exadata_iorm_config.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ExadataIormConfig(object):
     """
-    Response details which has IORM Settings for this Exadata System
+    The IORM settings of the Exadata DB system.
     """
 
     #: A constant which can be used with the lifecycle_state property of a ExadataIormConfig.
@@ -102,7 +102,7 @@ class ExadataIormConfig(object):
     def lifecycle_state(self):
         """
         Gets the lifecycle_state of this ExadataIormConfig.
-        The current config state of IORM settings for this Exadata System.
+        The current state of IORM configuration for the Exadata DB system.
 
         Allowed values for this property are: "BOOTSTRAPPING", "ENABLED", "DISABLED", "UPDATING", "FAILED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -117,7 +117,7 @@ class ExadataIormConfig(object):
     def lifecycle_state(self, lifecycle_state):
         """
         Sets the lifecycle_state of this ExadataIormConfig.
-        The current config state of IORM settings for this Exadata System.
+        The current state of IORM configuration for the Exadata DB system.
 
 
         :param lifecycle_state: The lifecycle_state of this ExadataIormConfig.
@@ -132,7 +132,7 @@ class ExadataIormConfig(object):
     def lifecycle_details(self):
         """
         Gets the lifecycle_details of this ExadataIormConfig.
-        Additional information about the current lifecycleState.
+        Additional information about the current `lifecycleState`.
 
 
         :return: The lifecycle_details of this ExadataIormConfig.
@@ -144,7 +144,7 @@ class ExadataIormConfig(object):
     def lifecycle_details(self, lifecycle_details):
         """
         Sets the lifecycle_details of this ExadataIormConfig.
-        Additional information about the current lifecycleState.
+        Additional information about the current `lifecycleState`.
 
 
         :param lifecycle_details: The lifecycle_details of this ExadataIormConfig.
@@ -156,8 +156,8 @@ class ExadataIormConfig(object):
     def objective(self):
         """
         Gets the objective of this ExadataIormConfig.
-        Value for the IORM objective
-        Default is \"Auto\"
+        The current value for the IORM objective.
+        The default is `AUTO`.
 
         Allowed values for this property are: "LOW_LATENCY", "HIGH_THROUGHPUT", "BALANCED", "AUTO", "BASIC", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -172,8 +172,8 @@ class ExadataIormConfig(object):
     def objective(self, objective):
         """
         Sets the objective of this ExadataIormConfig.
-        Value for the IORM objective
-        Default is \"Auto\"
+        The current value for the IORM objective.
+        The default is `AUTO`.
 
 
         :param objective: The objective of this ExadataIormConfig.
@@ -188,8 +188,8 @@ class ExadataIormConfig(object):
     def db_plans(self):
         """
         Gets the db_plans of this ExadataIormConfig.
-        Array of IORM Setting for all the database in
-        this Exadata DB System
+        An array of IORM settings for all the database in
+        the Exadata DB system.
 
 
         :return: The db_plans of this ExadataIormConfig.
@@ -201,8 +201,8 @@ class ExadataIormConfig(object):
     def db_plans(self, db_plans):
         """
         Sets the db_plans of this ExadataIormConfig.
-        Array of IORM Setting for all the database in
-        this Exadata DB System
+        An array of IORM settings for all the database in
+        the Exadata DB system.
 
 
         :param db_plans: The db_plans of this ExadataIormConfig.

--- a/src/oci/database/models/generate_recommended_network_details.py
+++ b/src/oci/database/models/generate_recommended_network_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class GenerateRecommendedNetworkDetails(object):
     """
-    Generates a recommended VM cluster network configuration.
+    Generates a recommended VM cluster network configuration for an Exadata Cloud@Customer system.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/database/models/info_for_network_gen_details.py
+++ b/src/oci/database/models/info_for_network_gen_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class InfoForNetworkGenDetails(object):
     """
-    Parameters for generation of the client or backup network in a VM cluster network.
+    Parameters for generation of the client or backup network in a VM cluster network in an Exadata Cloud@Customer system.
     """
 
     #: A constant which can be used with the network_type property of a InfoForNetworkGenDetails.

--- a/src/oci/database/models/launch_db_system_base.py
+++ b/src/oci/database/models/launch_db_system_base.py
@@ -488,7 +488,7 @@ class LaunchDbSystemBase(object):
     def backup_network_nsg_ids(self):
         """
         Gets the backup_network_nsg_ids of this LaunchDbSystemBase.
-        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata DB systems.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
         __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
@@ -503,7 +503,7 @@ class LaunchDbSystemBase(object):
     def backup_network_nsg_ids(self, backup_network_nsg_ids):
         """
         Sets the backup_network_nsg_ids of this LaunchDbSystemBase.
-        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata DB systems.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
         __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
@@ -764,7 +764,7 @@ class LaunchDbSystemBase(object):
     def cluster_name(self):
         """
         Gets the cluster_name of this LaunchDbSystemBase.
-        The cluster name for Exadata and 2-node RAC virtual machine DB systems. The cluster name must begin with an an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
+        The cluster name for Exadata and 2-node RAC virtual machine DB systems. The cluster name must begin with an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
 
 
         :return: The cluster_name of this LaunchDbSystemBase.
@@ -776,7 +776,7 @@ class LaunchDbSystemBase(object):
     def cluster_name(self, cluster_name):
         """
         Sets the cluster_name of this LaunchDbSystemBase.
-        The cluster name for Exadata and 2-node RAC virtual machine DB systems. The cluster name must begin with an an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
+        The cluster name for Exadata and 2-node RAC virtual machine DB systems. The cluster name must begin with an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.
 
 
         :param cluster_name: The cluster_name of this LaunchDbSystemBase.

--- a/src/oci/database/models/maintenance_run.py
+++ b/src/oci/database/models/maintenance_run.py
@@ -57,6 +57,10 @@ class MaintenanceRun(object):
     #: This constant has a value of "EXADATA_DB_SYSTEM"
     TARGET_RESOURCE_TYPE_EXADATA_DB_SYSTEM = "EXADATA_DB_SYSTEM"
 
+    #: A constant which can be used with the target_resource_type property of a MaintenanceRun.
+    #: This constant has a value of "CLOUD_EXADATA_INFRASTRUCTURE"
+    TARGET_RESOURCE_TYPE_CLOUD_EXADATA_INFRASTRUCTURE = "CLOUD_EXADATA_INFRASTRUCTURE"
+
     #: A constant which can be used with the maintenance_type property of a MaintenanceRun.
     #: This constant has a value of "PLANNED"
     MAINTENANCE_TYPE_PLANNED = "PLANNED"
@@ -122,7 +126,7 @@ class MaintenanceRun(object):
 
         :param target_resource_type:
             The value to assign to the target_resource_type property of this MaintenanceRun.
-            Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", "CLOUD_EXADATA_INFRASTRUCTURE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type target_resource_type: str
 
@@ -424,7 +428,7 @@ class MaintenanceRun(object):
         Gets the target_resource_type of this MaintenanceRun.
         The type of the target resource on which the maintenance run occurs.
 
-        Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", "CLOUD_EXADATA_INFRASTRUCTURE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -443,7 +447,7 @@ class MaintenanceRun(object):
         :param target_resource_type: The target_resource_type of this MaintenanceRun.
         :type: str
         """
-        allowed_values = ["AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM"]
+        allowed_values = ["AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", "CLOUD_EXADATA_INFRASTRUCTURE"]
         if not value_allowed_none_or_none_sentinel(target_resource_type, allowed_values):
             target_resource_type = 'UNKNOWN_ENUM_VALUE'
         self._target_resource_type = target_resource_type

--- a/src/oci/database/models/maintenance_run_summary.py
+++ b/src/oci/database/models/maintenance_run_summary.py
@@ -57,6 +57,10 @@ class MaintenanceRunSummary(object):
     #: This constant has a value of "EXADATA_DB_SYSTEM"
     TARGET_RESOURCE_TYPE_EXADATA_DB_SYSTEM = "EXADATA_DB_SYSTEM"
 
+    #: A constant which can be used with the target_resource_type property of a MaintenanceRunSummary.
+    #: This constant has a value of "CLOUD_EXADATA_INFRASTRUCTURE"
+    TARGET_RESOURCE_TYPE_CLOUD_EXADATA_INFRASTRUCTURE = "CLOUD_EXADATA_INFRASTRUCTURE"
+
     #: A constant which can be used with the maintenance_type property of a MaintenanceRunSummary.
     #: This constant has a value of "PLANNED"
     MAINTENANCE_TYPE_PLANNED = "PLANNED"
@@ -122,7 +126,7 @@ class MaintenanceRunSummary(object):
 
         :param target_resource_type:
             The value to assign to the target_resource_type property of this MaintenanceRunSummary.
-            Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", "CLOUD_EXADATA_INFRASTRUCTURE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type target_resource_type: str
 
@@ -424,7 +428,7 @@ class MaintenanceRunSummary(object):
         Gets the target_resource_type of this MaintenanceRunSummary.
         The type of the target resource on which the maintenance run occurs.
 
-        Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", "CLOUD_EXADATA_INFRASTRUCTURE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -443,7 +447,7 @@ class MaintenanceRunSummary(object):
         :param target_resource_type: The target_resource_type of this MaintenanceRunSummary.
         :type: str
         """
-        allowed_values = ["AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM"]
+        allowed_values = ["AUTONOMOUS_EXADATA_INFRASTRUCTURE", "AUTONOMOUS_CONTAINER_DATABASE", "EXADATA_DB_SYSTEM", "CLOUD_EXADATA_INFRASTRUCTURE"]
         if not value_allowed_none_or_none_sentinel(target_resource_type, allowed_values):
             target_resource_type = 'UNKNOWN_ENUM_VALUE'
         self._target_resource_type = target_resource_type

--- a/src/oci/database/models/update.py
+++ b/src/oci/database/models/update.py
@@ -1,0 +1,398 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Update(object):
+    """
+    Update model.
+    """
+
+    #: A constant which can be used with the last_action property of a Update.
+    #: This constant has a value of "ROLLING_APPLY"
+    LAST_ACTION_ROLLING_APPLY = "ROLLING_APPLY"
+
+    #: A constant which can be used with the last_action property of a Update.
+    #: This constant has a value of "NON_ROLLING_APPLY"
+    LAST_ACTION_NON_ROLLING_APPLY = "NON_ROLLING_APPLY"
+
+    #: A constant which can be used with the last_action property of a Update.
+    #: This constant has a value of "PRECHECK"
+    LAST_ACTION_PRECHECK = "PRECHECK"
+
+    #: A constant which can be used with the available_actions property of a Update.
+    #: This constant has a value of "ROLLING_APPLY"
+    AVAILABLE_ACTIONS_ROLLING_APPLY = "ROLLING_APPLY"
+
+    #: A constant which can be used with the available_actions property of a Update.
+    #: This constant has a value of "NON_ROLLING_APPLY"
+    AVAILABLE_ACTIONS_NON_ROLLING_APPLY = "NON_ROLLING_APPLY"
+
+    #: A constant which can be used with the available_actions property of a Update.
+    #: This constant has a value of "PRECHECK"
+    AVAILABLE_ACTIONS_PRECHECK = "PRECHECK"
+
+    #: A constant which can be used with the update_type property of a Update.
+    #: This constant has a value of "GI_PATCH"
+    UPDATE_TYPE_GI_PATCH = "GI_PATCH"
+
+    #: A constant which can be used with the lifecycle_state property of a Update.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a Update.
+    #: This constant has a value of "SUCCESS"
+    LIFECYCLE_STATE_SUCCESS = "SUCCESS"
+
+    #: A constant which can be used with the lifecycle_state property of a Update.
+    #: This constant has a value of "IN_PROGRESS"
+    LIFECYCLE_STATE_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the lifecycle_state property of a Update.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Update object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this Update.
+        :type id: str
+
+        :param description:
+            The value to assign to the description property of this Update.
+        :type description: str
+
+        :param last_action:
+            The value to assign to the last_action property of this Update.
+            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type last_action: str
+
+        :param available_actions:
+            The value to assign to the available_actions property of this Update.
+            Allowed values for items in this list are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type available_actions: list[str]
+
+        :param update_type:
+            The value to assign to the update_type property of this Update.
+            Allowed values for this property are: "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type update_type: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this Update.
+        :type lifecycle_details: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this Update.
+            Allowed values for this property are: "AVAILABLE", "SUCCESS", "IN_PROGRESS", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param time_released:
+            The value to assign to the time_released property of this Update.
+        :type time_released: datetime
+
+        :param version:
+            The value to assign to the version property of this Update.
+        :type version: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'description': 'str',
+            'last_action': 'str',
+            'available_actions': 'list[str]',
+            'update_type': 'str',
+            'lifecycle_details': 'str',
+            'lifecycle_state': 'str',
+            'time_released': 'datetime',
+            'version': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'description': 'description',
+            'last_action': 'lastAction',
+            'available_actions': 'availableActions',
+            'update_type': 'updateType',
+            'lifecycle_details': 'lifecycleDetails',
+            'lifecycle_state': 'lifecycleState',
+            'time_released': 'timeReleased',
+            'version': 'version'
+        }
+
+        self._id = None
+        self._description = None
+        self._last_action = None
+        self._available_actions = None
+        self._update_type = None
+        self._lifecycle_details = None
+        self._lifecycle_state = None
+        self._time_released = None
+        self._version = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this Update.
+        The `OCID`__ of the maintenance update.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this Update.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this Update.
+        The `OCID`__ of the maintenance update.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this Update.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def description(self):
+        """
+        **[Required]** Gets the description of this Update.
+        Details of the maintenance update package.
+
+
+        :return: The description of this Update.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this Update.
+        Details of the maintenance update package.
+
+
+        :param description: The description of this Update.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def last_action(self):
+        """
+        Gets the last_action of this Update.
+        The update action.
+
+        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The last_action of this Update.
+        :rtype: str
+        """
+        return self._last_action
+
+    @last_action.setter
+    def last_action(self, last_action):
+        """
+        Sets the last_action of this Update.
+        The update action.
+
+
+        :param last_action: The last_action of this Update.
+        :type: str
+        """
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        if not value_allowed_none_or_none_sentinel(last_action, allowed_values):
+            last_action = 'UNKNOWN_ENUM_VALUE'
+        self._last_action = last_action
+
+    @property
+    def available_actions(self):
+        """
+        Gets the available_actions of this Update.
+        The possible actions performed by the update operation on the infrastructure components.
+
+        Allowed values for items in this list are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The available_actions of this Update.
+        :rtype: list[str]
+        """
+        return self._available_actions
+
+    @available_actions.setter
+    def available_actions(self, available_actions):
+        """
+        Sets the available_actions of this Update.
+        The possible actions performed by the update operation on the infrastructure components.
+
+
+        :param available_actions: The available_actions of this Update.
+        :type: list[str]
+        """
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        if available_actions:
+            available_actions[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in available_actions]
+        self._available_actions = available_actions
+
+    @property
+    def update_type(self):
+        """
+        **[Required]** Gets the update_type of this Update.
+        The type of cloud VM cluster maintenance update.
+
+        Allowed values for this property are: "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The update_type of this Update.
+        :rtype: str
+        """
+        return self._update_type
+
+    @update_type.setter
+    def update_type(self, update_type):
+        """
+        Sets the update_type of this Update.
+        The type of cloud VM cluster maintenance update.
+
+
+        :param update_type: The update_type of this Update.
+        :type: str
+        """
+        allowed_values = ["GI_PATCH"]
+        if not value_allowed_none_or_none_sentinel(update_type, allowed_values):
+            update_type = 'UNKNOWN_ENUM_VALUE'
+        self._update_type = update_type
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this Update.
+        Descriptive text providing additional details about the lifecycle state.
+
+
+        :return: The lifecycle_details of this Update.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this Update.
+        Descriptive text providing additional details about the lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this Update.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this Update.
+        The current state of the maintenance update. Dependent on value of `lastAction`.
+
+        Allowed values for this property are: "AVAILABLE", "SUCCESS", "IN_PROGRESS", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this Update.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this Update.
+        The current state of the maintenance update. Dependent on value of `lastAction`.
+
+
+        :param lifecycle_state: The lifecycle_state of this Update.
+        :type: str
+        """
+        allowed_values = ["AVAILABLE", "SUCCESS", "IN_PROGRESS", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def time_released(self):
+        """
+        **[Required]** Gets the time_released of this Update.
+        The date and time the maintenance update was released.
+
+
+        :return: The time_released of this Update.
+        :rtype: datetime
+        """
+        return self._time_released
+
+    @time_released.setter
+    def time_released(self, time_released):
+        """
+        Sets the time_released of this Update.
+        The date and time the maintenance update was released.
+
+
+        :param time_released: The time_released of this Update.
+        :type: datetime
+        """
+        self._time_released = time_released
+
+    @property
+    def version(self):
+        """
+        **[Required]** Gets the version of this Update.
+        The version of the maintenance update package.
+
+
+        :return: The version of this Update.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this Update.
+        The version of the maintenance update package.
+
+
+        :param version: The version of this Update.
+        :type: str
+        """
+        self._version = version
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_autonomous_database_details.py
+++ b/src/oci/database/models/update_autonomous_database_details.py
@@ -526,8 +526,8 @@ class UpdateAutonomousDatabaseDetails(object):
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
 
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
-        For update operation, if you wish to delete all the existing whitelisted IP\u2019s, use an array with a single empty string entry.
-        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
+        For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
+        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.<unique_id>\",\"ocid1.vcn.oc1.sea.<unique_id1>;1.1.1.1\",\"ocid1.vcn.oc1.sea.<unique_id2>;1.1.0.0/16\"]`
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -545,8 +545,8 @@ class UpdateAutonomousDatabaseDetails(object):
         Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
 
         To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
-        For update operation, if you wish to delete all the existing whitelisted IP\u2019s, use an array with a single empty string entry.
-        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.1.1\",\"ocid1.vcn.oc1.sea.aaaaaaaard2hfx2nn3e5xeo6j6o62jga44xjizkw;1.1.0.0/16\"]`
+        For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
+        Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.<unique_id>\",\"ocid1.vcn.oc1.sea.<unique_id1>;1.1.1.1\",\"ocid1.vcn.oc1.sea.<unique_id2>;1.1.0.0/16\"]`
 
         __ https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI
 
@@ -760,7 +760,7 @@ class UpdateAutonomousDatabaseDetails(object):
 
         **Subnet Restrictions:**
         - For bare metal DB systems and for single node virtual machine DB systems, do not use a subnet that overlaps with 192.168.16.16/28.
-        - For Exadata and virtual machine 2-node RAC DB systems, do not use a subnet that overlaps with 192.168.128.0/20.
+        - For Exadata and virtual machine 2-node RAC systems, do not use a subnet that overlaps with 192.168.128.0/20.
         - For Autonomous Database, setting this will disable public secure access to the database.
 
         These subnets are used by the Oracle Clusterware private interconnect on the database instance.
@@ -783,7 +783,7 @@ class UpdateAutonomousDatabaseDetails(object):
 
         **Subnet Restrictions:**
         - For bare metal DB systems and for single node virtual machine DB systems, do not use a subnet that overlaps with 192.168.16.16/28.
-        - For Exadata and virtual machine 2-node RAC DB systems, do not use a subnet that overlaps with 192.168.128.0/20.
+        - For Exadata and virtual machine 2-node RAC systems, do not use a subnet that overlaps with 192.168.128.0/20.
         - For Autonomous Database, setting this will disable public secure access to the database.
 
         These subnets are used by the Oracle Clusterware private interconnect on the database instance.

--- a/src/oci/database/models/update_cloud_exadata_infrastructure_details.py
+++ b/src/oci/database/models/update_cloud_exadata_infrastructure_details.py
@@ -1,0 +1,237 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateCloudExadataInfrastructureDetails(object):
+    """
+    Updates the cloud Exadata infrastructure.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateCloudExadataInfrastructureDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateCloudExadataInfrastructureDetails.
+        :type display_name: str
+
+        :param maintenance_window:
+            The value to assign to the maintenance_window property of this UpdateCloudExadataInfrastructureDetails.
+        :type maintenance_window: MaintenanceWindow
+
+        :param compute_count:
+            The value to assign to the compute_count property of this UpdateCloudExadataInfrastructureDetails.
+        :type compute_count: int
+
+        :param storage_count:
+            The value to assign to the storage_count property of this UpdateCloudExadataInfrastructureDetails.
+        :type storage_count: int
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateCloudExadataInfrastructureDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateCloudExadataInfrastructureDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'maintenance_window': 'MaintenanceWindow',
+            'compute_count': 'int',
+            'storage_count': 'int',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'maintenance_window': 'maintenanceWindow',
+            'compute_count': 'computeCount',
+            'storage_count': 'storageCount',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._maintenance_window = None
+        self._compute_count = None
+        self._storage_count = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateCloudExadataInfrastructureDetails.
+        The user-friendly name for the cloud Exadata infrastructure. The name does not need to be unique.
+
+
+        :return: The display_name of this UpdateCloudExadataInfrastructureDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateCloudExadataInfrastructureDetails.
+        The user-friendly name for the cloud Exadata infrastructure. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this UpdateCloudExadataInfrastructureDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def maintenance_window(self):
+        """
+        Gets the maintenance_window of this UpdateCloudExadataInfrastructureDetails.
+
+        :return: The maintenance_window of this UpdateCloudExadataInfrastructureDetails.
+        :rtype: MaintenanceWindow
+        """
+        return self._maintenance_window
+
+    @maintenance_window.setter
+    def maintenance_window(self, maintenance_window):
+        """
+        Sets the maintenance_window of this UpdateCloudExadataInfrastructureDetails.
+
+        :param maintenance_window: The maintenance_window of this UpdateCloudExadataInfrastructureDetails.
+        :type: MaintenanceWindow
+        """
+        self._maintenance_window = maintenance_window
+
+    @property
+    def compute_count(self):
+        """
+        Gets the compute_count of this UpdateCloudExadataInfrastructureDetails.
+        The number of compute servers for the cloud Exadata infrastructure.
+
+
+        :return: The compute_count of this UpdateCloudExadataInfrastructureDetails.
+        :rtype: int
+        """
+        return self._compute_count
+
+    @compute_count.setter
+    def compute_count(self, compute_count):
+        """
+        Sets the compute_count of this UpdateCloudExadataInfrastructureDetails.
+        The number of compute servers for the cloud Exadata infrastructure.
+
+
+        :param compute_count: The compute_count of this UpdateCloudExadataInfrastructureDetails.
+        :type: int
+        """
+        self._compute_count = compute_count
+
+    @property
+    def storage_count(self):
+        """
+        Gets the storage_count of this UpdateCloudExadataInfrastructureDetails.
+        The number of storage servers for the cloud Exadata infrastructure.
+
+
+        :return: The storage_count of this UpdateCloudExadataInfrastructureDetails.
+        :rtype: int
+        """
+        return self._storage_count
+
+    @storage_count.setter
+    def storage_count(self, storage_count):
+        """
+        Sets the storage_count of this UpdateCloudExadataInfrastructureDetails.
+        The number of storage servers for the cloud Exadata infrastructure.
+
+
+        :param storage_count: The storage_count of this UpdateCloudExadataInfrastructureDetails.
+        :type: int
+        """
+        self._storage_count = storage_count
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateCloudExadataInfrastructureDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateCloudExadataInfrastructureDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateCloudExadataInfrastructureDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateCloudExadataInfrastructureDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateCloudExadataInfrastructureDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateCloudExadataInfrastructureDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateCloudExadataInfrastructureDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateCloudExadataInfrastructureDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_cloud_vm_cluster_details.py
+++ b/src/oci/database/models/update_cloud_vm_cluster_details.py
@@ -1,0 +1,425 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateCloudVmClusterDetails(object):
+    """
+    Details for updating the cloud VM cluster.
+    """
+
+    #: A constant which can be used with the license_model property of a UpdateCloudVmClusterDetails.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a UpdateCloudVmClusterDetails.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateCloudVmClusterDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateCloudVmClusterDetails.
+        :type display_name: str
+
+        :param cpu_core_count:
+            The value to assign to the cpu_core_count property of this UpdateCloudVmClusterDetails.
+        :type cpu_core_count: int
+
+        :param license_model:
+            The value to assign to the license_model property of this UpdateCloudVmClusterDetails.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+        :type license_model: str
+
+        :param ssh_public_keys:
+            The value to assign to the ssh_public_keys property of this UpdateCloudVmClusterDetails.
+        :type ssh_public_keys: list[str]
+
+        :param update_details:
+            The value to assign to the update_details property of this UpdateCloudVmClusterDetails.
+        :type update_details: UpdateDetails
+
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this UpdateCloudVmClusterDetails.
+        :type nsg_ids: list[str]
+
+        :param backup_network_nsg_ids:
+            The value to assign to the backup_network_nsg_ids property of this UpdateCloudVmClusterDetails.
+        :type backup_network_nsg_ids: list[str]
+
+        :param compute_nodes:
+            The value to assign to the compute_nodes property of this UpdateCloudVmClusterDetails.
+        :type compute_nodes: list[str]
+
+        :param storage_size_in_gbs:
+            The value to assign to the storage_size_in_gbs property of this UpdateCloudVmClusterDetails.
+        :type storage_size_in_gbs: int
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateCloudVmClusterDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateCloudVmClusterDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'cpu_core_count': 'int',
+            'license_model': 'str',
+            'ssh_public_keys': 'list[str]',
+            'update_details': 'UpdateDetails',
+            'nsg_ids': 'list[str]',
+            'backup_network_nsg_ids': 'list[str]',
+            'compute_nodes': 'list[str]',
+            'storage_size_in_gbs': 'int',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'cpu_core_count': 'cpuCoreCount',
+            'license_model': 'licenseModel',
+            'ssh_public_keys': 'sshPublicKeys',
+            'update_details': 'updateDetails',
+            'nsg_ids': 'nsgIds',
+            'backup_network_nsg_ids': 'backupNetworkNsgIds',
+            'compute_nodes': 'computeNodes',
+            'storage_size_in_gbs': 'storageSizeInGBs',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._cpu_core_count = None
+        self._license_model = None
+        self._ssh_public_keys = None
+        self._update_details = None
+        self._nsg_ids = None
+        self._backup_network_nsg_ids = None
+        self._compute_nodes = None
+        self._storage_size_in_gbs = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateCloudVmClusterDetails.
+        The user-friendly name for the cloud VM cluster. The name does not need to be unique.
+
+
+        :return: The display_name of this UpdateCloudVmClusterDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateCloudVmClusterDetails.
+        The user-friendly name for the cloud VM cluster. The name does not need to be unique.
+
+
+        :param display_name: The display_name of this UpdateCloudVmClusterDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def cpu_core_count(self):
+        """
+        Gets the cpu_core_count of this UpdateCloudVmClusterDetails.
+        The number of CPU cores to enable for the cloud VM cluster.
+
+
+        :return: The cpu_core_count of this UpdateCloudVmClusterDetails.
+        :rtype: int
+        """
+        return self._cpu_core_count
+
+    @cpu_core_count.setter
+    def cpu_core_count(self, cpu_core_count):
+        """
+        Sets the cpu_core_count of this UpdateCloudVmClusterDetails.
+        The number of CPU cores to enable for the cloud VM cluster.
+
+
+        :param cpu_core_count: The cpu_core_count of this UpdateCloudVmClusterDetails.
+        :type: int
+        """
+        self._cpu_core_count = cpu_core_count
+
+    @property
+    def license_model(self):
+        """
+        Gets the license_model of this UpdateCloudVmClusterDetails.
+        The Oracle license model that applies to the cloud VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+
+
+        :return: The license_model of this UpdateCloudVmClusterDetails.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this UpdateCloudVmClusterDetails.
+        The Oracle license model that applies to the cloud VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+
+
+        :param license_model: The license_model of this UpdateCloudVmClusterDetails.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            raise ValueError(
+                "Invalid value for `license_model`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._license_model = license_model
+
+    @property
+    def ssh_public_keys(self):
+        """
+        Gets the ssh_public_keys of this UpdateCloudVmClusterDetails.
+        The public key portion of one or more key pairs used for SSH access to the cloud VM cluster.
+
+
+        :return: The ssh_public_keys of this UpdateCloudVmClusterDetails.
+        :rtype: list[str]
+        """
+        return self._ssh_public_keys
+
+    @ssh_public_keys.setter
+    def ssh_public_keys(self, ssh_public_keys):
+        """
+        Sets the ssh_public_keys of this UpdateCloudVmClusterDetails.
+        The public key portion of one or more key pairs used for SSH access to the cloud VM cluster.
+
+
+        :param ssh_public_keys: The ssh_public_keys of this UpdateCloudVmClusterDetails.
+        :type: list[str]
+        """
+        self._ssh_public_keys = ssh_public_keys
+
+    @property
+    def update_details(self):
+        """
+        Gets the update_details of this UpdateCloudVmClusterDetails.
+
+        :return: The update_details of this UpdateCloudVmClusterDetails.
+        :rtype: UpdateDetails
+        """
+        return self._update_details
+
+    @update_details.setter
+    def update_details(self, update_details):
+        """
+        Sets the update_details of this UpdateCloudVmClusterDetails.
+
+        :param update_details: The update_details of this UpdateCloudVmClusterDetails.
+        :type: UpdateDetails
+        """
+        self._update_details = update_details
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this UpdateCloudVmClusterDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+        **NsgIds restrictions:**
+        - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :return: The nsg_ids of this UpdateCloudVmClusterDetails.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this UpdateCloudVmClusterDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__.
+        **NsgIds restrictions:**
+        - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :param nsg_ids: The nsg_ids of this UpdateCloudVmClusterDetails.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
+
+    @property
+    def backup_network_nsg_ids(self):
+        """
+        Gets the backup_network_nsg_ids of this UpdateCloudVmClusterDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :return: The backup_network_nsg_ids of this UpdateCloudVmClusterDetails.
+        :rtype: list[str]
+        """
+        return self._backup_network_nsg_ids
+
+    @backup_network_nsg_ids.setter
+    def backup_network_nsg_ids(self, backup_network_nsg_ids):
+        """
+        Sets the backup_network_nsg_ids of this UpdateCloudVmClusterDetails.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
+
+
+        :param backup_network_nsg_ids: The backup_network_nsg_ids of this UpdateCloudVmClusterDetails.
+        :type: list[str]
+        """
+        self._backup_network_nsg_ids = backup_network_nsg_ids
+
+    @property
+    def compute_nodes(self):
+        """
+        Gets the compute_nodes of this UpdateCloudVmClusterDetails.
+        The list of compute servers to be added to the cloud VM cluster.
+
+
+        :return: The compute_nodes of this UpdateCloudVmClusterDetails.
+        :rtype: list[str]
+        """
+        return self._compute_nodes
+
+    @compute_nodes.setter
+    def compute_nodes(self, compute_nodes):
+        """
+        Sets the compute_nodes of this UpdateCloudVmClusterDetails.
+        The list of compute servers to be added to the cloud VM cluster.
+
+
+        :param compute_nodes: The compute_nodes of this UpdateCloudVmClusterDetails.
+        :type: list[str]
+        """
+        self._compute_nodes = compute_nodes
+
+    @property
+    def storage_size_in_gbs(self):
+        """
+        Gets the storage_size_in_gbs of this UpdateCloudVmClusterDetails.
+        The disk group size to be allocated in GBs.
+
+
+        :return: The storage_size_in_gbs of this UpdateCloudVmClusterDetails.
+        :rtype: int
+        """
+        return self._storage_size_in_gbs
+
+    @storage_size_in_gbs.setter
+    def storage_size_in_gbs(self, storage_size_in_gbs):
+        """
+        Sets the storage_size_in_gbs of this UpdateCloudVmClusterDetails.
+        The disk group size to be allocated in GBs.
+
+
+        :param storage_size_in_gbs: The storage_size_in_gbs of this UpdateCloudVmClusterDetails.
+        :type: int
+        """
+        self._storage_size_in_gbs = storage_size_in_gbs
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateCloudVmClusterDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateCloudVmClusterDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateCloudVmClusterDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateCloudVmClusterDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateCloudVmClusterDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateCloudVmClusterDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateCloudVmClusterDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateCloudVmClusterDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_db_system_details.py
+++ b/src/oci/database/models/update_db_system_details.py
@@ -338,7 +338,7 @@ class UpdateDbSystemDetails(object):
     def backup_network_nsg_ids(self):
         """
         Gets the backup_network_nsg_ids of this UpdateDbSystemDetails.
-        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata DB systems.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
         __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm
@@ -353,7 +353,7 @@ class UpdateDbSystemDetails(object):
     def backup_network_nsg_ids(self, backup_network_nsg_ids):
         """
         Sets the backup_network_nsg_ids of this UpdateDbSystemDetails.
-        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata DB systems.
+        A list of the `OCIDs`__ of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see `Security Rules`__. Applicable only to Exadata systems.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
         __ https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm

--- a/src/oci/database/models/update_details.py
+++ b/src/oci/database/models/update_details.py
@@ -1,0 +1,126 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateDetails(object):
+    """
+    Details specifying which maintenance update to apply to the target and which actions are to be performed by the maintenance update.
+    """
+
+    #: A constant which can be used with the update_action property of a UpdateDetails.
+    #: This constant has a value of "ROLLING_APPLY"
+    UPDATE_ACTION_ROLLING_APPLY = "ROLLING_APPLY"
+
+    #: A constant which can be used with the update_action property of a UpdateDetails.
+    #: This constant has a value of "NON_ROLLING_APPLY"
+    UPDATE_ACTION_NON_ROLLING_APPLY = "NON_ROLLING_APPLY"
+
+    #: A constant which can be used with the update_action property of a UpdateDetails.
+    #: This constant has a value of "PRECHECK"
+    UPDATE_ACTION_PRECHECK = "PRECHECK"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param update_id:
+            The value to assign to the update_id property of this UpdateDetails.
+        :type update_id: str
+
+        :param update_action:
+            The value to assign to the update_action property of this UpdateDetails.
+            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"
+        :type update_action: str
+
+        """
+        self.swagger_types = {
+            'update_id': 'str',
+            'update_action': 'str'
+        }
+
+        self.attribute_map = {
+            'update_id': 'updateId',
+            'update_action': 'updateAction'
+        }
+
+        self._update_id = None
+        self._update_action = None
+
+    @property
+    def update_id(self):
+        """
+        Gets the update_id of this UpdateDetails.
+        The `OCID`__ of the maintenance update.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The update_id of this UpdateDetails.
+        :rtype: str
+        """
+        return self._update_id
+
+    @update_id.setter
+    def update_id(self, update_id):
+        """
+        Sets the update_id of this UpdateDetails.
+        The `OCID`__ of the maintenance update.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param update_id: The update_id of this UpdateDetails.
+        :type: str
+        """
+        self._update_id = update_id
+
+    @property
+    def update_action(self):
+        """
+        Gets the update_action of this UpdateDetails.
+        The update action.
+
+        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"
+
+
+        :return: The update_action of this UpdateDetails.
+        :rtype: str
+        """
+        return self._update_action
+
+    @update_action.setter
+    def update_action(self, update_action):
+        """
+        Sets the update_action of this UpdateDetails.
+        The update action.
+
+
+        :param update_action: The update_action of this UpdateDetails.
+        :type: str
+        """
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        if not value_allowed_none_or_none_sentinel(update_action, allowed_values):
+            raise ValueError(
+                "Invalid value for `update_action`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._update_action = update_action
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_exadata_infrastructure_details.py
+++ b/src/oci/database/models/update_exadata_infrastructure_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateExadataInfrastructureDetails(object):
     """
-    Updates the Exadata infrastructure.
+    Updates the Exadata Cloud@Customer infrastructure.
     """
 
     def __init__(self, **kwargs):
@@ -289,7 +289,7 @@ class UpdateExadataInfrastructureDetails(object):
     def contacts(self):
         """
         Gets the contacts of this UpdateExadataInfrastructureDetails.
-        The list of contacts for the Exadata Infrastructure.
+        The list of contacts for the Exadata infrastructure.
 
 
         :return: The contacts of this UpdateExadataInfrastructureDetails.
@@ -301,7 +301,7 @@ class UpdateExadataInfrastructureDetails(object):
     def contacts(self, contacts):
         """
         Sets the contacts of this UpdateExadataInfrastructureDetails.
-        The list of contacts for the Exadata Infrastructure.
+        The list of contacts for the Exadata infrastructure.
 
 
         :param contacts: The contacts of this UpdateExadataInfrastructureDetails.

--- a/src/oci/database/models/update_history_entry.py
+++ b/src/oci/database/models/update_history_entry.py
@@ -1,0 +1,347 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateHistoryEntry(object):
+    """
+    UpdateHistoryEntry model.
+    """
+
+    #: A constant which can be used with the update_action property of a UpdateHistoryEntry.
+    #: This constant has a value of "ROLLING_APPLY"
+    UPDATE_ACTION_ROLLING_APPLY = "ROLLING_APPLY"
+
+    #: A constant which can be used with the update_action property of a UpdateHistoryEntry.
+    #: This constant has a value of "NON_ROLLING_APPLY"
+    UPDATE_ACTION_NON_ROLLING_APPLY = "NON_ROLLING_APPLY"
+
+    #: A constant which can be used with the update_action property of a UpdateHistoryEntry.
+    #: This constant has a value of "PRECHECK"
+    UPDATE_ACTION_PRECHECK = "PRECHECK"
+
+    #: A constant which can be used with the update_type property of a UpdateHistoryEntry.
+    #: This constant has a value of "GI_PATCH"
+    UPDATE_TYPE_GI_PATCH = "GI_PATCH"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateHistoryEntry.
+    #: This constant has a value of "IN_PROGRESS"
+    LIFECYCLE_STATE_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateHistoryEntry.
+    #: This constant has a value of "SUCCEEDED"
+    LIFECYCLE_STATE_SUCCEEDED = "SUCCEEDED"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateHistoryEntry.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateHistoryEntry object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this UpdateHistoryEntry.
+        :type id: str
+
+        :param update_id:
+            The value to assign to the update_id property of this UpdateHistoryEntry.
+        :type update_id: str
+
+        :param update_action:
+            The value to assign to the update_action property of this UpdateHistoryEntry.
+            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type update_action: str
+
+        :param update_type:
+            The value to assign to the update_type property of this UpdateHistoryEntry.
+            Allowed values for this property are: "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type update_type: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this UpdateHistoryEntry.
+            Allowed values for this property are: "IN_PROGRESS", "SUCCEEDED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this UpdateHistoryEntry.
+        :type lifecycle_details: str
+
+        :param time_started:
+            The value to assign to the time_started property of this UpdateHistoryEntry.
+        :type time_started: datetime
+
+        :param time_completed:
+            The value to assign to the time_completed property of this UpdateHistoryEntry.
+        :type time_completed: datetime
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'update_id': 'str',
+            'update_action': 'str',
+            'update_type': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'time_started': 'datetime',
+            'time_completed': 'datetime'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'update_id': 'updateId',
+            'update_action': 'updateAction',
+            'update_type': 'updateType',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_started': 'timeStarted',
+            'time_completed': 'timeCompleted'
+        }
+
+        self._id = None
+        self._update_id = None
+        self._update_action = None
+        self._update_type = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._time_started = None
+        self._time_completed = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this UpdateHistoryEntry.
+        The `OCID`__ of the maintenance update history entry.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this UpdateHistoryEntry.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this UpdateHistoryEntry.
+        The `OCID`__ of the maintenance update history entry.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this UpdateHistoryEntry.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def update_id(self):
+        """
+        **[Required]** Gets the update_id of this UpdateHistoryEntry.
+        The `OCID`__ of the maintenance update.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The update_id of this UpdateHistoryEntry.
+        :rtype: str
+        """
+        return self._update_id
+
+    @update_id.setter
+    def update_id(self, update_id):
+        """
+        Sets the update_id of this UpdateHistoryEntry.
+        The `OCID`__ of the maintenance update.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param update_id: The update_id of this UpdateHistoryEntry.
+        :type: str
+        """
+        self._update_id = update_id
+
+    @property
+    def update_action(self):
+        """
+        Gets the update_action of this UpdateHistoryEntry.
+        The update action.
+
+        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The update_action of this UpdateHistoryEntry.
+        :rtype: str
+        """
+        return self._update_action
+
+    @update_action.setter
+    def update_action(self, update_action):
+        """
+        Sets the update_action of this UpdateHistoryEntry.
+        The update action.
+
+
+        :param update_action: The update_action of this UpdateHistoryEntry.
+        :type: str
+        """
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        if not value_allowed_none_or_none_sentinel(update_action, allowed_values):
+            update_action = 'UNKNOWN_ENUM_VALUE'
+        self._update_action = update_action
+
+    @property
+    def update_type(self):
+        """
+        **[Required]** Gets the update_type of this UpdateHistoryEntry.
+        The type of cloud VM cluster maintenance update.
+
+        Allowed values for this property are: "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The update_type of this UpdateHistoryEntry.
+        :rtype: str
+        """
+        return self._update_type
+
+    @update_type.setter
+    def update_type(self, update_type):
+        """
+        Sets the update_type of this UpdateHistoryEntry.
+        The type of cloud VM cluster maintenance update.
+
+
+        :param update_type: The update_type of this UpdateHistoryEntry.
+        :type: str
+        """
+        allowed_values = ["GI_PATCH"]
+        if not value_allowed_none_or_none_sentinel(update_type, allowed_values):
+            update_type = 'UNKNOWN_ENUM_VALUE'
+        self._update_type = update_type
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this UpdateHistoryEntry.
+        The current lifecycle state of the maintenance update operation.
+
+        Allowed values for this property are: "IN_PROGRESS", "SUCCEEDED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this UpdateHistoryEntry.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this UpdateHistoryEntry.
+        The current lifecycle state of the maintenance update operation.
+
+
+        :param lifecycle_state: The lifecycle_state of this UpdateHistoryEntry.
+        :type: str
+        """
+        allowed_values = ["IN_PROGRESS", "SUCCEEDED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this UpdateHistoryEntry.
+        Descriptive text providing additional details about the lifecycle state.
+
+
+        :return: The lifecycle_details of this UpdateHistoryEntry.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this UpdateHistoryEntry.
+        Descriptive text providing additional details about the lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this UpdateHistoryEntry.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def time_started(self):
+        """
+        **[Required]** Gets the time_started of this UpdateHistoryEntry.
+        The date and time when the maintenance update action started.
+
+
+        :return: The time_started of this UpdateHistoryEntry.
+        :rtype: datetime
+        """
+        return self._time_started
+
+    @time_started.setter
+    def time_started(self, time_started):
+        """
+        Sets the time_started of this UpdateHistoryEntry.
+        The date and time when the maintenance update action started.
+
+
+        :param time_started: The time_started of this UpdateHistoryEntry.
+        :type: datetime
+        """
+        self._time_started = time_started
+
+    @property
+    def time_completed(self):
+        """
+        Gets the time_completed of this UpdateHistoryEntry.
+        The date and time when the maintenance update action completed.
+
+
+        :return: The time_completed of this UpdateHistoryEntry.
+        :rtype: datetime
+        """
+        return self._time_completed
+
+    @time_completed.setter
+    def time_completed(self, time_completed):
+        """
+        Sets the time_completed of this UpdateHistoryEntry.
+        The date and time when the maintenance update action completed.
+
+
+        :param time_completed: The time_completed of this UpdateHistoryEntry.
+        :type: datetime
+        """
+        self._time_completed = time_completed
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_history_entry_summary.py
+++ b/src/oci/database/models/update_history_entry_summary.py
@@ -1,0 +1,347 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateHistoryEntrySummary(object):
+    """
+    The record of an update action on a specified target.
+    """
+
+    #: A constant which can be used with the update_action property of a UpdateHistoryEntrySummary.
+    #: This constant has a value of "ROLLING_APPLY"
+    UPDATE_ACTION_ROLLING_APPLY = "ROLLING_APPLY"
+
+    #: A constant which can be used with the update_action property of a UpdateHistoryEntrySummary.
+    #: This constant has a value of "NON_ROLLING_APPLY"
+    UPDATE_ACTION_NON_ROLLING_APPLY = "NON_ROLLING_APPLY"
+
+    #: A constant which can be used with the update_action property of a UpdateHistoryEntrySummary.
+    #: This constant has a value of "PRECHECK"
+    UPDATE_ACTION_PRECHECK = "PRECHECK"
+
+    #: A constant which can be used with the update_type property of a UpdateHistoryEntrySummary.
+    #: This constant has a value of "GI_PATCH"
+    UPDATE_TYPE_GI_PATCH = "GI_PATCH"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateHistoryEntrySummary.
+    #: This constant has a value of "IN_PROGRESS"
+    LIFECYCLE_STATE_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateHistoryEntrySummary.
+    #: This constant has a value of "SUCCEEDED"
+    LIFECYCLE_STATE_SUCCEEDED = "SUCCEEDED"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateHistoryEntrySummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateHistoryEntrySummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this UpdateHistoryEntrySummary.
+        :type id: str
+
+        :param update_id:
+            The value to assign to the update_id property of this UpdateHistoryEntrySummary.
+        :type update_id: str
+
+        :param update_action:
+            The value to assign to the update_action property of this UpdateHistoryEntrySummary.
+            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type update_action: str
+
+        :param update_type:
+            The value to assign to the update_type property of this UpdateHistoryEntrySummary.
+            Allowed values for this property are: "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type update_type: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this UpdateHistoryEntrySummary.
+            Allowed values for this property are: "IN_PROGRESS", "SUCCEEDED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this UpdateHistoryEntrySummary.
+        :type lifecycle_details: str
+
+        :param time_started:
+            The value to assign to the time_started property of this UpdateHistoryEntrySummary.
+        :type time_started: datetime
+
+        :param time_completed:
+            The value to assign to the time_completed property of this UpdateHistoryEntrySummary.
+        :type time_completed: datetime
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'update_id': 'str',
+            'update_action': 'str',
+            'update_type': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'time_started': 'datetime',
+            'time_completed': 'datetime'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'update_id': 'updateId',
+            'update_action': 'updateAction',
+            'update_type': 'updateType',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_started': 'timeStarted',
+            'time_completed': 'timeCompleted'
+        }
+
+        self._id = None
+        self._update_id = None
+        self._update_action = None
+        self._update_type = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._time_started = None
+        self._time_completed = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this UpdateHistoryEntrySummary.
+        The `OCID`__ of the maintenance update history entry.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this UpdateHistoryEntrySummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this UpdateHistoryEntrySummary.
+        The `OCID`__ of the maintenance update history entry.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this UpdateHistoryEntrySummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def update_id(self):
+        """
+        **[Required]** Gets the update_id of this UpdateHistoryEntrySummary.
+        The `OCID`__ of the maintenance update.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The update_id of this UpdateHistoryEntrySummary.
+        :rtype: str
+        """
+        return self._update_id
+
+    @update_id.setter
+    def update_id(self, update_id):
+        """
+        Sets the update_id of this UpdateHistoryEntrySummary.
+        The `OCID`__ of the maintenance update.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param update_id: The update_id of this UpdateHistoryEntrySummary.
+        :type: str
+        """
+        self._update_id = update_id
+
+    @property
+    def update_action(self):
+        """
+        Gets the update_action of this UpdateHistoryEntrySummary.
+        The update action.
+
+        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The update_action of this UpdateHistoryEntrySummary.
+        :rtype: str
+        """
+        return self._update_action
+
+    @update_action.setter
+    def update_action(self, update_action):
+        """
+        Sets the update_action of this UpdateHistoryEntrySummary.
+        The update action.
+
+
+        :param update_action: The update_action of this UpdateHistoryEntrySummary.
+        :type: str
+        """
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        if not value_allowed_none_or_none_sentinel(update_action, allowed_values):
+            update_action = 'UNKNOWN_ENUM_VALUE'
+        self._update_action = update_action
+
+    @property
+    def update_type(self):
+        """
+        **[Required]** Gets the update_type of this UpdateHistoryEntrySummary.
+        The type of cloud VM cluster maintenance update.
+
+        Allowed values for this property are: "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The update_type of this UpdateHistoryEntrySummary.
+        :rtype: str
+        """
+        return self._update_type
+
+    @update_type.setter
+    def update_type(self, update_type):
+        """
+        Sets the update_type of this UpdateHistoryEntrySummary.
+        The type of cloud VM cluster maintenance update.
+
+
+        :param update_type: The update_type of this UpdateHistoryEntrySummary.
+        :type: str
+        """
+        allowed_values = ["GI_PATCH"]
+        if not value_allowed_none_or_none_sentinel(update_type, allowed_values):
+            update_type = 'UNKNOWN_ENUM_VALUE'
+        self._update_type = update_type
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this UpdateHistoryEntrySummary.
+        The current lifecycle state of the maintenance update operation.
+
+        Allowed values for this property are: "IN_PROGRESS", "SUCCEEDED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this UpdateHistoryEntrySummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this UpdateHistoryEntrySummary.
+        The current lifecycle state of the maintenance update operation.
+
+
+        :param lifecycle_state: The lifecycle_state of this UpdateHistoryEntrySummary.
+        :type: str
+        """
+        allowed_values = ["IN_PROGRESS", "SUCCEEDED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this UpdateHistoryEntrySummary.
+        Descriptive text providing additional details about the lifecycle state.
+
+
+        :return: The lifecycle_details of this UpdateHistoryEntrySummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this UpdateHistoryEntrySummary.
+        Descriptive text providing additional details about the lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this UpdateHistoryEntrySummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def time_started(self):
+        """
+        **[Required]** Gets the time_started of this UpdateHistoryEntrySummary.
+        The date and time when the maintenance update action started.
+
+
+        :return: The time_started of this UpdateHistoryEntrySummary.
+        :rtype: datetime
+        """
+        return self._time_started
+
+    @time_started.setter
+    def time_started(self, time_started):
+        """
+        Sets the time_started of this UpdateHistoryEntrySummary.
+        The date and time when the maintenance update action started.
+
+
+        :param time_started: The time_started of this UpdateHistoryEntrySummary.
+        :type: datetime
+        """
+        self._time_started = time_started
+
+    @property
+    def time_completed(self):
+        """
+        Gets the time_completed of this UpdateHistoryEntrySummary.
+        The date and time when the maintenance update action completed.
+
+
+        :return: The time_completed of this UpdateHistoryEntrySummary.
+        :rtype: datetime
+        """
+        return self._time_completed
+
+    @time_completed.setter
+    def time_completed(self, time_completed):
+        """
+        Sets the time_completed of this UpdateHistoryEntrySummary.
+        The date and time when the maintenance update action completed.
+
+
+        :param time_completed: The time_completed of this UpdateHistoryEntrySummary.
+        :type: datetime
+        """
+        self._time_completed = time_completed
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_summary.py
+++ b/src/oci/database/models/update_summary.py
@@ -1,0 +1,404 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateSummary(object):
+    """
+    A maintenance update for a cloud VM cluster.
+
+    To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
+    talk to an administrator. If you're an administrator who needs to write policies to give users access,
+    see `Getting Started with Policies`__.
+
+    __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
+    """
+
+    #: A constant which can be used with the last_action property of a UpdateSummary.
+    #: This constant has a value of "ROLLING_APPLY"
+    LAST_ACTION_ROLLING_APPLY = "ROLLING_APPLY"
+
+    #: A constant which can be used with the last_action property of a UpdateSummary.
+    #: This constant has a value of "NON_ROLLING_APPLY"
+    LAST_ACTION_NON_ROLLING_APPLY = "NON_ROLLING_APPLY"
+
+    #: A constant which can be used with the last_action property of a UpdateSummary.
+    #: This constant has a value of "PRECHECK"
+    LAST_ACTION_PRECHECK = "PRECHECK"
+
+    #: A constant which can be used with the available_actions property of a UpdateSummary.
+    #: This constant has a value of "ROLLING_APPLY"
+    AVAILABLE_ACTIONS_ROLLING_APPLY = "ROLLING_APPLY"
+
+    #: A constant which can be used with the available_actions property of a UpdateSummary.
+    #: This constant has a value of "NON_ROLLING_APPLY"
+    AVAILABLE_ACTIONS_NON_ROLLING_APPLY = "NON_ROLLING_APPLY"
+
+    #: A constant which can be used with the available_actions property of a UpdateSummary.
+    #: This constant has a value of "PRECHECK"
+    AVAILABLE_ACTIONS_PRECHECK = "PRECHECK"
+
+    #: A constant which can be used with the update_type property of a UpdateSummary.
+    #: This constant has a value of "GI_PATCH"
+    UPDATE_TYPE_GI_PATCH = "GI_PATCH"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateSummary.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateSummary.
+    #: This constant has a value of "SUCCESS"
+    LIFECYCLE_STATE_SUCCESS = "SUCCESS"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateSummary.
+    #: This constant has a value of "IN_PROGRESS"
+    LIFECYCLE_STATE_IN_PROGRESS = "IN_PROGRESS"
+
+    #: A constant which can be used with the lifecycle_state property of a UpdateSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this UpdateSummary.
+        :type id: str
+
+        :param description:
+            The value to assign to the description property of this UpdateSummary.
+        :type description: str
+
+        :param last_action:
+            The value to assign to the last_action property of this UpdateSummary.
+            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type last_action: str
+
+        :param available_actions:
+            The value to assign to the available_actions property of this UpdateSummary.
+            Allowed values for items in this list are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type available_actions: list[str]
+
+        :param update_type:
+            The value to assign to the update_type property of this UpdateSummary.
+            Allowed values for this property are: "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type update_type: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this UpdateSummary.
+        :type lifecycle_details: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this UpdateSummary.
+            Allowed values for this property are: "AVAILABLE", "SUCCESS", "IN_PROGRESS", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param time_released:
+            The value to assign to the time_released property of this UpdateSummary.
+        :type time_released: datetime
+
+        :param version:
+            The value to assign to the version property of this UpdateSummary.
+        :type version: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'description': 'str',
+            'last_action': 'str',
+            'available_actions': 'list[str]',
+            'update_type': 'str',
+            'lifecycle_details': 'str',
+            'lifecycle_state': 'str',
+            'time_released': 'datetime',
+            'version': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'description': 'description',
+            'last_action': 'lastAction',
+            'available_actions': 'availableActions',
+            'update_type': 'updateType',
+            'lifecycle_details': 'lifecycleDetails',
+            'lifecycle_state': 'lifecycleState',
+            'time_released': 'timeReleased',
+            'version': 'version'
+        }
+
+        self._id = None
+        self._description = None
+        self._last_action = None
+        self._available_actions = None
+        self._update_type = None
+        self._lifecycle_details = None
+        self._lifecycle_state = None
+        self._time_released = None
+        self._version = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this UpdateSummary.
+        The `OCID`__ of the maintenance update.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this UpdateSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this UpdateSummary.
+        The `OCID`__ of the maintenance update.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this UpdateSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def description(self):
+        """
+        **[Required]** Gets the description of this UpdateSummary.
+        Details of the maintenance update package.
+
+
+        :return: The description of this UpdateSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this UpdateSummary.
+        Details of the maintenance update package.
+
+
+        :param description: The description of this UpdateSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def last_action(self):
+        """
+        Gets the last_action of this UpdateSummary.
+        The update action.
+
+        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The last_action of this UpdateSummary.
+        :rtype: str
+        """
+        return self._last_action
+
+    @last_action.setter
+    def last_action(self, last_action):
+        """
+        Sets the last_action of this UpdateSummary.
+        The update action.
+
+
+        :param last_action: The last_action of this UpdateSummary.
+        :type: str
+        """
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        if not value_allowed_none_or_none_sentinel(last_action, allowed_values):
+            last_action = 'UNKNOWN_ENUM_VALUE'
+        self._last_action = last_action
+
+    @property
+    def available_actions(self):
+        """
+        Gets the available_actions of this UpdateSummary.
+        The possible actions performed by the update operation on the infrastructure components.
+
+        Allowed values for items in this list are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The available_actions of this UpdateSummary.
+        :rtype: list[str]
+        """
+        return self._available_actions
+
+    @available_actions.setter
+    def available_actions(self, available_actions):
+        """
+        Sets the available_actions of this UpdateSummary.
+        The possible actions performed by the update operation on the infrastructure components.
+
+
+        :param available_actions: The available_actions of this UpdateSummary.
+        :type: list[str]
+        """
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        if available_actions:
+            available_actions[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in available_actions]
+        self._available_actions = available_actions
+
+    @property
+    def update_type(self):
+        """
+        **[Required]** Gets the update_type of this UpdateSummary.
+        The type of cloud VM cluster maintenance update.
+
+        Allowed values for this property are: "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The update_type of this UpdateSummary.
+        :rtype: str
+        """
+        return self._update_type
+
+    @update_type.setter
+    def update_type(self, update_type):
+        """
+        Sets the update_type of this UpdateSummary.
+        The type of cloud VM cluster maintenance update.
+
+
+        :param update_type: The update_type of this UpdateSummary.
+        :type: str
+        """
+        allowed_values = ["GI_PATCH"]
+        if not value_allowed_none_or_none_sentinel(update_type, allowed_values):
+            update_type = 'UNKNOWN_ENUM_VALUE'
+        self._update_type = update_type
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this UpdateSummary.
+        Descriptive text providing additional details about the lifecycle state.
+
+
+        :return: The lifecycle_details of this UpdateSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this UpdateSummary.
+        Descriptive text providing additional details about the lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this UpdateSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this UpdateSummary.
+        The current state of the maintenance update. Dependent on value of `lastAction`.
+
+        Allowed values for this property are: "AVAILABLE", "SUCCESS", "IN_PROGRESS", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this UpdateSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this UpdateSummary.
+        The current state of the maintenance update. Dependent on value of `lastAction`.
+
+
+        :param lifecycle_state: The lifecycle_state of this UpdateSummary.
+        :type: str
+        """
+        allowed_values = ["AVAILABLE", "SUCCESS", "IN_PROGRESS", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def time_released(self):
+        """
+        **[Required]** Gets the time_released of this UpdateSummary.
+        The date and time the maintenance update was released.
+
+
+        :return: The time_released of this UpdateSummary.
+        :rtype: datetime
+        """
+        return self._time_released
+
+    @time_released.setter
+    def time_released(self, time_released):
+        """
+        Sets the time_released of this UpdateSummary.
+        The date and time the maintenance update was released.
+
+
+        :param time_released: The time_released of this UpdateSummary.
+        :type: datetime
+        """
+        self._time_released = time_released
+
+    @property
+    def version(self):
+        """
+        **[Required]** Gets the version of this UpdateSummary.
+        The version of the maintenance update package.
+
+
+        :return: The version of this UpdateSummary.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this UpdateSummary.
+        The version of the maintenance update package.
+
+
+        :param version: The version of this UpdateSummary.
+        :type: str
+        """
+        self._version = version
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_vm_cluster_details.py
+++ b/src/oci/database/models/update_vm_cluster_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateVmClusterDetails(object):
     """
-    Details for updating the VM cluster.
+    Details for updating the Exadata Cloud@Customer VM cluster.
     """
 
     #: A constant which can be used with the license_model property of a UpdateVmClusterDetails.

--- a/src/oci/database/models/update_vm_cluster_network_details.py
+++ b/src/oci/database/models/update_vm_cluster_network_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateVmClusterNetworkDetails(object):
     """
-    Details for a VM cluster network.
+    Details for an Exadata Cloud@Customer VM cluster network.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/database/models/vm_cluster.py
+++ b/src/oci/database/models/vm_cluster.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class VmCluster(object):
     """
-    Details of the VM cluster.
+    Details of the Exadata Cloud@Customer VM cluster.
     """
 
     #: A constant which can be used with the lifecycle_state property of a VmCluster.
@@ -334,7 +334,7 @@ class VmCluster(object):
     def display_name(self):
         """
         Gets the display_name of this VmCluster.
-        The user-friendly name for the VM cluster. The name does not need to be unique.
+        The user-friendly name for the Exadata Cloud@Customer VM cluster. The name does not need to be unique.
 
 
         :return: The display_name of this VmCluster.
@@ -346,7 +346,7 @@ class VmCluster(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this VmCluster.
-        The user-friendly name for the VM cluster. The name does not need to be unique.
+        The user-friendly name for the Exadata Cloud@Customer VM cluster. The name does not need to be unique.
 
 
         :param display_name: The display_name of this VmCluster.

--- a/src/oci/database/models/vm_cluster_network_details.py
+++ b/src/oci/database/models/vm_cluster_network_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class VmClusterNetworkDetails(object):
     """
-    Details for a VM cluster network.
+    Details for an Exadata Cloud@Customer VM cluster network.
     """
 
     def __init__(self, **kwargs):
@@ -114,7 +114,7 @@ class VmClusterNetworkDetails(object):
     def display_name(self):
         """
         **[Required]** Gets the display_name of this VmClusterNetworkDetails.
-        The user-friendly name for the VM cluster network. The name does not need to be unique.
+        The user-friendly name for the Exadata Cloud@Customer VM cluster network. The name does not need to be unique.
 
 
         :return: The display_name of this VmClusterNetworkDetails.
@@ -126,7 +126,7 @@ class VmClusterNetworkDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this VmClusterNetworkDetails.
-        The user-friendly name for the VM cluster network. The name does not need to be unique.
+        The user-friendly name for the Exadata Cloud@Customer VM cluster network. The name does not need to be unique.
 
 
         :param display_name: The display_name of this VmClusterNetworkDetails.

--- a/src/oci/database/models/vm_cluster_network_summary.py
+++ b/src/oci/database/models/vm_cluster_network_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class VmClusterNetworkSummary(object):
     """
-    Details of the VM cluster network.
+    Details of the Exadata Cloud@Customer VM cluster network.
     """
 
     #: A constant which can be used with the lifecycle_state property of a VmClusterNetworkSummary.

--- a/src/oci/database/models/vm_cluster_summary.py
+++ b/src/oci/database/models/vm_cluster_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class VmClusterSummary(object):
     """
-    Details of the VM cluster.
+    Details of the Exadata Cloud@Customer VM cluster.
     """
 
     #: A constant which can be used with the lifecycle_state property of a VmClusterSummary.
@@ -334,7 +334,7 @@ class VmClusterSummary(object):
     def display_name(self):
         """
         Gets the display_name of this VmClusterSummary.
-        The user-friendly name for the VM cluster. The name does not need to be unique.
+        The user-friendly name for the Exadata Cloud@Customer VM cluster. The name does not need to be unique.
 
 
         :return: The display_name of this VmClusterSummary.
@@ -346,7 +346,7 @@ class VmClusterSummary(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this VmClusterSummary.
-        The user-friendly name for the VM cluster. The name does not need to be unique.
+        The user-friendly name for the Exadata Cloud@Customer VM cluster. The name does not need to be unique.
 
 
         :param display_name: The display_name of this VmClusterSummary.

--- a/src/oci/database/models/vm_network_details.py
+++ b/src/oci/database/models/vm_network_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class VmNetworkDetails(object):
     """
-    Details of the client or backup networks in a VM cluster network.
+    Details of the client or backup networks in an Exadata Cloud@Customer VM cluster network.
     """
 
     #: A constant which can be used with the network_type property of a VmNetworkDetails.

--- a/src/oci/marketplace/marketplace_client.py
+++ b/src/oci/marketplace/marketplace_client.py
@@ -170,7 +170,7 @@ class MarketplaceClient(object):
             The unique identifier for the accepted terms of use agreement.
 
         :param str signature: (optional)
-            Deprecated. The signature value is ignored.
+            Previously, the signature generated for the listing package terms of use agreement, but now deprecated and ignored.
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
@@ -1500,6 +1500,90 @@ class MarketplaceClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="ReportCollection")
+
+    def list_taxes(self, listing_id, **kwargs):
+        """
+        Returns list of all tax implications that current tenant may be liable to once they launch the listing.
+
+
+        :param str listing_id: (required)
+            The unique identifier for the listing.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param str compartment_id: (optional)
+            The unique identifier for the compartment.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.marketplace.models.TaxSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/listings/{listingId}/taxes"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "compartment_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_taxes got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "listingId": listing_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "compartmentId": kwargs.get("compartment_id", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[TaxSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[TaxSummary]")
 
     def update_accepted_agreement(self, accepted_agreement_id, update_accepted_agreement_details, **kwargs):
         """

--- a/src/oci/marketplace/models/__init__.py
+++ b/src/oci/marketplace/models/__init__.py
@@ -32,6 +32,7 @@ from .report_type_collection import ReportTypeCollection
 from .report_type_summary import ReportTypeSummary
 from .screenshot import Screenshot
 from .support_contact import SupportContact
+from .tax_summary import TaxSummary
 from .update_accepted_agreement_details import UpdateAcceptedAgreementDetails
 from .upload_data import UploadData
 
@@ -65,6 +66,7 @@ marketplace_type_mapping = {
     "ReportTypeSummary": ReportTypeSummary,
     "Screenshot": Screenshot,
     "SupportContact": SupportContact,
+    "TaxSummary": TaxSummary,
     "UpdateAcceptedAgreementDetails": UpdateAcceptedAgreementDetails,
     "UploadData": UploadData
 }

--- a/src/oci/marketplace/models/image_listing_package.py
+++ b/src/oci/marketplace/models/image_listing_package.py
@@ -162,7 +162,7 @@ class ImageListingPackage(ListingPackage):
     def image_id(self):
         """
         Gets the image_id of this ImageListingPackage.
-        The id of the image corresponding to the package.
+        The ID of the image corresponding to the package.
 
 
         :return: The image_id of this ImageListingPackage.
@@ -174,7 +174,7 @@ class ImageListingPackage(ListingPackage):
     def image_id(self, image_id):
         """
         Sets the image_id of this ImageListingPackage.
-        The id of the image corresponding to the package.
+        The ID of the image corresponding to the package.
 
 
         :param image_id: The image_id of this ImageListingPackage.
@@ -186,7 +186,7 @@ class ImageListingPackage(ListingPackage):
     def regions(self):
         """
         Gets the regions of this ImageListingPackage.
-        List of regions in which this ListingPackage is available.
+        The regions where you can deploy the listing package. (Some packages have restrictions that limit their deployment to United States regions only.)
 
 
         :return: The regions of this ImageListingPackage.
@@ -198,7 +198,7 @@ class ImageListingPackage(ListingPackage):
     def regions(self, regions):
         """
         Sets the regions of this ImageListingPackage.
-        List of regions in which this ListingPackage is available.
+        The regions where you can deploy the listing package. (Some packages have restrictions that limit their deployment to United States regions only.)
 
 
         :param regions: The regions of this ImageListingPackage.

--- a/src/oci/marketplace/models/listing.py
+++ b/src/oci/marketplace/models/listing.py
@@ -745,7 +745,7 @@ class Listing(object):
     def regions(self):
         """
         Gets the regions of this Listing.
-        The regions where the listing is eligible to be deployed.
+        The regions where you can deploy the listing. (Some listings have restrictions that limit their deployment to United States regions only.)
 
 
         :return: The regions of this Listing.
@@ -757,7 +757,7 @@ class Listing(object):
     def regions(self, regions):
         """
         Sets the regions of this Listing.
-        The regions where the listing is eligible to be deployed.
+        The regions where you can deploy the listing. (Some listings have restrictions that limit their deployment to United States regions only.)
 
 
         :param regions: The regions of this Listing.

--- a/src/oci/marketplace/models/listing_package_summary.py
+++ b/src/oci/marketplace/models/listing_package_summary.py
@@ -82,7 +82,7 @@ class ListingPackageSummary(object):
     def listing_id(self):
         """
         Gets the listing_id of this ListingPackageSummary.
-        The id of the listing the specified package belongs to.
+        The ID of the listing that the specified package belongs to.
 
 
         :return: The listing_id of this ListingPackageSummary.
@@ -94,7 +94,7 @@ class ListingPackageSummary(object):
     def listing_id(self, listing_id):
         """
         Sets the listing_id of this ListingPackageSummary.
-        The id of the listing the specified package belongs to.
+        The ID of the listing that the specified package belongs to.
 
 
         :param listing_id: The listing_id of this ListingPackageSummary.
@@ -160,7 +160,7 @@ class ListingPackageSummary(object):
     def regions(self):
         """
         Gets the regions of this ListingPackageSummary.
-        The regions where the package is eligible to be deployed.
+        The regions where you can deploy the listing package. (Some packages have restrictions that limit their deployment to United States regions only.)
 
 
         :return: The regions of this ListingPackageSummary.
@@ -172,7 +172,7 @@ class ListingPackageSummary(object):
     def regions(self, regions):
         """
         Sets the regions of this ListingPackageSummary.
-        The regions where the package is eligible to be deployed.
+        The regions where you can deploy the listing package. (Some packages have restrictions that limit their deployment to United States regions only.)
 
 
         :param regions: The regions of this ListingPackageSummary.

--- a/src/oci/marketplace/models/listing_summary.py
+++ b/src/oci/marketplace/models/listing_summary.py
@@ -307,7 +307,7 @@ class ListingSummary(object):
     def regions(self):
         """
         Gets the regions of this ListingSummary.
-        The regions where the listing is eligible to be deployed.
+        The regions where you can deploy the listing. (Some listings have restrictions that limit their deployment to United States regions only.)
 
 
         :return: The regions of this ListingSummary.
@@ -319,7 +319,7 @@ class ListingSummary(object):
     def regions(self, regions):
         """
         Sets the regions of this ListingSummary.
-        The regions where the listing is eligible to be deployed.
+        The regions where you can deploy the listing. (Some listings have restrictions that limit their deployment to United States regions only.)
 
 
         :param regions: The regions of this ListingSummary.

--- a/src/oci/marketplace/models/orchestration_listing_package.py
+++ b/src/oci/marketplace/models/orchestration_listing_package.py
@@ -151,7 +151,7 @@ class OrchestrationListingPackage(ListingPackage):
     def regions(self):
         """
         Gets the regions of this OrchestrationListingPackage.
-        List of regions in which this ListingPackage is available.
+        The regions where you can deploy this listing package. (Some packages have restrictions that limit their deployment to United States regions only.)
 
 
         :return: The regions of this OrchestrationListingPackage.
@@ -163,7 +163,7 @@ class OrchestrationListingPackage(ListingPackage):
     def regions(self, regions):
         """
         Sets the regions of this OrchestrationListingPackage.
-        List of regions in which this ListingPackage is available.
+        The regions where you can deploy this listing package. (Some packages have restrictions that limit their deployment to United States regions only.)
 
 
         :param regions: The regions of this OrchestrationListingPackage.

--- a/src/oci/marketplace/models/tax_summary.py
+++ b/src/oci/marketplace/models/tax_summary.py
@@ -1,0 +1,163 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TaxSummary(object):
+    """
+    Tax implication that current tenant may be eligible while using specific listing
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TaxSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param code:
+            The value to assign to the code property of this TaxSummary.
+        :type code: str
+
+        :param name:
+            The value to assign to the name property of this TaxSummary.
+        :type name: str
+
+        :param country:
+            The value to assign to the country property of this TaxSummary.
+        :type country: str
+
+        :param url:
+            The value to assign to the url property of this TaxSummary.
+        :type url: str
+
+        """
+        self.swagger_types = {
+            'code': 'str',
+            'name': 'str',
+            'country': 'str',
+            'url': 'str'
+        }
+
+        self.attribute_map = {
+            'code': 'code',
+            'name': 'name',
+            'country': 'country',
+            'url': 'url'
+        }
+
+        self._code = None
+        self._name = None
+        self._country = None
+        self._url = None
+
+    @property
+    def code(self):
+        """
+        **[Required]** Gets the code of this TaxSummary.
+        Unique code for the tax.
+
+
+        :return: The code of this TaxSummary.
+        :rtype: str
+        """
+        return self._code
+
+    @code.setter
+    def code(self, code):
+        """
+        Sets the code of this TaxSummary.
+        Unique code for the tax.
+
+
+        :param code: The code of this TaxSummary.
+        :type: str
+        """
+        self._code = code
+
+    @property
+    def name(self):
+        """
+        Gets the name of this TaxSummary.
+        Name of the tax code.
+
+
+        :return: The name of this TaxSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this TaxSummary.
+        Name of the tax code.
+
+
+        :param name: The name of this TaxSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def country(self):
+        """
+        Gets the country of this TaxSummary.
+        Country, which imposes the tax.
+
+
+        :return: The country of this TaxSummary.
+        :rtype: str
+        """
+        return self._country
+
+    @country.setter
+    def country(self, country):
+        """
+        Sets the country of this TaxSummary.
+        Country, which imposes the tax.
+
+
+        :param country: The country of this TaxSummary.
+        :type: str
+        """
+        self._country = country
+
+    @property
+    def url(self):
+        """
+        Gets the url of this TaxSummary.
+        The URL with more details about this tax.
+
+
+        :return: The url of this TaxSummary.
+        :rtype: str
+        """
+        return self._url
+
+    @url.setter
+    def url(self, url):
+        """
+        Sets the url of this TaxSummary.
+        The URL with more details about this tax.
+
+
+        :param url: The url of this TaxSummary.
+        :type: str
+        """
+        self._url = url
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/regions.py
+++ b/src/oci/regions.py
@@ -37,7 +37,8 @@ REGIONS_SHORT_NAMES = {
     'hyd': 'ap-hyderabad-1',
     'yny': 'ap-chuncheon-1',
     'brs': 'uk-gov-cardiff-1',
-    'nja': 'ap-chiyoda-1'
+    'nja': 'ap-chiyoda-1',
+    'dxb': 'me-dubai-1'
 }
 REGION_REALMS = {
     'ap-melbourne-1': 'oc1',
@@ -54,6 +55,7 @@ REGION_REALMS = {
     'eu-amsterdam-1': 'oc1',
     'eu-frankfurt-1': 'oc1',
     'eu-zurich-1': 'oc1',
+    'me-dubai-1': 'oc1',
     'me-jeddah-1': 'oc1',
     'uk-london-1': 'oc1',
     'ca-toronto-1': 'oc1',
@@ -95,6 +97,7 @@ REGIONS = [
     "eu-amsterdam-1",
     "eu-frankfurt-1",
     "eu-zurich-1",
+    "me-dubai-1",
     "me-jeddah-1",
     "uk-london-1",
     "uk-gov-cardiff-1",

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.21.6"
+__version__ = "2.22.0"


### PR DESCRIPTION
## Added

* Support for calling Oracle Cloud Infrastructure services in the me-dubai-1 region

* Support for rotating keys on autonomous container databases and autonomous databases in the Database service

* Support for cloud Exadata infrastructure and cloud VM clusters in the Database service

* Support for controlling the display of tax banners in the Marketplace service

* Support for application references, patch changes, generic JDBC and MySQL data asset types, and publishing tasks to OCI Dataflow in the Data Integration service

* Support for disabling the legacy Instance Metadata endpoints v1 in the Compute service

* Support for instance configurations specifying instance options in the Compute Management service



## Breaking

* The attribute `model_type` in `TypedObject` model now raises `ValueError` when provided with an invalid value. Please see the `documentation <https://docs.cloud.oracle.com/en-us/iaas/tools/python/2.21.6/api/data_integration/models/oci.data_integration.models.TypedObject.html#oci.data_integration.models.TypedObject.model_type>`_ for a list of allowed values.




