### PR TITLE
Releasing version 2.25.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.25.0 - 2020-12-01
+====================
+
+Added
+-----
+* Support for calling Oracle Cloud Infrastructure services in the sa-santiago-1 region
+* Support for peer and OSN resources, as well as retry tokens, in the Blockchain Platform service
+* Support for getting the availability status of management agents in the Management Agent service
+* Support for the on-prem-connector resource type in the Data Safe service
+* Support for service channels in the MySQL Database service
+* Support for getting the creation type of backups, and for filtering backups by creation type in the MySQL Database service
+
+Breaking
+--------
+* Parameter `compartment_id` changed from optional to required for method `list_work_requests` in the Data Safe service
+* Return type of method `create_data_safe_private_endpoint` changed from `None` to `oci.data_safe.models.DataSafePrivateEndpoint` in the Data Safe service
+* Parameters `freeform_tags` and `defined_tags` are removed from model `EnableDataSafeConfigurationDetails` in the Data Safe service
+
+====================
 2.24.1 - 2020-11-24
 ====================
 

--- a/docs/api/blockchain.rst
+++ b/docs/api/blockchain.rst
@@ -54,4 +54,5 @@ Blockchain
     oci.blockchain.models.WorkRequestLogEntry
     oci.blockchain.models.WorkRequestLogEntryCollection
     oci.blockchain.models.WorkRequestResource
+    oci.blockchain.models.WorkRequestResourceSubTypeDetail
     oci.blockchain.models.WorkRequestSummary

--- a/docs/api/blockchain/models/oci.blockchain.models.WorkRequestResourceSubTypeDetail.rst
+++ b/docs/api/blockchain/models/oci.blockchain.models.WorkRequestResourceSubTypeDetail.rst
@@ -1,0 +1,11 @@
+WorkRequestResourceSubTypeDetail
+================================
+
+.. currentmodule:: oci.blockchain.models
+
+.. autoclass:: WorkRequestResourceSubTypeDetail
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_safe.rst
+++ b/docs/api/data_safe.rst
@@ -19,12 +19,19 @@ Data Safe
     :template: autosummary/model_class.rst
 
     oci.data_safe.models.ChangeDataSafePrivateEndpointCompartmentDetails
+    oci.data_safe.models.ChangeOnPremConnectorCompartmentDetails
     oci.data_safe.models.CreateDataSafePrivateEndpointDetails
+    oci.data_safe.models.CreateOnPremConnectorDetails
     oci.data_safe.models.DataSafeConfiguration
     oci.data_safe.models.DataSafePrivateEndpoint
     oci.data_safe.models.DataSafePrivateEndpointSummary
     oci.data_safe.models.EnableDataSafeConfigurationDetails
+    oci.data_safe.models.GenerateOnPremConnectorConfigurationDetails
+    oci.data_safe.models.OnPremConnector
+    oci.data_safe.models.OnPremConnectorSummary
     oci.data_safe.models.UpdateDataSafePrivateEndpointDetails
+    oci.data_safe.models.UpdateOnPremConnectorDetails
+    oci.data_safe.models.UpdateOnPremConnectorWalletDetails
     oci.data_safe.models.WorkRequest
     oci.data_safe.models.WorkRequestError
     oci.data_safe.models.WorkRequestLogEntry

--- a/docs/api/data_safe/models/oci.data_safe.models.ChangeOnPremConnectorCompartmentDetails.rst
+++ b/docs/api/data_safe/models/oci.data_safe.models.ChangeOnPremConnectorCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeOnPremConnectorCompartmentDetails
+=======================================
+
+.. currentmodule:: oci.data_safe.models
+
+.. autoclass:: ChangeOnPremConnectorCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_safe/models/oci.data_safe.models.CreateOnPremConnectorDetails.rst
+++ b/docs/api/data_safe/models/oci.data_safe.models.CreateOnPremConnectorDetails.rst
@@ -1,0 +1,11 @@
+CreateOnPremConnectorDetails
+============================
+
+.. currentmodule:: oci.data_safe.models
+
+.. autoclass:: CreateOnPremConnectorDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_safe/models/oci.data_safe.models.GenerateOnPremConnectorConfigurationDetails.rst
+++ b/docs/api/data_safe/models/oci.data_safe.models.GenerateOnPremConnectorConfigurationDetails.rst
@@ -1,0 +1,11 @@
+GenerateOnPremConnectorConfigurationDetails
+===========================================
+
+.. currentmodule:: oci.data_safe.models
+
+.. autoclass:: GenerateOnPremConnectorConfigurationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_safe/models/oci.data_safe.models.OnPremConnector.rst
+++ b/docs/api/data_safe/models/oci.data_safe.models.OnPremConnector.rst
@@ -1,0 +1,11 @@
+OnPremConnector
+===============
+
+.. currentmodule:: oci.data_safe.models
+
+.. autoclass:: OnPremConnector
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_safe/models/oci.data_safe.models.OnPremConnectorSummary.rst
+++ b/docs/api/data_safe/models/oci.data_safe.models.OnPremConnectorSummary.rst
@@ -1,0 +1,11 @@
+OnPremConnectorSummary
+======================
+
+.. currentmodule:: oci.data_safe.models
+
+.. autoclass:: OnPremConnectorSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_safe/models/oci.data_safe.models.UpdateOnPremConnectorDetails.rst
+++ b/docs/api/data_safe/models/oci.data_safe.models.UpdateOnPremConnectorDetails.rst
@@ -1,0 +1,11 @@
+UpdateOnPremConnectorDetails
+============================
+
+.. currentmodule:: oci.data_safe.models
+
+.. autoclass:: UpdateOnPremConnectorDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_safe/models/oci.data_safe.models.UpdateOnPremConnectorWalletDetails.rst
+++ b/docs/api/data_safe/models/oci.data_safe.models.UpdateOnPremConnectorWalletDetails.rst
@@ -1,0 +1,11 @@
+UpdateOnPremConnectorWalletDetails
+==================================
+
+.. currentmodule:: oci.data_safe.models
+
+.. autoclass:: UpdateOnPremConnectorWalletDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/landing.rst
+++ b/docs/api/landing.rst
@@ -60,6 +60,7 @@ API Reference
 * :doc:`Dashx Apis <management_dashboard/client/oci.management_dashboard.DashxApisClient>`
 * :doc:`Marketplace <marketplace/client/oci.marketplace.MarketplaceClient>`
 * :doc:`Monitoring <monitoring/client/oci.monitoring.MonitoringClient>`
+* :doc:`Channels <mysql/client/oci.mysql.ChannelsClient>`
 * :doc:`Db Backups <mysql/client/oci.mysql.DbBackupsClient>`
 * :doc:`Db System <mysql/client/oci.mysql.DbSystemClient>`
 * :doc:`Mysqlaas <mysql/client/oci.mysql.MysqlaasClient>`

--- a/docs/api/management_agent.rst
+++ b/docs/api/management_agent.rst
@@ -18,6 +18,7 @@ Management Agent
     :nosignatures:
     :template: autosummary/model_class.rst
 
+    oci.management_agent.models.AvailabilityHistorySummary
     oci.management_agent.models.CreateManagementAgentInstallKeyDetails
     oci.management_agent.models.DeployPluginsDetails
     oci.management_agent.models.ManagementAgent

--- a/docs/api/management_agent/models/oci.management_agent.models.AvailabilityHistorySummary.rst
+++ b/docs/api/management_agent/models/oci.management_agent.models.AvailabilityHistorySummary.rst
@@ -1,0 +1,11 @@
+AvailabilityHistorySummary
+==========================
+
+.. currentmodule:: oci.management_agent.models
+
+.. autoclass:: AvailabilityHistorySummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql.rst
+++ b/docs/api/mysql.rst
@@ -6,10 +6,12 @@ Mysql
     :nosignatures:
     :template: autosummary/service_client.rst
 
+    oci.mysql.ChannelsClient
     oci.mysql.DbBackupsClient
     oci.mysql.DbSystemClient
     oci.mysql.MysqlaasClient
     oci.mysql.WorkRequestsClient
+    oci.mysql.ChannelsClientCompositeOperations
     oci.mysql.DbBackupsClientCompositeOperations
     oci.mysql.DbSystemClientCompositeOperations
     oci.mysql.MysqlaasClientCompositeOperations
@@ -34,30 +36,51 @@ Mysql
     oci.mysql.models.Backup
     oci.mysql.models.BackupPolicy
     oci.mysql.models.BackupSummary
+    oci.mysql.models.CaCertificate
+    oci.mysql.models.Channel
+    oci.mysql.models.ChannelSource
+    oci.mysql.models.ChannelSourceMysql
+    oci.mysql.models.ChannelSummary
+    oci.mysql.models.ChannelTarget
+    oci.mysql.models.ChannelTargetDbSystem
     oci.mysql.models.Configuration
     oci.mysql.models.ConfigurationSummary
     oci.mysql.models.ConfigurationVariables
     oci.mysql.models.CreateBackupDetails
     oci.mysql.models.CreateBackupPolicyDetails
+    oci.mysql.models.CreateChannelDetails
+    oci.mysql.models.CreateChannelSourceDetails
+    oci.mysql.models.CreateChannelSourceFromMysqlDetails
+    oci.mysql.models.CreateChannelTargetDetails
+    oci.mysql.models.CreateChannelTargetFromDbSystemDetails
     oci.mysql.models.CreateConfigurationDetails
     oci.mysql.models.CreateDbSystemDetails
     oci.mysql.models.CreateDbSystemSourceDetails
     oci.mysql.models.CreateDbSystemSourceFromBackupDetails
+    oci.mysql.models.CreateDbSystemSourceFromNoneDetails
     oci.mysql.models.CreateDbSystemSourceImportFromUrlDetails
     oci.mysql.models.CreateMaintenanceDetails
     oci.mysql.models.DbSystem
     oci.mysql.models.DbSystemEndpoint
+    oci.mysql.models.DbSystemSnapshot
     oci.mysql.models.DbSystemSource
     oci.mysql.models.DbSystemSourceFromBackup
+    oci.mysql.models.DbSystemSourceFromNone
     oci.mysql.models.DbSystemSourceImportFromUrl
     oci.mysql.models.DbSystemSummary
     oci.mysql.models.MaintenanceDetails
+    oci.mysql.models.PemCaCertificate
     oci.mysql.models.RestartDbSystemDetails
     oci.mysql.models.ShapeSummary
     oci.mysql.models.StopDbSystemDetails
     oci.mysql.models.UpdateAnalyticsClusterDetails
     oci.mysql.models.UpdateBackupDetails
     oci.mysql.models.UpdateBackupPolicyDetails
+    oci.mysql.models.UpdateChannelDetails
+    oci.mysql.models.UpdateChannelSourceDetails
+    oci.mysql.models.UpdateChannelSourceFromMysqlDetails
+    oci.mysql.models.UpdateChannelTargetDetails
+    oci.mysql.models.UpdateChannelTargetFromDbSystemDetails
     oci.mysql.models.UpdateConfigurationDetails
     oci.mysql.models.UpdateDbSystemDetails
     oci.mysql.models.UpdateMaintenanceDetails

--- a/docs/api/mysql/client/oci.mysql.ChannelsClient.rst
+++ b/docs/api/mysql/client/oci.mysql.ChannelsClient.rst
@@ -1,0 +1,8 @@
+ChannelsClient
+==============
+
+.. currentmodule:: oci.mysql
+
+.. autoclass:: ChannelsClient
+    :special-members: __init__
+    :members:

--- a/docs/api/mysql/client/oci.mysql.ChannelsClientCompositeOperations.rst
+++ b/docs/api/mysql/client/oci.mysql.ChannelsClientCompositeOperations.rst
@@ -1,0 +1,8 @@
+ChannelsClientCompositeOperations
+=================================
+
+.. currentmodule:: oci.mysql
+
+.. autoclass:: ChannelsClientCompositeOperations
+    :special-members: __init__
+    :members:

--- a/docs/api/mysql/models/oci.mysql.models.CaCertificate.rst
+++ b/docs/api/mysql/models/oci.mysql.models.CaCertificate.rst
@@ -1,0 +1,11 @@
+CaCertificate
+=============
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: CaCertificate
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.Channel.rst
+++ b/docs/api/mysql/models/oci.mysql.models.Channel.rst
@@ -1,0 +1,11 @@
+Channel
+=======
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: Channel
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.ChannelSource.rst
+++ b/docs/api/mysql/models/oci.mysql.models.ChannelSource.rst
@@ -1,0 +1,11 @@
+ChannelSource
+=============
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: ChannelSource
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.ChannelSourceMysql.rst
+++ b/docs/api/mysql/models/oci.mysql.models.ChannelSourceMysql.rst
@@ -1,0 +1,11 @@
+ChannelSourceMysql
+==================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: ChannelSourceMysql
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.ChannelSummary.rst
+++ b/docs/api/mysql/models/oci.mysql.models.ChannelSummary.rst
@@ -1,0 +1,11 @@
+ChannelSummary
+==============
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: ChannelSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.ChannelTarget.rst
+++ b/docs/api/mysql/models/oci.mysql.models.ChannelTarget.rst
@@ -1,0 +1,11 @@
+ChannelTarget
+=============
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: ChannelTarget
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.ChannelTargetDbSystem.rst
+++ b/docs/api/mysql/models/oci.mysql.models.ChannelTargetDbSystem.rst
@@ -1,0 +1,11 @@
+ChannelTargetDbSystem
+=====================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: ChannelTargetDbSystem
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.CreateChannelDetails.rst
+++ b/docs/api/mysql/models/oci.mysql.models.CreateChannelDetails.rst
@@ -1,0 +1,11 @@
+CreateChannelDetails
+====================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: CreateChannelDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.CreateChannelSourceDetails.rst
+++ b/docs/api/mysql/models/oci.mysql.models.CreateChannelSourceDetails.rst
@@ -1,0 +1,11 @@
+CreateChannelSourceDetails
+==========================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: CreateChannelSourceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.CreateChannelSourceFromMysqlDetails.rst
+++ b/docs/api/mysql/models/oci.mysql.models.CreateChannelSourceFromMysqlDetails.rst
@@ -1,0 +1,11 @@
+CreateChannelSourceFromMysqlDetails
+===================================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: CreateChannelSourceFromMysqlDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.CreateChannelTargetDetails.rst
+++ b/docs/api/mysql/models/oci.mysql.models.CreateChannelTargetDetails.rst
@@ -1,0 +1,11 @@
+CreateChannelTargetDetails
+==========================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: CreateChannelTargetDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.CreateChannelTargetFromDbSystemDetails.rst
+++ b/docs/api/mysql/models/oci.mysql.models.CreateChannelTargetFromDbSystemDetails.rst
@@ -1,0 +1,11 @@
+CreateChannelTargetFromDbSystemDetails
+======================================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: CreateChannelTargetFromDbSystemDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.CreateDbSystemSourceFromNoneDetails.rst
+++ b/docs/api/mysql/models/oci.mysql.models.CreateDbSystemSourceFromNoneDetails.rst
@@ -1,0 +1,11 @@
+CreateDbSystemSourceFromNoneDetails
+===================================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: CreateDbSystemSourceFromNoneDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.DbSystemSnapshot.rst
+++ b/docs/api/mysql/models/oci.mysql.models.DbSystemSnapshot.rst
@@ -1,0 +1,11 @@
+DbSystemSnapshot
+================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: DbSystemSnapshot
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.DbSystemSourceFromNone.rst
+++ b/docs/api/mysql/models/oci.mysql.models.DbSystemSourceFromNone.rst
@@ -1,0 +1,11 @@
+DbSystemSourceFromNone
+======================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: DbSystemSourceFromNone
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.PemCaCertificate.rst
+++ b/docs/api/mysql/models/oci.mysql.models.PemCaCertificate.rst
@@ -1,0 +1,11 @@
+PemCaCertificate
+================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: PemCaCertificate
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.UpdateChannelDetails.rst
+++ b/docs/api/mysql/models/oci.mysql.models.UpdateChannelDetails.rst
@@ -1,0 +1,11 @@
+UpdateChannelDetails
+====================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: UpdateChannelDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.UpdateChannelSourceDetails.rst
+++ b/docs/api/mysql/models/oci.mysql.models.UpdateChannelSourceDetails.rst
@@ -1,0 +1,11 @@
+UpdateChannelSourceDetails
+==========================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: UpdateChannelSourceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.UpdateChannelSourceFromMysqlDetails.rst
+++ b/docs/api/mysql/models/oci.mysql.models.UpdateChannelSourceFromMysqlDetails.rst
@@ -1,0 +1,11 @@
+UpdateChannelSourceFromMysqlDetails
+===================================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: UpdateChannelSourceFromMysqlDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.UpdateChannelTargetDetails.rst
+++ b/docs/api/mysql/models/oci.mysql.models.UpdateChannelTargetDetails.rst
@@ -1,0 +1,11 @@
+UpdateChannelTargetDetails
+==========================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: UpdateChannelTargetDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql/models/oci.mysql.models.UpdateChannelTargetFromDbSystemDetails.rst
+++ b/docs/api/mysql/models/oci.mysql.models.UpdateChannelTargetFromDbSystemDetails.rst
@@ -1,0 +1,11 @@
+UpdateChannelTargetFromDbSystemDetails
+======================================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: UpdateChannelTargetFromDbSystemDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/object_storage/object_storage_bulk_copy.py
+++ b/examples/object_storage/object_storage_bulk_copy.py
@@ -1,33 +1,6 @@
 # coding: utf-8
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
-##########################################################################
-# object_storage_bulk_copy.py
-#
-# @author: Tim S and Adi Z
-#
-# Supports Python 3
-##########################################################################
-# Info:
-#    Bulk copy object storage bucket to other bucket with parallel threads
-#
-##########################################################################
-# Application Command line parameters
-#
-#   -c config  - Config file section to use (tenancy profile)
-#   -t profile - Profile in config file, DEFAULT as default
-#   -p proxy   - Set Proxy (i.e. www-proxy-server.com:80)
-#   -ip        - Use Instance Principals for Authentication
-#   -dt        - Use Instance Principals with delegation token for cloud shell
-#   -sb source_bucket
-#   -sr source_region
-#   -sn source_namespace
-#   -sp source_prefix_include
-#   -se source_prefix_exclude
-#   -db destination_bucket
-#   -dr destination_region
-#   -ig ignore_check_exist
-##########################################################################
 
 import pickle
 import threading

--- a/examples/object_storage/object_storage_bulk_delete.py
+++ b/examples/object_storage/object_storage_bulk_delete.py
@@ -1,28 +1,6 @@
 # coding: utf-8
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
-##########################################################################
-# object_storage_bulk_delete.py
-#
-# @author: Adi Zohar
-#
-# Supports Python 3
-##########################################################################
-# Info:
-#    Bulk delete with parallel threads
-#
-##########################################################################
-# Application Command line parameters
-#
-#   -c config  - Config file section to use (tenancy profile)
-#   -t profile - Profile in config file, DEFAULT as default
-#   -p proxy   - Set Proxy (i.e. www-proxy-server.com:80)
-#   -ip        - Use Instance Principals for Authentication
-#   -dt        - Use Instance Principals with delegation token for cloud shell
-#   -sb source_bucket
-#   -sp source_prefix
-#   -sr source_region
-##########################################################################
 
 import threading
 import time

--- a/examples/object_storage/object_storage_bulk_restore.py
+++ b/examples/object_storage/object_storage_bulk_restore.py
@@ -1,28 +1,6 @@
 # coding: utf-8
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
-##########################################################################
-# object_storage_bulk_restore.py
-#
-# @author: Tim S and Adi Z
-#
-# Supports Python 3
-##########################################################################
-# Info:
-#    Bulk restore with parallel threads
-#
-##########################################################################
-# Application Command line parameters
-#
-#   -c config  - Config file section to use (tenancy profile)
-#   -t profile - Profile in config file, DEFAULT as default
-#   -p proxy   - Set Proxy (i.e. www-proxy-server.com:80)
-#   -ip        - Use Instance Principals for Authentication
-#   -dt        - Use Instance Principals with delegation token for cloud shell
-#   -sb source_bucket
-#   -sp source_prefix_include
-#   -sr source_region
-##########################################################################
 
 import threading
 import time

--- a/examples/object_storage/object_storage_list_objects.py
+++ b/examples/object_storage/object_storage_list_objects.py
@@ -1,31 +1,7 @@
 # coding: utf-8
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
-##########################################################################
-# object_storage_list_objects.py
-#
-# @author: Adi Zohar, Oct 18th 2020
-#
-# Supports Python 3
-##########################################################################
-# Info:
-# count objects or list objects with option to filter by prefix and write to file
-#
-##########################################################################
-# Application Command line parameters
-#
-#   -c config  - Config file section to use (tenancy profile)
-#   -t profile - Profile in config file, DEFAULT as default
-#   -p proxy   - Set Proxy (i.e. www-proxy-server.com:80)
-#   -ip        - Use Instance Principals for Authentication
-#   -dt        - Use Instance Principals with delegation token for cloud shell
-#   -co        - count only
-#   -f         - write to file
-#   -sb source_bucket
-#   -sp source_prefix_include
-#   -se source_prefix_exclude
-#   -sr source_region
-##########################################################################
+
 import oci
 import argparse
 import datetime

--- a/src/oci/blockchain/blockchain_platform_client.py
+++ b/src/oci/blockchain/blockchain_platform_client.py
@@ -1919,6 +1919,13 @@ class BlockchainPlatformClient(object):
         :param str opc_request_id: (optional)
             The client request ID for tracing.
 
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -1937,7 +1944,8 @@ class BlockchainPlatformClient(object):
         expected_kwargs = [
             "retry_strategy",
             "if_match",
-            "opc_request_id"
+            "opc_request_id",
+            "opc_retry_token"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -1958,7 +1966,8 @@ class BlockchainPlatformClient(object):
             "accept": "application/json",
             "content-type": "application/json",
             "if-match": kwargs.get("if_match", missing),
-            "opc-request-id": kwargs.get("opc_request_id", missing)
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
@@ -1967,6 +1976,8 @@ class BlockchainPlatformClient(object):
             retry_strategy = kwargs.get('retry_strategy')
 
         if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
             return retry_strategy.make_retrying_call(
                 self.base_client.call_api,
                 resource_path=resource_path,
@@ -1998,6 +2009,13 @@ class BlockchainPlatformClient(object):
         :param str opc_request_id: (optional)
             The client request ID for tracing.
 
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -2016,7 +2034,8 @@ class BlockchainPlatformClient(object):
         expected_kwargs = [
             "retry_strategy",
             "if_match",
-            "opc_request_id"
+            "opc_request_id",
+            "opc_retry_token"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -2037,7 +2056,8 @@ class BlockchainPlatformClient(object):
             "accept": "application/json",
             "content-type": "application/json",
             "if-match": kwargs.get("if_match", missing),
-            "opc-request-id": kwargs.get("opc_request_id", missing)
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
@@ -2046,6 +2066,8 @@ class BlockchainPlatformClient(object):
             retry_strategy = kwargs.get('retry_strategy')
 
         if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
             return retry_strategy.make_retrying_call(
                 self.base_client.call_api,
                 resource_path=resource_path,
@@ -2080,6 +2102,13 @@ class BlockchainPlatformClient(object):
             The resource will be updated or deleted only if the etag you
             provide matches the resource's current etag value.
 
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -2098,7 +2127,8 @@ class BlockchainPlatformClient(object):
         expected_kwargs = [
             "retry_strategy",
             "opc_request_id",
-            "if_match"
+            "if_match",
+            "opc_retry_token"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -2119,7 +2149,8 @@ class BlockchainPlatformClient(object):
             "accept": "application/json",
             "content-type": "application/json",
             "opc-request-id": kwargs.get("opc_request_id", missing),
-            "if-match": kwargs.get("if_match", missing)
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
@@ -2128,6 +2159,8 @@ class BlockchainPlatformClient(object):
             retry_strategy = kwargs.get('retry_strategy')
 
         if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
             return retry_strategy.make_retrying_call(
                 self.base_client.call_api,
                 resource_path=resource_path,
@@ -2266,6 +2299,13 @@ class BlockchainPlatformClient(object):
         :param str opc_request_id: (optional)
             The client request ID for tracing.
 
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -2284,7 +2324,8 @@ class BlockchainPlatformClient(object):
         expected_kwargs = [
             "retry_strategy",
             "if_match",
-            "opc_request_id"
+            "opc_request_id",
+            "opc_retry_token"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -2306,7 +2347,8 @@ class BlockchainPlatformClient(object):
             "accept": "application/json",
             "content-type": "application/json",
             "if-match": kwargs.get("if_match", missing),
-            "opc-request-id": kwargs.get("opc_request_id", missing)
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
         }
         header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
 
@@ -2315,6 +2357,8 @@ class BlockchainPlatformClient(object):
             retry_strategy = kwargs.get('retry_strategy')
 
         if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
             return retry_strategy.make_retrying_call(
                 self.base_client.call_api,
                 resource_path=resource_path,

--- a/src/oci/blockchain/models/__init__.py
+++ b/src/oci/blockchain/models/__init__.py
@@ -40,6 +40,7 @@ from .work_request_error_collection import WorkRequestErrorCollection
 from .work_request_log_entry import WorkRequestLogEntry
 from .work_request_log_entry_collection import WorkRequestLogEntryCollection
 from .work_request_resource import WorkRequestResource
+from .work_request_resource_sub_type_detail import WorkRequestResourceSubTypeDetail
 from .work_request_summary import WorkRequestSummary
 
 # Maps type names to classes for blockchain services.
@@ -80,5 +81,6 @@ blockchain_type_mapping = {
     "WorkRequestLogEntry": WorkRequestLogEntry,
     "WorkRequestLogEntryCollection": WorkRequestLogEntryCollection,
     "WorkRequestResource": WorkRequestResource,
+    "WorkRequestResourceSubTypeDetail": WorkRequestResourceSubTypeDetail,
     "WorkRequestSummary": WorkRequestSummary
 }

--- a/src/oci/blockchain/models/blockchain_platform.py
+++ b/src/oci/blockchain/models/blockchain_platform.py
@@ -45,6 +45,14 @@ class BlockchainPlatform(object):
     #: This constant has a value of "ENTERPRISE_CUSTOM"
     COMPUTE_SHAPE_ENTERPRISE_CUSTOM = "ENTERPRISE_CUSTOM"
 
+    #: A constant which can be used with the platform_shape_type property of a BlockchainPlatform.
+    #: This constant has a value of "DEFAULT"
+    PLATFORM_SHAPE_TYPE_DEFAULT = "DEFAULT"
+
+    #: A constant which can be used with the platform_shape_type property of a BlockchainPlatform.
+    #: This constant has a value of "CUSTOM"
+    PLATFORM_SHAPE_TYPE_CUSTOM = "CUSTOM"
+
     #: A constant which can be used with the lifecycle_state property of a BlockchainPlatform.
     #: This constant has a value of "CREATING"
     LIFECYCLE_STATE_CREATING = "CREATING"
@@ -126,6 +134,12 @@ class BlockchainPlatform(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type compute_shape: str
 
+        :param platform_shape_type:
+            The value to assign to the platform_shape_type property of this BlockchainPlatform.
+            Allowed values for this property are: "DEFAULT", "CUSTOM", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type platform_shape_type: str
+
         :param service_endpoint:
             The value to assign to the service_endpoint property of this BlockchainPlatform.
         :type service_endpoint: str
@@ -188,6 +202,7 @@ class BlockchainPlatform(object):
             'service_version': 'str',
             'platform_role': 'str',
             'compute_shape': 'str',
+            'platform_shape_type': 'str',
             'service_endpoint': 'str',
             'lifecycle_state': 'str',
             'lifecycle_details': 'str',
@@ -213,6 +228,7 @@ class BlockchainPlatform(object):
             'service_version': 'serviceVersion',
             'platform_role': 'platformRole',
             'compute_shape': 'computeShape',
+            'platform_shape_type': 'platformShapeType',
             'service_endpoint': 'serviceEndpoint',
             'lifecycle_state': 'lifecycleState',
             'lifecycle_details': 'lifecycleDetails',
@@ -237,6 +253,7 @@ class BlockchainPlatform(object):
         self._service_version = None
         self._platform_role = None
         self._compute_shape = None
+        self._platform_shape_type = None
         self._service_endpoint = None
         self._lifecycle_state = None
         self._lifecycle_details = None
@@ -446,7 +463,7 @@ class BlockchainPlatform(object):
     def platform_role(self):
         """
         **[Required]** Gets the platform_role of this BlockchainPlatform.
-        Role of platform - founder or participant
+        Role of platform - FOUNDER or PARTICIPANT
 
         Allowed values for this property are: "FOUNDER", "PARTICIPANT", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -461,7 +478,7 @@ class BlockchainPlatform(object):
     def platform_role(self, platform_role):
         """
         Sets the platform_role of this BlockchainPlatform.
-        Role of platform - founder or participant
+        Role of platform - FOUNDER or PARTICIPANT
 
 
         :param platform_role: The platform_role of this BlockchainPlatform.
@@ -476,7 +493,7 @@ class BlockchainPlatform(object):
     def compute_shape(self):
         """
         **[Required]** Gets the compute_shape of this BlockchainPlatform.
-        Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+        Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE or ENTERPRISE_CUSTOM
 
         Allowed values for this property are: "STANDARD", "ENTERPRISE_SMALL", "ENTERPRISE_MEDIUM", "ENTERPRISE_LARGE", "ENTERPRISE_EXTRA_LARGE", "ENTERPRISE_CUSTOM", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -491,7 +508,7 @@ class BlockchainPlatform(object):
     def compute_shape(self, compute_shape):
         """
         Sets the compute_shape of this BlockchainPlatform.
-        Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+        Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE or ENTERPRISE_CUSTOM
 
 
         :param compute_shape: The compute_shape of this BlockchainPlatform.
@@ -501,6 +518,36 @@ class BlockchainPlatform(object):
         if not value_allowed_none_or_none_sentinel(compute_shape, allowed_values):
             compute_shape = 'UNKNOWN_ENUM_VALUE'
         self._compute_shape = compute_shape
+
+    @property
+    def platform_shape_type(self):
+        """
+        Gets the platform_shape_type of this BlockchainPlatform.
+        Type of Platform shape - DEFAULT or CUSTOM
+
+        Allowed values for this property are: "DEFAULT", "CUSTOM", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The platform_shape_type of this BlockchainPlatform.
+        :rtype: str
+        """
+        return self._platform_shape_type
+
+    @platform_shape_type.setter
+    def platform_shape_type(self, platform_shape_type):
+        """
+        Sets the platform_shape_type of this BlockchainPlatform.
+        Type of Platform shape - DEFAULT or CUSTOM
+
+
+        :param platform_shape_type: The platform_shape_type of this BlockchainPlatform.
+        :type: str
+        """
+        allowed_values = ["DEFAULT", "CUSTOM"]
+        if not value_allowed_none_or_none_sentinel(platform_shape_type, allowed_values):
+            platform_shape_type = 'UNKNOWN_ENUM_VALUE'
+        self._platform_shape_type = platform_shape_type
 
     @property
     def service_endpoint(self):

--- a/src/oci/blockchain/models/blockchain_platform_by_hostname.py
+++ b/src/oci/blockchain/models/blockchain_platform_by_hostname.py
@@ -313,7 +313,7 @@ class BlockchainPlatformByHostname(object):
     def compute_shape(self):
         """
         **[Required]** Gets the compute_shape of this BlockchainPlatformByHostname.
-        Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+        Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE or ENTERPRISE_CUSTOM
 
 
         :return: The compute_shape of this BlockchainPlatformByHostname.
@@ -325,7 +325,7 @@ class BlockchainPlatformByHostname(object):
     def compute_shape(self, compute_shape):
         """
         Sets the compute_shape of this BlockchainPlatformByHostname.
-        Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+        Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE or ENTERPRISE_CUSTOM
 
 
         :param compute_shape: The compute_shape of this BlockchainPlatformByHostname.

--- a/src/oci/blockchain/models/blockchain_platform_summary.py
+++ b/src/oci/blockchain/models/blockchain_platform_summary.py
@@ -289,7 +289,7 @@ class BlockchainPlatformSummary(object):
     def compute_shape(self):
         """
         **[Required]** Gets the compute_shape of this BlockchainPlatformSummary.
-        Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+        Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE or ENTERPRISE_CUSTOM
 
 
         :return: The compute_shape of this BlockchainPlatformSummary.
@@ -301,7 +301,7 @@ class BlockchainPlatformSummary(object):
     def compute_shape(self, compute_shape):
         """
         Sets the compute_shape of this BlockchainPlatformSummary.
-        Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+        Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE or ENTERPRISE_CUSTOM
 
 
         :param compute_shape: The compute_shape of this BlockchainPlatformSummary.

--- a/src/oci/blockchain/models/create_blockchain_platform_details.py
+++ b/src/oci/blockchain/models/create_blockchain_platform_details.py
@@ -203,7 +203,7 @@ class CreateBlockchainPlatformDetails(object):
     def compute_shape(self):
         """
         **[Required]** Gets the compute_shape of this CreateBlockchainPlatformDetails.
-        Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+        Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE
 
 
         :return: The compute_shape of this CreateBlockchainPlatformDetails.
@@ -215,7 +215,7 @@ class CreateBlockchainPlatformDetails(object):
     def compute_shape(self, compute_shape):
         """
         Sets the compute_shape of this CreateBlockchainPlatformDetails.
-        Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+        Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE
 
 
         :param compute_shape: The compute_shape of this CreateBlockchainPlatformDetails.
@@ -251,7 +251,7 @@ class CreateBlockchainPlatformDetails(object):
     def idcs_access_token(self):
         """
         Gets the idcs_access_token of this CreateBlockchainPlatformDetails.
-        IDCS access token
+        IDCS access token with Identity Domain Administrator role
 
 
         :return: The idcs_access_token of this CreateBlockchainPlatformDetails.
@@ -263,7 +263,7 @@ class CreateBlockchainPlatformDetails(object):
     def idcs_access_token(self, idcs_access_token):
         """
         Sets the idcs_access_token of this CreateBlockchainPlatformDetails.
-        IDCS access token
+        IDCS access token with Identity Domain Administrator role
 
 
         :param idcs_access_token: The idcs_access_token of this CreateBlockchainPlatformDetails.

--- a/src/oci/blockchain/models/scaled_blockchain_platform_preview.py
+++ b/src/oci/blockchain/models/scaled_blockchain_platform_preview.py
@@ -238,7 +238,7 @@ class ScaledBlockchainPlatformPreview(object):
     def compute_shape(self):
         """
         **[Required]** Gets the compute_shape of this ScaledBlockchainPlatformPreview.
-        Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+        Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE or ENTERPRISE_CUSTOM
 
 
         :return: The compute_shape of this ScaledBlockchainPlatformPreview.
@@ -250,7 +250,7 @@ class ScaledBlockchainPlatformPreview(object):
     def compute_shape(self, compute_shape):
         """
         Sets the compute_shape of this ScaledBlockchainPlatformPreview.
-        Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+        Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE or ENTERPRISE_CUSTOM
 
 
         :param compute_shape: The compute_shape of this ScaledBlockchainPlatformPreview.

--- a/src/oci/blockchain/models/work_request.py
+++ b/src/oci/blockchain/models/work_request.py
@@ -41,6 +41,10 @@ class WorkRequest(object):
     #: This constant has a value of "CUSTOMIZE_PLATFORM"
     OPERATION_TYPE_CUSTOMIZE_PLATFORM = "CUSTOMIZE_PLATFORM"
 
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "SCALE_STORAGE"
+    OPERATION_TYPE_SCALE_STORAGE = "SCALE_STORAGE"
+
     #: A constant which can be used with the status property of a WorkRequest.
     #: This constant has a value of "ACCEPTED"
     STATUS_ACCEPTED = "ACCEPTED"
@@ -72,7 +76,7 @@ class WorkRequest(object):
 
         :param operation_type:
             The value to assign to the operation_type property of this WorkRequest.
-            Allowed values for this property are: "CREATE_PLATFORM", "UPDATE_PLATFORM", "DELETE_PLATFORM", "SCALE_PLATFORM", "START_PLATFORM", "STOP_PLATFORM", "CUSTOMIZE_PLATFORM", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATE_PLATFORM", "UPDATE_PLATFORM", "DELETE_PLATFORM", "SCALE_PLATFORM", "START_PLATFORM", "STOP_PLATFORM", "CUSTOMIZE_PLATFORM", "SCALE_STORAGE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type operation_type: str
 
@@ -151,7 +155,7 @@ class WorkRequest(object):
         **[Required]** Gets the operation_type of this WorkRequest.
         type of the work request
 
-        Allowed values for this property are: "CREATE_PLATFORM", "UPDATE_PLATFORM", "DELETE_PLATFORM", "SCALE_PLATFORM", "START_PLATFORM", "STOP_PLATFORM", "CUSTOMIZE_PLATFORM", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATE_PLATFORM", "UPDATE_PLATFORM", "DELETE_PLATFORM", "SCALE_PLATFORM", "START_PLATFORM", "STOP_PLATFORM", "CUSTOMIZE_PLATFORM", "SCALE_STORAGE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -170,7 +174,7 @@ class WorkRequest(object):
         :param operation_type: The operation_type of this WorkRequest.
         :type: str
         """
-        allowed_values = ["CREATE_PLATFORM", "UPDATE_PLATFORM", "DELETE_PLATFORM", "SCALE_PLATFORM", "START_PLATFORM", "STOP_PLATFORM", "CUSTOMIZE_PLATFORM"]
+        allowed_values = ["CREATE_PLATFORM", "UPDATE_PLATFORM", "DELETE_PLATFORM", "SCALE_PLATFORM", "START_PLATFORM", "STOP_PLATFORM", "CUSTOMIZE_PLATFORM", "SCALE_STORAGE"]
         if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
             operation_type = 'UNKNOWN_ENUM_VALUE'
         self._operation_type = operation_type

--- a/src/oci/blockchain/models/work_request_resource.py
+++ b/src/oci/blockchain/models/work_request_resource.py
@@ -56,25 +56,32 @@ class WorkRequestResource(object):
             The value to assign to the entity_uri property of this WorkRequestResource.
         :type entity_uri: str
 
+        :param sub_type_details:
+            The value to assign to the sub_type_details property of this WorkRequestResource.
+        :type sub_type_details: list[WorkRequestResourceSubTypeDetail]
+
         """
         self.swagger_types = {
             'entity_type': 'str',
             'action_type': 'str',
             'identifier': 'str',
-            'entity_uri': 'str'
+            'entity_uri': 'str',
+            'sub_type_details': 'list[WorkRequestResourceSubTypeDetail]'
         }
 
         self.attribute_map = {
             'entity_type': 'entityType',
             'action_type': 'actionType',
             'identifier': 'identifier',
-            'entity_uri': 'entityUri'
+            'entity_uri': 'entityUri',
+            'sub_type_details': 'subTypeDetails'
         }
 
         self._entity_type = None
         self._action_type = None
         self._identifier = None
         self._entity_uri = None
+        self._sub_type_details = None
 
     @property
     def entity_type(self):
@@ -183,6 +190,30 @@ class WorkRequestResource(object):
         :type: str
         """
         self._entity_uri = entity_uri
+
+    @property
+    def sub_type_details(self):
+        """
+        Gets the sub_type_details of this WorkRequestResource.
+        Collection of SubType information for a work request resource\u00A9
+
+
+        :return: The sub_type_details of this WorkRequestResource.
+        :rtype: list[WorkRequestResourceSubTypeDetail]
+        """
+        return self._sub_type_details
+
+    @sub_type_details.setter
+    def sub_type_details(self, sub_type_details):
+        """
+        Sets the sub_type_details of this WorkRequestResource.
+        Collection of SubType information for a work request resource\u00A9
+
+
+        :param sub_type_details: The sub_type_details of this WorkRequestResource.
+        :type: list[WorkRequestResourceSubTypeDetail]
+        """
+        self._sub_type_details = sub_type_details
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/blockchain/models/work_request_resource_sub_type_detail.py
+++ b/src/oci/blockchain/models/work_request_resource_sub_type_detail.py
@@ -1,0 +1,154 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WorkRequestResourceSubTypeDetail(object):
+    """
+    SubType information for a work request resource.
+    """
+
+    #: A constant which can be used with the sub_type_status property of a WorkRequestResourceSubTypeDetail.
+    #: This constant has a value of "CREATED"
+    SUB_TYPE_STATUS_CREATED = "CREATED"
+
+    #: A constant which can be used with the sub_type_status property of a WorkRequestResourceSubTypeDetail.
+    #: This constant has a value of "UPDATED"
+    SUB_TYPE_STATUS_UPDATED = "UPDATED"
+
+    #: A constant which can be used with the sub_type_status property of a WorkRequestResourceSubTypeDetail.
+    #: This constant has a value of "DELETED"
+    SUB_TYPE_STATUS_DELETED = "DELETED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WorkRequestResourceSubTypeDetail object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param sub_type:
+            The value to assign to the sub_type property of this WorkRequestResourceSubTypeDetail.
+        :type sub_type: str
+
+        :param sub_type_key:
+            The value to assign to the sub_type_key property of this WorkRequestResourceSubTypeDetail.
+        :type sub_type_key: str
+
+        :param sub_type_status:
+            The value to assign to the sub_type_status property of this WorkRequestResourceSubTypeDetail.
+            Allowed values for this property are: "CREATED", "UPDATED", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type sub_type_status: str
+
+        """
+        self.swagger_types = {
+            'sub_type': 'str',
+            'sub_type_key': 'str',
+            'sub_type_status': 'str'
+        }
+
+        self.attribute_map = {
+            'sub_type': 'subType',
+            'sub_type_key': 'subTypeKey',
+            'sub_type_status': 'subTypeStatus'
+        }
+
+        self._sub_type = None
+        self._sub_type_key = None
+        self._sub_type_status = None
+
+    @property
+    def sub_type(self):
+        """
+        **[Required]** Gets the sub_type of this WorkRequestResourceSubTypeDetail.
+        Subtype of the work request resource like osn or peer.
+
+
+        :return: The sub_type of this WorkRequestResourceSubTypeDetail.
+        :rtype: str
+        """
+        return self._sub_type
+
+    @sub_type.setter
+    def sub_type(self, sub_type):
+        """
+        Sets the sub_type of this WorkRequestResourceSubTypeDetail.
+        Subtype of the work request resource like osn or peer.
+
+
+        :param sub_type: The sub_type of this WorkRequestResourceSubTypeDetail.
+        :type: str
+        """
+        self._sub_type = sub_type
+
+    @property
+    def sub_type_key(self):
+        """
+        **[Required]** Gets the sub_type_key of this WorkRequestResourceSubTypeDetail.
+        The identifier of the resource subType.
+
+
+        :return: The sub_type_key of this WorkRequestResourceSubTypeDetail.
+        :rtype: str
+        """
+        return self._sub_type_key
+
+    @sub_type_key.setter
+    def sub_type_key(self, sub_type_key):
+        """
+        Sets the sub_type_key of this WorkRequestResourceSubTypeDetail.
+        The identifier of the resource subType.
+
+
+        :param sub_type_key: The sub_type_key of this WorkRequestResourceSubTypeDetail.
+        :type: str
+        """
+        self._sub_type_key = sub_type_key
+
+    @property
+    def sub_type_status(self):
+        """
+        **[Required]** Gets the sub_type_status of this WorkRequestResourceSubTypeDetail.
+        Status of the resource subType, as a result of the work tracked in this work request.
+        A resource subType would be CREATED, UPDATED or DELETED, after the work request is completed.
+
+        Allowed values for this property are: "CREATED", "UPDATED", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The sub_type_status of this WorkRequestResourceSubTypeDetail.
+        :rtype: str
+        """
+        return self._sub_type_status
+
+    @sub_type_status.setter
+    def sub_type_status(self, sub_type_status):
+        """
+        Sets the sub_type_status of this WorkRequestResourceSubTypeDetail.
+        Status of the resource subType, as a result of the work tracked in this work request.
+        A resource subType would be CREATED, UPDATED or DELETED, after the work request is completed.
+
+
+        :param sub_type_status: The sub_type_status of this WorkRequestResourceSubTypeDetail.
+        :type: str
+        """
+        allowed_values = ["CREATED", "UPDATED", "DELETED"]
+        if not value_allowed_none_or_none_sentinel(sub_type_status, allowed_values):
+            sub_type_status = 'UNKNOWN_ENUM_VALUE'
+        self._sub_type_status = sub_type_status
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/blockchain/models/work_request_summary.py
+++ b/src/oci/blockchain/models/work_request_summary.py
@@ -41,6 +41,10 @@ class WorkRequestSummary(object):
     #: This constant has a value of "CUSTOMIZE_PLATFORM"
     OPERATION_TYPE_CUSTOMIZE_PLATFORM = "CUSTOMIZE_PLATFORM"
 
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "SCALE_STORAGE"
+    OPERATION_TYPE_SCALE_STORAGE = "SCALE_STORAGE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new WorkRequestSummary object with values from keyword arguments.
@@ -48,7 +52,7 @@ class WorkRequestSummary(object):
 
         :param operation_type:
             The value to assign to the operation_type property of this WorkRequestSummary.
-            Allowed values for this property are: "CREATE_PLATFORM", "UPDATE_PLATFORM", "DELETE_PLATFORM", "SCALE_PLATFORM", "START_PLATFORM", "STOP_PLATFORM", "CUSTOMIZE_PLATFORM", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATE_PLATFORM", "UPDATE_PLATFORM", "DELETE_PLATFORM", "SCALE_PLATFORM", "START_PLATFORM", "STOP_PLATFORM", "CUSTOMIZE_PLATFORM", "SCALE_STORAGE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type operation_type: str
 
@@ -125,7 +129,7 @@ class WorkRequestSummary(object):
         **[Required]** Gets the operation_type of this WorkRequestSummary.
         type of the work request
 
-        Allowed values for this property are: "CREATE_PLATFORM", "UPDATE_PLATFORM", "DELETE_PLATFORM", "SCALE_PLATFORM", "START_PLATFORM", "STOP_PLATFORM", "CUSTOMIZE_PLATFORM", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATE_PLATFORM", "UPDATE_PLATFORM", "DELETE_PLATFORM", "SCALE_PLATFORM", "START_PLATFORM", "STOP_PLATFORM", "CUSTOMIZE_PLATFORM", "SCALE_STORAGE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -144,7 +148,7 @@ class WorkRequestSummary(object):
         :param operation_type: The operation_type of this WorkRequestSummary.
         :type: str
         """
-        allowed_values = ["CREATE_PLATFORM", "UPDATE_PLATFORM", "DELETE_PLATFORM", "SCALE_PLATFORM", "START_PLATFORM", "STOP_PLATFORM", "CUSTOMIZE_PLATFORM"]
+        allowed_values = ["CREATE_PLATFORM", "UPDATE_PLATFORM", "DELETE_PLATFORM", "SCALE_PLATFORM", "START_PLATFORM", "STOP_PLATFORM", "CUSTOMIZE_PLATFORM", "SCALE_STORAGE"]
         if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
             operation_type = 'UNKNOWN_ENUM_VALUE'
         self._operation_type = operation_type

--- a/src/oci/data_safe/data_safe_client.py
+++ b/src/oci/data_safe/data_safe_client.py
@@ -169,6 +169,100 @@ class DataSafeClient(object):
                 header_params=header_params,
                 body=change_data_safe_private_endpoint_compartment_details)
 
+    def change_on_prem_connector_compartment(self, on_prem_connector_id, change_on_prem_connector_compartment_details, **kwargs):
+        """
+        Moves the specified on-premises connector into a different compartment.
+
+
+        :param str on_prem_connector_id: (required)
+            The OCID of the on-premises connector.
+
+        :param oci.data_safe.models.ChangeOnPremConnectorCompartmentDetails change_on_prem_connector_compartment_details: (required)
+            The details used to change the compartment of an on-premises connector.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the if-match parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/onPremConnectors/{onPremConnectorId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_on_prem_connector_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "onPremConnectorId": on_prem_connector_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_on_prem_connector_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_on_prem_connector_compartment_details)
+
     def create_data_safe_private_endpoint(self, create_data_safe_private_endpoint_details, **kwargs):
         """
         Creates a new Data Safe private endpoint.
@@ -194,7 +288,7 @@ class DataSafeClient(object):
 
             To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
 
-        :return: A :class:`~oci.response.Response` object with data of type None
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_safe.models.DataSafePrivateEndpoint`
         :rtype: :class:`~oci.response.Response`
         """
         resource_path = "/dataSafePrivateEndpoints"
@@ -231,13 +325,87 @@ class DataSafeClient(object):
                 resource_path=resource_path,
                 method=method,
                 header_params=header_params,
-                body=create_data_safe_private_endpoint_details)
+                body=create_data_safe_private_endpoint_details,
+                response_type="DataSafePrivateEndpoint")
         else:
             return self.base_client.call_api(
                 resource_path=resource_path,
                 method=method,
                 header_params=header_params,
-                body=create_data_safe_private_endpoint_details)
+                body=create_data_safe_private_endpoint_details,
+                response_type="DataSafePrivateEndpoint")
+
+    def create_on_prem_connector(self, create_on_prem_connector_details, **kwargs):
+        """
+        Creates a new on-premises connector.
+
+
+        :param oci.data_safe.models.CreateOnPremConnectorDetails create_on_prem_connector_details: (required)
+            The details used to create a new on-premises connector.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_safe.models.OnPremConnector`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/onPremConnectors"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_on_prem_connector got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_on_prem_connector_details,
+                response_type="OnPremConnector")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_on_prem_connector_details,
+                response_type="OnPremConnector")
 
     def delete_data_safe_private_endpoint(self, data_safe_private_endpoint_id, **kwargs):
         """
@@ -284,6 +452,85 @@ class DataSafeClient(object):
 
         path_params = {
             "dataSafePrivateEndpointId": data_safe_private_endpoint_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_on_prem_connector(self, on_prem_connector_id, **kwargs):
+        """
+        Deletes the specified on-premises connector.
+
+
+        :param str on_prem_connector_id: (required)
+            The OCID of the on-premises connector.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the if-match parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/onPremConnectors/{onPremConnectorId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_on_prem_connector got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "onPremConnectorId": on_prem_connector_id
         }
 
         path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
@@ -397,6 +644,102 @@ class DataSafeClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 body=enable_data_safe_configuration_details)
+
+    def generate_on_prem_connector_configuration(self, generate_on_prem_connector_configuration_details, on_prem_connector_id, **kwargs):
+        """
+        Creates and downloads the configuration of the specified on-premises connector.
+
+
+        :param oci.data_safe.models.GenerateOnPremConnectorConfigurationDetails generate_on_prem_connector_configuration_details: (required)
+            The details used to create and download on-premises connector's configuration.
+
+        :param str on_prem_connector_id: (required)
+            The OCID of the on-premises connector.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the if-match parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type stream
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/onPremConnectors/{onPremConnectorId}/actions/generateConfiguration"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "generate_on_prem_connector_configuration got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "onPremConnectorId": on_prem_connector_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/octet-stream",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=generate_on_prem_connector_configuration_details,
+                response_type="stream")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=generate_on_prem_connector_configuration_details,
+                response_type="stream")
 
     def get_data_safe_configuration(self, **kwargs):
         """
@@ -538,6 +881,78 @@ class DataSafeClient(object):
                 header_params=header_params,
                 response_type="DataSafePrivateEndpoint")
 
+    def get_on_prem_connector(self, on_prem_connector_id, **kwargs):
+        """
+        Gets the details of the specified on-premises connector.
+
+
+        :param str on_prem_connector_id: (required)
+            The OCID of the on-premises connector.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_safe.models.OnPremConnector`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/onPremConnectors/{onPremConnectorId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_on_prem_connector got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "onPremConnectorId": on_prem_connector_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="OnPremConnector")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="OnPremConnector")
+
     def get_work_request(self, work_request_id, **kwargs):
         """
         Gets the details of the specified work request.
@@ -610,19 +1025,19 @@ class DataSafeClient(object):
                 header_params=header_params,
                 response_type="WorkRequest")
 
-    def list_data_safe_private_endpoints(self, **kwargs):
+    def list_data_safe_private_endpoints(self, compartment_id, **kwargs):
         """
         Gets a list of Data Safe private endpoints.
 
 
-        :param str compartment_id: (optional)
+        :param str compartment_id: (required)
             A filter to return only resources that match the specified compartment OCID.
 
         :param str display_name: (optional)
             A filter to return only resources that match the specified display name.
 
         :param str vcn_id: (optional)
-            A filter to return only the private endpoints that match the specified VCN OCID.
+            A filter to return only resources that match the specified VCN OCID.
 
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the specified lifecycle state.
@@ -635,7 +1050,9 @@ class DataSafeClient(object):
             __ https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            The beginning page from which the results start retrieving.
+            For list pagination. The page token representing the page at which to start retrieving results. It is usually retrieved from a previous \"List\" call. For details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
             The sort order to use, either ascending (ASC) or descending (DESC).
@@ -667,7 +1084,6 @@ class DataSafeClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
-            "compartment_id",
             "display_name",
             "vcn_id",
             "lifecycle_state",
@@ -704,7 +1120,7 @@ class DataSafeClient(object):
                 )
 
         query_params = {
-            "compartmentId": kwargs.get("compartment_id", missing),
+            "compartmentId": compartment_id,
             "displayName": kwargs.get("display_name", missing),
             "vcnId": kwargs.get("vcn_id", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
@@ -742,6 +1158,139 @@ class DataSafeClient(object):
                 header_params=header_params,
                 response_type="list[DataSafePrivateEndpointSummary]")
 
+    def list_on_prem_connectors(self, compartment_id, **kwargs):
+        """
+        Gets a list of on-premises connectors.
+
+
+        :param str compartment_id: (required)
+            A filter to return only resources that match the specified compartment OCID.
+
+        :param str on_prem_connector_id: (optional)
+            A filter to return only the on-premises connector that matches the specified id.
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the specified display name.
+
+        :param str on_prem_connector_lifecycle_state: (optional)
+            A filter to return only on-premises connector resources that match the specified lifecycle state.
+
+            Allowed values are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED"
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of items to return per page in a paginated \"List\" call. For details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The page token representing the page at which to start retrieving results. It is usually retrieved from a previous \"List\" call. For details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (ASC) or descending (DESC).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. You can specify only one sort order (sortOrder). The default order for TIMECREATED is descending. The default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.data_safe.models.OnPremConnectorSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/onPremConnectors"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "on_prem_connector_id",
+            "display_name",
+            "on_prem_connector_lifecycle_state",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_on_prem_connectors got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'on_prem_connector_lifecycle_state' in kwargs:
+            on_prem_connector_lifecycle_state_allowed_values = ["CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED"]
+            if kwargs['on_prem_connector_lifecycle_state'] not in on_prem_connector_lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `on_prem_connector_lifecycle_state`, must be one of {0}".format(on_prem_connector_lifecycle_state_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "onPremConnectorId": kwargs.get("on_prem_connector_id", missing),
+            "displayName": kwargs.get("display_name", missing),
+            "onPremConnectorLifecycleState": kwargs.get("on_prem_connector_lifecycle_state", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[OnPremConnectorSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[OnPremConnectorSummary]")
+
     def list_work_request_errors(self, work_request_id, **kwargs):
         """
         Gets a list of errors for the specified work request.
@@ -754,7 +1303,9 @@ class DataSafeClient(object):
             Unique identifier for the request.
 
         :param str page: (optional)
-            The beginning page from which the results start retrieving.
+            For list pagination. The page token representing the page at which to start retrieving results. It is usually retrieved from a previous \"List\" call. For details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
             For list pagination. The maximum number of items to return per page in a paginated \"List\" call. For details about how pagination works, see `List Pagination`__.
@@ -844,7 +1395,9 @@ class DataSafeClient(object):
             Unique identifier for the request.
 
         :param str page: (optional)
-            The beginning page from which the results start retrieving.
+            For list pagination. The page token representing the page at which to start retrieving results. It is usually retrieved from a previous \"List\" call. For details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
             For list pagination. The maximum number of items to return per page in a paginated \"List\" call. For details about how pagination works, see `List Pagination`__.
@@ -922,12 +1475,12 @@ class DataSafeClient(object):
                 header_params=header_params,
                 response_type="list[WorkRequestLogEntry]")
 
-    def list_work_requests(self, **kwargs):
+    def list_work_requests(self, compartment_id, **kwargs):
         """
         Gets a list of work requests.
 
 
-        :param str compartment_id: (optional)
+        :param str compartment_id: (required)
             A filter to return only resources that match the specified compartment OCID.
 
         :param str resource_id: (optional)
@@ -937,7 +1490,9 @@ class DataSafeClient(object):
             Unique identifier for the request.
 
         :param str page: (optional)
-            The beginning page from which the results start retrieving.
+            For list pagination. The page token representing the page at which to start retrieving results. It is usually retrieved from a previous \"List\" call. For details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
             For list pagination. The maximum number of items to return per page in a paginated \"List\" call. For details about how pagination works, see `List Pagination`__.
@@ -961,7 +1516,6 @@ class DataSafeClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
-            "compartment_id",
             "resource_id",
             "opc_request_id",
             "page",
@@ -973,7 +1527,7 @@ class DataSafeClient(object):
                 "list_work_requests got unknown kwargs: {!r}".format(extra_kwargs))
 
         query_params = {
-            "compartmentId": kwargs.get("compartment_id", missing),
+            "compartmentId": compartment_id,
             "resourceId": kwargs.get("resource_id", missing),
             "page": kwargs.get("page", missing),
             "limit": kwargs.get("limit", missing)
@@ -1090,3 +1644,181 @@ class DataSafeClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 body=update_data_safe_private_endpoint_details)
+
+    def update_on_prem_connector(self, on_prem_connector_id, update_on_prem_connector_details, **kwargs):
+        """
+        Updates one or more attributes of the specified on-premises connector.
+
+
+        :param str on_prem_connector_id: (required)
+            The OCID of the on-premises connector.
+
+        :param oci.data_safe.models.UpdateOnPremConnectorDetails update_on_prem_connector_details: (required)
+            The details used to update a on-premises connector.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the if-match parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/onPremConnectors/{onPremConnectorId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_on_prem_connector got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "onPremConnectorId": on_prem_connector_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_on_prem_connector_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_on_prem_connector_details)
+
+    def update_on_prem_connector_wallet(self, update_on_prem_connector_wallet_details, on_prem_connector_id, **kwargs):
+        """
+        Updates the wallet for the specified on-premises connector to a new version.
+
+
+        :param oci.data_safe.models.UpdateOnPremConnectorWalletDetails update_on_prem_connector_wallet_details: (required)
+            The details used to update an on-premises connector's wallet.
+
+        :param str on_prem_connector_id: (required)
+            The OCID of the on-premises connector.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the if-match parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/onPremConnectors/{onPremConnectorId}/wallet"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_on_prem_connector_wallet got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "onPremConnectorId": on_prem_connector_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_on_prem_connector_wallet_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_on_prem_connector_wallet_details)

--- a/src/oci/data_safe/data_safe_client_composite_operations.py
+++ b/src/oci/data_safe/data_safe_client_composite_operations.py
@@ -102,6 +102,44 @@ class DataSafeClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def create_on_prem_connector_and_wait_for_state(self, create_on_prem_connector_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.data_safe.DataSafeClient.create_on_prem_connector` and waits for the :py:class:`~oci.data_safe.models.WorkRequest`
+        to enter the given state(s).
+
+        :param CreateOnPremConnectorDetails create_on_prem_connector_details: (required)
+            The details used to create a new on-premises connector.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.data_safe.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.data_safe.DataSafeClient.create_on_prem_connector`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_on_prem_connector(create_on_prem_connector_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def delete_data_safe_private_endpoint_and_wait_for_state(self, data_safe_private_endpoint_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.data_safe.DataSafeClient.delete_data_safe_private_endpoint` and waits for the :py:class:`~oci.data_safe.models.WorkRequest`
@@ -123,6 +161,52 @@ class DataSafeClientCompositeOperations(object):
         operation_result = None
         try:
             operation_result = self.client.delete_data_safe_private_endpoint(data_safe_private_endpoint_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_on_prem_connector_and_wait_for_state(self, on_prem_connector_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.data_safe.DataSafeClient.delete_on_prem_connector` and waits for the :py:class:`~oci.data_safe.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str on_prem_connector_id: (required)
+            The OCID of the on-premises connector.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.data_safe.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.data_safe.DataSafeClient.delete_on_prem_connector`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = None
+        try:
+            operation_result = self.client.delete_on_prem_connector(on_prem_connector_id, **operation_kwargs)
         except oci.exceptions.ServiceError as e:
             if e.status == 404:
                 return WAIT_RESOURCE_NOT_FOUND
@@ -208,6 +292,88 @@ class DataSafeClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         operation_result = self.client.update_data_safe_private_endpoint(data_safe_private_endpoint_id, update_data_safe_private_endpoint_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_on_prem_connector_and_wait_for_state(self, on_prem_connector_id, update_on_prem_connector_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.data_safe.DataSafeClient.update_on_prem_connector` and waits for the :py:class:`~oci.data_safe.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str on_prem_connector_id: (required)
+            The OCID of the on-premises connector.
+
+        :param UpdateOnPremConnectorDetails update_on_prem_connector_details: (required)
+            The details used to update a on-premises connector.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.data_safe.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.data_safe.DataSafeClient.update_on_prem_connector`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_on_prem_connector(on_prem_connector_id, update_on_prem_connector_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_on_prem_connector_wallet_and_wait_for_state(self, update_on_prem_connector_wallet_details, on_prem_connector_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.data_safe.DataSafeClient.update_on_prem_connector_wallet` and waits for the :py:class:`~oci.data_safe.models.WorkRequest`
+        to enter the given state(s).
+
+        :param UpdateOnPremConnectorWalletDetails update_on_prem_connector_wallet_details: (required)
+            The details used to update an on-premises connector's wallet.
+
+        :param str on_prem_connector_id: (required)
+            The OCID of the on-premises connector.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.data_safe.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.data_safe.DataSafeClient.update_on_prem_connector_wallet`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_on_prem_connector_wallet(update_on_prem_connector_wallet_details, on_prem_connector_id, **operation_kwargs)
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/data_safe/models/__init__.py
+++ b/src/oci/data_safe/models/__init__.py
@@ -5,12 +5,19 @@
 from __future__ import absolute_import
 
 from .change_data_safe_private_endpoint_compartment_details import ChangeDataSafePrivateEndpointCompartmentDetails
+from .change_on_prem_connector_compartment_details import ChangeOnPremConnectorCompartmentDetails
 from .create_data_safe_private_endpoint_details import CreateDataSafePrivateEndpointDetails
+from .create_on_prem_connector_details import CreateOnPremConnectorDetails
 from .data_safe_configuration import DataSafeConfiguration
 from .data_safe_private_endpoint import DataSafePrivateEndpoint
 from .data_safe_private_endpoint_summary import DataSafePrivateEndpointSummary
 from .enable_data_safe_configuration_details import EnableDataSafeConfigurationDetails
+from .generate_on_prem_connector_configuration_details import GenerateOnPremConnectorConfigurationDetails
+from .on_prem_connector import OnPremConnector
+from .on_prem_connector_summary import OnPremConnectorSummary
 from .update_data_safe_private_endpoint_details import UpdateDataSafePrivateEndpointDetails
+from .update_on_prem_connector_details import UpdateOnPremConnectorDetails
+from .update_on_prem_connector_wallet_details import UpdateOnPremConnectorWalletDetails
 from .work_request import WorkRequest
 from .work_request_error import WorkRequestError
 from .work_request_log_entry import WorkRequestLogEntry
@@ -20,12 +27,19 @@ from .work_request_summary import WorkRequestSummary
 # Maps type names to classes for data_safe services.
 data_safe_type_mapping = {
     "ChangeDataSafePrivateEndpointCompartmentDetails": ChangeDataSafePrivateEndpointCompartmentDetails,
+    "ChangeOnPremConnectorCompartmentDetails": ChangeOnPremConnectorCompartmentDetails,
     "CreateDataSafePrivateEndpointDetails": CreateDataSafePrivateEndpointDetails,
+    "CreateOnPremConnectorDetails": CreateOnPremConnectorDetails,
     "DataSafeConfiguration": DataSafeConfiguration,
     "DataSafePrivateEndpoint": DataSafePrivateEndpoint,
     "DataSafePrivateEndpointSummary": DataSafePrivateEndpointSummary,
     "EnableDataSafeConfigurationDetails": EnableDataSafeConfigurationDetails,
+    "GenerateOnPremConnectorConfigurationDetails": GenerateOnPremConnectorConfigurationDetails,
+    "OnPremConnector": OnPremConnector,
+    "OnPremConnectorSummary": OnPremConnectorSummary,
     "UpdateDataSafePrivateEndpointDetails": UpdateDataSafePrivateEndpointDetails,
+    "UpdateOnPremConnectorDetails": UpdateOnPremConnectorDetails,
+    "UpdateOnPremConnectorWalletDetails": UpdateOnPremConnectorWalletDetails,
     "WorkRequest": WorkRequest,
     "WorkRequestError": WorkRequestError,
     "WorkRequestLogEntry": WorkRequestLogEntry,

--- a/src/oci/data_safe/models/change_on_prem_connector_compartment_details.py
+++ b/src/oci/data_safe/models/change_on_prem_connector_compartment_details.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeOnPremConnectorCompartmentDetails(object):
+    """
+    The details used to change the compartment of a on-premises connector.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeOnPremConnectorCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeOnPremConnectorCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeOnPremConnectorCompartmentDetails.
+        The OCID of the new compartment where you want to move the on-premises connector.
+
+
+        :return: The compartment_id of this ChangeOnPremConnectorCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeOnPremConnectorCompartmentDetails.
+        The OCID of the new compartment where you want to move the on-premises connector.
+
+
+        :param compartment_id: The compartment_id of this ChangeOnPremConnectorCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_safe/models/create_data_safe_private_endpoint_details.py
+++ b/src/oci/data_safe/models/create_data_safe_private_endpoint_details.py
@@ -295,7 +295,7 @@ class CreateDataSafePrivateEndpointDetails(object):
         Gets the defined_tags of this CreateDataSafePrivateEndpointDetails.
         Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
 
-        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
 
@@ -311,7 +311,7 @@ class CreateDataSafePrivateEndpointDetails(object):
         Sets the defined_tags of this CreateDataSafePrivateEndpointDetails.
         Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
 
-        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/data_safe/models/create_on_prem_connector_details.py
+++ b/src/oci/data_safe/models/create_on_prem_connector_details.py
@@ -1,0 +1,210 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateOnPremConnectorDetails(object):
+    """
+    The details used to create a new on-premises connector.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateOnPremConnectorDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateOnPremConnectorDetails.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateOnPremConnectorDetails.
+        :type compartment_id: str
+
+        :param description:
+            The value to assign to the description property of this CreateOnPremConnectorDetails.
+        :type description: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateOnPremConnectorDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateOnPremConnectorDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'description': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'description': 'description',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._compartment_id = None
+        self._description = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateOnPremConnectorDetails.
+        The display name of the on-premises connector. The name does not have to be unique, and it's changeable.
+
+
+        :return: The display_name of this CreateOnPremConnectorDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateOnPremConnectorDetails.
+        The display name of the on-premises connector. The name does not have to be unique, and it's changeable.
+
+
+        :param display_name: The display_name of this CreateOnPremConnectorDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateOnPremConnectorDetails.
+        The OCID of the compartment where you want to create the on-premises connector.
+
+
+        :return: The compartment_id of this CreateOnPremConnectorDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateOnPremConnectorDetails.
+        The OCID of the compartment where you want to create the on-premises connector.
+
+
+        :param compartment_id: The compartment_id of this CreateOnPremConnectorDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this CreateOnPremConnectorDetails.
+        The description of the on-premises connector.
+
+
+        :return: The description of this CreateOnPremConnectorDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this CreateOnPremConnectorDetails.
+        The description of the on-premises connector.
+
+
+        :param description: The description of this CreateOnPremConnectorDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateOnPremConnectorDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateOnPremConnectorDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateOnPremConnectorDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateOnPremConnectorDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateOnPremConnectorDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateOnPremConnectorDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateOnPremConnectorDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateOnPremConnectorDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_safe/models/data_safe_configuration.py
+++ b/src/oci/data_safe/models/data_safe_configuration.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataSafeConfiguration(object):
     """
-    A Data Safe Configuration that allows customer to enable Data Safe in their tenancy.
+    A Data Safe configuration for a tenancy and region.
     """
 
     #: A constant which can be used with the lifecycle_state property of a DataSafeConfiguration.
@@ -108,7 +108,7 @@ class DataSafeConfiguration(object):
     @property
     def is_enabled(self):
         """
-        Gets the is_enabled of this DataSafeConfiguration.
+        **[Required]** Gets the is_enabled of this DataSafeConfiguration.
         Indicates if Data Safe is enabled.
 
 
@@ -181,7 +181,9 @@ class DataSafeConfiguration(object):
     def time_enabled(self):
         """
         Gets the time_enabled of this DataSafeConfiguration.
-        The specific time when Data Safe configuration was enabled.
+        The date and time Data Safe was enabled, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_enabled of this DataSafeConfiguration.
@@ -193,7 +195,9 @@ class DataSafeConfiguration(object):
     def time_enabled(self, time_enabled):
         """
         Sets the time_enabled of this DataSafeConfiguration.
-        The specific time when Data Safe configuration was enabled.
+        The date and time Data Safe was enabled, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_enabled: The time_enabled of this DataSafeConfiguration.
@@ -205,7 +209,7 @@ class DataSafeConfiguration(object):
     def lifecycle_state(self):
         """
         Gets the lifecycle_state of this DataSafeConfiguration.
-        The current state of Data Safe configuration.
+        The current state of Data Safe.
 
         Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "DELETING", "DELETED", "FAILED", "NA", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -220,7 +224,7 @@ class DataSafeConfiguration(object):
     def lifecycle_state(self, lifecycle_state):
         """
         Sets the lifecycle_state of this DataSafeConfiguration.
-        The current state of Data Safe configuration.
+        The current state of Data Safe.
 
 
         :param lifecycle_state: The lifecycle_state of this DataSafeConfiguration.
@@ -269,7 +273,7 @@ class DataSafeConfiguration(object):
         Gets the defined_tags of this DataSafeConfiguration.
         Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
 
-        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
 
@@ -285,7 +289,7 @@ class DataSafeConfiguration(object):
         Sets the defined_tags of this DataSafeConfiguration.
         Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
 
-        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/data_safe/models/data_safe_private_endpoint.py
+++ b/src/oci/data_safe/models/data_safe_private_endpoint.py
@@ -374,7 +374,9 @@ class DataSafePrivateEndpoint(object):
     def time_created(self):
         """
         Gets the time_created of this DataSafePrivateEndpoint.
-        The date and time the private endpoint was created, in the format defined by RFC3339.
+        The date and time the private endpoint was created, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this DataSafePrivateEndpoint.
@@ -386,7 +388,9 @@ class DataSafePrivateEndpoint(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this DataSafePrivateEndpoint.
-        The date and time the private endpoint was created, in the format defined by RFC3339.
+        The date and time the private endpoint was created, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this DataSafePrivateEndpoint.
@@ -486,7 +490,7 @@ class DataSafePrivateEndpoint(object):
         Gets the defined_tags of this DataSafePrivateEndpoint.
         Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
 
-        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
 
@@ -502,7 +506,7 @@ class DataSafePrivateEndpoint(object):
         Sets the defined_tags of this DataSafePrivateEndpoint.
         Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
 
-        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/data_safe/models/data_safe_private_endpoint_summary.py
+++ b/src/oci/data_safe/models/data_safe_private_endpoint_summary.py
@@ -291,7 +291,9 @@ class DataSafePrivateEndpointSummary(object):
     def time_created(self):
         """
         Gets the time_created of this DataSafePrivateEndpointSummary.
-        The date and time the private endpoint was created, in the format defined by RFC3339.
+        The date and time the private endpoint was created, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_created of this DataSafePrivateEndpointSummary.
@@ -303,7 +305,9 @@ class DataSafePrivateEndpointSummary(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this DataSafePrivateEndpointSummary.
-        The date and time the private endpoint was created, in the format defined by RFC3339.
+        The date and time the private endpoint was created, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_created: The time_created of this DataSafePrivateEndpointSummary.

--- a/src/oci/data_safe/models/enable_data_safe_configuration_details.py
+++ b/src/oci/data_safe/models/enable_data_safe_configuration_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class EnableDataSafeConfigurationDetails(object):
     """
-    The information needed to enable Data Safe in the tenancy.
+    The details used to enable Data Safe in the tenancy and region.
     """
 
     def __init__(self, **kwargs):
@@ -22,35 +22,21 @@ class EnableDataSafeConfigurationDetails(object):
             The value to assign to the is_enabled property of this EnableDataSafeConfigurationDetails.
         :type is_enabled: bool
 
-        :param freeform_tags:
-            The value to assign to the freeform_tags property of this EnableDataSafeConfigurationDetails.
-        :type freeform_tags: dict(str, str)
-
-        :param defined_tags:
-            The value to assign to the defined_tags property of this EnableDataSafeConfigurationDetails.
-        :type defined_tags: dict(str, dict(str, object))
-
         """
         self.swagger_types = {
-            'is_enabled': 'bool',
-            'freeform_tags': 'dict(str, str)',
-            'defined_tags': 'dict(str, dict(str, object))'
+            'is_enabled': 'bool'
         }
 
         self.attribute_map = {
-            'is_enabled': 'isEnabled',
-            'freeform_tags': 'freeformTags',
-            'defined_tags': 'definedTags'
+            'is_enabled': 'isEnabled'
         }
 
         self._is_enabled = None
-        self._freeform_tags = None
-        self._defined_tags = None
 
     @property
     def is_enabled(self):
         """
-        Gets the is_enabled of this EnableDataSafeConfigurationDetails.
+        **[Required]** Gets the is_enabled of this EnableDataSafeConfigurationDetails.
         Indicates if Data Safe is enabled.
 
 
@@ -70,70 +56,6 @@ class EnableDataSafeConfigurationDetails(object):
         :type: bool
         """
         self._is_enabled = is_enabled
-
-    @property
-    def freeform_tags(self):
-        """
-        Gets the freeform_tags of this EnableDataSafeConfigurationDetails.
-        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see `Resource Tags`__
-
-        Example: `{\"Department\": \"Finance\"}`
-
-        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
-
-
-        :return: The freeform_tags of this EnableDataSafeConfigurationDetails.
-        :rtype: dict(str, str)
-        """
-        return self._freeform_tags
-
-    @freeform_tags.setter
-    def freeform_tags(self, freeform_tags):
-        """
-        Sets the freeform_tags of this EnableDataSafeConfigurationDetails.
-        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see `Resource Tags`__
-
-        Example: `{\"Department\": \"Finance\"}`
-
-        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
-
-
-        :param freeform_tags: The freeform_tags of this EnableDataSafeConfigurationDetails.
-        :type: dict(str, str)
-        """
-        self._freeform_tags = freeform_tags
-
-    @property
-    def defined_tags(self):
-        """
-        Gets the defined_tags of this EnableDataSafeConfigurationDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
-
-        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
-
-        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
-
-
-        :return: The defined_tags of this EnableDataSafeConfigurationDetails.
-        :rtype: dict(str, dict(str, object))
-        """
-        return self._defined_tags
-
-    @defined_tags.setter
-    def defined_tags(self, defined_tags):
-        """
-        Sets the defined_tags of this EnableDataSafeConfigurationDetails.
-        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
-
-        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
-
-        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
-
-
-        :param defined_tags: The defined_tags of this EnableDataSafeConfigurationDetails.
-        :type: dict(str, dict(str, object))
-        """
-        self._defined_tags = defined_tags
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_safe/models/generate_on_prem_connector_configuration_details.py
+++ b/src/oci/data_safe/models/generate_on_prem_connector_configuration_details.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class GenerateOnPremConnectorConfigurationDetails(object):
+    """
+    The details used to create and download on-premises connector's configuration.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new GenerateOnPremConnectorConfigurationDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param password:
+            The value to assign to the password property of this GenerateOnPremConnectorConfigurationDetails.
+        :type password: str
+
+        """
+        self.swagger_types = {
+            'password': 'str'
+        }
+
+        self.attribute_map = {
+            'password': 'password'
+        }
+
+        self._password = None
+
+    @property
+    def password(self):
+        """
+        **[Required]** Gets the password of this GenerateOnPremConnectorConfigurationDetails.
+        The password to encrypt the keys inside the wallet included as part of the configuration. The password must be between 12 and 30 characters long and must contain atleast 1 uppercase, 1 lowercase, 1 numeric, and 1 special character.
+
+
+        :return: The password of this GenerateOnPremConnectorConfigurationDetails.
+        :rtype: str
+        """
+        return self._password
+
+    @password.setter
+    def password(self, password):
+        """
+        Sets the password of this GenerateOnPremConnectorConfigurationDetails.
+        The password to encrypt the keys inside the wallet included as part of the configuration. The password must be between 12 and 30 characters long and must contain atleast 1 uppercase, 1 lowercase, 1 numeric, and 1 special character.
+
+
+        :param password: The password of this GenerateOnPremConnectorConfigurationDetails.
+        :type: str
+        """
+        self._password = password
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_safe/models/on_prem_connector.py
+++ b/src/oci/data_safe/models/on_prem_connector.py
@@ -1,0 +1,436 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OnPremConnector(object):
+    """
+    A Data Safe on-premises connector that enables Data Safe to connect to on-premises databases.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnector.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnector.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnector.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnector.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnector.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnector.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnector.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OnPremConnector object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this OnPremConnector.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this OnPremConnector.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this OnPremConnector.
+        :type compartment_id: str
+
+        :param description:
+            The value to assign to the description property of this OnPremConnector.
+        :type description: str
+
+        :param time_created:
+            The value to assign to the time_created property of this OnPremConnector.
+        :type time_created: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this OnPremConnector.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this OnPremConnector.
+        :type lifecycle_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this OnPremConnector.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this OnPremConnector.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param available_version:
+            The value to assign to the available_version property of this OnPremConnector.
+        :type available_version: str
+
+        :param created_version:
+            The value to assign to the created_version property of this OnPremConnector.
+        :type created_version: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'description': 'str',
+            'time_created': 'datetime',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'available_version': 'str',
+            'created_version': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'description': 'description',
+            'time_created': 'timeCreated',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'available_version': 'availableVersion',
+            'created_version': 'createdVersion'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._description = None
+        self._time_created = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._available_version = None
+        self._created_version = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this OnPremConnector.
+        The OCID of the on-premises connector.
+
+
+        :return: The id of this OnPremConnector.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this OnPremConnector.
+        The OCID of the on-premises connector.
+
+
+        :param id: The id of this OnPremConnector.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this OnPremConnector.
+        The display name of the on-premises connector.
+
+
+        :return: The display_name of this OnPremConnector.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this OnPremConnector.
+        The display name of the on-premises connector.
+
+
+        :param display_name: The display_name of this OnPremConnector.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this OnPremConnector.
+        The OCID of the compartment that contains the on-premises connector.
+
+
+        :return: The compartment_id of this OnPremConnector.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this OnPremConnector.
+        The OCID of the compartment that contains the on-premises connector.
+
+
+        :param compartment_id: The compartment_id of this OnPremConnector.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this OnPremConnector.
+        The description of the on-premises connector.
+
+
+        :return: The description of this OnPremConnector.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this OnPremConnector.
+        The description of the on-premises connector.
+
+
+        :param description: The description of this OnPremConnector.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this OnPremConnector.
+        The date and time the on-premises connector was created, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this OnPremConnector.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this OnPremConnector.
+        The date and time the on-premises connector was created, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this OnPremConnector.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this OnPremConnector.
+        The current state of the on-premises connector.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this OnPremConnector.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this OnPremConnector.
+        The current state of the on-premises connector.
+
+
+        :param lifecycle_state: The lifecycle_state of this OnPremConnector.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this OnPremConnector.
+        Details about the current state of the on-premises connector.
+
+
+        :return: The lifecycle_details of this OnPremConnector.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this OnPremConnector.
+        Details about the current state of the on-premises connector.
+
+
+        :param lifecycle_details: The lifecycle_details of this OnPremConnector.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this OnPremConnector.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this OnPremConnector.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this OnPremConnector.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this OnPremConnector.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this OnPremConnector.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this OnPremConnector.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this OnPremConnector.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this OnPremConnector.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def available_version(self):
+        """
+        Gets the available_version of this OnPremConnector.
+        Latest available version of the on-premises connector.
+
+
+        :return: The available_version of this OnPremConnector.
+        :rtype: str
+        """
+        return self._available_version
+
+    @available_version.setter
+    def available_version(self, available_version):
+        """
+        Sets the available_version of this OnPremConnector.
+        Latest available version of the on-premises connector.
+
+
+        :param available_version: The available_version of this OnPremConnector.
+        :type: str
+        """
+        self._available_version = available_version
+
+    @property
+    def created_version(self):
+        """
+        Gets the created_version of this OnPremConnector.
+        Created version of the on-premises connector.
+
+
+        :return: The created_version of this OnPremConnector.
+        :rtype: str
+        """
+        return self._created_version
+
+    @created_version.setter
+    def created_version(self, created_version):
+        """
+        Sets the created_version of this OnPremConnector.
+        Created version of the on-premises connector.
+
+
+        :param created_version: The created_version of this OnPremConnector.
+        :type: str
+        """
+        self._created_version = created_version
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_safe/models/on_prem_connector_summary.py
+++ b/src/oci/data_safe/models/on_prem_connector_summary.py
@@ -1,0 +1,405 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OnPremConnectorSummary(object):
+    """
+    Summary of a Data Safe on-premises connector.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnectorSummary.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnectorSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnectorSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnectorSummary.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnectorSummary.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnectorSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a OnPremConnectorSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OnPremConnectorSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this OnPremConnectorSummary.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this OnPremConnectorSummary.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this OnPremConnectorSummary.
+        :type compartment_id: str
+
+        :param description:
+            The value to assign to the description property of this OnPremConnectorSummary.
+        :type description: str
+
+        :param time_created:
+            The value to assign to the time_created property of this OnPremConnectorSummary.
+        :type time_created: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this OnPremConnectorSummary.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this OnPremConnectorSummary.
+        :type lifecycle_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this OnPremConnectorSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this OnPremConnectorSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param created_version:
+            The value to assign to the created_version property of this OnPremConnectorSummary.
+        :type created_version: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'description': 'str',
+            'time_created': 'datetime',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'created_version': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'description': 'description',
+            'time_created': 'timeCreated',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'created_version': 'createdVersion'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._description = None
+        self._time_created = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._created_version = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this OnPremConnectorSummary.
+        The OCID of the on-premises connector.
+
+
+        :return: The id of this OnPremConnectorSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this OnPremConnectorSummary.
+        The OCID of the on-premises connector.
+
+
+        :param id: The id of this OnPremConnectorSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this OnPremConnectorSummary.
+        The display name of the on-premises connector.
+
+
+        :return: The display_name of this OnPremConnectorSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this OnPremConnectorSummary.
+        The display name of the on-premises connector.
+
+
+        :param display_name: The display_name of this OnPremConnectorSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this OnPremConnectorSummary.
+        The OCID of the compartment that contains the on-premises connector.
+
+
+        :return: The compartment_id of this OnPremConnectorSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this OnPremConnectorSummary.
+        The OCID of the compartment that contains the on-premises connector.
+
+
+        :param compartment_id: The compartment_id of this OnPremConnectorSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this OnPremConnectorSummary.
+        The description of the on-premises connector.
+
+
+        :return: The description of this OnPremConnectorSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this OnPremConnectorSummary.
+        The description of the on-premises connector.
+
+
+        :param description: The description of this OnPremConnectorSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this OnPremConnectorSummary.
+        The date and time the on-premises connector was created, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this OnPremConnectorSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this OnPremConnectorSummary.
+        The date and time the on-premises connector was created, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this OnPremConnectorSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this OnPremConnectorSummary.
+        The current state of the on-premises connector.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this OnPremConnectorSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this OnPremConnectorSummary.
+        The current state of the on-premises connector.
+
+
+        :param lifecycle_state: The lifecycle_state of this OnPremConnectorSummary.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this OnPremConnectorSummary.
+        Details about the current state of the on-premises connector.
+
+
+        :return: The lifecycle_details of this OnPremConnectorSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this OnPremConnectorSummary.
+        Details about the current state of the on-premises connector.
+
+
+        :param lifecycle_details: The lifecycle_details of this OnPremConnectorSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this OnPremConnectorSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this OnPremConnectorSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this OnPremConnectorSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this OnPremConnectorSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this OnPremConnectorSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this OnPremConnectorSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this OnPremConnectorSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this OnPremConnectorSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def created_version(self):
+        """
+        Gets the created_version of this OnPremConnectorSummary.
+        Created version of the on-premises connector.
+
+
+        :return: The created_version of this OnPremConnectorSummary.
+        :rtype: str
+        """
+        return self._created_version
+
+    @created_version.setter
+    def created_version(self, created_version):
+        """
+        Sets the created_version of this OnPremConnectorSummary.
+        Created version of the on-premises connector.
+
+
+        :param created_version: The created_version of this OnPremConnectorSummary.
+        :type: str
+        """
+        self._created_version = created_version
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_safe/models/update_data_safe_private_endpoint_details.py
+++ b/src/oci/data_safe/models/update_data_safe_private_endpoint_details.py
@@ -171,7 +171,7 @@ class UpdateDataSafePrivateEndpointDetails(object):
         Gets the defined_tags of this UpdateDataSafePrivateEndpointDetails.
         Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
 
-        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
 
@@ -187,7 +187,7 @@ class UpdateDataSafePrivateEndpointDetails(object):
         Sets the defined_tags of this UpdateDataSafePrivateEndpointDetails.
         Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
 
-        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
 
         __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
 

--- a/src/oci/data_safe/models/update_on_prem_connector_details.py
+++ b/src/oci/data_safe/models/update_on_prem_connector_details.py
@@ -1,0 +1,179 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateOnPremConnectorDetails(object):
+    """
+    The details used to update a on-premises connector.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateOnPremConnectorDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateOnPremConnectorDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this UpdateOnPremConnectorDetails.
+        :type description: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateOnPremConnectorDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateOnPremConnectorDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'description': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'description': 'description',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._description = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateOnPremConnectorDetails.
+        The display name of the on-premises connector. The name does not have to be unique, and it's changeable.
+
+
+        :return: The display_name of this UpdateOnPremConnectorDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateOnPremConnectorDetails.
+        The display name of the on-premises connector. The name does not have to be unique, and it's changeable.
+
+
+        :param display_name: The display_name of this UpdateOnPremConnectorDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this UpdateOnPremConnectorDetails.
+        The description of the on-premises connector.
+
+
+        :return: The description of this UpdateOnPremConnectorDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this UpdateOnPremConnectorDetails.
+        The description of the on-premises connector.
+
+
+        :param description: The description of this UpdateOnPremConnectorDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateOnPremConnectorDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateOnPremConnectorDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateOnPremConnectorDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateOnPremConnectorDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateOnPremConnectorDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateOnPremConnectorDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateOnPremConnectorDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see `Resource Tags`__
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateOnPremConnectorDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_safe/models/update_on_prem_connector_wallet_details.py
+++ b/src/oci/data_safe/models/update_on_prem_connector_wallet_details.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateOnPremConnectorWalletDetails(object):
+    """
+    The details used to update an on-premises connector's wallet.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateOnPremConnectorWalletDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param is_update:
+            The value to assign to the is_update property of this UpdateOnPremConnectorWalletDetails.
+        :type is_update: bool
+
+        """
+        self.swagger_types = {
+            'is_update': 'bool'
+        }
+
+        self.attribute_map = {
+            'is_update': 'isUpdate'
+        }
+
+        self._is_update = None
+
+    @property
+    def is_update(self):
+        """
+        Gets the is_update of this UpdateOnPremConnectorWalletDetails.
+        Indicates whether to update or not. If false, the wallet will not be updated. Default is false.
+
+
+        :return: The is_update of this UpdateOnPremConnectorWalletDetails.
+        :rtype: bool
+        """
+        return self._is_update
+
+    @is_update.setter
+    def is_update(self, is_update):
+        """
+        Sets the is_update of this UpdateOnPremConnectorWalletDetails.
+        Indicates whether to update or not. If false, the wallet will not be updated. Default is false.
+
+
+        :param is_update: The is_update of this UpdateOnPremConnectorWalletDetails.
+        :type: bool
+        """
+        self._is_update = is_update
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_safe/models/work_request.py
+++ b/src/oci/data_safe/models/work_request.py
@@ -33,6 +33,26 @@ class WorkRequest(object):
     #: This constant has a value of "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT"
     OPERATION_TYPE_CHANGE_PRIVATE_ENDPOINT_COMPARTMENT = "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT"
 
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "CREATE_ONPREM_CONNECTOR"
+    OPERATION_TYPE_CREATE_ONPREM_CONNECTOR = "CREATE_ONPREM_CONNECTOR"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "UPDATE_ONPREM_CONNECTOR"
+    OPERATION_TYPE_UPDATE_ONPREM_CONNECTOR = "UPDATE_ONPREM_CONNECTOR"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "DELETE_ONPREM_CONNECTOR"
+    OPERATION_TYPE_DELETE_ONPREM_CONNECTOR = "DELETE_ONPREM_CONNECTOR"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "UPDATE_ONPREM_CONNECTOR_WALLET"
+    OPERATION_TYPE_UPDATE_ONPREM_CONNECTOR_WALLET = "UPDATE_ONPREM_CONNECTOR_WALLET"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "CHANGE_ONPREM_CONNECTOR_COMPARTMENT"
+    OPERATION_TYPE_CHANGE_ONPREM_CONNECTOR_COMPARTMENT = "CHANGE_ONPREM_CONNECTOR_COMPARTMENT"
+
     #: A constant which can be used with the status property of a WorkRequest.
     #: This constant has a value of "ACCEPTED"
     STATUS_ACCEPTED = "ACCEPTED"
@@ -56,7 +76,7 @@ class WorkRequest(object):
 
         :param operation_type:
             The value to assign to the operation_type property of this WorkRequest.
-            Allowed values for this property are: "ENABLE_DATA_SAFE_CONFIGURATION", "CREATE_PRIVATE_ENDPOINT", "UPDATE_PRIVATE_ENDPOINT", "DELETE_PRIVATE_ENDPOINT", "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ENABLE_DATA_SAFE_CONFIGURATION", "CREATE_PRIVATE_ENDPOINT", "UPDATE_PRIVATE_ENDPOINT", "DELETE_PRIVATE_ENDPOINT", "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT", "CREATE_ONPREM_CONNECTOR", "UPDATE_ONPREM_CONNECTOR", "DELETE_ONPREM_CONNECTOR", "UPDATE_ONPREM_CONNECTOR_WALLET", "CHANGE_ONPREM_CONNECTOR_COMPARTMENT", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type operation_type: str
 
@@ -133,9 +153,9 @@ class WorkRequest(object):
     def operation_type(self):
         """
         **[Required]** Gets the operation_type of this WorkRequest.
-        The asynchronous operation tracked by this work request.
+        The resources that are affected by the work request.
 
-        Allowed values for this property are: "ENABLE_DATA_SAFE_CONFIGURATION", "CREATE_PRIVATE_ENDPOINT", "UPDATE_PRIVATE_ENDPOINT", "DELETE_PRIVATE_ENDPOINT", "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ENABLE_DATA_SAFE_CONFIGURATION", "CREATE_PRIVATE_ENDPOINT", "UPDATE_PRIVATE_ENDPOINT", "DELETE_PRIVATE_ENDPOINT", "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT", "CREATE_ONPREM_CONNECTOR", "UPDATE_ONPREM_CONNECTOR", "DELETE_ONPREM_CONNECTOR", "UPDATE_ONPREM_CONNECTOR_WALLET", "CHANGE_ONPREM_CONNECTOR_COMPARTMENT", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -148,13 +168,13 @@ class WorkRequest(object):
     def operation_type(self, operation_type):
         """
         Sets the operation_type of this WorkRequest.
-        The asynchronous operation tracked by this work request.
+        The resources that are affected by the work request.
 
 
         :param operation_type: The operation_type of this WorkRequest.
         :type: str
         """
-        allowed_values = ["ENABLE_DATA_SAFE_CONFIGURATION", "CREATE_PRIVATE_ENDPOINT", "UPDATE_PRIVATE_ENDPOINT", "DELETE_PRIVATE_ENDPOINT", "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT"]
+        allowed_values = ["ENABLE_DATA_SAFE_CONFIGURATION", "CREATE_PRIVATE_ENDPOINT", "UPDATE_PRIVATE_ENDPOINT", "DELETE_PRIVATE_ENDPOINT", "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT", "CREATE_ONPREM_CONNECTOR", "UPDATE_ONPREM_CONNECTOR", "DELETE_ONPREM_CONNECTOR", "UPDATE_ONPREM_CONNECTOR_WALLET", "CHANGE_ONPREM_CONNECTOR_COMPARTMENT"]
         if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
             operation_type = 'UNKNOWN_ENUM_VALUE'
         self._operation_type = operation_type
@@ -163,7 +183,7 @@ class WorkRequest(object):
     def status(self):
         """
         **[Required]** Gets the status of this WorkRequest.
-        The status of the work request.
+        The current status of the work request.
 
         Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -178,7 +198,7 @@ class WorkRequest(object):
     def status(self, status):
         """
         Sets the status of this WorkRequest.
-        The status of the work request.
+        The current status of the work request.
 
 
         :param status: The status of this WorkRequest.
@@ -265,7 +285,7 @@ class WorkRequest(object):
     def percent_complete(self):
         """
         **[Required]** Gets the percent_complete of this WorkRequest.
-        Progress of the request in percentage.
+        Progress of the work request in percentage.
 
 
         :return: The percent_complete of this WorkRequest.
@@ -277,7 +297,7 @@ class WorkRequest(object):
     def percent_complete(self, percent_complete):
         """
         Sets the percent_complete of this WorkRequest.
-        Progress of the request in percentage.
+        Progress of the work request in percentage.
 
 
         :param percent_complete: The percent_complete of this WorkRequest.
@@ -289,7 +309,9 @@ class WorkRequest(object):
     def time_accepted(self):
         """
         **[Required]** Gets the time_accepted of this WorkRequest.
-        The date and time the work request was created, in the format defined by RFC3339.
+        The date and time the work request was accepted, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_accepted of this WorkRequest.
@@ -301,7 +323,9 @@ class WorkRequest(object):
     def time_accepted(self, time_accepted):
         """
         Sets the time_accepted of this WorkRequest.
-        The date and time the work request was created, in the format defined by RFC3339.
+        The date and time the work request was accepted, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_accepted: The time_accepted of this WorkRequest.
@@ -313,7 +337,9 @@ class WorkRequest(object):
     def time_started(self):
         """
         Gets the time_started of this WorkRequest.
-        The date and time the work request transitioned from ACCEPTED to IN_PROGRESS, in the format defined by RFC3339.
+        The date and time the work request transitioned from ACCEPTED to IN_PROGRESS, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_started of this WorkRequest.
@@ -325,7 +351,9 @@ class WorkRequest(object):
     def time_started(self, time_started):
         """
         Sets the time_started of this WorkRequest.
-        The date and time the work request transitioned from ACCEPTED to IN_PROGRESS, in the format defined by RFC3339.
+        The date and time the work request transitioned from ACCEPTED to IN_PROGRESS, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_started: The time_started of this WorkRequest.
@@ -337,7 +365,9 @@ class WorkRequest(object):
     def time_finished(self):
         """
         Gets the time_finished of this WorkRequest.
-        The date and time the work request reached a terminal state, either FAILED or SUCCEEDED. Format is defined by RFC3339.
+        The date and time the work request reached a terminal state, either FAILED or SUCCEEDED. Format is defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_finished of this WorkRequest.
@@ -349,7 +379,9 @@ class WorkRequest(object):
     def time_finished(self, time_finished):
         """
         Sets the time_finished of this WorkRequest.
-        The date and time the work request reached a terminal state, either FAILED or SUCCEEDED. Format is defined by RFC3339.
+        The date and time the work request reached a terminal state, either FAILED or SUCCEEDED. Format is defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_finished: The time_finished of this WorkRequest.

--- a/src/oci/data_safe/models/work_request_error.py
+++ b/src/oci/data_safe/models/work_request_error.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class WorkRequestError(object):
     """
-    An error encountered while executing an operation that is tracked by a work request.
+    An error related to a work request.
     """
 
     def __init__(self, **kwargs):
@@ -51,8 +51,9 @@ class WorkRequestError(object):
     def code(self):
         """
         **[Required]** Gets the code of this WorkRequestError.
-        A machine-usable code for the error that occured. Error codes are listed on
-        (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
+        A machine-usable error code. For a list of common errors, see `API Errors`__.
+
+        __ https://docs.cloud.oracle.com/Content/API/References/apierrors.htm
 
 
         :return: The code of this WorkRequestError.
@@ -64,8 +65,9 @@ class WorkRequestError(object):
     def code(self, code):
         """
         Sets the code of this WorkRequestError.
-        A machine-usable code for the error that occured. Error codes are listed on
-        (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
+        A machine-usable error code. For a list of common errors, see `API Errors`__.
+
+        __ https://docs.cloud.oracle.com/Content/API/References/apierrors.htm
 
 
         :param code: The code of this WorkRequestError.
@@ -101,7 +103,9 @@ class WorkRequestError(object):
     def timestamp(self):
         """
         **[Required]** Gets the timestamp of this WorkRequestError.
-        The date and time the error occurred, in the format defined by RFC3339.
+        The date and time the error occurred, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The timestamp of this WorkRequestError.
@@ -113,7 +117,9 @@ class WorkRequestError(object):
     def timestamp(self, timestamp):
         """
         Sets the timestamp of this WorkRequestError.
-        The date and time the error occurred, in the format defined by RFC3339.
+        The date and time the error occurred, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param timestamp: The timestamp of this WorkRequestError.

--- a/src/oci/data_safe/models/work_request_log_entry.py
+++ b/src/oci/data_safe/models/work_request_log_entry.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class WorkRequestLogEntry(object):
     """
-    A log message from the execution of a work request.
+    A log entry related to a work request.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,7 @@ class WorkRequestLogEntry(object):
     def message(self):
         """
         **[Required]** Gets the message of this WorkRequestLogEntry.
-        Human-readable log message.
+        A human-readable log entry.
 
 
         :return: The message of this WorkRequestLogEntry.
@@ -56,7 +56,7 @@ class WorkRequestLogEntry(object):
     def message(self, message):
         """
         Sets the message of this WorkRequestLogEntry.
-        Human-readable log message.
+        A human-readable log entry.
 
 
         :param message: The message of this WorkRequestLogEntry.
@@ -68,7 +68,9 @@ class WorkRequestLogEntry(object):
     def timestamp(self):
         """
         **[Required]** Gets the timestamp of this WorkRequestLogEntry.
-        The time when the log message was created, in the format defined by RFC3339.
+        The date and time the log entry was created, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The timestamp of this WorkRequestLogEntry.
@@ -80,7 +82,9 @@ class WorkRequestLogEntry(object):
     def timestamp(self, timestamp):
         """
         Sets the timestamp of this WorkRequestLogEntry.
-        The time when the log message was created, in the format defined by RFC3339.
+        The date and time the log entry was created, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param timestamp: The timestamp of this WorkRequestLogEntry.

--- a/src/oci/data_safe/models/work_request_summary.py
+++ b/src/oci/data_safe/models/work_request_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class WorkRequestSummary(object):
     """
-    A summary of the work request status.
+    Summary of a work request.
     """
 
     #: A constant which can be used with the operation_type property of a WorkRequestSummary.
@@ -32,6 +32,26 @@ class WorkRequestSummary(object):
     #: A constant which can be used with the operation_type property of a WorkRequestSummary.
     #: This constant has a value of "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT"
     OPERATION_TYPE_CHANGE_PRIVATE_ENDPOINT_COMPARTMENT = "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "CREATE_ONPREM_CONNECTOR"
+    OPERATION_TYPE_CREATE_ONPREM_CONNECTOR = "CREATE_ONPREM_CONNECTOR"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "UPDATE_ONPREM_CONNECTOR"
+    OPERATION_TYPE_UPDATE_ONPREM_CONNECTOR = "UPDATE_ONPREM_CONNECTOR"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "DELETE_ONPREM_CONNECTOR"
+    OPERATION_TYPE_DELETE_ONPREM_CONNECTOR = "DELETE_ONPREM_CONNECTOR"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "UPDATE_ONPREM_CONNECTOR_WALLET"
+    OPERATION_TYPE_UPDATE_ONPREM_CONNECTOR_WALLET = "UPDATE_ONPREM_CONNECTOR_WALLET"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "CHANGE_ONPREM_CONNECTOR_COMPARTMENT"
+    OPERATION_TYPE_CHANGE_ONPREM_CONNECTOR_COMPARTMENT = "CHANGE_ONPREM_CONNECTOR_COMPARTMENT"
 
     #: A constant which can be used with the status property of a WorkRequestSummary.
     #: This constant has a value of "ACCEPTED"
@@ -56,7 +76,7 @@ class WorkRequestSummary(object):
 
         :param operation_type:
             The value to assign to the operation_type property of this WorkRequestSummary.
-            Allowed values for this property are: "ENABLE_DATA_SAFE_CONFIGURATION", "CREATE_PRIVATE_ENDPOINT", "UPDATE_PRIVATE_ENDPOINT", "DELETE_PRIVATE_ENDPOINT", "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ENABLE_DATA_SAFE_CONFIGURATION", "CREATE_PRIVATE_ENDPOINT", "UPDATE_PRIVATE_ENDPOINT", "DELETE_PRIVATE_ENDPOINT", "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT", "CREATE_ONPREM_CONNECTOR", "UPDATE_ONPREM_CONNECTOR", "DELETE_ONPREM_CONNECTOR", "UPDATE_ONPREM_CONNECTOR_WALLET", "CHANGE_ONPREM_CONNECTOR_COMPARTMENT", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type operation_type: str
 
@@ -135,7 +155,7 @@ class WorkRequestSummary(object):
         **[Required]** Gets the operation_type of this WorkRequestSummary.
         The asynchronous operation tracked by this work request.
 
-        Allowed values for this property are: "ENABLE_DATA_SAFE_CONFIGURATION", "CREATE_PRIVATE_ENDPOINT", "UPDATE_PRIVATE_ENDPOINT", "DELETE_PRIVATE_ENDPOINT", "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ENABLE_DATA_SAFE_CONFIGURATION", "CREATE_PRIVATE_ENDPOINT", "UPDATE_PRIVATE_ENDPOINT", "DELETE_PRIVATE_ENDPOINT", "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT", "CREATE_ONPREM_CONNECTOR", "UPDATE_ONPREM_CONNECTOR", "DELETE_ONPREM_CONNECTOR", "UPDATE_ONPREM_CONNECTOR_WALLET", "CHANGE_ONPREM_CONNECTOR_COMPARTMENT", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -154,7 +174,7 @@ class WorkRequestSummary(object):
         :param operation_type: The operation_type of this WorkRequestSummary.
         :type: str
         """
-        allowed_values = ["ENABLE_DATA_SAFE_CONFIGURATION", "CREATE_PRIVATE_ENDPOINT", "UPDATE_PRIVATE_ENDPOINT", "DELETE_PRIVATE_ENDPOINT", "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT"]
+        allowed_values = ["ENABLE_DATA_SAFE_CONFIGURATION", "CREATE_PRIVATE_ENDPOINT", "UPDATE_PRIVATE_ENDPOINT", "DELETE_PRIVATE_ENDPOINT", "CHANGE_PRIVATE_ENDPOINT_COMPARTMENT", "CREATE_ONPREM_CONNECTOR", "UPDATE_ONPREM_CONNECTOR", "DELETE_ONPREM_CONNECTOR", "UPDATE_ONPREM_CONNECTOR_WALLET", "CHANGE_ONPREM_CONNECTOR_COMPARTMENT"]
         if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
             operation_type = 'UNKNOWN_ENUM_VALUE'
         self._operation_type = operation_type
@@ -163,7 +183,7 @@ class WorkRequestSummary(object):
     def status(self):
         """
         **[Required]** Gets the status of this WorkRequestSummary.
-        The status of the work request.
+        The current status of the work request.
 
         Allowed values for this property are: "ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -178,7 +198,7 @@ class WorkRequestSummary(object):
     def status(self, status):
         """
         Sets the status of this WorkRequestSummary.
-        The status of the work request.
+        The current status of the work request.
 
 
         :param status: The status of this WorkRequestSummary.
@@ -217,7 +237,7 @@ class WorkRequestSummary(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this WorkRequestSummary.
-        The OCID of the compartment containing this work request.
+        The OCID of the compartment that contains the work request.
 
 
         :return: The compartment_id of this WorkRequestSummary.
@@ -229,7 +249,7 @@ class WorkRequestSummary(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this WorkRequestSummary.
-        The OCID of the compartment containing this work request.
+        The OCID of the compartment that contains the work request.
 
 
         :param compartment_id: The compartment_id of this WorkRequestSummary.
@@ -241,7 +261,7 @@ class WorkRequestSummary(object):
     def resources(self):
         """
         **[Required]** Gets the resources of this WorkRequestSummary.
-        The resources impacted by the work request.
+        The resources that are affected by the work request.
 
 
         :return: The resources of this WorkRequestSummary.
@@ -253,7 +273,7 @@ class WorkRequestSummary(object):
     def resources(self, resources):
         """
         Sets the resources of this WorkRequestSummary.
-        The resources impacted by the work request.
+        The resources that are affected by the work request.
 
 
         :param resources: The resources of this WorkRequestSummary.
@@ -265,7 +285,7 @@ class WorkRequestSummary(object):
     def percent_complete(self):
         """
         **[Required]** Gets the percent_complete of this WorkRequestSummary.
-        Progress of the request in percentage.
+        Progress of the work request in percentage.
 
 
         :return: The percent_complete of this WorkRequestSummary.
@@ -277,7 +297,7 @@ class WorkRequestSummary(object):
     def percent_complete(self, percent_complete):
         """
         Sets the percent_complete of this WorkRequestSummary.
-        Progress of the request in percentage.
+        Progress of the work request in percentage.
 
 
         :param percent_complete: The percent_complete of this WorkRequestSummary.
@@ -289,7 +309,9 @@ class WorkRequestSummary(object):
     def time_accepted(self):
         """
         **[Required]** Gets the time_accepted of this WorkRequestSummary.
-        The date and time the work request was created, in the format defined by RFC3339.
+        The date and time the work request was accepted, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_accepted of this WorkRequestSummary.
@@ -301,7 +323,9 @@ class WorkRequestSummary(object):
     def time_accepted(self, time_accepted):
         """
         Sets the time_accepted of this WorkRequestSummary.
-        The date and time the work request was created, in the format defined by RFC3339.
+        The date and time the work request was accepted, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_accepted: The time_accepted of this WorkRequestSummary.
@@ -313,7 +337,9 @@ class WorkRequestSummary(object):
     def time_started(self):
         """
         Gets the time_started of this WorkRequestSummary.
-        The date and time the work request transitioned from ACCEPTED to IN_PROGRESS, in the format defined by RFC3339.
+        The date and time the work request transitioned from ACCEPTED to IN_PROGRESS, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_started of this WorkRequestSummary.
@@ -325,7 +351,9 @@ class WorkRequestSummary(object):
     def time_started(self, time_started):
         """
         Sets the time_started of this WorkRequestSummary.
-        The date and time the work request transitioned from ACCEPTED to IN_PROGRESS, in the format defined by RFC3339.
+        The date and time the work request transitioned from ACCEPTED to IN_PROGRESS, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_started: The time_started of this WorkRequestSummary.
@@ -337,7 +365,9 @@ class WorkRequestSummary(object):
     def time_finished(self):
         """
         Gets the time_finished of this WorkRequestSummary.
-        The date and time the work request reached a terminal state, either FAILED or SUCCEEDED, in the format defined by RFC3339.
+        The date and time the work request reached a terminal state, either FAILED or SUCCEEDED, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :return: The time_finished of this WorkRequestSummary.
@@ -349,7 +379,9 @@ class WorkRequestSummary(object):
     def time_finished(self, time_finished):
         """
         Sets the time_finished of this WorkRequestSummary.
-        The date and time the work request reached a terminal state, either FAILED or SUCCEEDED, in the format defined by RFC3339.
+        The date and time the work request reached a terminal state, either FAILED or SUCCEEDED, in the format defined by `RFC3339`__.
+
+        __ https://tools.ietf.org/html/rfc3339
 
 
         :param time_finished: The time_finished of this WorkRequestSummary.

--- a/src/oci/management_agent/management_agent_client.py
+++ b/src/oci/management_agent/management_agent_client.py
@@ -765,6 +765,140 @@ class ManagementAgentClient(object):
                 header_params=header_params,
                 response_type="WorkRequest")
 
+    def list_availability_histories(self, management_agent_id, **kwargs):
+        """
+        Lists the availability history records of Management Agent
+
+
+        :param str management_agent_id: (required)
+            Unique Management Agent identifier
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param datetime time_availability_status_ended_greater_than: (optional)
+            Filter to limit the availability history results to that of time after the input time including the boundary record.
+            Defaulted to current date minus one year.
+            The date and time to be given as described in `RFC 3339`__, section 14.29.
+
+            __ https://tools.ietf.org/rfc/rfc3339
+
+        :param datetime time_availability_status_started_less_than: (optional)
+            Filter to limit the availability history results to that of time before the input time including the boundary record
+            Defaulted to current date.
+            The date and time to be given as described in `RFC 3339`__, section 14.29.
+
+            __ https://tools.ietf.org/rfc/rfc3339
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Default order for timeAvailabilityStatusStarted is descending.
+
+            Allowed values are: "timeAvailabilityStatusStarted"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.management_agent.models.AvailabilityHistorySummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/managementAgents/{managementAgentId}/availabilityHistories"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "time_availability_status_ended_greater_than",
+            "time_availability_status_started_less_than",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_availability_histories got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "managementAgentId": management_agent_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["timeAvailabilityStatusStarted"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "timeAvailabilityStatusEndedGreaterThan": kwargs.get("time_availability_status_ended_greater_than", missing),
+            "timeAvailabilityStatusStartedLessThan": kwargs.get("time_availability_status_started_less_than", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AvailabilityHistorySummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[AvailabilityHistorySummary]")
+
     def list_management_agent_images(self, compartment_id, **kwargs):
         """
         Get supported agent image information

--- a/src/oci/management_agent/models/__init__.py
+++ b/src/oci/management_agent/models/__init__.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import
 
+from .availability_history_summary import AvailabilityHistorySummary
 from .create_management_agent_install_key_details import CreateManagementAgentInstallKeyDetails
 from .deploy_plugins_details import DeployPluginsDetails
 from .management_agent import ManagementAgent
@@ -27,6 +28,7 @@ from .work_submission_key import WorkSubmissionKey
 
 # Maps type names to classes for management_agent services.
 management_agent_type_mapping = {
+    "AvailabilityHistorySummary": AvailabilityHistorySummary,
     "CreateManagementAgentInstallKeyDetails": CreateManagementAgentInstallKeyDetails,
     "DeployPluginsDetails": DeployPluginsDetails,
     "ManagementAgent": ManagementAgent,

--- a/src/oci/management_agent/models/availability_history_summary.py
+++ b/src/oci/management_agent/models/availability_history_summary.py
@@ -1,0 +1,183 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AvailabilityHistorySummary(object):
+    """
+    Availability history of Management Agent.
+    """
+
+    #: A constant which can be used with the availability_status property of a AvailabilityHistorySummary.
+    #: This constant has a value of "ACTIVE"
+    AVAILABILITY_STATUS_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the availability_status property of a AvailabilityHistorySummary.
+    #: This constant has a value of "SILENT"
+    AVAILABILITY_STATUS_SILENT = "SILENT"
+
+    #: A constant which can be used with the availability_status property of a AvailabilityHistorySummary.
+    #: This constant has a value of "NOT_AVAILABLE"
+    AVAILABILITY_STATUS_NOT_AVAILABLE = "NOT_AVAILABLE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AvailabilityHistorySummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param management_agent_id:
+            The value to assign to the management_agent_id property of this AvailabilityHistorySummary.
+        :type management_agent_id: str
+
+        :param availability_status:
+            The value to assign to the availability_status property of this AvailabilityHistorySummary.
+            Allowed values for this property are: "ACTIVE", "SILENT", "NOT_AVAILABLE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type availability_status: str
+
+        :param time_availability_status_started:
+            The value to assign to the time_availability_status_started property of this AvailabilityHistorySummary.
+        :type time_availability_status_started: datetime
+
+        :param time_availability_status_ended:
+            The value to assign to the time_availability_status_ended property of this AvailabilityHistorySummary.
+        :type time_availability_status_ended: datetime
+
+        """
+        self.swagger_types = {
+            'management_agent_id': 'str',
+            'availability_status': 'str',
+            'time_availability_status_started': 'datetime',
+            'time_availability_status_ended': 'datetime'
+        }
+
+        self.attribute_map = {
+            'management_agent_id': 'managementAgentId',
+            'availability_status': 'availabilityStatus',
+            'time_availability_status_started': 'timeAvailabilityStatusStarted',
+            'time_availability_status_ended': 'timeAvailabilityStatusEnded'
+        }
+
+        self._management_agent_id = None
+        self._availability_status = None
+        self._time_availability_status_started = None
+        self._time_availability_status_ended = None
+
+    @property
+    def management_agent_id(self):
+        """
+        **[Required]** Gets the management_agent_id of this AvailabilityHistorySummary.
+        agent identifier
+
+
+        :return: The management_agent_id of this AvailabilityHistorySummary.
+        :rtype: str
+        """
+        return self._management_agent_id
+
+    @management_agent_id.setter
+    def management_agent_id(self, management_agent_id):
+        """
+        Sets the management_agent_id of this AvailabilityHistorySummary.
+        agent identifier
+
+
+        :param management_agent_id: The management_agent_id of this AvailabilityHistorySummary.
+        :type: str
+        """
+        self._management_agent_id = management_agent_id
+
+    @property
+    def availability_status(self):
+        """
+        **[Required]** Gets the availability_status of this AvailabilityHistorySummary.
+        The availability status of managementAgent
+
+        Allowed values for this property are: "ACTIVE", "SILENT", "NOT_AVAILABLE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The availability_status of this AvailabilityHistorySummary.
+        :rtype: str
+        """
+        return self._availability_status
+
+    @availability_status.setter
+    def availability_status(self, availability_status):
+        """
+        Sets the availability_status of this AvailabilityHistorySummary.
+        The availability status of managementAgent
+
+
+        :param availability_status: The availability_status of this AvailabilityHistorySummary.
+        :type: str
+        """
+        allowed_values = ["ACTIVE", "SILENT", "NOT_AVAILABLE"]
+        if not value_allowed_none_or_none_sentinel(availability_status, allowed_values):
+            availability_status = 'UNKNOWN_ENUM_VALUE'
+        self._availability_status = availability_status
+
+    @property
+    def time_availability_status_started(self):
+        """
+        Gets the time_availability_status_started of this AvailabilityHistorySummary.
+        The time at which the Management Agent moved to the availability status. An RFC3339 formatted datetime string
+
+
+        :return: The time_availability_status_started of this AvailabilityHistorySummary.
+        :rtype: datetime
+        """
+        return self._time_availability_status_started
+
+    @time_availability_status_started.setter
+    def time_availability_status_started(self, time_availability_status_started):
+        """
+        Sets the time_availability_status_started of this AvailabilityHistorySummary.
+        The time at which the Management Agent moved to the availability status. An RFC3339 formatted datetime string
+
+
+        :param time_availability_status_started: The time_availability_status_started of this AvailabilityHistorySummary.
+        :type: datetime
+        """
+        self._time_availability_status_started = time_availability_status_started
+
+    @property
+    def time_availability_status_ended(self):
+        """
+        Gets the time_availability_status_ended of this AvailabilityHistorySummary.
+        The time till which the Management Agent was known to be in the availability status. An RFC3339 formatted datetime string
+
+
+        :return: The time_availability_status_ended of this AvailabilityHistorySummary.
+        :rtype: datetime
+        """
+        return self._time_availability_status_ended
+
+    @time_availability_status_ended.setter
+    def time_availability_status_ended(self, time_availability_status_ended):
+        """
+        Sets the time_availability_status_ended of this AvailabilityHistorySummary.
+        The time till which the Management Agent was known to be in the availability status. An RFC3339 formatted datetime string
+
+
+        :param time_availability_status_ended: The time_availability_status_ended of this AvailabilityHistorySummary.
+        :type: datetime
+        """
+        self._time_availability_status_ended = time_availability_status_ended
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/management_agent/models/management_agent.py
+++ b/src/oci/management_agent/models/management_agent.py
@@ -21,6 +21,18 @@ class ManagementAgent(object):
     #: This constant has a value of "WINDOWS"
     PLATFORM_TYPE_WINDOWS = "WINDOWS"
 
+    #: A constant which can be used with the availability_status property of a ManagementAgent.
+    #: This constant has a value of "ACTIVE"
+    AVAILABILITY_STATUS_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the availability_status property of a ManagementAgent.
+    #: This constant has a value of "SILENT"
+    AVAILABILITY_STATUS_SILENT = "SILENT"
+
+    #: A constant which can be used with the availability_status property of a ManagementAgent.
+    #: This constant has a value of "NOT_AVAILABLE"
+    AVAILABILITY_STATUS_NOT_AVAILABLE = "NOT_AVAILABLE"
+
     #: A constant which can be used with the lifecycle_state property of a ManagementAgent.
     #: This constant has a value of "CREATING"
     LIFECYCLE_STATE_CREATING = "CREATING"
@@ -120,6 +132,12 @@ class ManagementAgent(object):
             The value to assign to the time_last_heartbeat property of this ManagementAgent.
         :type time_last_heartbeat: datetime
 
+        :param availability_status:
+            The value to assign to the availability_status property of this ManagementAgent.
+            Allowed values for this property are: "ACTIVE", "SILENT", "NOT_AVAILABLE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type availability_status: str
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this ManagementAgent.
             Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "TERMINATED", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
@@ -155,6 +173,7 @@ class ManagementAgent(object):
             'time_created': 'datetime',
             'time_updated': 'datetime',
             'time_last_heartbeat': 'datetime',
+            'availability_status': 'str',
             'lifecycle_state': 'str',
             'lifecycle_details': 'str',
             'freeform_tags': 'dict(str, str)',
@@ -177,6 +196,7 @@ class ManagementAgent(object):
             'time_created': 'timeCreated',
             'time_updated': 'timeUpdated',
             'time_last_heartbeat': 'timeLastHeartbeat',
+            'availability_status': 'availabilityStatus',
             'lifecycle_state': 'lifecycleState',
             'lifecycle_details': 'lifecycleDetails',
             'freeform_tags': 'freeformTags',
@@ -198,6 +218,7 @@ class ManagementAgent(object):
         self._time_created = None
         self._time_updated = None
         self._time_last_heartbeat = None
+        self._availability_status = None
         self._lifecycle_state = None
         self._lifecycle_details = None
         self._freeform_tags = None
@@ -568,6 +589,36 @@ class ManagementAgent(object):
         :type: datetime
         """
         self._time_last_heartbeat = time_last_heartbeat
+
+    @property
+    def availability_status(self):
+        """
+        Gets the availability_status of this ManagementAgent.
+        The current availability status of managementAgent
+
+        Allowed values for this property are: "ACTIVE", "SILENT", "NOT_AVAILABLE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The availability_status of this ManagementAgent.
+        :rtype: str
+        """
+        return self._availability_status
+
+    @availability_status.setter
+    def availability_status(self, availability_status):
+        """
+        Sets the availability_status of this ManagementAgent.
+        The current availability status of managementAgent
+
+
+        :param availability_status: The availability_status of this ManagementAgent.
+        :type: str
+        """
+        allowed_values = ["ACTIVE", "SILENT", "NOT_AVAILABLE"]
+        if not value_allowed_none_or_none_sentinel(availability_status, allowed_values):
+            availability_status = 'UNKNOWN_ENUM_VALUE'
+        self._availability_status = availability_status
 
     @property
     def lifecycle_state(self):

--- a/src/oci/management_agent/models/management_agent_summary.py
+++ b/src/oci/management_agent/models/management_agent_summary.py
@@ -21,6 +21,18 @@ class ManagementAgentSummary(object):
     #: This constant has a value of "WINDOWS"
     PLATFORM_TYPE_WINDOWS = "WINDOWS"
 
+    #: A constant which can be used with the availability_status property of a ManagementAgentSummary.
+    #: This constant has a value of "ACTIVE"
+    AVAILABILITY_STATUS_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the availability_status property of a ManagementAgentSummary.
+    #: This constant has a value of "SILENT"
+    AVAILABILITY_STATUS_SILENT = "SILENT"
+
+    #: A constant which can be used with the availability_status property of a ManagementAgentSummary.
+    #: This constant has a value of "NOT_AVAILABLE"
+    AVAILABILITY_STATUS_NOT_AVAILABLE = "NOT_AVAILABLE"
+
     #: A constant which can be used with the lifecycle_state property of a ManagementAgentSummary.
     #: This constant has a value of "CREATING"
     LIFECYCLE_STATE_CREATING = "CREATING"
@@ -108,6 +120,16 @@ class ManagementAgentSummary(object):
             The value to assign to the compartment_id property of this ManagementAgentSummary.
         :type compartment_id: str
 
+        :param time_last_heartbeat:
+            The value to assign to the time_last_heartbeat property of this ManagementAgentSummary.
+        :type time_last_heartbeat: datetime
+
+        :param availability_status:
+            The value to assign to the availability_status property of this ManagementAgentSummary.
+            Allowed values for this property are: "ACTIVE", "SILENT", "NOT_AVAILABLE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type availability_status: str
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this ManagementAgentSummary.
             Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "TERMINATED", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
@@ -140,6 +162,8 @@ class ManagementAgentSummary(object):
             'host': 'str',
             'plugin_list': 'list[ManagementAgentPluginDetails]',
             'compartment_id': 'str',
+            'time_last_heartbeat': 'datetime',
+            'availability_status': 'str',
             'lifecycle_state': 'str',
             'lifecycle_details': 'str',
             'freeform_tags': 'dict(str, str)',
@@ -159,6 +183,8 @@ class ManagementAgentSummary(object):
             'host': 'host',
             'plugin_list': 'pluginList',
             'compartment_id': 'compartmentId',
+            'time_last_heartbeat': 'timeLastHeartbeat',
+            'availability_status': 'availabilityStatus',
             'lifecycle_state': 'lifecycleState',
             'lifecycle_details': 'lifecycleDetails',
             'freeform_tags': 'freeformTags',
@@ -177,6 +203,8 @@ class ManagementAgentSummary(object):
         self._host = None
         self._plugin_list = None
         self._compartment_id = None
+        self._time_last_heartbeat = None
+        self._availability_status = None
         self._lifecycle_state = None
         self._lifecycle_details = None
         self._freeform_tags = None
@@ -475,6 +503,60 @@ class ManagementAgentSummary(object):
         :type: str
         """
         self._compartment_id = compartment_id
+
+    @property
+    def time_last_heartbeat(self):
+        """
+        Gets the time_last_heartbeat of this ManagementAgentSummary.
+        The time the Management Agent has last recorded its heartbeat. An RFC3339 formatted datetime string
+
+
+        :return: The time_last_heartbeat of this ManagementAgentSummary.
+        :rtype: datetime
+        """
+        return self._time_last_heartbeat
+
+    @time_last_heartbeat.setter
+    def time_last_heartbeat(self, time_last_heartbeat):
+        """
+        Sets the time_last_heartbeat of this ManagementAgentSummary.
+        The time the Management Agent has last recorded its heartbeat. An RFC3339 formatted datetime string
+
+
+        :param time_last_heartbeat: The time_last_heartbeat of this ManagementAgentSummary.
+        :type: datetime
+        """
+        self._time_last_heartbeat = time_last_heartbeat
+
+    @property
+    def availability_status(self):
+        """
+        Gets the availability_status of this ManagementAgentSummary.
+        The current availability status of managementAgent
+
+        Allowed values for this property are: "ACTIVE", "SILENT", "NOT_AVAILABLE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The availability_status of this ManagementAgentSummary.
+        :rtype: str
+        """
+        return self._availability_status
+
+    @availability_status.setter
+    def availability_status(self, availability_status):
+        """
+        Sets the availability_status of this ManagementAgentSummary.
+        The current availability status of managementAgent
+
+
+        :param availability_status: The availability_status of this ManagementAgentSummary.
+        :type: str
+        """
+        allowed_values = ["ACTIVE", "SILENT", "NOT_AVAILABLE"]
+        if not value_allowed_none_or_none_sentinel(availability_status, allowed_values):
+            availability_status = 'UNKNOWN_ENUM_VALUE'
+        self._availability_status = availability_status
 
     @property
     def lifecycle_state(self):

--- a/src/oci/mysql/__init__.py
+++ b/src/oci/mysql/__init__.py
@@ -5,6 +5,8 @@
 from __future__ import absolute_import
 
 
+from .channels_client import ChannelsClient
+from .channels_client_composite_operations import ChannelsClientCompositeOperations
 from .db_backups_client import DbBackupsClient
 from .db_backups_client_composite_operations import DbBackupsClientCompositeOperations
 from .db_system_client import DbSystemClient
@@ -15,4 +17,4 @@ from .work_requests_client import WorkRequestsClient
 from .work_requests_client_composite_operations import WorkRequestsClientCompositeOperations
 from . import models
 
-__all__ = ["DbBackupsClient", "DbBackupsClientCompositeOperations", "DbSystemClient", "DbSystemClientCompositeOperations", "MysqlaasClient", "MysqlaasClientCompositeOperations", "WorkRequestsClient", "WorkRequestsClientCompositeOperations", "models"]
+__all__ = ["ChannelsClient", "ChannelsClientCompositeOperations", "DbBackupsClient", "DbBackupsClientCompositeOperations", "DbSystemClient", "DbSystemClientCompositeOperations", "MysqlaasClient", "MysqlaasClientCompositeOperations", "WorkRequestsClient", "WorkRequestsClientCompositeOperations", "models"]

--- a/src/oci/mysql/channels_client.py
+++ b/src/oci/mysql/channels_client.py
@@ -1,0 +1,781 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from __future__ import absolute_import
+
+from oci._vendor import requests  # noqa: F401
+from oci._vendor import six
+
+from oci import retry  # noqa: F401
+from oci.base_client import BaseClient
+from oci.config import get_config_value_or_default, validate_config
+from oci.signer import Signer
+from oci.util import Sentinel, get_signer_from_authentication_type, AUTHENTICATION_TYPE_FIELD_NAME
+from .models import mysql_type_mapping
+missing = Sentinel("Missing")
+
+
+class ChannelsClient(object):
+    """
+    The API for the MySQL Database Service
+    """
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates a new service client
+
+        :param dict config:
+            Configuration keys and values as per `SDK and Tool Configuration <https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm>`__.
+            The :py:meth:`~oci.config.from_file` method can be used to load configuration from a file. Alternatively, a ``dict`` can be passed. You can validate_config
+            the dict using :py:meth:`~oci.config.validate_config`
+
+        :param str service_endpoint: (optional)
+            The endpoint of the service to call using this client. For example ``https://iaas.us-ashburn-1.oraclecloud.com``. If this keyword argument is
+            not provided then it will be derived using the region in the config parameter. You should only provide this keyword argument if you have an explicit
+            need to specify a service endpoint.
+
+        :param timeout: (optional)
+            The connection and read timeouts for the client. The default values are connection timeout 10 seconds and read timeout 60 seconds. This keyword argument can be provided
+            as a single float, in which case the value provided is used for both the read and connection timeouts, or as a tuple of two floats. If
+            a tuple is provided then the first value is used as the connection timeout and the second value as the read timeout.
+        :type timeout: float or tuple(float, float)
+
+        :param signer: (optional)
+            The signer to use when signing requests made by the service client. The default is to use a :py:class:`~oci.signer.Signer` based on the values
+            provided in the config parameter.
+
+            One use case for this parameter is for `Instance Principals authentication <https://docs.cloud.oracle.com/Content/Identity/Tasks/callingservicesfrominstances.htm>`__
+            by passing an instance of :py:class:`~oci.auth.signers.InstancePrincipalsSecurityTokenSigner` as the value for this keyword argument
+        :type signer: :py:class:`~oci.signer.AbstractBaseSigner`
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to all calls made by this service client (i.e. at the client level). There is no retry strategy applied by default.
+            Retry strategies can also be applied at the operation level by passing a ``retry_strategy`` keyword argument as part of calling the operation.
+            Any value provided at the operation level will override whatever is specified at the client level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+        """
+        validate_config(config, signer=kwargs.get('signer'))
+        if 'signer' in kwargs:
+            signer = kwargs['signer']
+
+        elif AUTHENTICATION_TYPE_FIELD_NAME in config:
+            signer = get_signer_from_authentication_type(config)
+
+        else:
+            signer = Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config.get("key_file"),
+                pass_phrase=get_config_value_or_default(config, "pass_phrase"),
+                private_key_content=config.get("key_content")
+            )
+
+        base_client_init_kwargs = {
+            'regional_client': True,
+            'service_endpoint': kwargs.get('service_endpoint'),
+            'timeout': kwargs.get('timeout'),
+            'base_path': '/20190415',
+            'service_endpoint_template': 'https://mysql.{region}.ocp.{secondLevelDomain}',
+            'skip_deserialization': kwargs.get('skip_deserialization', False)
+        }
+        self.base_client = BaseClient("channels", config, signer, mysql_type_mapping, **base_client_init_kwargs)
+        self.retry_strategy = kwargs.get('retry_strategy')
+
+    def create_channel(self, create_channel_details, **kwargs):
+        """
+        Creates a Channel to establish replication from a source to a target.
+
+
+        :param oci.mysql.models.CreateChannelDetails create_channel_details: (required)
+            The parameters of the request to create the Channel.
+
+        :param str opc_request_id: (optional)
+            Customer-defined unique identifier for the request. If you need to
+            contact Oracle about a specific request, please provide the request
+            ID that you supplied in this header with the request.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case
+            of a timeout or server error without risk of executing that same action
+            again. Retry tokens expire after 24 hours, but can be invalidated before
+            then due to conflicting operations (for example, if a resource has been
+            deleted and purged from the system, then a retry of the original
+            creation request may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.mysql.models.Channel`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/channels"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_channel got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_channel_details,
+                response_type="Channel")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_channel_details,
+                response_type="Channel")
+
+    def delete_channel(self, channel_id, **kwargs):
+        """
+        Deletes the specified Channel.
+
+
+        :param str channel_id: (required)
+            The Channel `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a
+            resource, set the `If-Match` header to the value of the etag from a
+            previous GET or POST response for that resource. The resource will be
+            updated or deleted only if the etag you provide matches the resource's
+            current etag value.
+
+        :param str opc_request_id: (optional)
+            Customer-defined unique identifier for the request. If you need to
+            contact Oracle about a specific request, please provide the request
+            ID that you supplied in this header with the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/channels/{channelId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_channel got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "channelId": channel_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def get_channel(self, channel_id, **kwargs):
+        """
+        Gets the full details of the specified Channel, including the user-specified
+        configuration parameters (passwords are omitted), as well as information about
+        the state of the Channel, its sources and targets.
+
+
+        :param str channel_id: (required)
+            The Channel `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Customer-defined unique identifier for the request. If you need to
+            contact Oracle about a specific request, please provide the request
+            ID that you supplied in this header with the request.
+
+        :param str if_none_match: (optional)
+            For conditional requests. In the GET call for a resource, set the
+            `If-None-Match` header to the value of the ETag from a previous GET (or
+            POST or PUT) response for that resource. The server will return with
+            either a 304 Not Modified response if the resource has not changed, or a
+            200 OK response with the updated representation.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.mysql.models.Channel`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/channels/{channelId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_none_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_channel got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "channelId": channel_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-none-match": kwargs.get("if_none_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Channel")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Channel")
+
+    def list_channels(self, compartment_id, **kwargs):
+        """
+        Lists all the Channels that match the specified filters.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Customer-defined unique identifier for the request. If you need to
+            contact Oracle about a specific request, please provide the request
+            ID that you supplied in this header with the request.
+
+        :param str db_system_id: (optional)
+            The DB System `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str channel_id: (optional)
+            The OCID of the Channel.
+
+        :param str display_name: (optional)
+            A filter to return only the resource matching the given display name exactly.
+
+        :param str lifecycle_state: (optional)
+            The LifecycleState of the Channel.
+
+            Allowed values are: "CREATING", "ACTIVE", "NEEDS_ATTENTION", "INACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED"
+
+        :param bool is_enabled: (optional)
+            If true, returns only Channels that are enabled. If false, returns only
+            Channels that are disabled.
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Time fields are default ordered as descending. Display name is default ordered as ascending.
+
+            Allowed values are: "displayName", "timeCreated"
+
+        :param str sort_order: (optional)
+            The sort order to use (ASC or DESC).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param int limit: (optional)
+            The maximum number of items to return in a paginated list call. For information about pagination, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/#API/Concepts/usingapi.htm#List_Pagination
+
+        :param str page: (optional)
+            The value of the `opc-next-page` or `opc-prev-page` response header from
+            the previous list call. For information about pagination, see `List
+            Pagination`__.
+
+            __ https://docs.cloud.oracle.com/#API/Concepts/usingapi.htm#List_Pagination
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.mysql.models.ChannelSummary`
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/channels"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "db_system_id",
+            "channel_id",
+            "display_name",
+            "lifecycle_state",
+            "is_enabled",
+            "sort_by",
+            "sort_order",
+            "limit",
+            "page"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_channels got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "NEEDS_ATTENTION", "INACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["displayName", "timeCreated"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "dbSystemId": kwargs.get("db_system_id", missing),
+            "channelId": kwargs.get("channel_id", missing),
+            "displayName": kwargs.get("display_name", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "isEnabled": kwargs.get("is_enabled", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ChannelSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ChannelSummary]")
+
+    def reset_channel(self, channel_id, **kwargs):
+        """
+        Resets the specified Channel by purging its cached information, leaving the Channel
+        as if it had just been created. This operation is only accepted in Inactive Channels.
+
+
+        :param str channel_id: (required)
+            The Channel `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a
+            resource, set the `If-Match` header to the value of the etag from a
+            previous GET or POST response for that resource. The resource will be
+            updated or deleted only if the etag you provide matches the resource's
+            current etag value.
+
+        :param str opc_request_id: (optional)
+            Customer-defined unique identifier for the request. If you need to
+            contact Oracle about a specific request, please provide the request
+            ID that you supplied in this header with the request.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case
+            of a timeout or server error without risk of executing that same action
+            again. Retry tokens expire after 24 hours, but can be invalidated before
+            then due to conflicting operations (for example, if a resource has been
+            deleted and purged from the system, then a retry of the original
+            creation request may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/channels/{channelId}/actions/reset"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "reset_channel got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "channelId": channel_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def resume_channel(self, channel_id, **kwargs):
+        """
+        Resumes an enabled Channel that has become Inactive due to an error. The resume operation
+        requires that the error that cause the Channel to become Inactive has already been fixed,
+        otherwise the operation may fail.
+
+
+        :param str channel_id: (required)
+            The Channel `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a
+            resource, set the `If-Match` header to the value of the etag from a
+            previous GET or POST response for that resource. The resource will be
+            updated or deleted only if the etag you provide matches the resource's
+            current etag value.
+
+        :param str opc_request_id: (optional)
+            Customer-defined unique identifier for the request. If you need to
+            contact Oracle about a specific request, please provide the request
+            ID that you supplied in this header with the request.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case
+            of a timeout or server error without risk of executing that same action
+            again. Retry tokens expire after 24 hours, but can be invalidated before
+            then due to conflicting operations (for example, if a resource has been
+            deleted and purged from the system, then a retry of the original
+            creation request may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/channels/{channelId}/actions/resume"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "resume_channel got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "channelId": channel_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def update_channel(self, channel_id, update_channel_details, **kwargs):
+        """
+        Updates the properties of the specified Channel.
+        If the Channel is Active the Update operation will asynchronously apply the new configuration
+        parameters to the Channel and the Channel may become temporarily unavailable. Otherwise, the
+        new configuration will be applied the next time the Channel becomes Active.
+
+
+        :param str channel_id: (required)
+            The Channel `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.mysql.models.UpdateChannelDetails update_channel_details: (required)
+            The parameters of the request to update the Channel.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a
+            resource, set the `If-Match` header to the value of the etag from a
+            previous GET or POST response for that resource. The resource will be
+            updated or deleted only if the etag you provide matches the resource's
+            current etag value.
+
+        :param str opc_request_id: (optional)
+            Customer-defined unique identifier for the request. If you need to
+            contact Oracle about a specific request, please provide the request
+            ID that you supplied in this header with the request.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case
+            of a timeout or server error without risk of executing that same action
+            again. Retry tokens expire after 24 hours, but can be invalidated before
+            then due to conflicting operations (for example, if a resource has been
+            deleted and purged from the system, then a retry of the original
+            creation request may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+        """
+        resource_path = "/channels/{channelId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_channel got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "channelId": channel_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_channel_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_channel_details)

--- a/src/oci/mysql/channels_client_composite_operations.py
+++ b/src/oci/mysql/channels_client_composite_operations.py
@@ -1,0 +1,233 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+import oci  # noqa: F401
+from oci.util import WAIT_RESOURCE_NOT_FOUND  # noqa: F401
+
+
+class ChannelsClientCompositeOperations(object):
+    """
+    This class provides a wrapper around :py:class:`~oci.mysql.ChannelsClient` and offers convenience methods
+    for operations that would otherwise need to be chained together. For example, instead of performing an action
+    on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+    to enter a given state, you can call a single method in this class to accomplish the same functionality
+    """
+
+    def __init__(self, client, **kwargs):
+        """
+        Creates a new ChannelsClientCompositeOperations object
+
+        :param ChannelsClient client:
+            The service client which will be wrapped by this object
+        """
+        self.client = client
+
+    def create_channel_and_wait_for_state(self, create_channel_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.mysql.ChannelsClient.create_channel` and waits for the :py:class:`~oci.mysql.models.WorkRequest`
+        to enter the given state(s).
+
+        :param CreateChannelDetails create_channel_details: (required)
+            The parameters of the request to create the Channel.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.mysql.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.mysql.ChannelsClient.create_channel`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_channel(create_channel_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_channel_and_wait_for_state(self, channel_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.mysql.ChannelsClient.delete_channel` and waits for the :py:class:`~oci.mysql.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str channel_id: (required)
+            The Channel `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.mysql.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.mysql.ChannelsClient.delete_channel`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = None
+        try:
+            operation_result = self.client.delete_channel(channel_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def reset_channel_and_wait_for_state(self, channel_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.mysql.ChannelsClient.reset_channel` and waits for the :py:class:`~oci.mysql.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str channel_id: (required)
+            The Channel `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.mysql.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.mysql.ChannelsClient.reset_channel`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.reset_channel(channel_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def resume_channel_and_wait_for_state(self, channel_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.mysql.ChannelsClient.resume_channel` and waits for the :py:class:`~oci.mysql.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str channel_id: (required)
+            The Channel `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.mysql.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.mysql.ChannelsClient.resume_channel`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.resume_channel(channel_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_channel_and_wait_for_state(self, channel_id, update_channel_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.mysql.ChannelsClient.update_channel` and waits for the :py:class:`~oci.mysql.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str channel_id: (required)
+            The Channel `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param UpdateChannelDetails update_channel_details: (required)
+            The parameters of the request to update the Channel.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.mysql.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.mysql.ChannelsClient.update_channel`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_channel(channel_id, update_channel_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)

--- a/src/oci/mysql/db_backups_client.py
+++ b/src/oci/mysql/db_backups_client.py
@@ -356,6 +356,11 @@ class DbBackupsClient(object):
         :param str display_name: (optional)
             A filter to return only the resource matching the given display name exactly.
 
+        :param str creation_type: (optional)
+            Backup creationType
+
+            Allowed values are: "MANUAL", "AUTOMATIC"
+
         :param str sort_by: (optional)
             The field to sort by. Only one sort order may be provided. Time fields are default ordered as descending.
 
@@ -401,6 +406,7 @@ class DbBackupsClient(object):
             "lifecycle_state",
             "db_system_id",
             "display_name",
+            "creation_type",
             "sort_by",
             "sort_order",
             "limit",
@@ -416,6 +422,13 @@ class DbBackupsClient(object):
             if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
                 raise ValueError(
                     "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        if 'creation_type' in kwargs:
+            creation_type_allowed_values = ["MANUAL", "AUTOMATIC"]
+            if kwargs['creation_type'] not in creation_type_allowed_values:
+                raise ValueError(
+                    "Invalid value for `creation_type`, must be one of {0}".format(creation_type_allowed_values)
                 )
 
         if 'sort_by' in kwargs:
@@ -438,6 +451,7 @@ class DbBackupsClient(object):
             "compartmentId": compartment_id,
             "dbSystemId": kwargs.get("db_system_id", missing),
             "displayName": kwargs.get("display_name", missing),
+            "creationType": kwargs.get("creation_type", missing),
             "sortBy": kwargs.get("sort_by", missing),
             "sortOrder": kwargs.get("sort_order", missing),
             "limit": kwargs.get("limit", missing),

--- a/src/oci/mysql/models/__init__.py
+++ b/src/oci/mysql/models/__init__.py
@@ -14,30 +14,51 @@ from .analytics_cluster_table_memory_estimate import AnalyticsClusterTableMemory
 from .backup import Backup
 from .backup_policy import BackupPolicy
 from .backup_summary import BackupSummary
+from .ca_certificate import CaCertificate
+from .channel import Channel
+from .channel_source import ChannelSource
+from .channel_source_mysql import ChannelSourceMysql
+from .channel_summary import ChannelSummary
+from .channel_target import ChannelTarget
+from .channel_target_db_system import ChannelTargetDbSystem
 from .configuration import Configuration
 from .configuration_summary import ConfigurationSummary
 from .configuration_variables import ConfigurationVariables
 from .create_backup_details import CreateBackupDetails
 from .create_backup_policy_details import CreateBackupPolicyDetails
+from .create_channel_details import CreateChannelDetails
+from .create_channel_source_details import CreateChannelSourceDetails
+from .create_channel_source_from_mysql_details import CreateChannelSourceFromMysqlDetails
+from .create_channel_target_details import CreateChannelTargetDetails
+from .create_channel_target_from_db_system_details import CreateChannelTargetFromDbSystemDetails
 from .create_configuration_details import CreateConfigurationDetails
 from .create_db_system_details import CreateDbSystemDetails
 from .create_db_system_source_details import CreateDbSystemSourceDetails
 from .create_db_system_source_from_backup_details import CreateDbSystemSourceFromBackupDetails
+from .create_db_system_source_from_none_details import CreateDbSystemSourceFromNoneDetails
 from .create_db_system_source_import_from_url_details import CreateDbSystemSourceImportFromUrlDetails
 from .create_maintenance_details import CreateMaintenanceDetails
 from .db_system import DbSystem
 from .db_system_endpoint import DbSystemEndpoint
+from .db_system_snapshot import DbSystemSnapshot
 from .db_system_source import DbSystemSource
 from .db_system_source_from_backup import DbSystemSourceFromBackup
+from .db_system_source_from_none import DbSystemSourceFromNone
 from .db_system_source_import_from_url import DbSystemSourceImportFromUrl
 from .db_system_summary import DbSystemSummary
 from .maintenance_details import MaintenanceDetails
+from .pem_ca_certificate import PemCaCertificate
 from .restart_db_system_details import RestartDbSystemDetails
 from .shape_summary import ShapeSummary
 from .stop_db_system_details import StopDbSystemDetails
 from .update_analytics_cluster_details import UpdateAnalyticsClusterDetails
 from .update_backup_details import UpdateBackupDetails
 from .update_backup_policy_details import UpdateBackupPolicyDetails
+from .update_channel_details import UpdateChannelDetails
+from .update_channel_source_details import UpdateChannelSourceDetails
+from .update_channel_source_from_mysql_details import UpdateChannelSourceFromMysqlDetails
+from .update_channel_target_details import UpdateChannelTargetDetails
+from .update_channel_target_from_db_system_details import UpdateChannelTargetFromDbSystemDetails
 from .update_configuration_details import UpdateConfigurationDetails
 from .update_db_system_details import UpdateDbSystemDetails
 from .update_maintenance_details import UpdateMaintenanceDetails
@@ -61,30 +82,51 @@ mysql_type_mapping = {
     "Backup": Backup,
     "BackupPolicy": BackupPolicy,
     "BackupSummary": BackupSummary,
+    "CaCertificate": CaCertificate,
+    "Channel": Channel,
+    "ChannelSource": ChannelSource,
+    "ChannelSourceMysql": ChannelSourceMysql,
+    "ChannelSummary": ChannelSummary,
+    "ChannelTarget": ChannelTarget,
+    "ChannelTargetDbSystem": ChannelTargetDbSystem,
     "Configuration": Configuration,
     "ConfigurationSummary": ConfigurationSummary,
     "ConfigurationVariables": ConfigurationVariables,
     "CreateBackupDetails": CreateBackupDetails,
     "CreateBackupPolicyDetails": CreateBackupPolicyDetails,
+    "CreateChannelDetails": CreateChannelDetails,
+    "CreateChannelSourceDetails": CreateChannelSourceDetails,
+    "CreateChannelSourceFromMysqlDetails": CreateChannelSourceFromMysqlDetails,
+    "CreateChannelTargetDetails": CreateChannelTargetDetails,
+    "CreateChannelTargetFromDbSystemDetails": CreateChannelTargetFromDbSystemDetails,
     "CreateConfigurationDetails": CreateConfigurationDetails,
     "CreateDbSystemDetails": CreateDbSystemDetails,
     "CreateDbSystemSourceDetails": CreateDbSystemSourceDetails,
     "CreateDbSystemSourceFromBackupDetails": CreateDbSystemSourceFromBackupDetails,
+    "CreateDbSystemSourceFromNoneDetails": CreateDbSystemSourceFromNoneDetails,
     "CreateDbSystemSourceImportFromUrlDetails": CreateDbSystemSourceImportFromUrlDetails,
     "CreateMaintenanceDetails": CreateMaintenanceDetails,
     "DbSystem": DbSystem,
     "DbSystemEndpoint": DbSystemEndpoint,
+    "DbSystemSnapshot": DbSystemSnapshot,
     "DbSystemSource": DbSystemSource,
     "DbSystemSourceFromBackup": DbSystemSourceFromBackup,
+    "DbSystemSourceFromNone": DbSystemSourceFromNone,
     "DbSystemSourceImportFromUrl": DbSystemSourceImportFromUrl,
     "DbSystemSummary": DbSystemSummary,
     "MaintenanceDetails": MaintenanceDetails,
+    "PemCaCertificate": PemCaCertificate,
     "RestartDbSystemDetails": RestartDbSystemDetails,
     "ShapeSummary": ShapeSummary,
     "StopDbSystemDetails": StopDbSystemDetails,
     "UpdateAnalyticsClusterDetails": UpdateAnalyticsClusterDetails,
     "UpdateBackupDetails": UpdateBackupDetails,
     "UpdateBackupPolicyDetails": UpdateBackupPolicyDetails,
+    "UpdateChannelDetails": UpdateChannelDetails,
+    "UpdateChannelSourceDetails": UpdateChannelSourceDetails,
+    "UpdateChannelSourceFromMysqlDetails": UpdateChannelSourceFromMysqlDetails,
+    "UpdateChannelTargetDetails": UpdateChannelTargetDetails,
+    "UpdateChannelTargetFromDbSystemDetails": UpdateChannelTargetFromDbSystemDetails,
     "UpdateConfigurationDetails": UpdateConfigurationDetails,
     "UpdateDbSystemDetails": UpdateDbSystemDetails,
     "UpdateMaintenanceDetails": UpdateMaintenanceDetails,

--- a/src/oci/mysql/models/backup.py
+++ b/src/oci/mysql/models/backup.py
@@ -121,6 +121,10 @@ class Backup(object):
             The value to assign to the db_system_id property of this Backup.
         :type db_system_id: str
 
+        :param db_system_snapshot:
+            The value to assign to the db_system_snapshot property of this Backup.
+        :type db_system_snapshot: DbSystemSnapshot
+
         :param backup_size_in_gbs:
             The value to assign to the backup_size_in_gbs property of this Backup.
         :type backup_size_in_gbs: int
@@ -162,6 +166,7 @@ class Backup(object):
             'backup_type': 'str',
             'creation_type': 'str',
             'db_system_id': 'str',
+            'db_system_snapshot': 'DbSystemSnapshot',
             'backup_size_in_gbs': 'int',
             'retention_in_days': 'int',
             'data_storage_size_in_gbs': 'int',
@@ -183,6 +188,7 @@ class Backup(object):
             'backup_type': 'backupType',
             'creation_type': 'creationType',
             'db_system_id': 'dbSystemId',
+            'db_system_snapshot': 'dbSystemSnapshot',
             'backup_size_in_gbs': 'backupSizeInGBs',
             'retention_in_days': 'retentionInDays',
             'data_storage_size_in_gbs': 'dataStorageSizeInGBs',
@@ -203,6 +209,7 @@ class Backup(object):
         self._backup_type = None
         self._creation_type = None
         self._db_system_id = None
+        self._db_system_snapshot = None
         self._backup_size_in_gbs = None
         self._retention_in_days = None
         self._data_storage_size_in_gbs = None
@@ -494,6 +501,26 @@ class Backup(object):
         self._db_system_id = db_system_id
 
     @property
+    def db_system_snapshot(self):
+        """
+        Gets the db_system_snapshot of this Backup.
+
+        :return: The db_system_snapshot of this Backup.
+        :rtype: DbSystemSnapshot
+        """
+        return self._db_system_snapshot
+
+    @db_system_snapshot.setter
+    def db_system_snapshot(self, db_system_snapshot):
+        """
+        Sets the db_system_snapshot of this Backup.
+
+        :param db_system_snapshot: The db_system_snapshot of this Backup.
+        :type: DbSystemSnapshot
+        """
+        self._db_system_snapshot = db_system_snapshot
+
+    @property
     def backup_size_in_gbs(self):
         """
         Gets the backup_size_in_gbs of this Backup.
@@ -617,7 +644,7 @@ class Backup(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this Backup.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -630,7 +657,7 @@ class Backup(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this Backup.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -643,7 +670,7 @@ class Backup(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this Backup.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 
@@ -656,7 +683,7 @@ class Backup(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this Backup.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 

--- a/src/oci/mysql/models/backup_summary.py
+++ b/src/oci/mysql/models/backup_summary.py
@@ -49,6 +49,10 @@ class BackupSummary(object):
             The value to assign to the backup_type property of this BackupSummary.
         :type backup_type: str
 
+        :param creation_type:
+            The value to assign to the creation_type property of this BackupSummary.
+        :type creation_type: str
+
         :param db_system_id:
             The value to assign to the db_system_id property of this BackupSummary.
         :type db_system_id: str
@@ -89,6 +93,7 @@ class BackupSummary(object):
             'time_created': 'datetime',
             'lifecycle_state': 'str',
             'backup_type': 'str',
+            'creation_type': 'str',
             'db_system_id': 'str',
             'data_storage_size_in_gbs': 'int',
             'backup_size_in_gbs': 'int',
@@ -106,6 +111,7 @@ class BackupSummary(object):
             'time_created': 'timeCreated',
             'lifecycle_state': 'lifecycleState',
             'backup_type': 'backupType',
+            'creation_type': 'creationType',
             'db_system_id': 'dbSystemId',
             'data_storage_size_in_gbs': 'dataStorageSizeInGBs',
             'backup_size_in_gbs': 'backupSizeInGBs',
@@ -122,6 +128,7 @@ class BackupSummary(object):
         self._time_created = None
         self._lifecycle_state = None
         self._backup_type = None
+        self._creation_type = None
         self._db_system_id = None
         self._data_storage_size_in_gbs = None
         self._backup_size_in_gbs = None
@@ -276,6 +283,30 @@ class BackupSummary(object):
         self._backup_type = backup_type
 
     @property
+    def creation_type(self):
+        """
+        **[Required]** Gets the creation_type of this BackupSummary.
+        If the backup was created automatically, or by a manual request.
+
+
+        :return: The creation_type of this BackupSummary.
+        :rtype: str
+        """
+        return self._creation_type
+
+    @creation_type.setter
+    def creation_type(self, creation_type):
+        """
+        Sets the creation_type of this BackupSummary.
+        If the backup was created automatically, or by a manual request.
+
+
+        :param creation_type: The creation_type of this BackupSummary.
+        :type: str
+        """
+        self._creation_type = creation_type
+
+    @property
     def db_system_id(self):
         """
         **[Required]** Gets the db_system_id of this BackupSummary.
@@ -423,7 +454,7 @@ class BackupSummary(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this BackupSummary.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -436,7 +467,7 @@ class BackupSummary(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this BackupSummary.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -449,7 +480,7 @@ class BackupSummary(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this BackupSummary.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 
@@ -462,7 +493,7 @@ class BackupSummary(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this BackupSummary.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 

--- a/src/oci/mysql/models/ca_certificate.py
+++ b/src/oci/mysql/models/ca_certificate.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CaCertificate(object):
+    """
+    The CA certificate of the server used for VERIFY_IDENTITY and VERIFY_CA ssl modes.
+    """
+
+    #: A constant which can be used with the certificate_type property of a CaCertificate.
+    #: This constant has a value of "PEM"
+    CERTIFICATE_TYPE_PEM = "PEM"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CaCertificate object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.mysql.models.PemCaCertificate`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param certificate_type:
+            The value to assign to the certificate_type property of this CaCertificate.
+            Allowed values for this property are: "PEM", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type certificate_type: str
+
+        """
+        self.swagger_types = {
+            'certificate_type': 'str'
+        }
+
+        self.attribute_map = {
+            'certificate_type': 'certificateType'
+        }
+
+        self._certificate_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['certificateType']
+
+        if type == 'PEM':
+            return 'PemCaCertificate'
+        else:
+            return 'CaCertificate'
+
+    @property
+    def certificate_type(self):
+        """
+        **[Required]** Gets the certificate_type of this CaCertificate.
+        The type of CA certificate.
+
+        Allowed values for this property are: "PEM", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The certificate_type of this CaCertificate.
+        :rtype: str
+        """
+        return self._certificate_type
+
+    @certificate_type.setter
+    def certificate_type(self, certificate_type):
+        """
+        Sets the certificate_type of this CaCertificate.
+        The type of CA certificate.
+
+
+        :param certificate_type: The certificate_type of this CaCertificate.
+        :type: str
+        """
+        allowed_values = ["PEM"]
+        if not value_allowed_none_or_none_sentinel(certificate_type, allowed_values):
+            certificate_type = 'UNKNOWN_ENUM_VALUE'
+        self._certificate_type = certificate_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/channel.py
+++ b/src/oci/mysql/models/channel.py
@@ -1,0 +1,486 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Channel(object):
+    """
+    A Channel connecting a DB System to an external entity.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a Channel.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a Channel.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a Channel.
+    #: This constant has a value of "NEEDS_ATTENTION"
+    LIFECYCLE_STATE_NEEDS_ATTENTION = "NEEDS_ATTENTION"
+
+    #: A constant which can be used with the lifecycle_state property of a Channel.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a Channel.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a Channel.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a Channel.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a Channel.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Channel object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this Channel.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this Channel.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this Channel.
+        :type display_name: str
+
+        :param is_enabled:
+            The value to assign to the is_enabled property of this Channel.
+        :type is_enabled: bool
+
+        :param source:
+            The value to assign to the source property of this Channel.
+        :type source: ChannelSource
+
+        :param target:
+            The value to assign to the target property of this Channel.
+        :type target: ChannelTarget
+
+        :param description:
+            The value to assign to the description property of this Channel.
+        :type description: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this Channel.
+            Allowed values for this property are: "CREATING", "ACTIVE", "NEEDS_ATTENTION", "INACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this Channel.
+        :type lifecycle_details: str
+
+        :param time_created:
+            The value to assign to the time_created property of this Channel.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this Channel.
+        :type time_updated: datetime
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this Channel.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this Channel.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'is_enabled': 'bool',
+            'source': 'ChannelSource',
+            'target': 'ChannelTarget',
+            'description': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'is_enabled': 'isEnabled',
+            'source': 'source',
+            'target': 'target',
+            'description': 'description',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._display_name = None
+        self._is_enabled = None
+        self._source = None
+        self._target = None
+        self._description = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._time_created = None
+        self._time_updated = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this Channel.
+        The OCID of the Channel.
+
+
+        :return: The id of this Channel.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this Channel.
+        The OCID of the Channel.
+
+
+        :param id: The id of this Channel.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this Channel.
+        The OCID of the compartment.
+
+
+        :return: The compartment_id of this Channel.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this Channel.
+        The OCID of the compartment.
+
+
+        :param compartment_id: The compartment_id of this Channel.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this Channel.
+        The user-friendly name for the Channel. It does not have to be unique.
+
+
+        :return: The display_name of this Channel.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this Channel.
+        The user-friendly name for the Channel. It does not have to be unique.
+
+
+        :param display_name: The display_name of this Channel.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def is_enabled(self):
+        """
+        **[Required]** Gets the is_enabled of this Channel.
+        Whether the Channel has been enabled by the user.
+
+
+        :return: The is_enabled of this Channel.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this Channel.
+        Whether the Channel has been enabled by the user.
+
+
+        :param is_enabled: The is_enabled of this Channel.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
+
+    @property
+    def source(self):
+        """
+        **[Required]** Gets the source of this Channel.
+
+        :return: The source of this Channel.
+        :rtype: ChannelSource
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """
+        Sets the source of this Channel.
+
+        :param source: The source of this Channel.
+        :type: ChannelSource
+        """
+        self._source = source
+
+    @property
+    def target(self):
+        """
+        **[Required]** Gets the target of this Channel.
+
+        :return: The target of this Channel.
+        :rtype: ChannelTarget
+        """
+        return self._target
+
+    @target.setter
+    def target(self, target):
+        """
+        Sets the target of this Channel.
+
+        :param target: The target of this Channel.
+        :type: ChannelTarget
+        """
+        self._target = target
+
+    @property
+    def description(self):
+        """
+        Gets the description of this Channel.
+        User provided description of the Channel.
+
+
+        :return: The description of this Channel.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this Channel.
+        User provided description of the Channel.
+
+
+        :param description: The description of this Channel.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this Channel.
+        The state of the Channel.
+
+        Allowed values for this property are: "CREATING", "ACTIVE", "NEEDS_ATTENTION", "INACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this Channel.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this Channel.
+        The state of the Channel.
+
+
+        :param lifecycle_state: The lifecycle_state of this Channel.
+        :type: str
+        """
+        allowed_values = ["CREATING", "ACTIVE", "NEEDS_ATTENTION", "INACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this Channel.
+        A message describing the state of the Channel.
+
+
+        :return: The lifecycle_details of this Channel.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this Channel.
+        A message describing the state of the Channel.
+
+
+        :param lifecycle_details: The lifecycle_details of this Channel.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this Channel.
+        The date and time the Channel was created, as described by `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_created of this Channel.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this Channel.
+        The date and time the Channel was created, as described by `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_created: The time_created of this Channel.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        **[Required]** Gets the time_updated of this Channel.
+        The time the Channel was last updated, as described by `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_updated of this Channel.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this Channel.
+        The time the Channel was last updated, as described by `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_updated: The time_updated of this Channel.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this Channel.
+        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this Channel.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this Channel.
+        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this Channel.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this Channel.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this Channel.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this Channel.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this Channel.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/channel_source.py
+++ b/src/oci/mysql/models/channel_source.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChannelSource(object):
+    """
+    Parameters detailing how to provision the source for the given Channel.
+    """
+
+    #: A constant which can be used with the source_type property of a ChannelSource.
+    #: This constant has a value of "MYSQL"
+    SOURCE_TYPE_MYSQL = "MYSQL"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChannelSource object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.mysql.models.ChannelSourceMysql`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param source_type:
+            The value to assign to the source_type property of this ChannelSource.
+            Allowed values for this property are: "MYSQL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type source_type: str
+
+        """
+        self.swagger_types = {
+            'source_type': 'str'
+        }
+
+        self.attribute_map = {
+            'source_type': 'sourceType'
+        }
+
+        self._source_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['sourceType']
+
+        if type == 'MYSQL':
+            return 'ChannelSourceMysql'
+        else:
+            return 'ChannelSource'
+
+    @property
+    def source_type(self):
+        """
+        **[Required]** Gets the source_type of this ChannelSource.
+        The specific source identifier.
+
+        Allowed values for this property are: "MYSQL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The source_type of this ChannelSource.
+        :rtype: str
+        """
+        return self._source_type
+
+    @source_type.setter
+    def source_type(self, source_type):
+        """
+        Sets the source_type of this ChannelSource.
+        The specific source identifier.
+
+
+        :param source_type: The source_type of this ChannelSource.
+        :type: str
+        """
+        allowed_values = ["MYSQL"]
+        if not value_allowed_none_or_none_sentinel(source_type, allowed_values):
+            source_type = 'UNKNOWN_ENUM_VALUE'
+        self._source_type = source_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/channel_source_mysql.py
+++ b/src/oci/mysql/models/channel_source_mysql.py
@@ -1,0 +1,233 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .channel_source import ChannelSource
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChannelSourceMysql(ChannelSource):
+    """
+    Core properties of a Mysql Channel source.
+    """
+
+    #: A constant which can be used with the ssl_mode property of a ChannelSourceMysql.
+    #: This constant has a value of "VERIFY_IDENTITY"
+    SSL_MODE_VERIFY_IDENTITY = "VERIFY_IDENTITY"
+
+    #: A constant which can be used with the ssl_mode property of a ChannelSourceMysql.
+    #: This constant has a value of "VERIFY_CA"
+    SSL_MODE_VERIFY_CA = "VERIFY_CA"
+
+    #: A constant which can be used with the ssl_mode property of a ChannelSourceMysql.
+    #: This constant has a value of "REQUIRED"
+    SSL_MODE_REQUIRED = "REQUIRED"
+
+    #: A constant which can be used with the ssl_mode property of a ChannelSourceMysql.
+    #: This constant has a value of "DISABLED"
+    SSL_MODE_DISABLED = "DISABLED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChannelSourceMysql object with values from keyword arguments. The default value of the :py:attr:`~oci.mysql.models.ChannelSourceMysql.source_type` attribute
+        of this class is ``MYSQL`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param source_type:
+            The value to assign to the source_type property of this ChannelSourceMysql.
+            Allowed values for this property are: "MYSQL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type source_type: str
+
+        :param hostname:
+            The value to assign to the hostname property of this ChannelSourceMysql.
+        :type hostname: str
+
+        :param port:
+            The value to assign to the port property of this ChannelSourceMysql.
+        :type port: int
+
+        :param username:
+            The value to assign to the username property of this ChannelSourceMysql.
+        :type username: str
+
+        :param ssl_mode:
+            The value to assign to the ssl_mode property of this ChannelSourceMysql.
+            Allowed values for this property are: "VERIFY_IDENTITY", "VERIFY_CA", "REQUIRED", "DISABLED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type ssl_mode: str
+
+        :param ssl_ca_certificate:
+            The value to assign to the ssl_ca_certificate property of this ChannelSourceMysql.
+        :type ssl_ca_certificate: CaCertificate
+
+        """
+        self.swagger_types = {
+            'source_type': 'str',
+            'hostname': 'str',
+            'port': 'int',
+            'username': 'str',
+            'ssl_mode': 'str',
+            'ssl_ca_certificate': 'CaCertificate'
+        }
+
+        self.attribute_map = {
+            'source_type': 'sourceType',
+            'hostname': 'hostname',
+            'port': 'port',
+            'username': 'username',
+            'ssl_mode': 'sslMode',
+            'ssl_ca_certificate': 'sslCaCertificate'
+        }
+
+        self._source_type = None
+        self._hostname = None
+        self._port = None
+        self._username = None
+        self._ssl_mode = None
+        self._ssl_ca_certificate = None
+        self._source_type = 'MYSQL'
+
+    @property
+    def hostname(self):
+        """
+        **[Required]** Gets the hostname of this ChannelSourceMysql.
+        The network address of the MySQL instance.
+
+
+        :return: The hostname of this ChannelSourceMysql.
+        :rtype: str
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, hostname):
+        """
+        Sets the hostname of this ChannelSourceMysql.
+        The network address of the MySQL instance.
+
+
+        :param hostname: The hostname of this ChannelSourceMysql.
+        :type: str
+        """
+        self._hostname = hostname
+
+    @property
+    def port(self):
+        """
+        **[Required]** Gets the port of this ChannelSourceMysql.
+        The port the source MySQL instance listens on.
+
+
+        :return: The port of this ChannelSourceMysql.
+        :rtype: int
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this ChannelSourceMysql.
+        The port the source MySQL instance listens on.
+
+
+        :param port: The port of this ChannelSourceMysql.
+        :type: int
+        """
+        self._port = port
+
+    @property
+    def username(self):
+        """
+        **[Required]** Gets the username of this ChannelSourceMysql.
+        The name of the replication user on the source MySQL instance.
+        The username has a maximum length of 96 characters. For more information,
+        please see the `MySQL documentation`__
+
+        __ https://dev.mysql.com/doc/refman/8.0/en/change-master-to.html
+
+
+        :return: The username of this ChannelSourceMysql.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this ChannelSourceMysql.
+        The name of the replication user on the source MySQL instance.
+        The username has a maximum length of 96 characters. For more information,
+        please see the `MySQL documentation`__
+
+        __ https://dev.mysql.com/doc/refman/8.0/en/change-master-to.html
+
+
+        :param username: The username of this ChannelSourceMysql.
+        :type: str
+        """
+        self._username = username
+
+    @property
+    def ssl_mode(self):
+        """
+        **[Required]** Gets the ssl_mode of this ChannelSourceMysql.
+        The SSL mode of the Channel.
+
+        Allowed values for this property are: "VERIFY_IDENTITY", "VERIFY_CA", "REQUIRED", "DISABLED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The ssl_mode of this ChannelSourceMysql.
+        :rtype: str
+        """
+        return self._ssl_mode
+
+    @ssl_mode.setter
+    def ssl_mode(self, ssl_mode):
+        """
+        Sets the ssl_mode of this ChannelSourceMysql.
+        The SSL mode of the Channel.
+
+
+        :param ssl_mode: The ssl_mode of this ChannelSourceMysql.
+        :type: str
+        """
+        allowed_values = ["VERIFY_IDENTITY", "VERIFY_CA", "REQUIRED", "DISABLED"]
+        if not value_allowed_none_or_none_sentinel(ssl_mode, allowed_values):
+            ssl_mode = 'UNKNOWN_ENUM_VALUE'
+        self._ssl_mode = ssl_mode
+
+    @property
+    def ssl_ca_certificate(self):
+        """
+        Gets the ssl_ca_certificate of this ChannelSourceMysql.
+
+        :return: The ssl_ca_certificate of this ChannelSourceMysql.
+        :rtype: CaCertificate
+        """
+        return self._ssl_ca_certificate
+
+    @ssl_ca_certificate.setter
+    def ssl_ca_certificate(self, ssl_ca_certificate):
+        """
+        Sets the ssl_ca_certificate of this ChannelSourceMysql.
+
+        :param ssl_ca_certificate: The ssl_ca_certificate of this ChannelSourceMysql.
+        :type: CaCertificate
+        """
+        self._ssl_ca_certificate = ssl_ca_certificate
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/channel_summary.py
+++ b/src/oci/mysql/models/channel_summary.py
@@ -1,0 +1,415 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChannelSummary(object):
+    """
+    Summary of a Channel.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChannelSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this ChannelSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChannelSummary.
+        :type compartment_id: str
+
+        :param is_enabled:
+            The value to assign to the is_enabled property of this ChannelSummary.
+        :type is_enabled: bool
+
+        :param source:
+            The value to assign to the source property of this ChannelSummary.
+        :type source: ChannelSource
+
+        :param target:
+            The value to assign to the target property of this ChannelSummary.
+        :type target: ChannelTarget
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ChannelSummary.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ChannelSummary.
+        :type lifecycle_details: str
+
+        :param display_name:
+            The value to assign to the display_name property of this ChannelSummary.
+        :type display_name: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ChannelSummary.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this ChannelSummary.
+        :type time_updated: datetime
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ChannelSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ChannelSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'is_enabled': 'bool',
+            'source': 'ChannelSource',
+            'target': 'ChannelTarget',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'display_name': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'is_enabled': 'isEnabled',
+            'source': 'source',
+            'target': 'target',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'display_name': 'displayName',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._is_enabled = None
+        self._source = None
+        self._target = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._display_name = None
+        self._time_created = None
+        self._time_updated = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ChannelSummary.
+        The OCID of the Channel.
+
+
+        :return: The id of this ChannelSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ChannelSummary.
+        The OCID of the Channel.
+
+
+        :param id: The id of this ChannelSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChannelSummary.
+        The OCID of the compartment.
+
+
+        :return: The compartment_id of this ChannelSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChannelSummary.
+        The OCID of the compartment.
+
+
+        :param compartment_id: The compartment_id of this ChannelSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def is_enabled(self):
+        """
+        **[Required]** Gets the is_enabled of this ChannelSummary.
+        Whether the Channel has been enabled by the user.
+
+
+        :return: The is_enabled of this ChannelSummary.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this ChannelSummary.
+        Whether the Channel has been enabled by the user.
+
+
+        :param is_enabled: The is_enabled of this ChannelSummary.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
+
+    @property
+    def source(self):
+        """
+        **[Required]** Gets the source of this ChannelSummary.
+
+        :return: The source of this ChannelSummary.
+        :rtype: ChannelSource
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """
+        Sets the source of this ChannelSummary.
+
+        :param source: The source of this ChannelSummary.
+        :type: ChannelSource
+        """
+        self._source = source
+
+    @property
+    def target(self):
+        """
+        **[Required]** Gets the target of this ChannelSummary.
+
+        :return: The target of this ChannelSummary.
+        :rtype: ChannelTarget
+        """
+        return self._target
+
+    @target.setter
+    def target(self, target):
+        """
+        Sets the target of this ChannelSummary.
+
+        :param target: The target of this ChannelSummary.
+        :type: ChannelTarget
+        """
+        self._target = target
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ChannelSummary.
+        The state of the Channel.
+
+
+        :return: The lifecycle_state of this ChannelSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ChannelSummary.
+        The state of the Channel.
+
+
+        :param lifecycle_state: The lifecycle_state of this ChannelSummary.
+        :type: str
+        """
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this ChannelSummary.
+        A message describing the state of the Channel.
+
+
+        :return: The lifecycle_details of this ChannelSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this ChannelSummary.
+        A message describing the state of the Channel.
+
+
+        :param lifecycle_details: The lifecycle_details of this ChannelSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ChannelSummary.
+        The user-friendly name for the Channel. It does not have to be unique.
+
+
+        :return: The display_name of this ChannelSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ChannelSummary.
+        The user-friendly name for the Channel. It does not have to be unique.
+
+
+        :param display_name: The display_name of this ChannelSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ChannelSummary.
+        The date and time the Channel was created, as described by `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_created of this ChannelSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ChannelSummary.
+        The date and time the Channel was created, as described by `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_created: The time_created of this ChannelSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        **[Required]** Gets the time_updated of this ChannelSummary.
+        The time the Channel was last updated, as described by `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :return: The time_updated of this ChannelSummary.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this ChannelSummary.
+        The time the Channel was last updated, as described by `RFC 3339`__.
+
+        __ https://tools.ietf.org/rfc/rfc3339
+
+
+        :param time_updated: The time_updated of this ChannelSummary.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ChannelSummary.
+        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this ChannelSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ChannelSummary.
+        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this ChannelSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ChannelSummary.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this ChannelSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ChannelSummary.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this ChannelSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/channel_target.py
+++ b/src/oci/mysql/models/channel_target.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChannelTarget(object):
+    """
+    Details about the Channel target.
+    """
+
+    #: A constant which can be used with the target_type property of a ChannelTarget.
+    #: This constant has a value of "DBSYSTEM"
+    TARGET_TYPE_DBSYSTEM = "DBSYSTEM"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChannelTarget object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.mysql.models.ChannelTargetDbSystem`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param target_type:
+            The value to assign to the target_type property of this ChannelTarget.
+            Allowed values for this property are: "DBSYSTEM", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type target_type: str
+
+        """
+        self.swagger_types = {
+            'target_type': 'str'
+        }
+
+        self.attribute_map = {
+            'target_type': 'targetType'
+        }
+
+        self._target_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['targetType']
+
+        if type == 'DBSYSTEM':
+            return 'ChannelTargetDbSystem'
+        else:
+            return 'ChannelTarget'
+
+    @property
+    def target_type(self):
+        """
+        **[Required]** Gets the target_type of this ChannelTarget.
+        The specific target identifier.
+
+        Allowed values for this property are: "DBSYSTEM", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The target_type of this ChannelTarget.
+        :rtype: str
+        """
+        return self._target_type
+
+    @target_type.setter
+    def target_type(self, target_type):
+        """
+        Sets the target_type of this ChannelTarget.
+        The specific target identifier.
+
+
+        :param target_type: The target_type of this ChannelTarget.
+        :type: str
+        """
+        allowed_values = ["DBSYSTEM"]
+        if not value_allowed_none_or_none_sentinel(target_type, allowed_values):
+            target_type = 'UNKNOWN_ENUM_VALUE'
+        self._target_type = target_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/channel_target_db_system.py
+++ b/src/oci/mysql/models/channel_target_db_system.py
@@ -1,0 +1,150 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .channel_target import ChannelTarget
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChannelTargetDbSystem(ChannelTarget):
+    """
+    Core properties of a DB System Channel target.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChannelTargetDbSystem object with values from keyword arguments. The default value of the :py:attr:`~oci.mysql.models.ChannelTargetDbSystem.target_type` attribute
+        of this class is ``DBSYSTEM`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param target_type:
+            The value to assign to the target_type property of this ChannelTargetDbSystem.
+            Allowed values for this property are: "DBSYSTEM"
+        :type target_type: str
+
+        :param db_system_id:
+            The value to assign to the db_system_id property of this ChannelTargetDbSystem.
+        :type db_system_id: str
+
+        :param channel_name:
+            The value to assign to the channel_name property of this ChannelTargetDbSystem.
+        :type channel_name: str
+
+        :param applier_username:
+            The value to assign to the applier_username property of this ChannelTargetDbSystem.
+        :type applier_username: str
+
+        """
+        self.swagger_types = {
+            'target_type': 'str',
+            'db_system_id': 'str',
+            'channel_name': 'str',
+            'applier_username': 'str'
+        }
+
+        self.attribute_map = {
+            'target_type': 'targetType',
+            'db_system_id': 'dbSystemId',
+            'channel_name': 'channelName',
+            'applier_username': 'applierUsername'
+        }
+
+        self._target_type = None
+        self._db_system_id = None
+        self._channel_name = None
+        self._applier_username = None
+        self._target_type = 'DBSYSTEM'
+
+    @property
+    def db_system_id(self):
+        """
+        **[Required]** Gets the db_system_id of this ChannelTargetDbSystem.
+        The OCID of the source DB System.
+
+
+        :return: The db_system_id of this ChannelTargetDbSystem.
+        :rtype: str
+        """
+        return self._db_system_id
+
+    @db_system_id.setter
+    def db_system_id(self, db_system_id):
+        """
+        Sets the db_system_id of this ChannelTargetDbSystem.
+        The OCID of the source DB System.
+
+
+        :param db_system_id: The db_system_id of this ChannelTargetDbSystem.
+        :type: str
+        """
+        self._db_system_id = db_system_id
+
+    @property
+    def channel_name(self):
+        """
+        **[Required]** Gets the channel_name of this ChannelTargetDbSystem.
+        The case-insensitive name that identifies the replication channel. Channel names
+        must follow the rules defined for `MySQL identifiers`__.
+        The names of non-Deleted Channels must be unique for each DB System.
+
+        __ https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
+
+
+        :return: The channel_name of this ChannelTargetDbSystem.
+        :rtype: str
+        """
+        return self._channel_name
+
+    @channel_name.setter
+    def channel_name(self, channel_name):
+        """
+        Sets the channel_name of this ChannelTargetDbSystem.
+        The case-insensitive name that identifies the replication channel. Channel names
+        must follow the rules defined for `MySQL identifiers`__.
+        The names of non-Deleted Channels must be unique for each DB System.
+
+        __ https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
+
+
+        :param channel_name: The channel_name of this ChannelTargetDbSystem.
+        :type: str
+        """
+        self._channel_name = channel_name
+
+    @property
+    def applier_username(self):
+        """
+        **[Required]** Gets the applier_username of this ChannelTargetDbSystem.
+        The username for the replication applier of the target MySQL DB System.
+
+
+        :return: The applier_username of this ChannelTargetDbSystem.
+        :rtype: str
+        """
+        return self._applier_username
+
+    @applier_username.setter
+    def applier_username(self, applier_username):
+        """
+        Sets the applier_username of this ChannelTargetDbSystem.
+        The username for the replication applier of the target MySQL DB System.
+
+
+        :param applier_username: The applier_username of this ChannelTargetDbSystem.
+        :type: str
+        """
+        self._applier_username = applier_username
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/configuration.py
+++ b/src/oci/mysql/models/configuration.py
@@ -425,7 +425,7 @@ class Configuration(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this Configuration.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -438,7 +438,7 @@ class Configuration(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this Configuration.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -451,7 +451,7 @@ class Configuration(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this Configuration.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 
@@ -464,7 +464,7 @@ class Configuration(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this Configuration.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 

--- a/src/oci/mysql/models/configuration_summary.py
+++ b/src/oci/mysql/models/configuration_summary.py
@@ -331,7 +331,7 @@ class ConfigurationSummary(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this ConfigurationSummary.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -344,7 +344,7 @@ class ConfigurationSummary(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this ConfigurationSummary.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -357,7 +357,7 @@ class ConfigurationSummary(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this ConfigurationSummary.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 
@@ -370,7 +370,7 @@ class ConfigurationSummary(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this ConfigurationSummary.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 

--- a/src/oci/mysql/models/configuration_variables.py
+++ b/src/oci/mysql/models/configuration_variables.py
@@ -46,6 +46,10 @@ class ConfigurationVariables(object):
     TRANSACTION_ISOLATION_READ_COMMITED = "READ-COMMITED"
 
     #: A constant which can be used with the transaction_isolation property of a ConfigurationVariables.
+    #: This constant has a value of "READ-COMMITTED"
+    TRANSACTION_ISOLATION_READ_COMMITTED = "READ-COMMITTED"
+
+    #: A constant which can be used with the transaction_isolation property of a ConfigurationVariables.
     #: This constant has a value of "REPEATABLE-READ"
     TRANSACTION_ISOLATION_REPEATABLE_READ = "REPEATABLE-READ"
 
@@ -72,7 +76,7 @@ class ConfigurationVariables(object):
 
         :param transaction_isolation:
             The value to assign to the transaction_isolation property of this ConfigurationVariables.
-            Allowed values for this property are: "READ-UNCOMMITTED", "READ-COMMITED", "REPEATABLE-READ", "SERIALIZABLE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "READ-UNCOMMITTED", "READ-COMMITED", "READ-COMMITTED", "REPEATABLE-READ", "SERIALIZABLE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type transaction_isolation: str
 
@@ -256,6 +260,10 @@ class ConfigurationVariables(object):
             The value to assign to the mysqlx_zstd_max_client_compression_level property of this ConfigurationVariables.
         :type mysqlx_zstd_max_client_compression_level: int
 
+        :param mysqlx_zstd_default_compression_level:
+            The value to assign to the mysqlx_zstd_default_compression_level property of this ConfigurationVariables.
+        :type mysqlx_zstd_default_compression_level: int
+
         :param mysql_zstd_default_compression_level:
             The value to assign to the mysql_zstd_default_compression_level property of this ConfigurationVariables.
         :type mysql_zstd_default_compression_level: int
@@ -310,6 +318,7 @@ class ConfigurationVariables(object):
             'mysqlx_lz4_max_client_compression_level': 'int',
             'mysqlx_lz4_default_compression_level': 'int',
             'mysqlx_zstd_max_client_compression_level': 'int',
+            'mysqlx_zstd_default_compression_level': 'int',
             'mysql_zstd_default_compression_level': 'int'
         }
 
@@ -362,6 +371,7 @@ class ConfigurationVariables(object):
             'mysqlx_lz4_max_client_compression_level': 'mysqlxLz4MaxClientCompressionLevel',
             'mysqlx_lz4_default_compression_level': 'mysqlxLz4DefaultCompressionLevel',
             'mysqlx_zstd_max_client_compression_level': 'mysqlxZstdMaxClientCompressionLevel',
+            'mysqlx_zstd_default_compression_level': 'mysqlxZstdDefaultCompressionLevel',
             'mysql_zstd_default_compression_level': 'mysqlZstdDefaultCompressionLevel'
         }
 
@@ -413,6 +423,7 @@ class ConfigurationVariables(object):
         self._mysqlx_lz4_max_client_compression_level = None
         self._mysqlx_lz4_default_compression_level = None
         self._mysqlx_zstd_max_client_compression_level = None
+        self._mysqlx_zstd_default_compression_level = None
         self._mysql_zstd_default_compression_level = None
 
     @property
@@ -481,7 +492,7 @@ class ConfigurationVariables(object):
         Gets the transaction_isolation of this ConfigurationVariables.
         (\"transaction_isolation\")
 
-        Allowed values for this property are: "READ-UNCOMMITTED", "READ-COMMITED", "REPEATABLE-READ", "SERIALIZABLE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "READ-UNCOMMITTED", "READ-COMMITED", "READ-COMMITTED", "REPEATABLE-READ", "SERIALIZABLE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -500,7 +511,7 @@ class ConfigurationVariables(object):
         :param transaction_isolation: The transaction_isolation of this ConfigurationVariables.
         :type: str
         """
-        allowed_values = ["READ-UNCOMMITTED", "READ-COMMITED", "REPEATABLE-READ", "SERIALIZABLE"]
+        allowed_values = ["READ-UNCOMMITTED", "READ-COMMITED", "READ-COMMITTED", "REPEATABLE-READ", "SERIALIZABLE"]
         if not value_allowed_none_or_none_sentinel(transaction_isolation, allowed_values):
             transaction_isolation = 'UNKNOWN_ENUM_VALUE'
         self._transaction_isolation = transaction_isolation
@@ -677,7 +688,7 @@ class ConfigurationVariables(object):
     def mysqlx_enable_hello_notice(self):
         """
         Gets the mysqlx_enable_hello_notice of this ConfigurationVariables.
-        (\"mysqlx_enable_hello_notice\")
+        (\"mysqlx_enable_hello_notice\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The mysqlx_enable_hello_notice of this ConfigurationVariables.
@@ -689,7 +700,7 @@ class ConfigurationVariables(object):
     def mysqlx_enable_hello_notice(self, mysqlx_enable_hello_notice):
         """
         Sets the mysqlx_enable_hello_notice of this ConfigurationVariables.
-        (\"mysqlx_enable_hello_notice\")
+        (\"mysqlx_enable_hello_notice\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param mysqlx_enable_hello_notice: The mysqlx_enable_hello_notice of this ConfigurationVariables.
@@ -749,7 +760,7 @@ class ConfigurationVariables(object):
     def binlog_expire_logs_seconds(self):
         """
         Gets the binlog_expire_logs_seconds of this ConfigurationVariables.
-        (\"binlog_expire_logs_seconds\")
+        (\"binlog_expire_logs_seconds\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The binlog_expire_logs_seconds of this ConfigurationVariables.
@@ -761,7 +772,7 @@ class ConfigurationVariables(object):
     def binlog_expire_logs_seconds(self, binlog_expire_logs_seconds):
         """
         Sets the binlog_expire_logs_seconds of this ConfigurationVariables.
-        (\"binlog_expire_logs_seconds\")
+        (\"binlog_expire_logs_seconds\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param binlog_expire_logs_seconds: The binlog_expire_logs_seconds of this ConfigurationVariables.
@@ -917,7 +928,7 @@ class ConfigurationVariables(object):
     def generated_random_password_length(self):
         """
         Gets the generated_random_password_length of this ConfigurationVariables.
-        (\"generated_random_password_length\")
+        (\"generated_random_password_length\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The generated_random_password_length of this ConfigurationVariables.
@@ -929,7 +940,7 @@ class ConfigurationVariables(object):
     def generated_random_password_length(self, generated_random_password_length):
         """
         Sets the generated_random_password_length of this ConfigurationVariables.
-        (\"generated_random_password_length\")
+        (\"generated_random_password_length\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param generated_random_password_length: The generated_random_password_length of this ConfigurationVariables.
@@ -1157,7 +1168,7 @@ class ConfigurationVariables(object):
     def mysqlx_connect_timeout(self):
         """
         Gets the mysqlx_connect_timeout of this ConfigurationVariables.
-        (\"mysqlx_connect_timeout\")
+        (\"mysqlx_connect_timeout\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The mysqlx_connect_timeout of this ConfigurationVariables.
@@ -1169,7 +1180,7 @@ class ConfigurationVariables(object):
     def mysqlx_connect_timeout(self, mysqlx_connect_timeout):
         """
         Sets the mysqlx_connect_timeout of this ConfigurationVariables.
-        (\"mysqlx_connect_timeout\")
+        (\"mysqlx_connect_timeout\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param mysqlx_connect_timeout: The mysqlx_connect_timeout of this ConfigurationVariables.
@@ -1181,7 +1192,7 @@ class ConfigurationVariables(object):
     def mysqlx_document_id_unique_prefix(self):
         """
         Gets the mysqlx_document_id_unique_prefix of this ConfigurationVariables.
-        (\"mysqlx_document_id_unique_prefix\")
+        (\"mysqlx_document_id_unique_prefix\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The mysqlx_document_id_unique_prefix of this ConfigurationVariables.
@@ -1193,7 +1204,7 @@ class ConfigurationVariables(object):
     def mysqlx_document_id_unique_prefix(self, mysqlx_document_id_unique_prefix):
         """
         Sets the mysqlx_document_id_unique_prefix of this ConfigurationVariables.
-        (\"mysqlx_document_id_unique_prefix\")
+        (\"mysqlx_document_id_unique_prefix\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param mysqlx_document_id_unique_prefix: The mysqlx_document_id_unique_prefix of this ConfigurationVariables.
@@ -1205,7 +1216,7 @@ class ConfigurationVariables(object):
     def mysqlx_idle_worker_thread_timeout(self):
         """
         Gets the mysqlx_idle_worker_thread_timeout of this ConfigurationVariables.
-        (\"mysqlx_idle_worker_thread_timeout\")
+        (\"mysqlx_idle_worker_thread_timeout\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The mysqlx_idle_worker_thread_timeout of this ConfigurationVariables.
@@ -1217,7 +1228,7 @@ class ConfigurationVariables(object):
     def mysqlx_idle_worker_thread_timeout(self, mysqlx_idle_worker_thread_timeout):
         """
         Sets the mysqlx_idle_worker_thread_timeout of this ConfigurationVariables.
-        (\"mysqlx_idle_worker_thread_timeout\")
+        (\"mysqlx_idle_worker_thread_timeout\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param mysqlx_idle_worker_thread_timeout: The mysqlx_idle_worker_thread_timeout of this ConfigurationVariables.
@@ -1229,7 +1240,7 @@ class ConfigurationVariables(object):
     def mysqlx_interactive_timeout(self):
         """
         Gets the mysqlx_interactive_timeout of this ConfigurationVariables.
-        (\"mysqlx_interactive_timeout\")
+        (\"mysqlx_interactive_timeout\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The mysqlx_interactive_timeout of this ConfigurationVariables.
@@ -1241,7 +1252,7 @@ class ConfigurationVariables(object):
     def mysqlx_interactive_timeout(self, mysqlx_interactive_timeout):
         """
         Sets the mysqlx_interactive_timeout of this ConfigurationVariables.
-        (\"mysqlx_interactive_timeout\")
+        (\"mysqlx_interactive_timeout\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param mysqlx_interactive_timeout: The mysqlx_interactive_timeout of this ConfigurationVariables.
@@ -1253,7 +1264,7 @@ class ConfigurationVariables(object):
     def mysqlx_max_allowed_packet(self):
         """
         Gets the mysqlx_max_allowed_packet of this ConfigurationVariables.
-        (\"mysqlx_max_allowed_packet\")
+        (\"mysqlx_max_allowed_packet\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The mysqlx_max_allowed_packet of this ConfigurationVariables.
@@ -1265,7 +1276,7 @@ class ConfigurationVariables(object):
     def mysqlx_max_allowed_packet(self, mysqlx_max_allowed_packet):
         """
         Sets the mysqlx_max_allowed_packet of this ConfigurationVariables.
-        (\"mysqlx_max_allowed_packet\")
+        (\"mysqlx_max_allowed_packet\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param mysqlx_max_allowed_packet: The mysqlx_max_allowed_packet of this ConfigurationVariables.
@@ -1277,7 +1288,7 @@ class ConfigurationVariables(object):
     def mysqlx_min_worker_threads(self):
         """
         Gets the mysqlx_min_worker_threads of this ConfigurationVariables.
-        (\"mysqlx_min_worker_threads\")
+        (\"mysqlx_min_worker_threads\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The mysqlx_min_worker_threads of this ConfigurationVariables.
@@ -1289,7 +1300,7 @@ class ConfigurationVariables(object):
     def mysqlx_min_worker_threads(self, mysqlx_min_worker_threads):
         """
         Sets the mysqlx_min_worker_threads of this ConfigurationVariables.
-        (\"mysqlx_min_worker_threads\")
+        (\"mysqlx_min_worker_threads\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param mysqlx_min_worker_threads: The mysqlx_min_worker_threads of this ConfigurationVariables.
@@ -1301,7 +1312,7 @@ class ConfigurationVariables(object):
     def mysqlx_read_timeout(self):
         """
         Gets the mysqlx_read_timeout of this ConfigurationVariables.
-        (\"mysqlx_read_timeout\")
+        (\"mysqlx_read_timeout\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The mysqlx_read_timeout of this ConfigurationVariables.
@@ -1313,7 +1324,7 @@ class ConfigurationVariables(object):
     def mysqlx_read_timeout(self, mysqlx_read_timeout):
         """
         Sets the mysqlx_read_timeout of this ConfigurationVariables.
-        (\"mysqlx_read_timeout\")
+        (\"mysqlx_read_timeout\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param mysqlx_read_timeout: The mysqlx_read_timeout of this ConfigurationVariables.
@@ -1325,7 +1336,7 @@ class ConfigurationVariables(object):
     def mysqlx_wait_timeout(self):
         """
         Gets the mysqlx_wait_timeout of this ConfigurationVariables.
-        (\"mysqlx_wait_timeout\")
+        (\"mysqlx_wait_timeout\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The mysqlx_wait_timeout of this ConfigurationVariables.
@@ -1337,7 +1348,7 @@ class ConfigurationVariables(object):
     def mysqlx_wait_timeout(self, mysqlx_wait_timeout):
         """
         Sets the mysqlx_wait_timeout of this ConfigurationVariables.
-        (\"mysqlx_wait_timeout\")
+        (\"mysqlx_wait_timeout\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param mysqlx_wait_timeout: The mysqlx_wait_timeout of this ConfigurationVariables.
@@ -1349,7 +1360,7 @@ class ConfigurationVariables(object):
     def mysqlx_write_timeout(self):
         """
         Gets the mysqlx_write_timeout of this ConfigurationVariables.
-        (\"mysqlx_write_timeout\")
+        (\"mysqlx_write_timeout\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The mysqlx_write_timeout of this ConfigurationVariables.
@@ -1361,7 +1372,7 @@ class ConfigurationVariables(object):
     def mysqlx_write_timeout(self, mysqlx_write_timeout):
         """
         Sets the mysqlx_write_timeout of this ConfigurationVariables.
-        (\"mysqlx_write_timeout\")
+        (\"mysqlx_write_timeout\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param mysqlx_write_timeout: The mysqlx_write_timeout of this ConfigurationVariables.
@@ -1397,7 +1408,7 @@ class ConfigurationVariables(object):
     def query_alloc_block_size(self):
         """
         Gets the query_alloc_block_size of this ConfigurationVariables.
-        (\"query_alloc_block_size\")
+        (\"query_alloc_block_size\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The query_alloc_block_size of this ConfigurationVariables.
@@ -1409,7 +1420,7 @@ class ConfigurationVariables(object):
     def query_alloc_block_size(self, query_alloc_block_size):
         """
         Sets the query_alloc_block_size of this ConfigurationVariables.
-        (\"query_alloc_block_size\")
+        (\"query_alloc_block_size\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param query_alloc_block_size: The query_alloc_block_size of this ConfigurationVariables.
@@ -1421,7 +1432,7 @@ class ConfigurationVariables(object):
     def query_prealloc_size(self):
         """
         Gets the query_prealloc_size of this ConfigurationVariables.
-        (\"query_prealloc_size\")
+        (\"query_prealloc_size\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :return: The query_prealloc_size of this ConfigurationVariables.
@@ -1433,7 +1444,7 @@ class ConfigurationVariables(object):
     def query_prealloc_size(self, query_prealloc_size):
         """
         Sets the query_prealloc_size of this ConfigurationVariables.
-        (\"query_prealloc_size\")
+        (\"query_prealloc_size\") DEPRECATED -- variable should not be settable and will be ignored
 
 
         :param query_prealloc_size: The query_prealloc_size of this ConfigurationVariables.
@@ -1586,10 +1597,34 @@ class ConfigurationVariables(object):
         self._mysqlx_zstd_max_client_compression_level = mysqlx_zstd_max_client_compression_level
 
     @property
+    def mysqlx_zstd_default_compression_level(self):
+        """
+        Gets the mysqlx_zstd_default_compression_level of this ConfigurationVariables.
+        Set the default compression level for the zstd algorithm. (\"mysqlx_zstd_default_compression_level\")
+
+
+        :return: The mysqlx_zstd_default_compression_level of this ConfigurationVariables.
+        :rtype: int
+        """
+        return self._mysqlx_zstd_default_compression_level
+
+    @mysqlx_zstd_default_compression_level.setter
+    def mysqlx_zstd_default_compression_level(self, mysqlx_zstd_default_compression_level):
+        """
+        Sets the mysqlx_zstd_default_compression_level of this ConfigurationVariables.
+        Set the default compression level for the zstd algorithm. (\"mysqlx_zstd_default_compression_level\")
+
+
+        :param mysqlx_zstd_default_compression_level: The mysqlx_zstd_default_compression_level of this ConfigurationVariables.
+        :type: int
+        """
+        self._mysqlx_zstd_default_compression_level = mysqlx_zstd_default_compression_level
+
+    @property
     def mysql_zstd_default_compression_level(self):
         """
         Gets the mysql_zstd_default_compression_level of this ConfigurationVariables.
-        Set the default compression level for the zstd algorithm. (\"mysqlx_zstd_default_compression_level\")
+        DEPRECATED -- typo of mysqlx_zstd_default_compression_level. variable will be ignored.
 
 
         :return: The mysql_zstd_default_compression_level of this ConfigurationVariables.
@@ -1601,7 +1636,7 @@ class ConfigurationVariables(object):
     def mysql_zstd_default_compression_level(self, mysql_zstd_default_compression_level):
         """
         Sets the mysql_zstd_default_compression_level of this ConfigurationVariables.
-        Set the default compression level for the zstd algorithm. (\"mysqlx_zstd_default_compression_level\")
+        DEPRECATED -- typo of mysqlx_zstd_default_compression_level. variable will be ignored.
 
 
         :param mysql_zstd_default_compression_level: The mysql_zstd_default_compression_level of this ConfigurationVariables.

--- a/src/oci/mysql/models/create_backup_details.py
+++ b/src/oci/mysql/models/create_backup_details.py
@@ -216,7 +216,7 @@ class CreateBackupDetails(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this CreateBackupDetails.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -229,7 +229,7 @@ class CreateBackupDetails(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this CreateBackupDetails.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -242,7 +242,7 @@ class CreateBackupDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateBackupDetails.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 
@@ -255,7 +255,7 @@ class CreateBackupDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateBackupDetails.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 

--- a/src/oci/mysql/models/create_backup_policy_details.py
+++ b/src/oci/mysql/models/create_backup_policy_details.py
@@ -146,6 +146,9 @@ class CreateBackupPolicyDetails(object):
         """
         Gets the freeform_tags of this CreateBackupPolicyDetails.
         Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+
+        Tags defined here will be copied verbatim as tags on the Backup resource created by this BackupPolicy.
+
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -159,6 +162,9 @@ class CreateBackupPolicyDetails(object):
         """
         Sets the freeform_tags of this CreateBackupPolicyDetails.
         Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+
+        Tags defined here will be copied verbatim as tags on the Backup resource created by this BackupPolicy.
+
         Example: `{\"bar-key\": \"value\"}`
 
 

--- a/src/oci/mysql/models/create_channel_details.py
+++ b/src/oci/mysql/models/create_channel_details.py
@@ -1,0 +1,285 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateChannelDetails(object):
+    """
+    Details required to create a Channel.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateChannelDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateChannelDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateChannelDetails.
+        :type display_name: str
+
+        :param is_enabled:
+            The value to assign to the is_enabled property of this CreateChannelDetails.
+        :type is_enabled: bool
+
+        :param source:
+            The value to assign to the source property of this CreateChannelDetails.
+        :type source: CreateChannelSourceDetails
+
+        :param target:
+            The value to assign to the target property of this CreateChannelDetails.
+        :type target: CreateChannelTargetDetails
+
+        :param description:
+            The value to assign to the description property of this CreateChannelDetails.
+        :type description: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateChannelDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateChannelDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'is_enabled': 'bool',
+            'source': 'CreateChannelSourceDetails',
+            'target': 'CreateChannelTargetDetails',
+            'description': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'is_enabled': 'isEnabled',
+            'source': 'source',
+            'target': 'target',
+            'description': 'description',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._display_name = None
+        self._is_enabled = None
+        self._source = None
+        self._target = None
+        self._description = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this CreateChannelDetails.
+        The OCID of the compartment.
+
+
+        :return: The compartment_id of this CreateChannelDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateChannelDetails.
+        The OCID of the compartment.
+
+
+        :param compartment_id: The compartment_id of this CreateChannelDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateChannelDetails.
+        The user-friendly name for the Channel. It does not have to be unique.
+
+
+        :return: The display_name of this CreateChannelDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateChannelDetails.
+        The user-friendly name for the Channel. It does not have to be unique.
+
+
+        :param display_name: The display_name of this CreateChannelDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this CreateChannelDetails.
+        Whether the Channel should be enabled upon creation. If set to true, the Channel
+        will be asynchronously started as a result of the create Channel operation.
+
+
+        :return: The is_enabled of this CreateChannelDetails.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this CreateChannelDetails.
+        Whether the Channel should be enabled upon creation. If set to true, the Channel
+        will be asynchronously started as a result of the create Channel operation.
+
+
+        :param is_enabled: The is_enabled of this CreateChannelDetails.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
+
+    @property
+    def source(self):
+        """
+        **[Required]** Gets the source of this CreateChannelDetails.
+
+        :return: The source of this CreateChannelDetails.
+        :rtype: CreateChannelSourceDetails
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """
+        Sets the source of this CreateChannelDetails.
+
+        :param source: The source of this CreateChannelDetails.
+        :type: CreateChannelSourceDetails
+        """
+        self._source = source
+
+    @property
+    def target(self):
+        """
+        **[Required]** Gets the target of this CreateChannelDetails.
+
+        :return: The target of this CreateChannelDetails.
+        :rtype: CreateChannelTargetDetails
+        """
+        return self._target
+
+    @target.setter
+    def target(self, target):
+        """
+        Sets the target of this CreateChannelDetails.
+
+        :param target: The target of this CreateChannelDetails.
+        :type: CreateChannelTargetDetails
+        """
+        self._target = target
+
+    @property
+    def description(self):
+        """
+        Gets the description of this CreateChannelDetails.
+        User provided information about the Channel.
+
+
+        :return: The description of this CreateChannelDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this CreateChannelDetails.
+        User provided information about the Channel.
+
+
+        :param description: The description of this CreateChannelDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateChannelDetails.
+        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this CreateChannelDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateChannelDetails.
+        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this CreateChannelDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateChannelDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this CreateChannelDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateChannelDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this CreateChannelDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/create_channel_source_details.py
+++ b/src/oci/mysql/models/create_channel_source_details.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateChannelSourceDetails(object):
+    """
+    Parameters detailing how to provision the source for the given Channel.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateChannelSourceDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.mysql.models.CreateChannelSourceFromMysqlDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param source_type:
+            The value to assign to the source_type property of this CreateChannelSourceDetails.
+        :type source_type: str
+
+        """
+        self.swagger_types = {
+            'source_type': 'str'
+        }
+
+        self.attribute_map = {
+            'source_type': 'sourceType'
+        }
+
+        self._source_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['sourceType']
+
+        if type == 'MYSQL':
+            return 'CreateChannelSourceFromMysqlDetails'
+        else:
+            return 'CreateChannelSourceDetails'
+
+    @property
+    def source_type(self):
+        """
+        **[Required]** Gets the source_type of this CreateChannelSourceDetails.
+        The specific source identifier.
+
+
+        :return: The source_type of this CreateChannelSourceDetails.
+        :rtype: str
+        """
+        return self._source_type
+
+    @source_type.setter
+    def source_type(self, source_type):
+        """
+        Sets the source_type of this CreateChannelSourceDetails.
+        The specific source identifier.
+
+
+        :param source_type: The source_type of this CreateChannelSourceDetails.
+        :type: str
+        """
+        self._source_type = source_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/create_channel_source_from_mysql_details.py
+++ b/src/oci/mysql/models/create_channel_source_from_mysql_details.py
@@ -1,0 +1,245 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_channel_source_details import CreateChannelSourceDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateChannelSourceFromMysqlDetails(CreateChannelSourceDetails):
+    """
+    Parameters detailing how to provision the source endpoint that is a MySQL Server.
+    Typically a MySQL Server that is not managed by the MySQL Database Service.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateChannelSourceFromMysqlDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.mysql.models.CreateChannelSourceFromMysqlDetails.source_type` attribute
+        of this class is ``MYSQL`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param source_type:
+            The value to assign to the source_type property of this CreateChannelSourceFromMysqlDetails.
+        :type source_type: str
+
+        :param hostname:
+            The value to assign to the hostname property of this CreateChannelSourceFromMysqlDetails.
+        :type hostname: str
+
+        :param port:
+            The value to assign to the port property of this CreateChannelSourceFromMysqlDetails.
+        :type port: int
+
+        :param username:
+            The value to assign to the username property of this CreateChannelSourceFromMysqlDetails.
+        :type username: str
+
+        :param password:
+            The value to assign to the password property of this CreateChannelSourceFromMysqlDetails.
+        :type password: str
+
+        :param ssl_mode:
+            The value to assign to the ssl_mode property of this CreateChannelSourceFromMysqlDetails.
+        :type ssl_mode: str
+
+        :param ssl_ca_certificate:
+            The value to assign to the ssl_ca_certificate property of this CreateChannelSourceFromMysqlDetails.
+        :type ssl_ca_certificate: CaCertificate
+
+        """
+        self.swagger_types = {
+            'source_type': 'str',
+            'hostname': 'str',
+            'port': 'int',
+            'username': 'str',
+            'password': 'str',
+            'ssl_mode': 'str',
+            'ssl_ca_certificate': 'CaCertificate'
+        }
+
+        self.attribute_map = {
+            'source_type': 'sourceType',
+            'hostname': 'hostname',
+            'port': 'port',
+            'username': 'username',
+            'password': 'password',
+            'ssl_mode': 'sslMode',
+            'ssl_ca_certificate': 'sslCaCertificate'
+        }
+
+        self._source_type = None
+        self._hostname = None
+        self._port = None
+        self._username = None
+        self._password = None
+        self._ssl_mode = None
+        self._ssl_ca_certificate = None
+        self._source_type = 'MYSQL'
+
+    @property
+    def hostname(self):
+        """
+        **[Required]** Gets the hostname of this CreateChannelSourceFromMysqlDetails.
+        The network address of the MySQL instance.
+
+
+        :return: The hostname of this CreateChannelSourceFromMysqlDetails.
+        :rtype: str
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, hostname):
+        """
+        Sets the hostname of this CreateChannelSourceFromMysqlDetails.
+        The network address of the MySQL instance.
+
+
+        :param hostname: The hostname of this CreateChannelSourceFromMysqlDetails.
+        :type: str
+        """
+        self._hostname = hostname
+
+    @property
+    def port(self):
+        """
+        Gets the port of this CreateChannelSourceFromMysqlDetails.
+        The port the source MySQL instance listens on.
+
+
+        :return: The port of this CreateChannelSourceFromMysqlDetails.
+        :rtype: int
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this CreateChannelSourceFromMysqlDetails.
+        The port the source MySQL instance listens on.
+
+
+        :param port: The port of this CreateChannelSourceFromMysqlDetails.
+        :type: int
+        """
+        self._port = port
+
+    @property
+    def username(self):
+        """
+        **[Required]** Gets the username of this CreateChannelSourceFromMysqlDetails.
+        The name of the replication user on the source MySQL instance.
+        The username has a maximum length of 96 characters. For more information,
+        please see the `MySQL documentation`__
+
+        __ https://dev.mysql.com/doc/refman/8.0/en/change-master-to.html
+
+
+        :return: The username of this CreateChannelSourceFromMysqlDetails.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this CreateChannelSourceFromMysqlDetails.
+        The name of the replication user on the source MySQL instance.
+        The username has a maximum length of 96 characters. For more information,
+        please see the `MySQL documentation`__
+
+        __ https://dev.mysql.com/doc/refman/8.0/en/change-master-to.html
+
+
+        :param username: The username of this CreateChannelSourceFromMysqlDetails.
+        :type: str
+        """
+        self._username = username
+
+    @property
+    def password(self):
+        """
+        **[Required]** Gets the password of this CreateChannelSourceFromMysqlDetails.
+        The password for the replication user. The password must be
+        between 8 and 32 characters long, and must contain at least 1
+        numeric character, 1 lowercase character, 1 uppercase character,
+        and 1 special (nonalphanumeric) character.
+
+
+        :return: The password of this CreateChannelSourceFromMysqlDetails.
+        :rtype: str
+        """
+        return self._password
+
+    @password.setter
+    def password(self, password):
+        """
+        Sets the password of this CreateChannelSourceFromMysqlDetails.
+        The password for the replication user. The password must be
+        between 8 and 32 characters long, and must contain at least 1
+        numeric character, 1 lowercase character, 1 uppercase character,
+        and 1 special (nonalphanumeric) character.
+
+
+        :param password: The password of this CreateChannelSourceFromMysqlDetails.
+        :type: str
+        """
+        self._password = password
+
+    @property
+    def ssl_mode(self):
+        """
+        **[Required]** Gets the ssl_mode of this CreateChannelSourceFromMysqlDetails.
+        The SSL mode of the Channel.
+
+
+        :return: The ssl_mode of this CreateChannelSourceFromMysqlDetails.
+        :rtype: str
+        """
+        return self._ssl_mode
+
+    @ssl_mode.setter
+    def ssl_mode(self, ssl_mode):
+        """
+        Sets the ssl_mode of this CreateChannelSourceFromMysqlDetails.
+        The SSL mode of the Channel.
+
+
+        :param ssl_mode: The ssl_mode of this CreateChannelSourceFromMysqlDetails.
+        :type: str
+        """
+        self._ssl_mode = ssl_mode
+
+    @property
+    def ssl_ca_certificate(self):
+        """
+        Gets the ssl_ca_certificate of this CreateChannelSourceFromMysqlDetails.
+
+        :return: The ssl_ca_certificate of this CreateChannelSourceFromMysqlDetails.
+        :rtype: CaCertificate
+        """
+        return self._ssl_ca_certificate
+
+    @ssl_ca_certificate.setter
+    def ssl_ca_certificate(self, ssl_ca_certificate):
+        """
+        Sets the ssl_ca_certificate of this CreateChannelSourceFromMysqlDetails.
+
+        :param ssl_ca_certificate: The ssl_ca_certificate of this CreateChannelSourceFromMysqlDetails.
+        :type: CaCertificate
+        """
+        self._ssl_ca_certificate = ssl_ca_certificate
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/create_channel_target_details.py
+++ b/src/oci/mysql/models/create_channel_target_details.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateChannelTargetDetails(object):
+    """
+    Parameters detailing how to provision the target for the given Channel.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateChannelTargetDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.mysql.models.CreateChannelTargetFromDbSystemDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param target_type:
+            The value to assign to the target_type property of this CreateChannelTargetDetails.
+        :type target_type: str
+
+        """
+        self.swagger_types = {
+            'target_type': 'str'
+        }
+
+        self.attribute_map = {
+            'target_type': 'targetType'
+        }
+
+        self._target_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['targetType']
+
+        if type == 'DBSYSTEM':
+            return 'CreateChannelTargetFromDbSystemDetails'
+        else:
+            return 'CreateChannelTargetDetails'
+
+    @property
+    def target_type(self):
+        """
+        **[Required]** Gets the target_type of this CreateChannelTargetDetails.
+        The specific target identifier.
+
+
+        :return: The target_type of this CreateChannelTargetDetails.
+        :rtype: str
+        """
+        return self._target_type
+
+    @target_type.setter
+    def target_type(self, target_type):
+        """
+        Sets the target_type of this CreateChannelTargetDetails.
+        The specific target identifier.
+
+
+        :param target_type: The target_type of this CreateChannelTargetDetails.
+        :type: str
+        """
+        self._target_type = target_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/create_channel_target_from_db_system_details.py
+++ b/src/oci/mysql/models/create_channel_target_from_db_system_details.py
@@ -1,0 +1,149 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_channel_target_details import CreateChannelTargetDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateChannelTargetFromDbSystemDetails(CreateChannelTargetDetails):
+    """
+    Parameters detailing how to provision the target endpoint that is a DB System.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateChannelTargetFromDbSystemDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.mysql.models.CreateChannelTargetFromDbSystemDetails.target_type` attribute
+        of this class is ``DBSYSTEM`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param target_type:
+            The value to assign to the target_type property of this CreateChannelTargetFromDbSystemDetails.
+        :type target_type: str
+
+        :param db_system_id:
+            The value to assign to the db_system_id property of this CreateChannelTargetFromDbSystemDetails.
+        :type db_system_id: str
+
+        :param channel_name:
+            The value to assign to the channel_name property of this CreateChannelTargetFromDbSystemDetails.
+        :type channel_name: str
+
+        :param applier_username:
+            The value to assign to the applier_username property of this CreateChannelTargetFromDbSystemDetails.
+        :type applier_username: str
+
+        """
+        self.swagger_types = {
+            'target_type': 'str',
+            'db_system_id': 'str',
+            'channel_name': 'str',
+            'applier_username': 'str'
+        }
+
+        self.attribute_map = {
+            'target_type': 'targetType',
+            'db_system_id': 'dbSystemId',
+            'channel_name': 'channelName',
+            'applier_username': 'applierUsername'
+        }
+
+        self._target_type = None
+        self._db_system_id = None
+        self._channel_name = None
+        self._applier_username = None
+        self._target_type = 'DBSYSTEM'
+
+    @property
+    def db_system_id(self):
+        """
+        **[Required]** Gets the db_system_id of this CreateChannelTargetFromDbSystemDetails.
+        The OCID of the target DB System.
+
+
+        :return: The db_system_id of this CreateChannelTargetFromDbSystemDetails.
+        :rtype: str
+        """
+        return self._db_system_id
+
+    @db_system_id.setter
+    def db_system_id(self, db_system_id):
+        """
+        Sets the db_system_id of this CreateChannelTargetFromDbSystemDetails.
+        The OCID of the target DB System.
+
+
+        :param db_system_id: The db_system_id of this CreateChannelTargetFromDbSystemDetails.
+        :type: str
+        """
+        self._db_system_id = db_system_id
+
+    @property
+    def channel_name(self):
+        """
+        Gets the channel_name of this CreateChannelTargetFromDbSystemDetails.
+        The case-insensitive name that identifies the replication channel. Channel names
+        must follow the rules defined for `MySQL identifiers`__.
+        The names of non-Deleted Channels must be unique for each DB System.
+
+        __ https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
+
+
+        :return: The channel_name of this CreateChannelTargetFromDbSystemDetails.
+        :rtype: str
+        """
+        return self._channel_name
+
+    @channel_name.setter
+    def channel_name(self, channel_name):
+        """
+        Sets the channel_name of this CreateChannelTargetFromDbSystemDetails.
+        The case-insensitive name that identifies the replication channel. Channel names
+        must follow the rules defined for `MySQL identifiers`__.
+        The names of non-Deleted Channels must be unique for each DB System.
+
+        __ https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
+
+
+        :param channel_name: The channel_name of this CreateChannelTargetFromDbSystemDetails.
+        :type: str
+        """
+        self._channel_name = channel_name
+
+    @property
+    def applier_username(self):
+        """
+        Gets the applier_username of this CreateChannelTargetFromDbSystemDetails.
+        The username for the replication applier of the target MySQL DB System.
+
+
+        :return: The applier_username of this CreateChannelTargetFromDbSystemDetails.
+        :rtype: str
+        """
+        return self._applier_username
+
+    @applier_username.setter
+    def applier_username(self, applier_username):
+        """
+        Sets the applier_username of this CreateChannelTargetFromDbSystemDetails.
+        The username for the replication applier of the target MySQL DB System.
+
+
+        :param applier_username: The applier_username of this CreateChannelTargetFromDbSystemDetails.
+        :type: str
+        """
+        self._applier_username = applier_username
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/create_configuration_details.py
+++ b/src/oci/mysql/models/create_configuration_details.py
@@ -181,7 +181,7 @@ class CreateConfigurationDetails(object):
     @property
     def variables(self):
         """
-        **[Required]** Gets the variables of this CreateConfigurationDetails.
+        Gets the variables of this CreateConfigurationDetails.
 
         :return: The variables of this CreateConfigurationDetails.
         :rtype: ConfigurationVariables
@@ -226,7 +226,7 @@ class CreateConfigurationDetails(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this CreateConfigurationDetails.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -239,7 +239,7 @@ class CreateConfigurationDetails(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this CreateConfigurationDetails.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -252,7 +252,7 @@ class CreateConfigurationDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this CreateConfigurationDetails.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 
@@ -265,7 +265,7 @@ class CreateConfigurationDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this CreateConfigurationDetails.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 

--- a/src/oci/mysql/models/create_db_system_details.py
+++ b/src/oci/mysql/models/create_db_system_details.py
@@ -296,7 +296,7 @@ class CreateDbSystemDetails(object):
     @property
     def configuration_id(self):
         """
-        **[Required]** Gets the configuration_id of this CreateDbSystemDetails.
+        Gets the configuration_id of this CreateDbSystemDetails.
         The OCID of the Configuration to be used for this DB System.
 
 

--- a/src/oci/mysql/models/create_db_system_source_details.py
+++ b/src/oci/mysql/models/create_db_system_source_details.py
@@ -31,6 +31,7 @@ class CreateDbSystemSourceDetails(object):
         to a service operations then you should favor using a subclass over the base class:
 
         * :class:`~oci.mysql.models.CreateDbSystemSourceFromBackupDetails`
+        * :class:`~oci.mysql.models.CreateDbSystemSourceFromNoneDetails`
         * :class:`~oci.mysql.models.CreateDbSystemSourceImportFromUrlDetails`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
@@ -61,6 +62,9 @@ class CreateDbSystemSourceDetails(object):
 
         if type == 'BACKUP':
             return 'CreateDbSystemSourceFromBackupDetails'
+
+        if type == 'NONE':
+            return 'CreateDbSystemSourceFromNoneDetails'
 
         if type == 'IMPORTURL':
             return 'CreateDbSystemSourceImportFromUrlDetails'

--- a/src/oci/mysql/models/create_db_system_source_from_none_details.py
+++ b/src/oci/mysql/models/create_db_system_source_from_none_details.py
@@ -1,0 +1,49 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_db_system_source_details import CreateDbSystemSourceDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDbSystemSourceFromNoneDetails(CreateDbSystemSourceDetails):
+    """
+    Creation of a DbSystem from no particular source.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDbSystemSourceFromNoneDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.mysql.models.CreateDbSystemSourceFromNoneDetails.source_type` attribute
+        of this class is ``NONE`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param source_type:
+            The value to assign to the source_type property of this CreateDbSystemSourceFromNoneDetails.
+            Allowed values for this property are: "NONE", "BACKUP", "IMPORTURL"
+        :type source_type: str
+
+        """
+        self.swagger_types = {
+            'source_type': 'str'
+        }
+
+        self.attribute_map = {
+            'source_type': 'sourceType'
+        }
+
+        self._source_type = None
+        self._source_type = 'NONE'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/db_system.py
+++ b/src/oci/mysql/models/db_system.py
@@ -11,6 +11,8 @@ from oci.decorators import init_model_state_from_kwargs
 class DbSystem(object):
     """
     A DB System is the core logical unit of MySQL Database Service.
+    # NOTE: definitions/DbSystemSnapshot is a snapshot version of DbSystem which is stored during backup. Any
+    # addition/deletion of properties should also consider snapshot's definition
     """
 
     #: A constant which can be used with the lifecycle_state property of a DbSystem.
@@ -126,6 +128,10 @@ class DbSystem(object):
             The value to assign to the endpoints property of this DbSystem.
         :type endpoints: list[DbSystemEndpoint]
 
+        :param channels:
+            The value to assign to the channels property of this DbSystem.
+        :type channels: list[ChannelSummary]
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this DbSystem.
             Allowed values for this property are: "CREATING", "ACTIVE", "INACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
@@ -178,6 +184,7 @@ class DbSystem(object):
             'port': 'int',
             'port_x': 'int',
             'endpoints': 'list[DbSystemEndpoint]',
+            'channels': 'list[ChannelSummary]',
             'lifecycle_state': 'str',
             'lifecycle_details': 'str',
             'maintenance': 'MaintenanceDetails',
@@ -208,6 +215,7 @@ class DbSystem(object):
             'port': 'port',
             'port_x': 'portX',
             'endpoints': 'endpoints',
+            'channels': 'channels',
             'lifecycle_state': 'lifecycleState',
             'lifecycle_details': 'lifecycleDetails',
             'maintenance': 'maintenance',
@@ -237,6 +245,7 @@ class DbSystem(object):
         self._port = None
         self._port_x = None
         self._endpoints = None
+        self._channels = None
         self._lifecycle_state = None
         self._lifecycle_details = None
         self._maintenance = None
@@ -734,6 +743,30 @@ class DbSystem(object):
         self._endpoints = endpoints
 
     @property
+    def channels(self):
+        """
+        Gets the channels of this DbSystem.
+        A list with a summary of all the Channels attached to the DB System.
+
+
+        :return: The channels of this DbSystem.
+        :rtype: list[ChannelSummary]
+        """
+        return self._channels
+
+    @channels.setter
+    def channels(self, channels):
+        """
+        Sets the channels of this DbSystem.
+        A list with a summary of all the Channels attached to the DB System.
+
+
+        :param channels: The channels of this DbSystem.
+        :type: list[ChannelSummary]
+        """
+        self._channels = channels
+
+    @property
     def lifecycle_state(self):
         """
         **[Required]** Gets the lifecycle_state of this DbSystem.
@@ -859,7 +892,7 @@ class DbSystem(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this DbSystem.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -872,7 +905,7 @@ class DbSystem(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this DbSystem.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -885,7 +918,7 @@ class DbSystem(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this DbSystem.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 
@@ -898,7 +931,7 @@ class DbSystem(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this DbSystem.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 

--- a/src/oci/mysql/models/db_system_snapshot.py
+++ b/src/oci/mysql/models/db_system_snapshot.py
@@ -1,0 +1,706 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DbSystemSnapshot(object):
+    """
+    Snapshot of the DbSystem details at the time of the backup
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DbSystemSnapshot object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this DbSystemSnapshot.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this DbSystemSnapshot.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this DbSystemSnapshot.
+        :type description: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this DbSystemSnapshot.
+        :type compartment_id: str
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this DbSystemSnapshot.
+        :type subnet_id: str
+
+        :param availability_domain:
+            The value to assign to the availability_domain property of this DbSystemSnapshot.
+        :type availability_domain: str
+
+        :param fault_domain:
+            The value to assign to the fault_domain property of this DbSystemSnapshot.
+        :type fault_domain: str
+
+        :param shape_name:
+            The value to assign to the shape_name property of this DbSystemSnapshot.
+        :type shape_name: str
+
+        :param mysql_version:
+            The value to assign to the mysql_version property of this DbSystemSnapshot.
+        :type mysql_version: str
+
+        :param admin_username:
+            The value to assign to the admin_username property of this DbSystemSnapshot.
+        :type admin_username: str
+
+        :param backup_policy:
+            The value to assign to the backup_policy property of this DbSystemSnapshot.
+        :type backup_policy: BackupPolicy
+
+        :param configuration_id:
+            The value to assign to the configuration_id property of this DbSystemSnapshot.
+        :type configuration_id: str
+
+        :param data_storage_size_in_gbs:
+            The value to assign to the data_storage_size_in_gbs property of this DbSystemSnapshot.
+        :type data_storage_size_in_gbs: int
+
+        :param hostname_label:
+            The value to assign to the hostname_label property of this DbSystemSnapshot.
+        :type hostname_label: str
+
+        :param ip_address:
+            The value to assign to the ip_address property of this DbSystemSnapshot.
+        :type ip_address: str
+
+        :param port:
+            The value to assign to the port property of this DbSystemSnapshot.
+        :type port: int
+
+        :param port_x:
+            The value to assign to the port_x property of this DbSystemSnapshot.
+        :type port_x: int
+
+        :param endpoints:
+            The value to assign to the endpoints property of this DbSystemSnapshot.
+        :type endpoints: list[DbSystemEndpoint]
+
+        :param maintenance:
+            The value to assign to the maintenance property of this DbSystemSnapshot.
+        :type maintenance: MaintenanceDetails
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this DbSystemSnapshot.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this DbSystemSnapshot.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'description': 'str',
+            'compartment_id': 'str',
+            'subnet_id': 'str',
+            'availability_domain': 'str',
+            'fault_domain': 'str',
+            'shape_name': 'str',
+            'mysql_version': 'str',
+            'admin_username': 'str',
+            'backup_policy': 'BackupPolicy',
+            'configuration_id': 'str',
+            'data_storage_size_in_gbs': 'int',
+            'hostname_label': 'str',
+            'ip_address': 'str',
+            'port': 'int',
+            'port_x': 'int',
+            'endpoints': 'list[DbSystemEndpoint]',
+            'maintenance': 'MaintenanceDetails',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'description': 'description',
+            'compartment_id': 'compartmentId',
+            'subnet_id': 'subnetId',
+            'availability_domain': 'availabilityDomain',
+            'fault_domain': 'faultDomain',
+            'shape_name': 'shapeName',
+            'mysql_version': 'mysqlVersion',
+            'admin_username': 'adminUsername',
+            'backup_policy': 'backupPolicy',
+            'configuration_id': 'configurationId',
+            'data_storage_size_in_gbs': 'dataStorageSizeInGBs',
+            'hostname_label': 'hostnameLabel',
+            'ip_address': 'ipAddress',
+            'port': 'port',
+            'port_x': 'portX',
+            'endpoints': 'endpoints',
+            'maintenance': 'maintenance',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._description = None
+        self._compartment_id = None
+        self._subnet_id = None
+        self._availability_domain = None
+        self._fault_domain = None
+        self._shape_name = None
+        self._mysql_version = None
+        self._admin_username = None
+        self._backup_policy = None
+        self._configuration_id = None
+        self._data_storage_size_in_gbs = None
+        self._hostname_label = None
+        self._ip_address = None
+        self._port = None
+        self._port_x = None
+        self._endpoints = None
+        self._maintenance = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this DbSystemSnapshot.
+        The OCID of the DB System.
+
+
+        :return: The id of this DbSystemSnapshot.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this DbSystemSnapshot.
+        The OCID of the DB System.
+
+
+        :param id: The id of this DbSystemSnapshot.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this DbSystemSnapshot.
+        The user-friendly name for the DB System. It does not have to be unique.
+
+
+        :return: The display_name of this DbSystemSnapshot.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this DbSystemSnapshot.
+        The user-friendly name for the DB System. It does not have to be unique.
+
+
+        :param display_name: The display_name of this DbSystemSnapshot.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this DbSystemSnapshot.
+        User-provided data about the DB System.
+
+
+        :return: The description of this DbSystemSnapshot.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this DbSystemSnapshot.
+        User-provided data about the DB System.
+
+
+        :param description: The description of this DbSystemSnapshot.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this DbSystemSnapshot.
+        The OCID of the compartment the DB System belongs in.
+
+
+        :return: The compartment_id of this DbSystemSnapshot.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this DbSystemSnapshot.
+        The OCID of the compartment the DB System belongs in.
+
+
+        :param compartment_id: The compartment_id of this DbSystemSnapshot.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def subnet_id(self):
+        """
+        **[Required]** Gets the subnet_id of this DbSystemSnapshot.
+        The OCID of the subnet the DB System is associated with.
+
+
+        :return: The subnet_id of this DbSystemSnapshot.
+        :rtype: str
+        """
+        return self._subnet_id
+
+    @subnet_id.setter
+    def subnet_id(self, subnet_id):
+        """
+        Sets the subnet_id of this DbSystemSnapshot.
+        The OCID of the subnet the DB System is associated with.
+
+
+        :param subnet_id: The subnet_id of this DbSystemSnapshot.
+        :type: str
+        """
+        self._subnet_id = subnet_id
+
+    @property
+    def availability_domain(self):
+        """
+        Gets the availability_domain of this DbSystemSnapshot.
+        The Availability Domain where the primary DB System should be located.
+
+
+        :return: The availability_domain of this DbSystemSnapshot.
+        :rtype: str
+        """
+        return self._availability_domain
+
+    @availability_domain.setter
+    def availability_domain(self, availability_domain):
+        """
+        Sets the availability_domain of this DbSystemSnapshot.
+        The Availability Domain where the primary DB System should be located.
+
+
+        :param availability_domain: The availability_domain of this DbSystemSnapshot.
+        :type: str
+        """
+        self._availability_domain = availability_domain
+
+    @property
+    def fault_domain(self):
+        """
+        Gets the fault_domain of this DbSystemSnapshot.
+        The name of the Fault Domain the DB System is located in.
+
+
+        :return: The fault_domain of this DbSystemSnapshot.
+        :rtype: str
+        """
+        return self._fault_domain
+
+    @fault_domain.setter
+    def fault_domain(self, fault_domain):
+        """
+        Sets the fault_domain of this DbSystemSnapshot.
+        The name of the Fault Domain the DB System is located in.
+
+
+        :param fault_domain: The fault_domain of this DbSystemSnapshot.
+        :type: str
+        """
+        self._fault_domain = fault_domain
+
+    @property
+    def shape_name(self):
+        """
+        Gets the shape_name of this DbSystemSnapshot.
+        The shape of the primary instances of the DB System. The shape
+        determines resources allocated to a DB System - CPU cores
+        and memory for VM shapes; CPU cores, memory and storage for non-VM
+        (or bare metal) shapes. To get a list of shapes, use (the
+        :func:`list_shapes` operation.
+
+
+        :return: The shape_name of this DbSystemSnapshot.
+        :rtype: str
+        """
+        return self._shape_name
+
+    @shape_name.setter
+    def shape_name(self, shape_name):
+        """
+        Sets the shape_name of this DbSystemSnapshot.
+        The shape of the primary instances of the DB System. The shape
+        determines resources allocated to a DB System - CPU cores
+        and memory for VM shapes; CPU cores, memory and storage for non-VM
+        (or bare metal) shapes. To get a list of shapes, use (the
+        :func:`list_shapes` operation.
+
+
+        :param shape_name: The shape_name of this DbSystemSnapshot.
+        :type: str
+        """
+        self._shape_name = shape_name
+
+    @property
+    def mysql_version(self):
+        """
+        **[Required]** Gets the mysql_version of this DbSystemSnapshot.
+        Name of the MySQL Version in use for the DB System.
+
+
+        :return: The mysql_version of this DbSystemSnapshot.
+        :rtype: str
+        """
+        return self._mysql_version
+
+    @mysql_version.setter
+    def mysql_version(self, mysql_version):
+        """
+        Sets the mysql_version of this DbSystemSnapshot.
+        Name of the MySQL Version in use for the DB System.
+
+
+        :param mysql_version: The mysql_version of this DbSystemSnapshot.
+        :type: str
+        """
+        self._mysql_version = mysql_version
+
+    @property
+    def admin_username(self):
+        """
+        Gets the admin_username of this DbSystemSnapshot.
+        The username for the administrative user.
+
+
+        :return: The admin_username of this DbSystemSnapshot.
+        :rtype: str
+        """
+        return self._admin_username
+
+    @admin_username.setter
+    def admin_username(self, admin_username):
+        """
+        Sets the admin_username of this DbSystemSnapshot.
+        The username for the administrative user.
+
+
+        :param admin_username: The admin_username of this DbSystemSnapshot.
+        :type: str
+        """
+        self._admin_username = admin_username
+
+    @property
+    def backup_policy(self):
+        """
+        Gets the backup_policy of this DbSystemSnapshot.
+
+        :return: The backup_policy of this DbSystemSnapshot.
+        :rtype: BackupPolicy
+        """
+        return self._backup_policy
+
+    @backup_policy.setter
+    def backup_policy(self, backup_policy):
+        """
+        Sets the backup_policy of this DbSystemSnapshot.
+
+        :param backup_policy: The backup_policy of this DbSystemSnapshot.
+        :type: BackupPolicy
+        """
+        self._backup_policy = backup_policy
+
+    @property
+    def configuration_id(self):
+        """
+        Gets the configuration_id of this DbSystemSnapshot.
+        The OCID of the Configuration to be used for Instances in this DB System.
+
+
+        :return: The configuration_id of this DbSystemSnapshot.
+        :rtype: str
+        """
+        return self._configuration_id
+
+    @configuration_id.setter
+    def configuration_id(self, configuration_id):
+        """
+        Sets the configuration_id of this DbSystemSnapshot.
+        The OCID of the Configuration to be used for Instances in this DB System.
+
+
+        :param configuration_id: The configuration_id of this DbSystemSnapshot.
+        :type: str
+        """
+        self._configuration_id = configuration_id
+
+    @property
+    def data_storage_size_in_gbs(self):
+        """
+        **[Required]** Gets the data_storage_size_in_gbs of this DbSystemSnapshot.
+        Initial size of the data volume in GiBs that will be created and attached.
+
+
+        :return: The data_storage_size_in_gbs of this DbSystemSnapshot.
+        :rtype: int
+        """
+        return self._data_storage_size_in_gbs
+
+    @data_storage_size_in_gbs.setter
+    def data_storage_size_in_gbs(self, data_storage_size_in_gbs):
+        """
+        Sets the data_storage_size_in_gbs of this DbSystemSnapshot.
+        Initial size of the data volume in GiBs that will be created and attached.
+
+
+        :param data_storage_size_in_gbs: The data_storage_size_in_gbs of this DbSystemSnapshot.
+        :type: int
+        """
+        self._data_storage_size_in_gbs = data_storage_size_in_gbs
+
+    @property
+    def hostname_label(self):
+        """
+        Gets the hostname_label of this DbSystemSnapshot.
+        The hostname for the primary endpoint of the DB System. Used for DNS.
+        The value is the hostname portion of the primary private IP's fully qualified domain name (FQDN)
+        (for example, \"dbsystem-1\" in FQDN \"dbsystem-1.subnet123.vcn1.oraclevcn.com\").
+        Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.
+
+
+        :return: The hostname_label of this DbSystemSnapshot.
+        :rtype: str
+        """
+        return self._hostname_label
+
+    @hostname_label.setter
+    def hostname_label(self, hostname_label):
+        """
+        Sets the hostname_label of this DbSystemSnapshot.
+        The hostname for the primary endpoint of the DB System. Used for DNS.
+        The value is the hostname portion of the primary private IP's fully qualified domain name (FQDN)
+        (for example, \"dbsystem-1\" in FQDN \"dbsystem-1.subnet123.vcn1.oraclevcn.com\").
+        Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.
+
+
+        :param hostname_label: The hostname_label of this DbSystemSnapshot.
+        :type: str
+        """
+        self._hostname_label = hostname_label
+
+    @property
+    def ip_address(self):
+        """
+        Gets the ip_address of this DbSystemSnapshot.
+        The IP address the DB System is configured to listen on. A private
+        IP address of the primary endpoint of the DB System. Must be an
+        available IP address within the subnet's CIDR. This will be a
+        \"dotted-quad\" style IPv4 address.
+
+
+        :return: The ip_address of this DbSystemSnapshot.
+        :rtype: str
+        """
+        return self._ip_address
+
+    @ip_address.setter
+    def ip_address(self, ip_address):
+        """
+        Sets the ip_address of this DbSystemSnapshot.
+        The IP address the DB System is configured to listen on. A private
+        IP address of the primary endpoint of the DB System. Must be an
+        available IP address within the subnet's CIDR. This will be a
+        \"dotted-quad\" style IPv4 address.
+
+
+        :param ip_address: The ip_address of this DbSystemSnapshot.
+        :type: str
+        """
+        self._ip_address = ip_address
+
+    @property
+    def port(self):
+        """
+        Gets the port of this DbSystemSnapshot.
+        The port for primary endpoint of the DB System to listen on.
+
+
+        :return: The port of this DbSystemSnapshot.
+        :rtype: int
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this DbSystemSnapshot.
+        The port for primary endpoint of the DB System to listen on.
+
+
+        :param port: The port of this DbSystemSnapshot.
+        :type: int
+        """
+        self._port = port
+
+    @property
+    def port_x(self):
+        """
+        Gets the port_x of this DbSystemSnapshot.
+        The network port on which X Plugin listens for TCP/IP connections. This is the X Plugin equivalent of port.
+
+
+        :return: The port_x of this DbSystemSnapshot.
+        :rtype: int
+        """
+        return self._port_x
+
+    @port_x.setter
+    def port_x(self, port_x):
+        """
+        Sets the port_x of this DbSystemSnapshot.
+        The network port on which X Plugin listens for TCP/IP connections. This is the X Plugin equivalent of port.
+
+
+        :param port_x: The port_x of this DbSystemSnapshot.
+        :type: int
+        """
+        self._port_x = port_x
+
+    @property
+    def endpoints(self):
+        """
+        Gets the endpoints of this DbSystemSnapshot.
+        The network endpoints available for this DB System.
+
+
+        :return: The endpoints of this DbSystemSnapshot.
+        :rtype: list[DbSystemEndpoint]
+        """
+        return self._endpoints
+
+    @endpoints.setter
+    def endpoints(self, endpoints):
+        """
+        Sets the endpoints of this DbSystemSnapshot.
+        The network endpoints available for this DB System.
+
+
+        :param endpoints: The endpoints of this DbSystemSnapshot.
+        :type: list[DbSystemEndpoint]
+        """
+        self._endpoints = endpoints
+
+    @property
+    def maintenance(self):
+        """
+        **[Required]** Gets the maintenance of this DbSystemSnapshot.
+
+        :return: The maintenance of this DbSystemSnapshot.
+        :rtype: MaintenanceDetails
+        """
+        return self._maintenance
+
+    @maintenance.setter
+    def maintenance(self, maintenance):
+        """
+        Sets the maintenance of this DbSystemSnapshot.
+
+        :param maintenance: The maintenance of this DbSystemSnapshot.
+        :type: MaintenanceDetails
+        """
+        self._maintenance = maintenance
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this DbSystemSnapshot.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this DbSystemSnapshot.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this DbSystemSnapshot.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this DbSystemSnapshot.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this DbSystemSnapshot.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this DbSystemSnapshot.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this DbSystemSnapshot.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this DbSystemSnapshot.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/db_system_source.py
+++ b/src/oci/mysql/models/db_system_source.py
@@ -31,6 +31,7 @@ class DbSystemSource(object):
         to a service operations then you should favor using a subclass over the base class:
 
         * :class:`~oci.mysql.models.DbSystemSourceFromBackup`
+        * :class:`~oci.mysql.models.DbSystemSourceFromNone`
         * :class:`~oci.mysql.models.DbSystemSourceImportFromUrl`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
@@ -62,6 +63,9 @@ class DbSystemSource(object):
 
         if type == 'BACKUP':
             return 'DbSystemSourceFromBackup'
+
+        if type == 'NONE':
+            return 'DbSystemSourceFromNone'
 
         if type == 'IMPORTURL':
             return 'DbSystemSourceImportFromUrl'

--- a/src/oci/mysql/models/db_system_source_from_none.py
+++ b/src/oci/mysql/models/db_system_source_from_none.py
@@ -1,0 +1,49 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .db_system_source import DbSystemSource
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DbSystemSourceFromNone(DbSystemSource):
+    """
+    A DB System created from no particular external source.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DbSystemSourceFromNone object with values from keyword arguments. The default value of the :py:attr:`~oci.mysql.models.DbSystemSourceFromNone.source_type` attribute
+        of this class is ``NONE`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param source_type:
+            The value to assign to the source_type property of this DbSystemSourceFromNone.
+            Allowed values for this property are: "NONE", "BACKUP", "IMPORTURL"
+        :type source_type: str
+
+        """
+        self.swagger_types = {
+            'source_type': 'str'
+        }
+
+        self.attribute_map = {
+            'source_type': 'sourceType'
+        }
+
+        self._source_type = None
+        self._source_type = 'NONE'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/db_system_summary.py
+++ b/src/oci/mysql/models/db_system_summary.py
@@ -443,7 +443,7 @@ class DbSystemSummary(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this DbSystemSummary.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -456,7 +456,7 @@ class DbSystemSummary(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this DbSystemSummary.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -469,7 +469,7 @@ class DbSystemSummary(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this DbSystemSummary.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 
@@ -482,7 +482,7 @@ class DbSystemSummary(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this DbSystemSummary.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 

--- a/src/oci/mysql/models/pem_ca_certificate.py
+++ b/src/oci/mysql/models/pem_ca_certificate.py
@@ -1,0 +1,80 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .ca_certificate import CaCertificate
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PemCaCertificate(CaCertificate):
+    """
+    The CA certificate in PEM format.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PemCaCertificate object with values from keyword arguments. The default value of the :py:attr:`~oci.mysql.models.PemCaCertificate.certificate_type` attribute
+        of this class is ``PEM`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param certificate_type:
+            The value to assign to the certificate_type property of this PemCaCertificate.
+            Allowed values for this property are: "PEM"
+        :type certificate_type: str
+
+        :param contents:
+            The value to assign to the contents property of this PemCaCertificate.
+        :type contents: str
+
+        """
+        self.swagger_types = {
+            'certificate_type': 'str',
+            'contents': 'str'
+        }
+
+        self.attribute_map = {
+            'certificate_type': 'certificateType',
+            'contents': 'contents'
+        }
+
+        self._certificate_type = None
+        self._contents = None
+        self._certificate_type = 'PEM'
+
+    @property
+    def contents(self):
+        """
+        **[Required]** Gets the contents of this PemCaCertificate.
+        The string containing the CA certificate in PEM format.
+
+
+        :return: The contents of this PemCaCertificate.
+        :rtype: str
+        """
+        return self._contents
+
+    @contents.setter
+    def contents(self, contents):
+        """
+        Sets the contents of this PemCaCertificate.
+        The string containing the CA certificate in PEM format.
+
+
+        :param contents: The contents of this PemCaCertificate.
+        :type: str
+        """
+        self._contents = contents
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/update_backup_details.py
+++ b/src/oci/mysql/models/update_backup_details.py
@@ -137,7 +137,7 @@ class UpdateBackupDetails(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this UpdateBackupDetails.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -150,7 +150,7 @@ class UpdateBackupDetails(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this UpdateBackupDetails.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -163,7 +163,7 @@ class UpdateBackupDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateBackupDetails.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 
@@ -176,7 +176,7 @@ class UpdateBackupDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateBackupDetails.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 

--- a/src/oci/mysql/models/update_backup_policy_details.py
+++ b/src/oci/mysql/models/update_backup_policy_details.py
@@ -146,6 +146,9 @@ class UpdateBackupPolicyDetails(object):
         """
         Gets the freeform_tags of this UpdateBackupPolicyDetails.
         Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+
+        Tags defined here will be copied verbatim as tags on the Backup resource created by this BackupPolicy.
+
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -159,6 +162,9 @@ class UpdateBackupPolicyDetails(object):
         """
         Sets the freeform_tags of this UpdateBackupPolicyDetails.
         Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+
+        Tags defined here will be copied verbatim as tags on the Backup resource created by this BackupPolicy.
+
         Example: `{\"bar-key\": \"value\"}`
 
 

--- a/src/oci/mysql/models/update_channel_details.py
+++ b/src/oci/mysql/models/update_channel_details.py
@@ -1,0 +1,258 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateChannelDetails(object):
+    """
+    Details required to update a Channel
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateChannelDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param source:
+            The value to assign to the source property of this UpdateChannelDetails.
+        :type source: UpdateChannelSourceDetails
+
+        :param target:
+            The value to assign to the target property of this UpdateChannelDetails.
+        :type target: UpdateChannelTargetDetails
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateChannelDetails.
+        :type display_name: str
+
+        :param is_enabled:
+            The value to assign to the is_enabled property of this UpdateChannelDetails.
+        :type is_enabled: bool
+
+        :param description:
+            The value to assign to the description property of this UpdateChannelDetails.
+        :type description: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateChannelDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateChannelDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'source': 'UpdateChannelSourceDetails',
+            'target': 'UpdateChannelTargetDetails',
+            'display_name': 'str',
+            'is_enabled': 'bool',
+            'description': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'source': 'source',
+            'target': 'target',
+            'display_name': 'displayName',
+            'is_enabled': 'isEnabled',
+            'description': 'description',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._source = None
+        self._target = None
+        self._display_name = None
+        self._is_enabled = None
+        self._description = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def source(self):
+        """
+        Gets the source of this UpdateChannelDetails.
+
+        :return: The source of this UpdateChannelDetails.
+        :rtype: UpdateChannelSourceDetails
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """
+        Sets the source of this UpdateChannelDetails.
+
+        :param source: The source of this UpdateChannelDetails.
+        :type: UpdateChannelSourceDetails
+        """
+        self._source = source
+
+    @property
+    def target(self):
+        """
+        Gets the target of this UpdateChannelDetails.
+
+        :return: The target of this UpdateChannelDetails.
+        :rtype: UpdateChannelTargetDetails
+        """
+        return self._target
+
+    @target.setter
+    def target(self, target):
+        """
+        Sets the target of this UpdateChannelDetails.
+
+        :param target: The target of this UpdateChannelDetails.
+        :type: UpdateChannelTargetDetails
+        """
+        self._target = target
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateChannelDetails.
+        The user-friendly name for the Channel. It does not have to be unique.
+
+
+        :return: The display_name of this UpdateChannelDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateChannelDetails.
+        The user-friendly name for the Channel. It does not have to be unique.
+
+
+        :param display_name: The display_name of this UpdateChannelDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this UpdateChannelDetails.
+        Whether the Channel should be enabled or disabled. Enabling a previously
+        disabled Channel will cause the Channel to be started. Conversely, disabling
+        a previously enabled Channel will stop the Channel. Both operations are
+        executed asynchronously.
+
+
+        :return: The is_enabled of this UpdateChannelDetails.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this UpdateChannelDetails.
+        Whether the Channel should be enabled or disabled. Enabling a previously
+        disabled Channel will cause the Channel to be started. Conversely, disabling
+        a previously enabled Channel will stop the Channel. Both operations are
+        executed asynchronously.
+
+
+        :param is_enabled: The is_enabled of this UpdateChannelDetails.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
+
+    @property
+    def description(self):
+        """
+        Gets the description of this UpdateChannelDetails.
+        User provided description of the Channel.
+
+
+        :return: The description of this UpdateChannelDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this UpdateChannelDetails.
+        User provided description of the Channel.
+
+
+        :param description: The description of this UpdateChannelDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateChannelDetails.
+        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this UpdateChannelDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateChannelDetails.
+        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this UpdateChannelDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateChannelDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this UpdateChannelDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateChannelDetails.
+        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this UpdateChannelDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/update_channel_source_details.py
+++ b/src/oci/mysql/models/update_channel_source_details.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateChannelSourceDetails(object):
+    """
+    Parameters detailing how to provision the source for the given Channel.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateChannelSourceDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.mysql.models.UpdateChannelSourceFromMysqlDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param source_type:
+            The value to assign to the source_type property of this UpdateChannelSourceDetails.
+        :type source_type: str
+
+        """
+        self.swagger_types = {
+            'source_type': 'str'
+        }
+
+        self.attribute_map = {
+            'source_type': 'sourceType'
+        }
+
+        self._source_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['sourceType']
+
+        if type == 'MYSQL':
+            return 'UpdateChannelSourceFromMysqlDetails'
+        else:
+            return 'UpdateChannelSourceDetails'
+
+    @property
+    def source_type(self):
+        """
+        **[Required]** Gets the source_type of this UpdateChannelSourceDetails.
+        The specific source identifier.
+
+
+        :return: The source_type of this UpdateChannelSourceDetails.
+        :rtype: str
+        """
+        return self._source_type
+
+    @source_type.setter
+    def source_type(self, source_type):
+        """
+        Sets the source_type of this UpdateChannelSourceDetails.
+        The specific source identifier.
+
+
+        :param source_type: The source_type of this UpdateChannelSourceDetails.
+        :type: str
+        """
+        self._source_type = source_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/update_channel_source_from_mysql_details.py
+++ b/src/oci/mysql/models/update_channel_source_from_mysql_details.py
@@ -1,0 +1,245 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .update_channel_source_details import UpdateChannelSourceDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateChannelSourceFromMysqlDetails(UpdateChannelSourceDetails):
+    """
+    Parameters detailing how to provision the source endpoint that is a MySQL Server.
+    Typically a MySQL Server that is not managed by the MySQL Database Service.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateChannelSourceFromMysqlDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.mysql.models.UpdateChannelSourceFromMysqlDetails.source_type` attribute
+        of this class is ``MYSQL`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param source_type:
+            The value to assign to the source_type property of this UpdateChannelSourceFromMysqlDetails.
+        :type source_type: str
+
+        :param hostname:
+            The value to assign to the hostname property of this UpdateChannelSourceFromMysqlDetails.
+        :type hostname: str
+
+        :param port:
+            The value to assign to the port property of this UpdateChannelSourceFromMysqlDetails.
+        :type port: int
+
+        :param username:
+            The value to assign to the username property of this UpdateChannelSourceFromMysqlDetails.
+        :type username: str
+
+        :param password:
+            The value to assign to the password property of this UpdateChannelSourceFromMysqlDetails.
+        :type password: str
+
+        :param ssl_mode:
+            The value to assign to the ssl_mode property of this UpdateChannelSourceFromMysqlDetails.
+        :type ssl_mode: str
+
+        :param ssl_ca_certificate:
+            The value to assign to the ssl_ca_certificate property of this UpdateChannelSourceFromMysqlDetails.
+        :type ssl_ca_certificate: CaCertificate
+
+        """
+        self.swagger_types = {
+            'source_type': 'str',
+            'hostname': 'str',
+            'port': 'int',
+            'username': 'str',
+            'password': 'str',
+            'ssl_mode': 'str',
+            'ssl_ca_certificate': 'CaCertificate'
+        }
+
+        self.attribute_map = {
+            'source_type': 'sourceType',
+            'hostname': 'hostname',
+            'port': 'port',
+            'username': 'username',
+            'password': 'password',
+            'ssl_mode': 'sslMode',
+            'ssl_ca_certificate': 'sslCaCertificate'
+        }
+
+        self._source_type = None
+        self._hostname = None
+        self._port = None
+        self._username = None
+        self._password = None
+        self._ssl_mode = None
+        self._ssl_ca_certificate = None
+        self._source_type = 'MYSQL'
+
+    @property
+    def hostname(self):
+        """
+        Gets the hostname of this UpdateChannelSourceFromMysqlDetails.
+        The network address of the MySQL instance.
+
+
+        :return: The hostname of this UpdateChannelSourceFromMysqlDetails.
+        :rtype: str
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, hostname):
+        """
+        Sets the hostname of this UpdateChannelSourceFromMysqlDetails.
+        The network address of the MySQL instance.
+
+
+        :param hostname: The hostname of this UpdateChannelSourceFromMysqlDetails.
+        :type: str
+        """
+        self._hostname = hostname
+
+    @property
+    def port(self):
+        """
+        Gets the port of this UpdateChannelSourceFromMysqlDetails.
+        The port the source MySQL instance listens on.
+
+
+        :return: The port of this UpdateChannelSourceFromMysqlDetails.
+        :rtype: int
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this UpdateChannelSourceFromMysqlDetails.
+        The port the source MySQL instance listens on.
+
+
+        :param port: The port of this UpdateChannelSourceFromMysqlDetails.
+        :type: int
+        """
+        self._port = port
+
+    @property
+    def username(self):
+        """
+        Gets the username of this UpdateChannelSourceFromMysqlDetails.
+        The name of the replication user on the source MySQL instance.
+        The username has a maximum length of 96 characters. For more information,
+        please see the `MySQL documentation`__
+
+        __ https://dev.mysql.com/doc/refman/8.0/en/change-master-to.html
+
+
+        :return: The username of this UpdateChannelSourceFromMysqlDetails.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this UpdateChannelSourceFromMysqlDetails.
+        The name of the replication user on the source MySQL instance.
+        The username has a maximum length of 96 characters. For more information,
+        please see the `MySQL documentation`__
+
+        __ https://dev.mysql.com/doc/refman/8.0/en/change-master-to.html
+
+
+        :param username: The username of this UpdateChannelSourceFromMysqlDetails.
+        :type: str
+        """
+        self._username = username
+
+    @property
+    def password(self):
+        """
+        Gets the password of this UpdateChannelSourceFromMysqlDetails.
+        The password for the replication user. The password must be
+        between 8 and 32 characters long, and must contain at least 1
+        numeric character, 1 lowercase character, 1 uppercase character,
+        and 1 special (nonalphanumeric) character.
+
+
+        :return: The password of this UpdateChannelSourceFromMysqlDetails.
+        :rtype: str
+        """
+        return self._password
+
+    @password.setter
+    def password(self, password):
+        """
+        Sets the password of this UpdateChannelSourceFromMysqlDetails.
+        The password for the replication user. The password must be
+        between 8 and 32 characters long, and must contain at least 1
+        numeric character, 1 lowercase character, 1 uppercase character,
+        and 1 special (nonalphanumeric) character.
+
+
+        :param password: The password of this UpdateChannelSourceFromMysqlDetails.
+        :type: str
+        """
+        self._password = password
+
+    @property
+    def ssl_mode(self):
+        """
+        Gets the ssl_mode of this UpdateChannelSourceFromMysqlDetails.
+        The SSL mode of the Channel.
+
+
+        :return: The ssl_mode of this UpdateChannelSourceFromMysqlDetails.
+        :rtype: str
+        """
+        return self._ssl_mode
+
+    @ssl_mode.setter
+    def ssl_mode(self, ssl_mode):
+        """
+        Sets the ssl_mode of this UpdateChannelSourceFromMysqlDetails.
+        The SSL mode of the Channel.
+
+
+        :param ssl_mode: The ssl_mode of this UpdateChannelSourceFromMysqlDetails.
+        :type: str
+        """
+        self._ssl_mode = ssl_mode
+
+    @property
+    def ssl_ca_certificate(self):
+        """
+        Gets the ssl_ca_certificate of this UpdateChannelSourceFromMysqlDetails.
+
+        :return: The ssl_ca_certificate of this UpdateChannelSourceFromMysqlDetails.
+        :rtype: CaCertificate
+        """
+        return self._ssl_ca_certificate
+
+    @ssl_ca_certificate.setter
+    def ssl_ca_certificate(self, ssl_ca_certificate):
+        """
+        Sets the ssl_ca_certificate of this UpdateChannelSourceFromMysqlDetails.
+
+        :param ssl_ca_certificate: The ssl_ca_certificate of this UpdateChannelSourceFromMysqlDetails.
+        :type: CaCertificate
+        """
+        self._ssl_ca_certificate = ssl_ca_certificate
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/update_channel_target_details.py
+++ b/src/oci/mysql/models/update_channel_target_details.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateChannelTargetDetails(object):
+    """
+    Parameters detailing how to provision the target for the given Channel.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateChannelTargetDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.mysql.models.UpdateChannelTargetFromDbSystemDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param target_type:
+            The value to assign to the target_type property of this UpdateChannelTargetDetails.
+        :type target_type: str
+
+        """
+        self.swagger_types = {
+            'target_type': 'str'
+        }
+
+        self.attribute_map = {
+            'target_type': 'targetType'
+        }
+
+        self._target_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['targetType']
+
+        if type == 'DBSYSTEM':
+            return 'UpdateChannelTargetFromDbSystemDetails'
+        else:
+            return 'UpdateChannelTargetDetails'
+
+    @property
+    def target_type(self):
+        """
+        **[Required]** Gets the target_type of this UpdateChannelTargetDetails.
+        The specific targetType identifier.
+
+
+        :return: The target_type of this UpdateChannelTargetDetails.
+        :rtype: str
+        """
+        return self._target_type
+
+    @target_type.setter
+    def target_type(self, target_type):
+        """
+        Sets the target_type of this UpdateChannelTargetDetails.
+        The specific targetType identifier.
+
+
+        :param target_type: The target_type of this UpdateChannelTargetDetails.
+        :type: str
+        """
+        self._target_type = target_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/update_channel_target_from_db_system_details.py
+++ b/src/oci/mysql/models/update_channel_target_from_db_system_details.py
@@ -1,0 +1,118 @@
+# coding: utf-8
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .update_channel_target_details import UpdateChannelTargetDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateChannelTargetFromDbSystemDetails(UpdateChannelTargetDetails):
+    """
+    Parameters detailing how to provision the target endpoint that is a DB System.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateChannelTargetFromDbSystemDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.mysql.models.UpdateChannelTargetFromDbSystemDetails.target_type` attribute
+        of this class is ``DBSYSTEM`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param target_type:
+            The value to assign to the target_type property of this UpdateChannelTargetFromDbSystemDetails.
+        :type target_type: str
+
+        :param channel_name:
+            The value to assign to the channel_name property of this UpdateChannelTargetFromDbSystemDetails.
+        :type channel_name: str
+
+        :param applier_username:
+            The value to assign to the applier_username property of this UpdateChannelTargetFromDbSystemDetails.
+        :type applier_username: str
+
+        """
+        self.swagger_types = {
+            'target_type': 'str',
+            'channel_name': 'str',
+            'applier_username': 'str'
+        }
+
+        self.attribute_map = {
+            'target_type': 'targetType',
+            'channel_name': 'channelName',
+            'applier_username': 'applierUsername'
+        }
+
+        self._target_type = None
+        self._channel_name = None
+        self._applier_username = None
+        self._target_type = 'DBSYSTEM'
+
+    @property
+    def channel_name(self):
+        """
+        Gets the channel_name of this UpdateChannelTargetFromDbSystemDetails.
+        The case-insensitive name that identifies the replication channel. Channel names
+        must follow the rules defined for `MySQL identifiers`__.
+        The names of non-Deleted Channels must be unique for each DB System.
+
+        __ https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
+
+
+        :return: The channel_name of this UpdateChannelTargetFromDbSystemDetails.
+        :rtype: str
+        """
+        return self._channel_name
+
+    @channel_name.setter
+    def channel_name(self, channel_name):
+        """
+        Sets the channel_name of this UpdateChannelTargetFromDbSystemDetails.
+        The case-insensitive name that identifies the replication channel. Channel names
+        must follow the rules defined for `MySQL identifiers`__.
+        The names of non-Deleted Channels must be unique for each DB System.
+
+        __ https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
+
+
+        :param channel_name: The channel_name of this UpdateChannelTargetFromDbSystemDetails.
+        :type: str
+        """
+        self._channel_name = channel_name
+
+    @property
+    def applier_username(self):
+        """
+        Gets the applier_username of this UpdateChannelTargetFromDbSystemDetails.
+        The username for the replication applier of the target MySQL DB System.
+
+
+        :return: The applier_username of this UpdateChannelTargetFromDbSystemDetails.
+        :rtype: str
+        """
+        return self._applier_username
+
+    @applier_username.setter
+    def applier_username(self, applier_username):
+        """
+        Sets the applier_username of this UpdateChannelTargetFromDbSystemDetails.
+        The username for the replication applier of the target MySQL DB System.
+
+
+        :param applier_username: The applier_username of this UpdateChannelTargetFromDbSystemDetails.
+        :type: str
+        """
+        self._applier_username = applier_username
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/mysql/models/update_configuration_details.py
+++ b/src/oci/mysql/models/update_configuration_details.py
@@ -106,7 +106,7 @@ class UpdateConfigurationDetails(object):
     def freeform_tags(self):
         """
         Gets the freeform_tags of this UpdateConfigurationDetails.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -119,7 +119,7 @@ class UpdateConfigurationDetails(object):
     def freeform_tags(self, freeform_tags):
         """
         Sets the freeform_tags of this UpdateConfigurationDetails.
-        Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
         Example: `{\"bar-key\": \"value\"}`
 
 
@@ -132,7 +132,7 @@ class UpdateConfigurationDetails(object):
     def defined_tags(self):
         """
         Gets the defined_tags of this UpdateConfigurationDetails.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 
@@ -145,7 +145,7 @@ class UpdateConfigurationDetails(object):
     def defined_tags(self, defined_tags):
         """
         Sets the defined_tags of this UpdateConfigurationDetails.
-        Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
         Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
 
 

--- a/src/oci/object_storage/models/object_lifecycle_rule.py
+++ b/src/oci/object_storage/models/object_lifecycle_rule.py
@@ -118,10 +118,12 @@ class ObjectLifecycleRule(object):
         """
         Gets the target of this ObjectLifecycleRule.
         The target of the object lifecycle policy rule. The values of target can be either \"objects\",
-        \"multipart-uploads\" or \"previous-object-versions\". This field when declared as \"objects\" is used to specify
-        archive or delete rule for objects. This field when declared as \"multipart-uploads\" is used to specify
-        the abort (only) rule for uncommitted multipart-uploads. This field when declared as \"previous-object-versions\"
-        is used to specify archive or delete rule for previous versions of existing objects.
+        \"multipart-uploads\" or \"previous-object-versions\".
+        This field when declared as \"objects\" is used to specify ARCHIVE or DELETE rule for objects.
+        This field when declared as \"previous-object-versions\" is used to specify ARCHIVE or DELETE
+        rule for previous versions of existing objects.
+        This field when declared as \"multipart-uploads\" is used to specify the ABORT (only) rule for
+        uncommitted multipart-uploads.
 
 
         :return: The target of this ObjectLifecycleRule.
@@ -134,10 +136,12 @@ class ObjectLifecycleRule(object):
         """
         Sets the target of this ObjectLifecycleRule.
         The target of the object lifecycle policy rule. The values of target can be either \"objects\",
-        \"multipart-uploads\" or \"previous-object-versions\". This field when declared as \"objects\" is used to specify
-        archive or delete rule for objects. This field when declared as \"multipart-uploads\" is used to specify
-        the abort (only) rule for uncommitted multipart-uploads. This field when declared as \"previous-object-versions\"
-        is used to specify archive or delete rule for previous versions of existing objects.
+        \"multipart-uploads\" or \"previous-object-versions\".
+        This field when declared as \"objects\" is used to specify ARCHIVE or DELETE rule for objects.
+        This field when declared as \"previous-object-versions\" is used to specify ARCHIVE or DELETE
+        rule for previous versions of existing objects.
+        This field when declared as \"multipart-uploads\" is used to specify the ABORT (only) rule for
+        uncommitted multipart-uploads.
 
 
         :param target: The target of this ObjectLifecycleRule.
@@ -149,11 +153,11 @@ class ObjectLifecycleRule(object):
     def action(self):
         """
         **[Required]** Gets the action of this ObjectLifecycleRule.
-        The action of the object lifecycle policy rule. Rules using the action 'ARCHIVE' move objects into the
-        `Archive Storage tier`__. Rules using the action
-        'DELETE' permanently delete objects from buckets. Rules using 'ABORT' abort the uncommitted multipart-uploads
-        and permanently delete their parts from buckets. 'ARCHIVE', 'DELETE' and 'ABORT' are the only three supported
-        actions at this time.
+        The action of the object lifecycle policy rule.
+        Rules using the action 'ARCHIVE' move objects from Standard storage tier into the
+        `Archive Storage tier]`__.
+        Rules using the action 'DELETE' permanently delete objects from buckets.
+        Rules using 'ABORT' abort the uncommitted multipart-uploads and permanently delete their parts from buckets.
 
         __ https://docs.cloud.oracle.com/Content/Archive/Concepts/archivestorageoverview.htm
 
@@ -167,11 +171,11 @@ class ObjectLifecycleRule(object):
     def action(self, action):
         """
         Sets the action of this ObjectLifecycleRule.
-        The action of the object lifecycle policy rule. Rules using the action 'ARCHIVE' move objects into the
-        `Archive Storage tier`__. Rules using the action
-        'DELETE' permanently delete objects from buckets. Rules using 'ABORT' abort the uncommitted multipart-uploads
-        and permanently delete their parts from buckets. 'ARCHIVE', 'DELETE' and 'ABORT' are the only three supported
-        actions at this time.
+        The action of the object lifecycle policy rule.
+        Rules using the action 'ARCHIVE' move objects from Standard storage tier into the
+        `Archive Storage tier]`__.
+        Rules using the action 'DELETE' permanently delete objects from buckets.
+        Rules using 'ABORT' abort the uncommitted multipart-uploads and permanently delete their parts from buckets.
 
         __ https://docs.cloud.oracle.com/Content/Archive/Concepts/archivestorageoverview.htm
 

--- a/src/oci/object_storage/object_storage_client.py
+++ b/src/oci/object_storage/object_storage_client.py
@@ -1770,22 +1770,22 @@ class ObjectStorageClient(object):
             __ https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm
 
         :param str http_response_content_disposition: (optional)
-            This value will be used in Content-Disposition header of the response.
+            Specify this query parameter to override the value of the Content-Disposition response header in the GetObject response.
 
         :param str http_response_cache_control: (optional)
-            This value will be used in Cache-Control header of the response.
+            Specify this query parameter to override the Cache-Control response header in the GetObject response.
 
         :param str http_response_content_type: (optional)
-            This value will be used in Content-Type header of the response.
+            Specify this query parameter to override the Content-Type response header in the GetObject response.
 
         :param str http_response_content_language: (optional)
-            This value will be used in Content-Language header of the response.
+            Specify this query parameter to override the Content-Language response header in the GetObject response.
 
         :param str http_response_content_encoding: (optional)
-            This value will be used in Content-Encoding header of the response
+            Specify this query parameter to override the Content-Encoding response header in the GetObject response.
 
         :param str http_response_expires: (optional)
-            This value will be used in Expires header of the response
+            Specify this query parameter to override the Expires response header in the GetObject response.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.

--- a/src/oci/regions.py
+++ b/src/oci/regions.py
@@ -28,6 +28,7 @@ REGIONS_SHORT_NAMES = {
     'icn': 'ap-seoul-1',
     'bom': 'ap-mumbai-1',
     'gru': 'sa-saopaulo-1',
+    'scl': 'sa-santiago-1',
     'syd': 'ap-sydney-1',
     'ltn': 'uk-gov-london-1',
     'kix': 'ap-osaka-1',
@@ -62,6 +63,7 @@ REGION_REALMS = {
     'uk-london-1': 'oc1',
     'ca-toronto-1': 'oc1',
     'sa-saopaulo-1': 'oc1',
+    'sa-santiago-1': 'oc1',
     'ca-montreal-1': 'oc1',
 
     'us-langley-1': 'oc2',
@@ -112,6 +114,7 @@ REGIONS = [
     "us-gov-chicago-1",
     "us-gov-phoenix-1",
     "sa-saopaulo-1",
+    "sa-santiago-1",
     "uk-gov-london-1"
 ]
 SERVICE_ENDPOINTS = service_endpoints.SERVICE_ENDPOINTS

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.24.1"
+__version__ = "2.25.0"


### PR DESCRIPTION
## Added

* Support for calling Oracle Cloud Infrastructure services in the sa-santiago-1 region

* Support for peer and OSN resources, as well as retry tokens, in the Blockchain Platform service

* Support for getting the availability status of management agents in the Management Agent service

* Support for the on-prem-connector resource type in the Data Safe service

* Support for service channels in the MySQL Database service

* Support for getting the creation type of backups, and for filtering backups by creation type in the MySQL Database service



## Breaking

* Parameter `compartment_id` changed from optional to required for method `list_work_requests` in the Data Safe service

* Return type of method `create_data_safe_private_endpoint` changed from `None` to `oci.data_safe.models.DataSafePrivateEndpoint` in the Data Safe service

* Parameters `freeform_tags` and `defined_tags` are removed from model `EnableDataSafeConfigurationDetails` in the Data Safe service
