### PR TITLE
Require content_length if passing streaming object for body

### DIFF
--- a/src/oci/object_storage/object_storage_client.py
+++ b/src/oci/object_storage/object_storage_client.py
@@ -4093,6 +4093,10 @@ class ObjectStorageClient(object):
                 if requests.utils.super_len(put_object_body) == 0:
                     header_params['Content-Length'] = '0'
 
+            if not hasattr(put_object_body, 'fileno') and not hasattr(header_params, 'Content-Length'):
+                raise TypeError('Must supply content_length parameter if passing stream for object body.')
+
+
         retry_strategy = self.retry_strategy
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')


### PR DESCRIPTION
**Problem**
Passing a streaming object to OCI's `put_object` method throws a `oci.exceptions.RequestException: [Errno 32] Broken pipe` error if a content length isn't passed to the method.

**Background**
I came across this error while trying to write a script that transfers large objects from S3 to OCI Object Storage. I could not download the object locally because of disk space constraints on my agent running the script so I used [boto3's `get_object` method](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.get_object) to retrieve a streaming object instead. The streaming object returned by this call is a [StreamingBody](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/response.html) object. When I tried to supply this object as the body for a `put_object` call, I was met with the broken pipe error.

**Solution**
After stepping through the error in a debugger, I realized that this operation would succeed if I passed the content length of the object I retrieved from S3 as a parameter to the method call. Since we cannot change the streaming object to implement a length suitable for OCI, instead have the operation fail early if the user supplies a streaming file-like object without also supplying the `content_length` parameter. Because these specific streaming object have no `fileno`, I used that metric to decide if a `put_object_body` is of this type.

**How To Reproduce**
You can reproduce this error by passing a streaming file-like object to the `put_object` method. See the following script for an example.

```
import boto3
import oci 

s3_client = boto3_client("s3")
stream = s3_client.get_object(Bucket="some-bucket", Key="source_object_path")

oci_config = {...}
oci.storage_client.put_object(
            "some_namespace",
            "destination_bucket",
            "object_name",
            stream,
        )
```
