### PR TITLE
Releasing version 2.28.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.28.0 - 2021-01-19
+====================
+
+Added
+-----
+* Support for Logging Analytics as a target in the Service Connector Hub service
+* Support for lookups, agent collection warnings, task commands, and data archive/recall in the Logging Analytics service
+
+Fixed
+-----
+* Fixed a bug in the endpoint used for the Management Dashboard service
+
+Breaking
+--------
+* A new required property `kind` is added to the models `UpdateScheduledTaskDetails` and `ScheduledTask` in the Log Analytics service
+* The allowed values for parameter `sort_by` are restricted for methods `list_meta_source_types`, `list_parser_functions`, `list_parser_meta_plugins`, `list_source_label_operators`, `list_source_meta_functions` in the Log Analytics service. For more information please see the documentation for `LogAnalyticsClient <https://docs.oracle.com/en-us/iaas/tools/python/latest/api/log_analytics/client/oci.log_analytics.LogAnalyticsClient.html#loganalyticsclient>`_
+
+====================
 2.27.0 - 2021-01-12
 ====================
 

--- a/docs/api/log_analytics.rst
+++ b/docs/api/log_analytics.rst
@@ -57,6 +57,7 @@ Log Analytics
     oci.log_analytics.models.CreateLogAnalyticsObjectCollectionRuleDetails
     oci.log_analytics.models.CreateScheduledTaskDetails
     oci.log_analytics.models.CreateStandardTaskDetails
+    oci.log_analytics.models.CreateViewCommandDescriptor
     oci.log_analytics.models.CronSchedule
     oci.log_analytics.models.DeleteCommandDescriptor
     oci.log_analytics.models.DeleteLogAnalyticsAssociation
@@ -69,8 +70,13 @@ Log Analytics
     oci.log_analytics.models.ErrorDetails
     oci.log_analytics.models.EstimatePurgeDataSizeDetails
     oci.log_analytics.models.EstimatePurgeDataSizeResult
+    oci.log_analytics.models.EstimateRecallDataSizeDetails
+    oci.log_analytics.models.EstimateRecallDataSizeResult
+    oci.log_analytics.models.EstimateReleaseDataSizeDetails
+    oci.log_analytics.models.EstimateReleaseDataSizeResult
     oci.log_analytics.models.EvalCommandDescriptor
     oci.log_analytics.models.EventStatsCommandDescriptor
+    oci.log_analytics.models.EventType
     oci.log_analytics.models.ExportContent
     oci.log_analytics.models.ExportDetails
     oci.log_analytics.models.ExtendedFieldsValidationResult
@@ -93,6 +99,7 @@ Log Analytics
     oci.log_analytics.models.FunctionField
     oci.log_analytics.models.HeadCommandDescriptor
     oci.log_analytics.models.HighlightCommandDescriptor
+    oci.log_analytics.models.HighlightGroupsCommandDescriptor
     oci.log_analytics.models.HighlightRowsCommandDescriptor
     oci.log_analytics.models.Indexes
     oci.log_analytics.models.LabelNames
@@ -139,6 +146,8 @@ Log Analytics
     oci.log_analytics.models.LogAnalyticsLogGroupSummary
     oci.log_analytics.models.LogAnalyticsLogGroupSummaryCollection
     oci.log_analytics.models.LogAnalyticsLookup
+    oci.log_analytics.models.LogAnalyticsLookupCollection
+    oci.log_analytics.models.LogAnalyticsLookupFields
     oci.log_analytics.models.LogAnalyticsMetaFunction
     oci.log_analytics.models.LogAnalyticsMetaFunctionArgument
     oci.log_analytics.models.LogAnalyticsMetaFunctionCollection
@@ -174,15 +183,20 @@ Log Analytics
     oci.log_analytics.models.LogAnalyticsSourcePattern
     oci.log_analytics.models.LogAnalyticsSourcePatternCollection
     oci.log_analytics.models.LogAnalyticsSourceSummary
+    oci.log_analytics.models.LogAnalyticsWarning
+    oci.log_analytics.models.LogAnalyticsWarningCollection
     oci.log_analytics.models.LogGroupSummaryReport
     oci.log_analytics.models.LookupCommandDescriptor
     oci.log_analytics.models.LookupField
     oci.log_analytics.models.MacroCommandDescriptor
+    oci.log_analytics.models.MapCommandDescriptor
     oci.log_analytics.models.MatchInfo
+    oci.log_analytics.models.MetricExtraction
     oci.log_analytics.models.MultiSearchCommandDescriptor
     oci.log_analytics.models.Namespace
     oci.log_analytics.models.NamespaceCollection
     oci.log_analytics.models.NamespaceSummary
+    oci.log_analytics.models.NlpCommandDescriptor
     oci.log_analytics.models.ParseQueryDetails
     oci.log_analytics.models.ParseQueryOutput
     oci.log_analytics.models.ParsedContent
@@ -198,6 +212,8 @@ Log Analytics
     oci.log_analytics.models.QueryWorkRequestCollection
     oci.log_analytics.models.QueryWorkRequestSummary
     oci.log_analytics.models.RecallArchivedDataDetails
+    oci.log_analytics.models.RecalledData
+    oci.log_analytics.models.RecalledDataCollection
     oci.log_analytics.models.RegexCommandDescriptor
     oci.log_analytics.models.RegexMatchResult
     oci.log_analytics.models.ReleaseRecalledDataDetails
@@ -218,6 +234,7 @@ Log Analytics
     oci.log_analytics.models.SourceSummaryReport
     oci.log_analytics.models.SourceValidateDetails
     oci.log_analytics.models.SourceValidateResults
+    oci.log_analytics.models.StandardTask
     oci.log_analytics.models.StatsCommandDescriptor
     oci.log_analytics.models.StatusSummary
     oci.log_analytics.models.StepInfo
@@ -244,7 +261,9 @@ Log Analytics
     oci.log_analytics.models.UpdateLogAnalyticsEntityTypeDetails
     oci.log_analytics.models.UpdateLogAnalyticsLogGroupDetails
     oci.log_analytics.models.UpdateLogAnalyticsObjectCollectionRuleDetails
+    oci.log_analytics.models.UpdateLookupMetadataDetails
     oci.log_analytics.models.UpdateScheduledTaskDetails
+    oci.log_analytics.models.UpdateStandardTaskDetails
     oci.log_analytics.models.UpdateStorageDetails
     oci.log_analytics.models.Upload
     oci.log_analytics.models.UploadCollection
@@ -263,6 +282,7 @@ Log Analytics
     oci.log_analytics.models.UsageStatusItem
     oci.log_analytics.models.VerifyOutput
     oci.log_analytics.models.Violation
+    oci.log_analytics.models.WarningReferenceDetails
     oci.log_analytics.models.WhereCommandDescriptor
     oci.log_analytics.models.WorkRequest
     oci.log_analytics.models.WorkRequestCollection

--- a/docs/api/log_analytics/models/oci.log_analytics.models.CreateViewCommandDescriptor.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.CreateViewCommandDescriptor.rst
@@ -1,0 +1,11 @@
+CreateViewCommandDescriptor
+===========================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: CreateViewCommandDescriptor
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.EstimateRecallDataSizeDetails.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.EstimateRecallDataSizeDetails.rst
@@ -1,0 +1,11 @@
+EstimateRecallDataSizeDetails
+=============================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: EstimateRecallDataSizeDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.EstimateRecallDataSizeResult.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.EstimateRecallDataSizeResult.rst
@@ -1,0 +1,11 @@
+EstimateRecallDataSizeResult
+============================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: EstimateRecallDataSizeResult
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.EstimateReleaseDataSizeDetails.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.EstimateReleaseDataSizeDetails.rst
@@ -1,0 +1,11 @@
+EstimateReleaseDataSizeDetails
+==============================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: EstimateReleaseDataSizeDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.EstimateReleaseDataSizeResult.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.EstimateReleaseDataSizeResult.rst
@@ -1,0 +1,11 @@
+EstimateReleaseDataSizeResult
+=============================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: EstimateReleaseDataSizeResult
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.EventType.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.EventType.rst
@@ -1,0 +1,11 @@
+EventType
+=========
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: EventType
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.HighlightGroupsCommandDescriptor.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.HighlightGroupsCommandDescriptor.rst
@@ -1,0 +1,11 @@
+HighlightGroupsCommandDescriptor
+================================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: HighlightGroupsCommandDescriptor
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.LogAnalyticsLookupCollection.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.LogAnalyticsLookupCollection.rst
@@ -1,0 +1,11 @@
+LogAnalyticsLookupCollection
+============================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: LogAnalyticsLookupCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.LogAnalyticsLookupFields.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.LogAnalyticsLookupFields.rst
@@ -1,0 +1,11 @@
+LogAnalyticsLookupFields
+========================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: LogAnalyticsLookupFields
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.LogAnalyticsWarning.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.LogAnalyticsWarning.rst
@@ -1,0 +1,11 @@
+LogAnalyticsWarning
+===================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: LogAnalyticsWarning
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.LogAnalyticsWarningCollection.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.LogAnalyticsWarningCollection.rst
@@ -1,0 +1,11 @@
+LogAnalyticsWarningCollection
+=============================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: LogAnalyticsWarningCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.MapCommandDescriptor.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.MapCommandDescriptor.rst
@@ -1,0 +1,11 @@
+MapCommandDescriptor
+====================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: MapCommandDescriptor
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.MetricExtraction.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.MetricExtraction.rst
@@ -1,0 +1,11 @@
+MetricExtraction
+================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: MetricExtraction
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.NlpCommandDescriptor.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.NlpCommandDescriptor.rst
@@ -1,0 +1,11 @@
+NlpCommandDescriptor
+====================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: NlpCommandDescriptor
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.RecalledData.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.RecalledData.rst
@@ -1,0 +1,11 @@
+RecalledData
+============
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: RecalledData
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.RecalledDataCollection.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.RecalledDataCollection.rst
@@ -1,0 +1,11 @@
+RecalledDataCollection
+======================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: RecalledDataCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.StandardTask.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.StandardTask.rst
@@ -1,0 +1,11 @@
+StandardTask
+============
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: StandardTask
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.UpdateLookupMetadataDetails.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.UpdateLookupMetadataDetails.rst
@@ -1,0 +1,11 @@
+UpdateLookupMetadataDetails
+===========================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: UpdateLookupMetadataDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.UpdateStandardTaskDetails.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.UpdateStandardTaskDetails.rst
@@ -1,0 +1,11 @@
+UpdateStandardTaskDetails
+=========================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: UpdateStandardTaskDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics/models/oci.log_analytics.models.WarningReferenceDetails.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.WarningReferenceDetails.rst
@@ -1,0 +1,11 @@
+WarningReferenceDetails
+=======================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: WarningReferenceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/sch.rst
+++ b/docs/api/sch.rst
@@ -23,6 +23,7 @@ Sch
     oci.sch.models.FunctionsTargetDetails
     oci.sch.models.LogRuleTaskDetails
     oci.sch.models.LogSource
+    oci.sch.models.LoggingAnalyticsTargetDetails
     oci.sch.models.LoggingSourceDetails
     oci.sch.models.MonitoringTargetDetails
     oci.sch.models.NotificationsTargetDetails

--- a/docs/api/sch/models/oci.sch.models.LoggingAnalyticsTargetDetails.rst
+++ b/docs/api/sch/models/oci.sch.models.LoggingAnalyticsTargetDetails.rst
@@ -1,0 +1,11 @@
+LoggingAnalyticsTargetDetails
+=============================
+
+.. currentmodule:: oci.sch.models
+
+.. autoclass:: LoggingAnalyticsTargetDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/src/oci/log_analytics/log_analytics_client.py
+++ b/src/oci/log_analytics/log_analytics_client.py
@@ -87,7 +87,7 @@ class LogAnalyticsClient(object):
 
     def add_entity_association(self, namespace_name, log_analytics_entity_id, add_entity_association_details, **kwargs):
         """
-        Adds association between input source log analytics entity and destination entities.
+        Adds association between input source log analytics entity and one or more existing destination entities.
 
 
         :param str namespace_name: (required)
@@ -97,7 +97,7 @@ class LogAnalyticsClient(object):
             The log analytics entity OCID.
 
         :param oci.log_analytics.models.AddEntityAssociationDetails add_entity_association_details: (required)
-            This parameter specifies the entity OCIDs with which associations are to be created. Specify destination OCIDs as comma separated string.
+            This parameter specifies the destination entity OCIDs with which associations are to be created.
 
         :param str opc_request_id: (optional)
             The client request ID for tracing.
@@ -186,6 +186,142 @@ class LogAnalyticsClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 body=add_entity_association_details)
+
+    def append_lookup_data(self, namespace_name, lookup_name, append_lookup_file_body, **kwargs):
+        """
+        Append data to a lookup.  The file containing the information to append
+        must be provided.
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str lookup_name: (required)
+            The name of the lookup to operate on.
+
+        :param stream append_lookup_file_body: (required)
+            The file to append.
+
+        :param bool is_force: (optional)
+            is force
+
+        :param str char_encoding: (optional)
+            Character Encoding
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/append_lookup_data.py.html>`__ to see an example of how to use append_lookup_data API.
+        """
+        resource_path = "/namespaces/{namespaceName}/lookups/{lookupName}/actions/appendData"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "is_force",
+            "char_encoding",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "append_lookup_data got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name,
+            "lookupName": lookup_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "isForce": kwargs.get("is_force", missing),
+            "charEncoding": kwargs.get("char_encoding", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        # If the body parameter is optional we need to assign it to a variable so additional type checking can be performed.
+        try:
+            append_lookup_file_body
+        except NameError:
+            append_lookup_file_body = kwargs.get("append_lookup_file_body", missing)
+
+        if append_lookup_file_body is not missing and append_lookup_file_body is not None:
+            if (not isinstance(append_lookup_file_body, (six.binary_type, six.string_types)) and
+                    not hasattr(append_lookup_file_body, "read")):
+                raise TypeError('The body must be a string, bytes, or provide a read() method.')
+
+            if hasattr(append_lookup_file_body, 'fileno') and hasattr(append_lookup_file_body, 'name') and append_lookup_file_body.name != '<stdin>':
+                if requests.utils.super_len(append_lookup_file_body) == 0:
+                    header_params['Content-Length'] = '0'
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        # Disable the retry_strategy to work around data corruption issue temporarily
+        if retry_strategy:
+            retry_strategy = None
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                body=append_lookup_file_body)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                body=append_lookup_file_body)
 
     def batch_get_basic_info(self, namespace_name, basic_details, is_include_deleted, **kwargs):
         """
@@ -609,14 +745,14 @@ class LogAnalyticsClient(object):
 
     def change_log_analytics_object_collection_rule_compartment(self, namespace_name, log_analytics_object_collection_rule_id, change_log_analytics_object_collection_rule_compartment_details, **kwargs):
         """
-        Move the rule from it's current compartment to given compartment.
+        Move the rule from it's current compartment to the given compartment.
 
 
         :param str namespace_name: (required)
             The Logging Analytics namespace used for the request.
 
         :param str log_analytics_object_collection_rule_id: (required)
-            The Logging Analytics Object Collection Rule `OCID`__
+            The Logging Analytics Object Collection Rule `OCID`__.
 
             __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
@@ -1184,7 +1320,7 @@ class LogAnalyticsClient(object):
 
     def create_log_analytics_object_collection_rule(self, namespace_name, create_log_analytics_object_collection_rule_details, **kwargs):
         """
-        Create a configuration to collect logs from object storage bucket.
+        Creates a rule to collect logs from an object storage bucket.
 
 
         :param str namespace_name: (required)
@@ -1724,7 +1860,7 @@ class LogAnalyticsClient(object):
 
     def delete_log_analytics_entity_type(self, namespace_name, entity_type_name, **kwargs):
         """
-        Delete the log analytics entity type with the given name.
+        Delete log analytics entity type with the given name.
 
 
         :param str namespace_name: (required)
@@ -1896,15 +2032,15 @@ class LogAnalyticsClient(object):
 
     def delete_log_analytics_object_collection_rule(self, namespace_name, log_analytics_object_collection_rule_id, **kwargs):
         """
-        Deletes a configured object storage bucket based collection rule to stop the log collection of the configured bucket .
-        It will not delete the already collected log data from the configured bucket.
+        Deletes the configured object storage bucket based collection rule and stop the log collection.
+        It will not delete the existing processed data associated with this bucket from logging analytics storage.
 
 
         :param str namespace_name: (required)
             The Logging Analytics namespace used for the request.
 
         :param str log_analytics_object_collection_rule_id: (required)
-            The Logging Analytics Object Collection Rule `OCID`__
+            The Logging Analytics Object Collection Rule `OCID`__.
 
             __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
@@ -1981,6 +2117,114 @@ class LogAnalyticsClient(object):
                 resource_path=resource_path,
                 method=method,
                 path_params=path_params,
+                header_params=header_params)
+
+    def delete_lookup(self, namespace_name, lookup_name, **kwargs):
+        """
+        Delete the specified lookup.
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str lookup_name: (required)
+            The name of the lookup to operate on.
+
+        :param bool is_force: (optional)
+            is force
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/delete_lookup.py.html>`__ to see an example of how to use delete_lookup API.
+        """
+        resource_path = "/namespaces/{namespaceName}/lookups/{lookupName}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "is_force",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_lookup got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name,
+            "lookupName": lookup_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "isForce": kwargs.get("is_force", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
                 header_params=header_params)
 
     def delete_parser(self, namespace_name, parser_name, **kwargs):
@@ -2274,7 +2518,7 @@ class LogAnalyticsClient(object):
             The Logging Analytics namespace used for the request.
 
         :param str upload_reference: (required)
-            Unique internal identifier to refer to upload container
+            Unique internal identifier to refer upload container.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
@@ -2353,18 +2597,18 @@ class LogAnalyticsClient(object):
 
     def delete_upload_file(self, namespace_name, upload_reference, file_reference, **kwargs):
         """
-        Deletes a specific log file inside an upload by providing upload file reference.
-        It deletes all the logs in storage asscoiated with the upload file and the corresponding upload metadata.
+        Deletes a specific log file inside an upload by upload file reference.
+        It deletes all the logs from storage associated with the file and the corresponding metadata.
 
 
         :param str namespace_name: (required)
             The Logging Analytics namespace used for the request.
 
         :param str upload_reference: (required)
-            Unique internal identifier to refer to upload container
+            Unique internal identifier to refer upload container.
 
         :param str file_reference: (required)
-            Unique internal identifier to refer to upload file
+            Unique internal identifier to refer upload file.
 
         :param str opc_request_id: (optional)
             The client request ID for tracing.
@@ -2442,10 +2686,10 @@ class LogAnalyticsClient(object):
             The Logging Analytics namespace used for the request.
 
         :param str upload_reference: (required)
-            Unique internal identifier to refer to upload container
+            Unique internal identifier to refer upload container.
 
         :param str warning_reference: (required)
-            Unique internal identifier to refer to upload warning
+            Unique internal identifier to refer upload warning.
 
         :param str opc_request_id: (optional)
             The client request ID for tracing.
@@ -2781,6 +3025,166 @@ class LogAnalyticsClient(object):
                 header_params=header_params,
                 body=estimate_purge_data_size_details,
                 response_type="EstimatePurgeDataSizeResult")
+
+    def estimate_recall_data_size(self, namespace_name, estimate_recall_data_size_details, **kwargs):
+        """
+        This API gives an active storage usage estimate for archived data to be recalled and the time range of such data.
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param oci.log_analytics.models.EstimateRecallDataSizeDetails estimate_recall_data_size_details: (required)
+            This is the input to estimate the size of data to be recalled.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.log_analytics.models.EstimateRecallDataSizeResult`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/estimate_recall_data_size.py.html>`__ to see an example of how to use estimate_recall_data_size API.
+        """
+        resource_path = "/namespaces/{namespaceName}/storage/actions/estimateRecallDataSize"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "estimate_recall_data_size got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=estimate_recall_data_size_details,
+                response_type="EstimateRecallDataSizeResult")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=estimate_recall_data_size_details,
+                response_type="EstimateRecallDataSizeResult")
+
+    def estimate_release_data_size(self, namespace_name, estimate_release_data_size_details, **kwargs):
+        """
+        This API gives an active storage usage estimate for recalled data to be released and the time range of such data.
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param oci.log_analytics.models.EstimateReleaseDataSizeDetails estimate_release_data_size_details: (required)
+            This is the input to estimate the size of recalled data to be released.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.log_analytics.models.EstimateReleaseDataSizeResult`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/estimate_release_data_size.py.html>`__ to see an example of how to use estimate_release_data_size API.
+        """
+        resource_path = "/namespaces/{namespaceName}/storage/actions/estimateReleaseDataSize"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "estimate_release_data_size got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=estimate_release_data_size_details,
+                response_type="EstimateReleaseDataSizeResult")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=estimate_release_data_size_details,
+                response_type="EstimateReleaseDataSizeResult")
 
     def export_custom_content(self, namespace_name, export_custom_content_details, **kwargs):
         """
@@ -3838,7 +4242,7 @@ class LogAnalyticsClient(object):
 
     def get_log_analytics_entities_summary(self, namespace_name, compartment_id, **kwargs):
         """
-        Returns log analytics entities count summary.
+        Returns log analytics entities count summary report.
 
 
         :param str namespace_name: (required)
@@ -4252,7 +4656,7 @@ class LogAnalyticsClient(object):
             The Logging Analytics namespace used for the request.
 
         :param str log_analytics_object_collection_rule_id: (required)
-            The Logging Analytics Object Collection Rule `OCID`__
+            The Logging Analytics Object Collection Rule `OCID`__.
 
             __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
@@ -4323,6 +4727,85 @@ class LogAnalyticsClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 response_type="LogAnalyticsObjectCollectionRule")
+
+    def get_lookup(self, namespace_name, lookup_name, **kwargs):
+        """
+        Obtains the lookup with the specified reference.
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str lookup_name: (required)
+            The name of the lookup to operate on.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.log_analytics.models.LogAnalyticsLookup`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/get_lookup.py.html>`__ to see an example of how to use get_lookup API.
+        """
+        resource_path = "/namespaces/{namespaceName}/lookups/{lookupName}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_lookup got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name,
+            "lookupName": lookup_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="LogAnalyticsLookup")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="LogAnalyticsLookup")
 
     def get_namespace(self, namespace_name, **kwargs):
         """
@@ -5235,14 +5718,14 @@ class LogAnalyticsClient(object):
 
     def get_upload(self, namespace_name, upload_reference, **kwargs):
         """
-        Gets an On-Demand Upload info by reference
+        Gets an On-Demand Upload info by reference.
 
 
         :param str namespace_name: (required)
             The Logging Analytics namespace used for the request.
 
         :param str upload_reference: (required)
-            Unique internal identifier to refer to upload container
+            Unique internal identifier to refer upload container.
 
         :param str opc_request_id: (optional)
             The client request ID for tracing.
@@ -7101,7 +7584,7 @@ class LogAnalyticsClient(object):
 
     def list_log_analytics_object_collection_rules(self, namespace_name, compartment_id, **kwargs):
         """
-        Gets list of configuration details of Object Storage based collection rules.
+        Gets list of collection rules.
 
 
         :param str namespace_name: (required)
@@ -7242,6 +7725,176 @@ class LogAnalyticsClient(object):
                 header_params=header_params,
                 response_type="LogAnalyticsObjectCollectionRuleCollection")
 
+    def list_lookups(self, namespace_name, type, **kwargs):
+        """
+        Obtains a list of lookups.  The list is filtered according to the filter criteria
+        specified by the user, and sorted according to the ordering criteria specified.
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str type: (required)
+            type - possible values are Lookup or Dictionary
+
+            Allowed values are: "Lookup", "Dictionary"
+
+        :param str lookup_display_text: (optional)
+            Search by lookup display name or description.
+
+        :param str is_system: (optional)
+            Is system param of value (all, custom, sourceUsing)
+
+            Allowed values are: "ALL", "CUSTOM", "BUILT_IN"
+
+        :param str sort_by: (optional)
+            sort by field
+
+            Allowed values are: "displayName", "status", "type", "updatedTime", "creationType"
+
+        :param str status: (optional)
+            The lookup status used for filtering when fetching a list of lookups.
+
+            Allowed values are: "ALL", "SUCCESFUL", "FAILED", "INPROGRESS"
+
+        :param bool is_hide_special: (optional)
+            is include items
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.log_analytics.models.LogAnalyticsLookupCollection`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/list_lookups.py.html>`__ to see an example of how to use list_lookups API.
+        """
+        resource_path = "/namespaces/{namespaceName}/lookups"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "lookup_display_text",
+            "is_system",
+            "sort_by",
+            "status",
+            "is_hide_special",
+            "limit",
+            "page",
+            "sort_order",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_lookups got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        type_allowed_values = ["Lookup", "Dictionary"]
+        if type not in type_allowed_values:
+            raise ValueError(
+                "Invalid value for `type`, must be one of {0}".format(type_allowed_values)
+            )
+
+        if 'is_system' in kwargs:
+            is_system_allowed_values = ["ALL", "CUSTOM", "BUILT_IN"]
+            if kwargs['is_system'] not in is_system_allowed_values:
+                raise ValueError(
+                    "Invalid value for `is_system`, must be one of {0}".format(is_system_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["displayName", "status", "type", "updatedTime", "creationType"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'status' in kwargs:
+            status_allowed_values = ["ALL", "SUCCESFUL", "FAILED", "INPROGRESS"]
+            if kwargs['status'] not in status_allowed_values:
+                raise ValueError(
+                    "Invalid value for `status`, must be one of {0}".format(status_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        query_params = {
+            "lookupDisplayText": kwargs.get("lookup_display_text", missing),
+            "type": type,
+            "isSystem": kwargs.get("is_system", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "status": kwargs.get("status", missing),
+            "isHideSpecial": kwargs.get("is_hide_special", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="LogAnalyticsLookupCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="LogAnalyticsLookupCollection")
+
     def list_meta_source_types(self, namespace_name, **kwargs):
         """
         get all meta source types
@@ -7258,6 +7911,8 @@ class LogAnalyticsClient(object):
 
         :param str sort_by: (optional)
             sort by field
+
+            Allowed values are: "name"
 
         :param str sort_order: (optional)
             The sort order to use, either ascending (`ASC`) or descending (`DESC`).
@@ -7307,6 +7962,13 @@ class LogAnalyticsClient(object):
         for (k, v) in six.iteritems(path_params):
             if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["name"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
 
         if 'sort_order' in kwargs:
             sort_order_allowed_values = ["ASC", "DESC"]
@@ -7443,6 +8105,8 @@ class LogAnalyticsClient(object):
         :param str sort_by: (optional)
             sort by field
 
+            Allowed values are: "name"
+
         :param str sort_order: (optional)
             The sort order to use, either ascending (`ASC`) or descending (`DESC`).
 
@@ -7492,6 +8156,13 @@ class LogAnalyticsClient(object):
         for (k, v) in six.iteritems(path_params):
             if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["name"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
 
         if 'sort_order' in kwargs:
             sort_order_allowed_values = ["ASC", "DESC"]
@@ -7555,6 +8226,8 @@ class LogAnalyticsClient(object):
         :param str sort_by: (optional)
             sort by field
 
+            Allowed values are: "name"
+
         :param str sort_order: (optional)
             The sort order to use, either ascending (`ASC`) or descending (`DESC`).
 
@@ -7603,6 +8276,13 @@ class LogAnalyticsClient(object):
         for (k, v) in six.iteritems(path_params):
             if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["name"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
 
         if 'sort_order' in kwargs:
             sort_order_allowed_values = ["ASC", "DESC"]
@@ -7960,6 +8640,136 @@ class LogAnalyticsClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="QueryWorkRequestCollection")
+
+    def list_recalled_data(self, namespace_name, **kwargs):
+        """
+        This API returns the list of recalled data of a tenancy.
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_by: (optional)
+            This is the query parameter of which field to sort by. Only one sort order may be provided. Default order for timeDataStarted
+            is descending. If no value is specified timeDataStarted is default.
+
+            Allowed values are: "timeStarted", "timeDataStarted"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param datetime time_data_started_greater_than_or_equal: (optional)
+            This is the start of the time range for recalled data
+
+        :param datetime time_data_ended_less_than: (optional)
+            This is the end of the time range for recalled data
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.log_analytics.models.RecalledDataCollection`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/list_recalled_data.py.html>`__ to see an example of how to use list_recalled_data API.
+        """
+        resource_path = "/namespaces/{namespaceName}/storage/recalledData"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order",
+            "time_data_started_greater_than_or_equal",
+            "time_data_ended_less_than"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_recalled_data got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["timeStarted", "timeDataStarted"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        query_params = {
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "timeDataStartedGreaterThanOrEqual": kwargs.get("time_data_started_greater_than_or_equal", missing),
+            "timeDataEndedLessThan": kwargs.get("time_data_ended_less_than", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="RecalledDataCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="RecalledDataCollection")
 
     def list_scheduled_tasks(self, namespace_name, task_type, compartment_id, **kwargs):
         """
@@ -8392,6 +9202,8 @@ class LogAnalyticsClient(object):
         :param str sort_by: (optional)
             sort by field
 
+            Allowed values are: "name"
+
         :param str sort_order: (optional)
             The sort order to use, either ascending (`ASC`) or descending (`DESC`).
 
@@ -8440,6 +9252,13 @@ class LogAnalyticsClient(object):
         for (k, v) in six.iteritems(path_params):
             if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["name"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
 
         if 'sort_order' in kwargs:
             sort_order_allowed_values = ["ASC", "DESC"]
@@ -8502,6 +9321,8 @@ class LogAnalyticsClient(object):
         :param str sort_by: (optional)
             sort by field
 
+            Allowed values are: "name"
+
         :param str sort_order: (optional)
             The sort order to use, either ascending (`ASC`) or descending (`DESC`).
 
@@ -8550,6 +9371,13 @@ class LogAnalyticsClient(object):
         for (k, v) in six.iteritems(path_params):
             if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["name"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
 
         if 'sort_order' in kwargs:
             sort_order_allowed_values = ["ASC", "DESC"]
@@ -8738,7 +9566,7 @@ class LogAnalyticsClient(object):
             entityType
 
         :param str source_display_text: (optional)
-            search by source display name or description
+            Search by source display name or description.
 
         :param str is_system: (optional)
             Is system param of value (all, custom, sourceUsing)
@@ -9189,7 +10017,7 @@ class LogAnalyticsClient(object):
 
     def list_supported_char_encodings(self, namespace_name, **kwargs):
         """
-        Gets the list of character encodings supported for log files.
+        Gets list of character encodings which are supported by on-demand upload.
 
 
         :param str namespace_name: (required)
@@ -9280,7 +10108,7 @@ class LogAnalyticsClient(object):
 
     def list_supported_timezones(self, namespace_name, **kwargs):
         """
-        Gets timezones that are supported when performing uploads.
+        Gets list of timezones which are supported by on-demand upload.
 
 
         :param str namespace_name: (required)
@@ -9371,14 +10199,14 @@ class LogAnalyticsClient(object):
 
     def list_upload_files(self, namespace_name, upload_reference, **kwargs):
         """
-        Gets list of files in an upload.
+        Gets list of files in an upload along with its processing state.
 
 
         :param str namespace_name: (required)
             The Logging Analytics namespace used for the request.
 
         :param str upload_reference: (required)
-            Unique internal identifier to refer to upload container
+            Unique internal identifier to refer upload container.
 
         :param int limit: (optional)
             The maximum number of items to return.
@@ -9392,15 +10220,16 @@ class LogAnalyticsClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending.
+            The field to sort by. Only one sort order may be provided. Default order for timeStarted is descending.
+            timeCreated, fileName and logGroup are deprecated. Instead use timestarted, name, logGroup accordingly.
 
-            Allowed values are: "timeCreated", "fileName", "logGroup", "sourceName", "status"
+            Allowed values are: "timeStarted", "name", "logGroupName", "sourceName", "status", "timeCreated", "fileName", "logGroup"
 
         :param str search_str: (optional)
-            Search string used to filtering uploads based on file name, log group name and log source name.
+            This can be used to filter upload files based on the file, log group and log source names.
 
         :param list[str] status: (optional)
-            Upload Status.
+            Upload File processing state.
 
             Allowed values are: "IN_PROGRESS", "SUCCESSFUL", "FAILED"
 
@@ -9459,7 +10288,7 @@ class LogAnalyticsClient(object):
                 )
 
         if 'sort_by' in kwargs:
-            sort_by_allowed_values = ["timeCreated", "fileName", "logGroup", "sourceName", "status"]
+            sort_by_allowed_values = ["timeStarted", "name", "logGroupName", "sourceName", "status", "timeCreated", "fileName", "logGroup"]
             if kwargs['sort_by'] not in sort_by_allowed_values:
                 raise ValueError(
                     "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
@@ -9514,14 +10343,14 @@ class LogAnalyticsClient(object):
 
     def list_upload_warnings(self, namespace_name, upload_reference, **kwargs):
         """
-        Gets list of warnings in an upload explaining the failures due to incorrect configuration.
+        Gets list of warnings in an upload caused by incorrect configuration.
 
 
         :param str namespace_name: (required)
             The Logging Analytics namespace used for the request.
 
         :param str upload_reference: (required)
-            Unique internal identifier to refer to upload container
+            Unique internal identifier to refer upload container.
 
         :param int limit: (optional)
             The maximum number of items to return.
@@ -9737,6 +10566,192 @@ class LogAnalyticsClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="UploadCollection")
+
+    def list_warnings(self, namespace_name, compartment_id, **kwargs):
+        """
+        Obtains a list of warnings.  The list is filtered according to the filter criteria
+        specified by the user, and sorted according to the ordering criteria specified.
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str warning_state: (optional)
+            The warning state used for filtering.  A value of SUPPRESSED will return only
+            suppressed warnings, a value of UNSUPPRESSED will return only unsuppressed
+            warnings, and a value of ALL will return all warnings regardless of their
+            suppression state.  Default is UNSUPPRESSED.
+
+            Allowed values are: "ALL", "SUPPRESSED", "UNSUPPRESSED"
+
+        :param str source_name: (optional)
+            sourceName
+
+        :param str source_pattern: (optional)
+            sourcePattern
+
+        :param str warning_message: (optional)
+            warning message query parameter
+
+        :param str entity_name: (optional)
+            entityName
+
+        :param str entity_type: (optional)
+            entity type name
+
+        :param str warning_type: (optional)
+            The warning type query parameter.
+
+        :param bool is_no_source: (optional)
+            isNoSource
+
+        :param str start_time: (optional)
+            The warning start date query parameter.
+
+        :param str end_time: (optional)
+            The warning end date query parameter.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The attribute used to sort the returned warnings
+
+            Allowed values are: "EntityType", "SourceName", "PatternText", "FirstReported", "WarningMessage", "Host", "EntityName", "InitialWarningDate"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.log_analytics.models.LogAnalyticsWarningCollection`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/list_warnings.py.html>`__ to see an example of how to use list_warnings API.
+        """
+        resource_path = "/namespaces/{namespaceName}/warnings"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "warning_state",
+            "source_name",
+            "source_pattern",
+            "warning_message",
+            "entity_name",
+            "entity_type",
+            "warning_type",
+            "is_no_source",
+            "start_time",
+            "end_time",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_warnings got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'warning_state' in kwargs:
+            warning_state_allowed_values = ["ALL", "SUPPRESSED", "UNSUPPRESSED"]
+            if kwargs['warning_state'] not in warning_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `warning_state`, must be one of {0}".format(warning_state_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["EntityType", "SourceName", "PatternText", "FirstReported", "WarningMessage", "Host", "EntityName", "InitialWarningDate"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "warningState": kwargs.get("warning_state", missing),
+            "sourceName": kwargs.get("source_name", missing),
+            "sourcePattern": kwargs.get("source_pattern", missing),
+            "warningMessage": kwargs.get("warning_message", missing),
+            "entityName": kwargs.get("entity_name", missing),
+            "entityType": kwargs.get("entity_type", missing),
+            "warningType": kwargs.get("warning_type", missing),
+            "isNoSource": kwargs.get("is_no_source", missing),
+            "startTime": kwargs.get("start_time", missing),
+            "endTime": kwargs.get("end_time", missing),
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="LogAnalyticsWarningCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="LogAnalyticsWarningCollection")
 
     def list_work_request_errors(self, namespace_name, work_request_id, **kwargs):
         """
@@ -10274,6 +11289,95 @@ class LogAnalyticsClient(object):
                 header_params=header_params,
                 body=parse_query_details,
                 response_type="ParseQueryOutput")
+
+    def pause_scheduled_task(self, namespace_name, scheduled_task_id, **kwargs):
+        """
+        Pause the scheduled task specified by {scheduledTaskId}.
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str scheduled_task_id: (required)
+            Unique scheduledTask id returned from task create.
+            If invalid will lead to a 404 not found.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.log_analytics.models.ScheduledTask`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/pause_scheduled_task.py.html>`__ to see an example of how to use pause_scheduled_task API.
+        """
+        resource_path = "/namespaces/{namespaceName}/scheduledTasks/{scheduledTaskId}/actions/pause"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "pause_scheduled_task got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name,
+            "scheduledTaskId": scheduled_task_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ScheduledTask")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ScheduledTask")
 
     def purge_storage_data(self, namespace_name, purge_storage_data_details, **kwargs):
         """
@@ -10915,7 +12019,7 @@ class LogAnalyticsClient(object):
             The log analytics entity OCID.
 
         :param oci.log_analytics.models.RemoveEntityAssociationsDetails remove_entity_associations_details: (required)
-            This parameter specifies the entity OCIDs with which associations are to be deleted. Specify destination OCIDs as comma separated string.
+            This parameter specifies the entity OCIDs with which associations are to be deleted.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
@@ -11004,6 +12108,95 @@ class LogAnalyticsClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 body=remove_entity_associations_details)
+
+    def resume_scheduled_task(self, namespace_name, scheduled_task_id, **kwargs):
+        """
+        Resume the scheduled task specified by {scheduledTaskId}.
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str scheduled_task_id: (required)
+            Unique scheduledTask id returned from task create.
+            If invalid will lead to a 404 not found.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.log_analytics.models.ScheduledTask`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/resume_scheduled_task.py.html>`__ to see an example of how to use resume_scheduled_task API.
+        """
+        resource_path = "/namespaces/{namespaceName}/scheduledTasks/{scheduledTaskId}/actions/resume"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "resume_scheduled_task got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name,
+            "scheduledTaskId": scheduled_task_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ScheduledTask")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ScheduledTask")
 
     def run(self, namespace_name, scheduled_task_id, **kwargs):
         """
@@ -11194,6 +12387,107 @@ class LogAnalyticsClient(object):
                 body=suggest_details,
                 response_type="SuggestOutput")
 
+    def suppress_warning(self, namespace_name, warning_reference_details, compartment_id, **kwargs):
+        """
+        Accepts a list of warnings.  Any unsuppressed warnings in the input list will
+        be suppressed.  Warnings in the input list which are already suppressed will
+        not be modified.
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param oci.log_analytics.models.WarningReferenceDetails warning_reference_details: (required)
+            list of agent warning references to suppress
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/suppress_warning.py.html>`__ to see an example of how to use suppress_warning API.
+        """
+        resource_path = "/namespaces/{namespaceName}/warnings/actions/suppress"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "suppress_warning got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "compartmentId": compartment_id
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                body=warning_reference_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                body=warning_reference_details)
+
     def test_parser(self, namespace_name, test_parser_payload_details, **kwargs):
         """
         test parser
@@ -11310,6 +12604,107 @@ class LogAnalyticsClient(object):
                 body=test_parser_payload_details,
                 response_type="ParserTestResult")
 
+    def unsuppress_warning(self, namespace_name, warning_reference_details, compartment_id, **kwargs):
+        """
+        Accepts a list of warnings.  Any suppressed warnings in the input list will
+        be unsuppressed.  Warnings in the input list which are unsuppressed will
+        not be modified.
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param oci.log_analytics.models.WarningReferenceDetails warning_reference_details: (required)
+            warnings list
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/unsuppress_warning.py.html>`__ to see an example of how to use unsuppress_warning API.
+        """
+        resource_path = "/namespaces/{namespaceName}/warnings/actions/unsuppress"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "unsuppress_warning got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "compartmentId": compartment_id
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                body=warning_reference_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                body=warning_reference_details)
+
     def update_log_analytics_entity(self, namespace_name, log_analytics_entity_id, update_log_analytics_entity_details, **kwargs):
         """
         Update the log analytics entity with the given id.
@@ -11322,7 +12717,7 @@ class LogAnalyticsClient(object):
             The log analytics entity OCID.
 
         :param oci.log_analytics.models.UpdateLogAnalyticsEntityDetails update_log_analytics_entity_details: (required)
-            The information to be updated.
+            Log analytics entity information to be updated.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
@@ -11589,14 +12984,14 @@ class LogAnalyticsClient(object):
 
     def update_log_analytics_object_collection_rule(self, namespace_name, log_analytics_object_collection_rule_id, update_log_analytics_object_collection_rule_details, **kwargs):
         """
-        Update the rule with the given id.
+        Updates configuration of the object collection rule for the given id.
 
 
         :param str namespace_name: (required)
             The Logging Analytics namespace used for the request.
 
         :param str log_analytics_object_collection_rule_id: (required)
-            The Logging Analytics Object Collection Rule `OCID`__
+            The Logging Analytics Object Collection Rule `OCID`__.
 
             __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
@@ -11681,6 +13076,246 @@ class LogAnalyticsClient(object):
                 header_params=header_params,
                 body=update_log_analytics_object_collection_rule_details,
                 response_type="LogAnalyticsObjectCollectionRule")
+
+    def update_lookup(self, namespace_name, lookup_name, update_lookup_metadata_details, **kwargs):
+        """
+        Updates the metadata of the specified lookup, such as the lookup description.
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str lookup_name: (required)
+            The name of the lookup to operate on.
+
+        :param oci.log_analytics.models.UpdateLookupMetadataDetails update_lookup_metadata_details: (required)
+            The information required to update a lookup.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.log_analytics.models.LogAnalyticsLookup`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/update_lookup.py.html>`__ to see an example of how to use update_lookup API.
+        """
+        resource_path = "/namespaces/{namespaceName}/lookups/{lookupName}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_lookup got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name,
+            "lookupName": lookup_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_lookup_metadata_details,
+                response_type="LogAnalyticsLookup")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_lookup_metadata_details,
+                response_type="LogAnalyticsLookup")
+
+    def update_lookup_data(self, namespace_name, lookup_name, update_lookup_file_body, **kwargs):
+        """
+        Updates the specified lookup with the details provided.  This API will not update
+        lookup metadata (such as lookup description).
+
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str lookup_name: (required)
+            The name of the lookup to operate on.
+
+        :param stream update_lookup_file_body: (required)
+            The file to use for the lookup update.
+
+        :param bool is_force: (optional)
+            is force
+
+        :param str char_encoding: (optional)
+            Character Encoding
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loganalytics/update_lookup_data.py.html>`__ to see an example of how to use update_lookup_data API.
+        """
+        resource_path = "/namespaces/{namespaceName}/lookups/{lookupName}/actions/updateData"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "is_force",
+            "char_encoding",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_lookup_data got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name,
+            "lookupName": lookup_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "isForce": kwargs.get("is_force", missing),
+            "charEncoding": kwargs.get("char_encoding", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        # If the body parameter is optional we need to assign it to a variable so additional type checking can be performed.
+        try:
+            update_lookup_file_body
+        except NameError:
+            update_lookup_file_body = kwargs.get("update_lookup_file_body", missing)
+
+        if update_lookup_file_body is not missing and update_lookup_file_body is not None:
+            if (not isinstance(update_lookup_file_body, (six.binary_type, six.string_types)) and
+                    not hasattr(update_lookup_file_body, "read")):
+                raise TypeError('The body must be a string, bytes, or provide a read() method.')
+
+            if hasattr(update_lookup_file_body, 'fileno') and hasattr(update_lookup_file_body, 'name') and update_lookup_file_body.name != '<stdin>':
+                if requests.utils.super_len(update_lookup_file_body) == 0:
+                    header_params['Content-Length'] = '0'
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        # Disable the retry_strategy to work around data corruption issue temporarily
+        if retry_strategy:
+            retry_strategy = None
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                body=update_lookup_file_body)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                body=update_lookup_file_body)
 
     def update_scheduled_task(self, namespace_name, scheduled_task_id, update_scheduled_task_details, **kwargs):
         """
@@ -11896,7 +13531,8 @@ class LogAnalyticsClient(object):
             Timezone to be used when processing log entries whose timestamps do not include an explicit timezone. When this property is not specified, the timezone of the entity specified is used. If the entity is also not specified or do not have a valid timezone then UTC is used
 
         :param str char_encoding: (optional)
-            Character Encoding
+            Character encoding to be used to detect the encoding type of file(s) being uploaded.
+            When this property is not specified, system detected character encoding will be used.
 
         :param str date_format: (optional)
             This property is used to specify the format of the date. This is to be used for ambiguous dates like 12/11/10. This property can take any of the following values -  MONTH_DAY_YEAR, DAY_MONTH_YEAR, YEAR_MONTH_DAY, MONTH_DAY, DAY_MONTH.
@@ -12700,14 +14336,14 @@ class LogAnalyticsClient(object):
 
     def validate_file(self, namespace_name, object_location, filename, **kwargs):
         """
-        Validates a log file to check whether it is eligible to upload or not.
+        Validates a log file to check whether it is eligible to be uploaded or not.
 
 
         :param str namespace_name: (required)
             The Logging Analytics namespace used for the request.
 
         :param str object_location: (required)
-            Location of the log file
+            Location of the log file.
 
         :param str filename: (required)
             The name of the file being uploaded. The extension of the filename part will be used to detect the type of file (like zip, tar).
@@ -12992,14 +14628,14 @@ class LogAnalyticsClient(object):
 
     def validate_source_mapping(self, namespace_name, object_location, filename, log_source_name, **kwargs):
         """
-        Validates the source mapping for given file and provides match status and parsed representation of log data.
+        Validates the source mapping for a given file and provides match status and the parsed representation of log data.
 
 
         :param str namespace_name: (required)
             The Logging Analytics namespace used for the request.
 
         :param str object_location: (required)
-            Location of the log file
+            Location of the log file.
 
         :param str filename: (required)
             The name of the file being uploaded. The extension of the filename part will be used to detect the type of file (like zip, tar).

--- a/src/oci/log_analytics/log_analytics_client_composite_operations.py
+++ b/src/oci/log_analytics/log_analytics_client_composite_operations.py
@@ -23,6 +23,50 @@ class LogAnalyticsClientCompositeOperations(object):
         """
         self.client = client
 
+    def append_lookup_data_and_wait_for_state(self, namespace_name, lookup_name, append_lookup_file_body, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.log_analytics.LogAnalyticsClient.append_lookup_data` and waits for the :py:class:`~oci.log_analytics.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str lookup_name: (required)
+            The name of the lookup to operate on.
+
+        :param stream append_lookup_file_body: (required)
+            The file to append.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.log_analytics.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.log_analytics.LogAnalyticsClient.append_lookup_data`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.append_lookup_data(namespace_name, lookup_name, append_lookup_file_body, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_log_analytics_entity_and_wait_for_state(self, namespace_name, create_log_analytics_entity_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.log_analytics.LogAnalyticsClient.create_log_analytics_entity` and waits for the :py:class:`~oci.log_analytics.models.LogAnalyticsEntity` acted upon
@@ -187,6 +231,55 @@ class LogAnalyticsClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def delete_lookup_and_wait_for_state(self, namespace_name, lookup_name, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.log_analytics.LogAnalyticsClient.delete_lookup` and waits for the :py:class:`~oci.log_analytics.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str lookup_name: (required)
+            The name of the lookup to operate on.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.log_analytics.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.log_analytics.LogAnalyticsClient.delete_lookup`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = None
+        try:
+            operation_result = self.client.delete_lookup(namespace_name, lookup_name, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def offboard_namespace_and_wait_for_state(self, namespace_name, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.log_analytics.LogAnalyticsClient.offboard_namespace` and waits for the :py:class:`~oci.log_analytics.models.WorkRequest`
@@ -255,6 +348,48 @@ class LogAnalyticsClientCompositeOperations(object):
                 self.client,
                 self.client.get_work_request(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def pause_scheduled_task_and_wait_for_state(self, namespace_name, scheduled_task_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.log_analytics.LogAnalyticsClient.pause_scheduled_task` and waits for the :py:class:`~oci.log_analytics.models.ScheduledTask` acted upon
+        to enter the given state(s).
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str scheduled_task_id: (required)
+            Unique scheduledTask id returned from task create.
+            If invalid will lead to a 404 not found.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.log_analytics.models.ScheduledTask.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.log_analytics.LogAnalyticsClient.pause_scheduled_task`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.pause_scheduled_task(namespace_name, scheduled_task_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_scheduled_task(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )
             result_to_return = waiter_result
@@ -427,6 +562,48 @@ class LogAnalyticsClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def resume_scheduled_task_and_wait_for_state(self, namespace_name, scheduled_task_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.log_analytics.LogAnalyticsClient.resume_scheduled_task` and waits for the :py:class:`~oci.log_analytics.models.ScheduledTask` acted upon
+        to enter the given state(s).
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str scheduled_task_id: (required)
+            Unique scheduledTask id returned from task create.
+            If invalid will lead to a 404 not found.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.log_analytics.models.ScheduledTask.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.log_analytics.LogAnalyticsClient.resume_scheduled_task`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.resume_scheduled_task(namespace_name, scheduled_task_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_scheduled_task(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def update_log_analytics_entity_and_wait_for_state(self, namespace_name, log_analytics_entity_id, update_log_analytics_entity_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.log_analytics.LogAnalyticsClient.update_log_analytics_entity` and waits for the :py:class:`~oci.log_analytics.models.LogAnalyticsEntity` acted upon
@@ -439,7 +616,7 @@ class LogAnalyticsClientCompositeOperations(object):
             The log analytics entity OCID.
 
         :param oci.log_analytics.models.UpdateLogAnalyticsEntityDetails update_log_analytics_entity_details: (required)
-            The information to be updated.
+            Log analytics entity information to be updated.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.log_analytics.models.LogAnalyticsEntity.lifecycle_state`
@@ -480,7 +657,7 @@ class LogAnalyticsClientCompositeOperations(object):
             The Logging Analytics namespace used for the request.
 
         :param str log_analytics_object_collection_rule_id: (required)
-            The Logging Analytics Object Collection Rule `OCID`__
+            The Logging Analytics Object Collection Rule `OCID`__.
 
             __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
@@ -509,6 +686,50 @@ class LogAnalyticsClientCompositeOperations(object):
                 self.client,
                 self.client.get_log_analytics_object_collection_rule(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_lookup_data_and_wait_for_state(self, namespace_name, lookup_name, update_lookup_file_body, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.log_analytics.LogAnalyticsClient.update_lookup_data` and waits for the :py:class:`~oci.log_analytics.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str namespace_name: (required)
+            The Logging Analytics namespace used for the request.
+
+        :param str lookup_name: (required)
+            The name of the lookup to operate on.
+
+        :param stream update_lookup_file_body: (required)
+            The file to use for the lookup update.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.log_analytics.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.log_analytics.LogAnalyticsClient.update_lookup_data`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_lookup_data(namespace_name, lookup_name, update_lookup_file_body, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )
             result_to_return = waiter_result

--- a/src/oci/log_analytics/models/__init__.py
+++ b/src/oci/log_analytics/models/__init__.py
@@ -43,6 +43,7 @@ from .create_log_analytics_log_group_details import CreateLogAnalyticsLogGroupDe
 from .create_log_analytics_object_collection_rule_details import CreateLogAnalyticsObjectCollectionRuleDetails
 from .create_scheduled_task_details import CreateScheduledTaskDetails
 from .create_standard_task_details import CreateStandardTaskDetails
+from .create_view_command_descriptor import CreateViewCommandDescriptor
 from .cron_schedule import CronSchedule
 from .delete_command_descriptor import DeleteCommandDescriptor
 from .delete_log_analytics_association import DeleteLogAnalyticsAssociation
@@ -55,8 +56,13 @@ from .entity_type_property import EntityTypeProperty
 from .error_details import ErrorDetails
 from .estimate_purge_data_size_details import EstimatePurgeDataSizeDetails
 from .estimate_purge_data_size_result import EstimatePurgeDataSizeResult
+from .estimate_recall_data_size_details import EstimateRecallDataSizeDetails
+from .estimate_recall_data_size_result import EstimateRecallDataSizeResult
+from .estimate_release_data_size_details import EstimateReleaseDataSizeDetails
+from .estimate_release_data_size_result import EstimateReleaseDataSizeResult
 from .eval_command_descriptor import EvalCommandDescriptor
 from .event_stats_command_descriptor import EventStatsCommandDescriptor
+from .event_type import EventType
 from .export_content import ExportContent
 from .export_details import ExportDetails
 from .extended_fields_validation_result import ExtendedFieldsValidationResult
@@ -79,6 +85,7 @@ from .fixed_frequency_schedule import FixedFrequencySchedule
 from .function_field import FunctionField
 from .head_command_descriptor import HeadCommandDescriptor
 from .highlight_command_descriptor import HighlightCommandDescriptor
+from .highlight_groups_command_descriptor import HighlightGroupsCommandDescriptor
 from .highlight_rows_command_descriptor import HighlightRowsCommandDescriptor
 from .indexes import Indexes
 from .label_names import LabelNames
@@ -125,6 +132,8 @@ from .log_analytics_log_group import LogAnalyticsLogGroup
 from .log_analytics_log_group_summary import LogAnalyticsLogGroupSummary
 from .log_analytics_log_group_summary_collection import LogAnalyticsLogGroupSummaryCollection
 from .log_analytics_lookup import LogAnalyticsLookup
+from .log_analytics_lookup_collection import LogAnalyticsLookupCollection
+from .log_analytics_lookup_fields import LogAnalyticsLookupFields
 from .log_analytics_meta_function import LogAnalyticsMetaFunction
 from .log_analytics_meta_function_argument import LogAnalyticsMetaFunctionArgument
 from .log_analytics_meta_function_collection import LogAnalyticsMetaFunctionCollection
@@ -160,15 +169,20 @@ from .log_analytics_source_metric import LogAnalyticsSourceMetric
 from .log_analytics_source_pattern import LogAnalyticsSourcePattern
 from .log_analytics_source_pattern_collection import LogAnalyticsSourcePatternCollection
 from .log_analytics_source_summary import LogAnalyticsSourceSummary
+from .log_analytics_warning import LogAnalyticsWarning
+from .log_analytics_warning_collection import LogAnalyticsWarningCollection
 from .log_group_summary_report import LogGroupSummaryReport
 from .lookup_command_descriptor import LookupCommandDescriptor
 from .lookup_field import LookupField
 from .macro_command_descriptor import MacroCommandDescriptor
+from .map_command_descriptor import MapCommandDescriptor
 from .match_info import MatchInfo
+from .metric_extraction import MetricExtraction
 from .multi_search_command_descriptor import MultiSearchCommandDescriptor
 from .namespace import Namespace
 from .namespace_collection import NamespaceCollection
 from .namespace_summary import NamespaceSummary
+from .nlp_command_descriptor import NlpCommandDescriptor
 from .parse_query_details import ParseQueryDetails
 from .parse_query_output import ParseQueryOutput
 from .parsed_content import ParsedContent
@@ -184,6 +198,8 @@ from .query_work_request import QueryWorkRequest
 from .query_work_request_collection import QueryWorkRequestCollection
 from .query_work_request_summary import QueryWorkRequestSummary
 from .recall_archived_data_details import RecallArchivedDataDetails
+from .recalled_data import RecalledData
+from .recalled_data_collection import RecalledDataCollection
 from .regex_command_descriptor import RegexCommandDescriptor
 from .regex_match_result import RegexMatchResult
 from .release_recalled_data_details import ReleaseRecalledDataDetails
@@ -204,6 +220,7 @@ from .source_mapping_response import SourceMappingResponse
 from .source_summary_report import SourceSummaryReport
 from .source_validate_details import SourceValidateDetails
 from .source_validate_results import SourceValidateResults
+from .standard_task import StandardTask
 from .stats_command_descriptor import StatsCommandDescriptor
 from .status_summary import StatusSummary
 from .step_info import StepInfo
@@ -230,7 +247,9 @@ from .update_log_analytics_entity_details import UpdateLogAnalyticsEntityDetails
 from .update_log_analytics_entity_type_details import UpdateLogAnalyticsEntityTypeDetails
 from .update_log_analytics_log_group_details import UpdateLogAnalyticsLogGroupDetails
 from .update_log_analytics_object_collection_rule_details import UpdateLogAnalyticsObjectCollectionRuleDetails
+from .update_lookup_metadata_details import UpdateLookupMetadataDetails
 from .update_scheduled_task_details import UpdateScheduledTaskDetails
+from .update_standard_task_details import UpdateStandardTaskDetails
 from .update_storage_details import UpdateStorageDetails
 from .upload import Upload
 from .upload_collection import UploadCollection
@@ -249,6 +268,7 @@ from .upsert_log_analytics_source_details import UpsertLogAnalyticsSourceDetails
 from .usage_status_item import UsageStatusItem
 from .verify_output import VerifyOutput
 from .violation import Violation
+from .warning_reference_details import WarningReferenceDetails
 from .where_command_descriptor import WhereCommandDescriptor
 from .work_request import WorkRequest
 from .work_request_collection import WorkRequestCollection
@@ -300,6 +320,7 @@ log_analytics_type_mapping = {
     "CreateLogAnalyticsObjectCollectionRuleDetails": CreateLogAnalyticsObjectCollectionRuleDetails,
     "CreateScheduledTaskDetails": CreateScheduledTaskDetails,
     "CreateStandardTaskDetails": CreateStandardTaskDetails,
+    "CreateViewCommandDescriptor": CreateViewCommandDescriptor,
     "CronSchedule": CronSchedule,
     "DeleteCommandDescriptor": DeleteCommandDescriptor,
     "DeleteLogAnalyticsAssociation": DeleteLogAnalyticsAssociation,
@@ -312,8 +333,13 @@ log_analytics_type_mapping = {
     "ErrorDetails": ErrorDetails,
     "EstimatePurgeDataSizeDetails": EstimatePurgeDataSizeDetails,
     "EstimatePurgeDataSizeResult": EstimatePurgeDataSizeResult,
+    "EstimateRecallDataSizeDetails": EstimateRecallDataSizeDetails,
+    "EstimateRecallDataSizeResult": EstimateRecallDataSizeResult,
+    "EstimateReleaseDataSizeDetails": EstimateReleaseDataSizeDetails,
+    "EstimateReleaseDataSizeResult": EstimateReleaseDataSizeResult,
     "EvalCommandDescriptor": EvalCommandDescriptor,
     "EventStatsCommandDescriptor": EventStatsCommandDescriptor,
+    "EventType": EventType,
     "ExportContent": ExportContent,
     "ExportDetails": ExportDetails,
     "ExtendedFieldsValidationResult": ExtendedFieldsValidationResult,
@@ -336,6 +362,7 @@ log_analytics_type_mapping = {
     "FunctionField": FunctionField,
     "HeadCommandDescriptor": HeadCommandDescriptor,
     "HighlightCommandDescriptor": HighlightCommandDescriptor,
+    "HighlightGroupsCommandDescriptor": HighlightGroupsCommandDescriptor,
     "HighlightRowsCommandDescriptor": HighlightRowsCommandDescriptor,
     "Indexes": Indexes,
     "LabelNames": LabelNames,
@@ -382,6 +409,8 @@ log_analytics_type_mapping = {
     "LogAnalyticsLogGroupSummary": LogAnalyticsLogGroupSummary,
     "LogAnalyticsLogGroupSummaryCollection": LogAnalyticsLogGroupSummaryCollection,
     "LogAnalyticsLookup": LogAnalyticsLookup,
+    "LogAnalyticsLookupCollection": LogAnalyticsLookupCollection,
+    "LogAnalyticsLookupFields": LogAnalyticsLookupFields,
     "LogAnalyticsMetaFunction": LogAnalyticsMetaFunction,
     "LogAnalyticsMetaFunctionArgument": LogAnalyticsMetaFunctionArgument,
     "LogAnalyticsMetaFunctionCollection": LogAnalyticsMetaFunctionCollection,
@@ -417,15 +446,20 @@ log_analytics_type_mapping = {
     "LogAnalyticsSourcePattern": LogAnalyticsSourcePattern,
     "LogAnalyticsSourcePatternCollection": LogAnalyticsSourcePatternCollection,
     "LogAnalyticsSourceSummary": LogAnalyticsSourceSummary,
+    "LogAnalyticsWarning": LogAnalyticsWarning,
+    "LogAnalyticsWarningCollection": LogAnalyticsWarningCollection,
     "LogGroupSummaryReport": LogGroupSummaryReport,
     "LookupCommandDescriptor": LookupCommandDescriptor,
     "LookupField": LookupField,
     "MacroCommandDescriptor": MacroCommandDescriptor,
+    "MapCommandDescriptor": MapCommandDescriptor,
     "MatchInfo": MatchInfo,
+    "MetricExtraction": MetricExtraction,
     "MultiSearchCommandDescriptor": MultiSearchCommandDescriptor,
     "Namespace": Namespace,
     "NamespaceCollection": NamespaceCollection,
     "NamespaceSummary": NamespaceSummary,
+    "NlpCommandDescriptor": NlpCommandDescriptor,
     "ParseQueryDetails": ParseQueryDetails,
     "ParseQueryOutput": ParseQueryOutput,
     "ParsedContent": ParsedContent,
@@ -441,6 +475,8 @@ log_analytics_type_mapping = {
     "QueryWorkRequestCollection": QueryWorkRequestCollection,
     "QueryWorkRequestSummary": QueryWorkRequestSummary,
     "RecallArchivedDataDetails": RecallArchivedDataDetails,
+    "RecalledData": RecalledData,
+    "RecalledDataCollection": RecalledDataCollection,
     "RegexCommandDescriptor": RegexCommandDescriptor,
     "RegexMatchResult": RegexMatchResult,
     "ReleaseRecalledDataDetails": ReleaseRecalledDataDetails,
@@ -461,6 +497,7 @@ log_analytics_type_mapping = {
     "SourceSummaryReport": SourceSummaryReport,
     "SourceValidateDetails": SourceValidateDetails,
     "SourceValidateResults": SourceValidateResults,
+    "StandardTask": StandardTask,
     "StatsCommandDescriptor": StatsCommandDescriptor,
     "StatusSummary": StatusSummary,
     "StepInfo": StepInfo,
@@ -487,7 +524,9 @@ log_analytics_type_mapping = {
     "UpdateLogAnalyticsEntityTypeDetails": UpdateLogAnalyticsEntityTypeDetails,
     "UpdateLogAnalyticsLogGroupDetails": UpdateLogAnalyticsLogGroupDetails,
     "UpdateLogAnalyticsObjectCollectionRuleDetails": UpdateLogAnalyticsObjectCollectionRuleDetails,
+    "UpdateLookupMetadataDetails": UpdateLookupMetadataDetails,
     "UpdateScheduledTaskDetails": UpdateScheduledTaskDetails,
+    "UpdateStandardTaskDetails": UpdateStandardTaskDetails,
     "UpdateStorageDetails": UpdateStorageDetails,
     "Upload": Upload,
     "UploadCollection": UploadCollection,
@@ -506,6 +545,7 @@ log_analytics_type_mapping = {
     "UsageStatusItem": UsageStatusItem,
     "VerifyOutput": VerifyOutput,
     "Violation": Violation,
+    "WarningReferenceDetails": WarningReferenceDetails,
     "WhereCommandDescriptor": WhereCommandDescriptor,
     "WorkRequest": WorkRequest,
     "WorkRequestCollection": WorkRequestCollection,

--- a/src/oci/log_analytics/models/abstract_command_descriptor.py
+++ b/src/oci/log_analytics/models/abstract_command_descriptor.py
@@ -161,6 +161,22 @@ class AbstractCommandDescriptor(object):
     #: This constant has a value of "HIGHLIGHT_ROWS"
     NAME_HIGHLIGHT_ROWS = "HIGHLIGHT_ROWS"
 
+    #: A constant which can be used with the name property of a AbstractCommandDescriptor.
+    #: This constant has a value of "HIGHLIGHT_GROUPS"
+    NAME_HIGHLIGHT_GROUPS = "HIGHLIGHT_GROUPS"
+
+    #: A constant which can be used with the name property of a AbstractCommandDescriptor.
+    #: This constant has a value of "CREATE_VIEW"
+    NAME_CREATE_VIEW = "CREATE_VIEW"
+
+    #: A constant which can be used with the name property of a AbstractCommandDescriptor.
+    #: This constant has a value of "MAP"
+    NAME_MAP = "MAP"
+
+    #: A constant which can be used with the name property of a AbstractCommandDescriptor.
+    #: This constant has a value of "NLP"
+    NAME_NLP = "NLP"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AbstractCommandDescriptor object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
@@ -177,7 +193,9 @@ class AbstractCommandDescriptor(object):
         * :class:`~oci.log_analytics.models.LookupCommandDescriptor`
         * :class:`~oci.log_analytics.models.DemoModeCommandDescriptor`
         * :class:`~oci.log_analytics.models.FieldSummaryCommandDescriptor`
+        * :class:`~oci.log_analytics.models.MapCommandDescriptor`
         * :class:`~oci.log_analytics.models.EventStatsCommandDescriptor`
+        * :class:`~oci.log_analytics.models.HighlightGroupsCommandDescriptor`
         * :class:`~oci.log_analytics.models.WhereCommandDescriptor`
         * :class:`~oci.log_analytics.models.ClusterSplitCommandDescriptor`
         * :class:`~oci.log_analytics.models.TimeStatsCommandDescriptor`
@@ -192,6 +210,7 @@ class AbstractCommandDescriptor(object):
         * :class:`~oci.log_analytics.models.LinkCommandDescriptor`
         * :class:`~oci.log_analytics.models.SortCommandDescriptor`
         * :class:`~oci.log_analytics.models.ExtractCommandDescriptor`
+        * :class:`~oci.log_analytics.models.NlpCommandDescriptor`
         * :class:`~oci.log_analytics.models.BottomCommandDescriptor`
         * :class:`~oci.log_analytics.models.FieldsCommandDescriptor`
         * :class:`~oci.log_analytics.models.HighlightRowsCommandDescriptor`
@@ -200,6 +219,7 @@ class AbstractCommandDescriptor(object):
         * :class:`~oci.log_analytics.models.LinkDetailsCommandDescriptor`
         * :class:`~oci.log_analytics.models.SearchLookupCommandDescriptor`
         * :class:`~oci.log_analytics.models.HeadCommandDescriptor`
+        * :class:`~oci.log_analytics.models.CreateViewCommandDescriptor`
         * :class:`~oci.log_analytics.models.AddFieldsCommandDescriptor`
         * :class:`~oci.log_analytics.models.EvalCommandDescriptor`
         * :class:`~oci.log_analytics.models.RenameCommandDescriptor`
@@ -208,7 +228,7 @@ class AbstractCommandDescriptor(object):
 
         :param name:
             The value to assign to the name property of this AbstractCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type name: str
 
@@ -299,8 +319,14 @@ class AbstractCommandDescriptor(object):
         if type == 'FIELD_SUMMARY':
             return 'FieldSummaryCommandDescriptor'
 
+        if type == 'MAP':
+            return 'MapCommandDescriptor'
+
         if type == 'EVENT_STATS':
             return 'EventStatsCommandDescriptor'
+
+        if type == 'HIGHLIGHT_GROUPS':
+            return 'HighlightGroupsCommandDescriptor'
 
         if type == 'WHERE':
             return 'WhereCommandDescriptor'
@@ -344,6 +370,9 @@ class AbstractCommandDescriptor(object):
         if type == 'EXTRACT':
             return 'ExtractCommandDescriptor'
 
+        if type == 'NLP':
+            return 'NlpCommandDescriptor'
+
         if type == 'BOTTOM':
             return 'BottomCommandDescriptor'
 
@@ -368,6 +397,9 @@ class AbstractCommandDescriptor(object):
         if type == 'HEAD':
             return 'HeadCommandDescriptor'
 
+        if type == 'CREATE_VIEW':
+            return 'CreateViewCommandDescriptor'
+
         if type == 'ADD_FIELDS':
             return 'AddFieldsCommandDescriptor'
 
@@ -385,7 +417,7 @@ class AbstractCommandDescriptor(object):
         **[Required]** Gets the name of this AbstractCommandDescriptor.
         Name of querylanguage command
 
-        Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -404,7 +436,7 @@ class AbstractCommandDescriptor(object):
         :param name: The name of this AbstractCommandDescriptor.
         :type: str
         """
-        allowed_values = ["COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"]
+        allowed_values = ["COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"]
         if not value_allowed_none_or_none_sentinel(name, allowed_values):
             name = 'UNKNOWN_ENUM_VALUE'
         self._name = name

--- a/src/oci/log_analytics/models/abstract_field.py
+++ b/src/oci/log_analytics/models/abstract_field.py
@@ -117,6 +117,10 @@ class AbstractField(object):
             The value to assign to the filter_query_string property of this AbstractField.
         :type filter_query_string: str
 
+        :param unit_type:
+            The value to assign to the unit_type property of this AbstractField.
+        :type unit_type: str
+
         """
         self.swagger_types = {
             'name': 'str',
@@ -128,7 +132,8 @@ class AbstractField(object):
             'is_groupable': 'bool',
             'is_duration': 'bool',
             'alias': 'str',
-            'filter_query_string': 'str'
+            'filter_query_string': 'str',
+            'unit_type': 'str'
         }
 
         self.attribute_map = {
@@ -141,7 +146,8 @@ class AbstractField(object):
             'is_groupable': 'isGroupable',
             'is_duration': 'isDuration',
             'alias': 'alias',
-            'filter_query_string': 'filterQueryString'
+            'filter_query_string': 'filterQueryString',
+            'unit_type': 'unitType'
         }
 
         self._name = None
@@ -154,6 +160,7 @@ class AbstractField(object):
         self._is_duration = None
         self._alias = None
         self._filter_query_string = None
+        self._unit_type = None
 
     @staticmethod
     def get_subtype(object_dictionary):
@@ -430,6 +437,30 @@ class AbstractField(object):
         :type: str
         """
         self._filter_query_string = filter_query_string
+
+    @property
+    def unit_type(self):
+        """
+        Gets the unit_type of this AbstractField.
+        Field denoting field unit type.
+
+
+        :return: The unit_type of this AbstractField.
+        :rtype: str
+        """
+        return self._unit_type
+
+    @unit_type.setter
+    def unit_type(self, unit_type):
+        """
+        Sets the unit_type of this AbstractField.
+        Field denoting field unit type.
+
+
+        :param unit_type: The unit_type of this AbstractField.
+        :type: str
+        """
+        self._unit_type = unit_type
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/log_analytics/models/add_entity_association_details.py
+++ b/src/oci/log_analytics/models/add_entity_association_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class AddEntityAssociationDetails(object):
     """
-    Information about the associations to be added between log analytics entity and other existing entities.
+    Information about the associations to be added between a source log analytics entity and other existing destination entities.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/log_analytics/models/add_fields_command_descriptor.py
+++ b/src/oci/log_analytics/models/add_fields_command_descriptor.py
@@ -21,7 +21,7 @@ class AddFieldsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this AddFieldsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/archiving_configuration.py
+++ b/src/oci/log_analytics/models/archiving_configuration.py
@@ -44,7 +44,7 @@ class ArchivingConfiguration(object):
     def active_storage_duration(self):
         """
         Gets the active_storage_duration of this ArchivingConfiguration.
-        Thi is the duration data in active storage before data is archived, as described in
+        This is the duration data in active storage before data is archived, as described in
         https://en.wikipedia.org/wiki/ISO_8601#Durations.
         The largest supported unit is D, e.g. P365D (not P1Y) or P14D (not P2W).
 
@@ -58,7 +58,7 @@ class ArchivingConfiguration(object):
     def active_storage_duration(self, active_storage_duration):
         """
         Sets the active_storage_duration of this ArchivingConfiguration.
-        Thi is the duration data in active storage before data is archived, as described in
+        This is the duration data in active storage before data is archived, as described in
         https://en.wikipedia.org/wiki/ISO_8601#Durations.
         The largest supported unit is D, e.g. P365D (not P1Y) or P14D (not P2W).
 
@@ -72,7 +72,7 @@ class ArchivingConfiguration(object):
     def archival_storage_duration(self):
         """
         Gets the archival_storage_duration of this ArchivingConfiguration.
-        The is the duration before archived data is deleted from object storage, as described in
+        This is the duration before archived data is deleted from object storage, as described in
         https://en.wikipedia.org/wiki/ISO_8601#Durations
         The largest supported unit is D, e.g. P365D (not P1Y) or P14D (not P2W).
 
@@ -86,7 +86,7 @@ class ArchivingConfiguration(object):
     def archival_storage_duration(self, archival_storage_duration):
         """
         Sets the archival_storage_duration of this ArchivingConfiguration.
-        The is the duration before archived data is deleted from object storage, as described in
+        This is the duration before archived data is deleted from object storage, as described in
         https://en.wikipedia.org/wiki/ISO_8601#Durations
         The largest supported unit is D, e.g. P365D (not P1Y) or P14D (not P2W).
 

--- a/src/oci/log_analytics/models/bottom_command_descriptor.py
+++ b/src/oci/log_analytics/models/bottom_command_descriptor.py
@@ -21,7 +21,7 @@ class BottomCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this BottomCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/bucket_command_descriptor.py
+++ b/src/oci/log_analytics/models/bucket_command_descriptor.py
@@ -21,7 +21,7 @@ class BucketCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this BucketCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/change_log_analytics_entity_compartment_details.py
+++ b/src/oci/log_analytics/models/change_log_analytics_entity_compartment_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ChangeLogAnalyticsEntityCompartmentDetails(object):
     """
-    log analytics entity compartment to be updated.
+    Log analytics entity compartment to be updated.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/log_analytics/models/change_log_analytics_object_collection_rule_compartment_details.py
+++ b/src/oci/log_analytics/models/change_log_analytics_object_collection_rule_compartment_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ChangeLogAnalyticsObjectCollectionRuleCompartmentDetails(object):
     """
-    The new compartment this Object Collection Rule will be moved to.
+    New compartment details.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +37,7 @@ class ChangeLogAnalyticsObjectCollectionRuleCompartmentDetails(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this ChangeLogAnalyticsObjectCollectionRuleCompartmentDetails.
-        The `OCID`__ of the compartment into which the rule should be moved.
+        The `OCID`__ of the compartment to which the rule have to be moved.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -51,7 +51,7 @@ class ChangeLogAnalyticsObjectCollectionRuleCompartmentDetails(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this ChangeLogAnalyticsObjectCollectionRuleCompartmentDetails.
-        The `OCID`__ of the compartment into which the rule should be moved.
+        The `OCID`__ of the compartment to which the rule have to be moved.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 

--- a/src/oci/log_analytics/models/char_encoding_collection.py
+++ b/src/oci/log_analytics/models/char_encoding_collection.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CharEncodingCollection(object):
     """
-    List of supported character encodings
+    List of supported character encodings.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +37,7 @@ class CharEncodingCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this CharEncodingCollection.
-        List of supported character encodings
+        List of supported character encodings.
 
 
         :return: The items of this CharEncodingCollection.
@@ -49,7 +49,7 @@ class CharEncodingCollection(object):
     def items(self, items):
         """
         Sets the items of this CharEncodingCollection.
-        List of supported character encodings
+        List of supported character encodings.
 
 
         :param items: The items of this CharEncodingCollection.

--- a/src/oci/log_analytics/models/classify_command_descriptor.py
+++ b/src/oci/log_analytics/models/classify_command_descriptor.py
@@ -21,7 +21,7 @@ class ClassifyCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this ClassifyCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/cluster_command_descriptor.py
+++ b/src/oci/log_analytics/models/cluster_command_descriptor.py
@@ -21,7 +21,7 @@ class ClusterCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this ClusterCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/cluster_compare_command_descriptor.py
+++ b/src/oci/log_analytics/models/cluster_compare_command_descriptor.py
@@ -21,7 +21,7 @@ class ClusterCompareCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this ClusterCompareCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/cluster_details_command_descriptor.py
+++ b/src/oci/log_analytics/models/cluster_details_command_descriptor.py
@@ -21,7 +21,7 @@ class ClusterDetailsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this ClusterDetailsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/cluster_split_command_descriptor.py
+++ b/src/oci/log_analytics/models/cluster_split_command_descriptor.py
@@ -21,7 +21,7 @@ class ClusterSplitCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this ClusterSplitCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/command_descriptor.py
+++ b/src/oci/log_analytics/models/command_descriptor.py
@@ -21,7 +21,7 @@ class CommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this CommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/create_log_analytics_entity_details.py
+++ b/src/oci/log_analytics/models/create_log_analytics_entity_details.py
@@ -107,7 +107,7 @@ class CreateLogAnalyticsEntityDetails(object):
     def name(self):
         """
         **[Required]** Gets the name of this CreateLogAnalyticsEntityDetails.
-        Log analytics entity name. The name must be unique, within the tenancy, and cannot be changed.
+        Log analytics entity name.
 
 
         :return: The name of this CreateLogAnalyticsEntityDetails.
@@ -119,7 +119,7 @@ class CreateLogAnalyticsEntityDetails(object):
     def name(self, name):
         """
         Sets the name of this CreateLogAnalyticsEntityDetails.
-        Log analytics entity name. The name must be unique, within the tenancy, and cannot be changed.
+        Log analytics entity name.
 
 
         :param name: The name of this CreateLogAnalyticsEntityDetails.

--- a/src/oci/log_analytics/models/create_log_analytics_object_collection_rule_details.py
+++ b/src/oci/log_analytics/models/create_log_analytics_object_collection_rule_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateLogAnalyticsObjectCollectionRuleDetails(object):
     """
-    The configuration details of an Object Storage based collection rule to enable automatic log collection.
+    The configuration details of collection rule to enable automatic log collection from an object storage bucket.
     """
 
     #: A constant which can be used with the collection_type property of a CreateLogAnalyticsObjectCollectionRuleDetails.
@@ -79,6 +79,10 @@ class CreateLogAnalyticsObjectCollectionRuleDetails(object):
             The value to assign to the char_encoding property of this CreateLogAnalyticsObjectCollectionRuleDetails.
         :type char_encoding: str
 
+        :param is_enabled:
+            The value to assign to the is_enabled property of this CreateLogAnalyticsObjectCollectionRuleDetails.
+        :type is_enabled: bool
+
         :param overrides:
             The value to assign to the overrides property of this CreateLogAnalyticsObjectCollectionRuleDetails.
         :type overrides: dict(str, list[PropertyOverride])
@@ -105,6 +109,7 @@ class CreateLogAnalyticsObjectCollectionRuleDetails(object):
             'log_source_name': 'str',
             'entity_id': 'str',
             'char_encoding': 'str',
+            'is_enabled': 'bool',
             'overrides': 'dict(str, list[PropertyOverride])',
             'defined_tags': 'dict(str, dict(str, object))',
             'freeform_tags': 'dict(str, str)'
@@ -123,6 +128,7 @@ class CreateLogAnalyticsObjectCollectionRuleDetails(object):
             'log_source_name': 'logSourceName',
             'entity_id': 'entityId',
             'char_encoding': 'charEncoding',
+            'is_enabled': 'isEnabled',
             'overrides': 'overrides',
             'defined_tags': 'definedTags',
             'freeform_tags': 'freeformTags'
@@ -140,6 +146,7 @@ class CreateLogAnalyticsObjectCollectionRuleDetails(object):
         self._log_source_name = None
         self._entity_id = None
         self._char_encoding = None
+        self._is_enabled = None
         self._overrides = None
         self._defined_tags = None
         self._freeform_tags = None
@@ -275,7 +282,6 @@ class CreateLogAnalyticsObjectCollectionRuleDetails(object):
         """
         Gets the collection_type of this CreateLogAnalyticsObjectCollectionRuleDetails.
         The type of collection.
-        Supported collection types: LIVE, HISTORIC, HISTORIC_LIVE
 
         Allowed values for this property are: "LIVE", "HISTORIC", "HISTORIC_LIVE"
 
@@ -290,7 +296,6 @@ class CreateLogAnalyticsObjectCollectionRuleDetails(object):
         """
         Sets the collection_type of this CreateLogAnalyticsObjectCollectionRuleDetails.
         The type of collection.
-        Supported collection types: LIVE, HISTORIC, HISTORIC_LIVE
 
 
         :param collection_type: The collection_type of this CreateLogAnalyticsObjectCollectionRuleDetails.
@@ -310,7 +315,7 @@ class CreateLogAnalyticsObjectCollectionRuleDetails(object):
         Gets the poll_since of this CreateLogAnalyticsObjectCollectionRuleDetails.
         The oldest time of the file in the bucket to consider for collection.
         Accepted values are: BEGINNING or CURRENT_TIME or RFC3339 formatted datetime string.
-        When collectionType is LIVE, specifying pollSince value other than CURRENT_TIME will result in error.
+        Use this for HISTORIC or HISTORIC_LIVE collection types. When collectionType is LIVE, specifying pollSince value other than CURRENT_TIME will result in error.
 
 
         :return: The poll_since of this CreateLogAnalyticsObjectCollectionRuleDetails.
@@ -324,7 +329,7 @@ class CreateLogAnalyticsObjectCollectionRuleDetails(object):
         Sets the poll_since of this CreateLogAnalyticsObjectCollectionRuleDetails.
         The oldest time of the file in the bucket to consider for collection.
         Accepted values are: BEGINNING or CURRENT_TIME or RFC3339 formatted datetime string.
-        When collectionType is LIVE, specifying pollSince value other than CURRENT_TIME will result in error.
+        Use this for HISTORIC or HISTORIC_LIVE collection types. When collectionType is LIVE, specifying pollSince value other than CURRENT_TIME will result in error.
 
 
         :param poll_since: The poll_since of this CreateLogAnalyticsObjectCollectionRuleDetails.
@@ -336,9 +341,9 @@ class CreateLogAnalyticsObjectCollectionRuleDetails(object):
     def poll_till(self):
         """
         Gets the poll_till of this CreateLogAnalyticsObjectCollectionRuleDetails.
-        The oldest time of the file in the bucket to consider for collection.
+        The newest time of the file in the bucket to consider for collection.
         Accepted values are: CURRENT_TIME or RFC3339 formatted datetime string.
-        When collectionType is LIVE, specifying pollTill will result in error.
+        Use this for HISTORIC collection type. When collectionType is LIVE or HISTORIC_LIVE, specifying pollTill will result in error.
 
 
         :return: The poll_till of this CreateLogAnalyticsObjectCollectionRuleDetails.
@@ -350,9 +355,9 @@ class CreateLogAnalyticsObjectCollectionRuleDetails(object):
     def poll_till(self, poll_till):
         """
         Sets the poll_till of this CreateLogAnalyticsObjectCollectionRuleDetails.
-        The oldest time of the file in the bucket to consider for collection.
+        The newest time of the file in the bucket to consider for collection.
         Accepted values are: CURRENT_TIME or RFC3339 formatted datetime string.
-        When collectionType is LIVE, specifying pollTill will result in error.
+        Use this for HISTORIC collection type. When collectionType is LIVE or HISTORIC_LIVE, specifying pollTill will result in error.
 
 
         :param poll_till: The poll_till of this CreateLogAnalyticsObjectCollectionRuleDetails.
@@ -437,7 +442,7 @@ class CreateLogAnalyticsObjectCollectionRuleDetails(object):
         """
         Gets the char_encoding of this CreateLogAnalyticsObjectCollectionRuleDetails.
         An optional character encoding to aid in detecting the character encoding of the contents of the objects while processing.
-        It is recommended to set this value as ISO_8589_1 when configuring content of the objects having more numeric characters,
+        It is recommended to set this value as ISO_8859_1 when configuring content of the objects having more numeric characters,
         and very few alphabets.
         For e.g. this applies when configuring VCN Flow Logs.
 
@@ -452,7 +457,7 @@ class CreateLogAnalyticsObjectCollectionRuleDetails(object):
         """
         Sets the char_encoding of this CreateLogAnalyticsObjectCollectionRuleDetails.
         An optional character encoding to aid in detecting the character encoding of the contents of the objects while processing.
-        It is recommended to set this value as ISO_8589_1 when configuring content of the objects having more numeric characters,
+        It is recommended to set this value as ISO_8859_1 when configuring content of the objects having more numeric characters,
         and very few alphabets.
         For e.g. this applies when configuring VCN Flow Logs.
 
@@ -461,6 +466,30 @@ class CreateLogAnalyticsObjectCollectionRuleDetails(object):
         :type: str
         """
         self._char_encoding = char_encoding
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this CreateLogAnalyticsObjectCollectionRuleDetails.
+        Whether or not this rule is currently enabled.
+
+
+        :return: The is_enabled of this CreateLogAnalyticsObjectCollectionRuleDetails.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this CreateLogAnalyticsObjectCollectionRuleDetails.
+        Whether or not this rule is currently enabled.
+
+
+        :param is_enabled: The is_enabled of this CreateLogAnalyticsObjectCollectionRuleDetails.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
 
     @property
     def overrides(self):

--- a/src/oci/log_analytics/models/create_standard_task_details.py
+++ b/src/oci/log_analytics/models/create_standard_task_details.py
@@ -141,6 +141,7 @@ class CreateStandardTaskDetails(CreateScheduledTaskDetails):
         """
         **[Required]** Gets the schedules of this CreateStandardTaskDetails.
         Schedules, typically a single schedule.
+        Note there may only be a single schedule for SAVED_SEARCH and PURGE scheduled tasks.
 
 
         :return: The schedules of this CreateStandardTaskDetails.
@@ -153,6 +154,7 @@ class CreateStandardTaskDetails(CreateScheduledTaskDetails):
         """
         Sets the schedules of this CreateStandardTaskDetails.
         Schedules, typically a single schedule.
+        Note there may only be a single schedule for SAVED_SEARCH and PURGE scheduled tasks.
 
 
         :param schedules: The schedules of this CreateStandardTaskDetails.

--- a/src/oci/log_analytics/models/create_view_command_descriptor.py
+++ b/src/oci/log_analytics/models/create_view_command_descriptor.py
@@ -1,0 +1,84 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .abstract_command_descriptor import AbstractCommandDescriptor
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateViewCommandDescriptor(AbstractCommandDescriptor):
+    """
+    Command descriptor for querylanguage CREATEVIEW command.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateViewCommandDescriptor object with values from keyword arguments. The default value of the :py:attr:`~oci.log_analytics.models.CreateViewCommandDescriptor.name` attribute
+        of this class is ``CREATE_VIEW`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this CreateViewCommandDescriptor.
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+        :type name: str
+
+        :param display_query_string:
+            The value to assign to the display_query_string property of this CreateViewCommandDescriptor.
+        :type display_query_string: str
+
+        :param internal_query_string:
+            The value to assign to the internal_query_string property of this CreateViewCommandDescriptor.
+        :type internal_query_string: str
+
+        :param category:
+            The value to assign to the category property of this CreateViewCommandDescriptor.
+        :type category: str
+
+        :param referenced_fields:
+            The value to assign to the referenced_fields property of this CreateViewCommandDescriptor.
+        :type referenced_fields: list[oci.log_analytics.models.AbstractField]
+
+        :param declared_fields:
+            The value to assign to the declared_fields property of this CreateViewCommandDescriptor.
+        :type declared_fields: list[oci.log_analytics.models.AbstractField]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'display_query_string': 'str',
+            'internal_query_string': 'str',
+            'category': 'str',
+            'referenced_fields': 'list[AbstractField]',
+            'declared_fields': 'list[AbstractField]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'display_query_string': 'displayQueryString',
+            'internal_query_string': 'internalQueryString',
+            'category': 'category',
+            'referenced_fields': 'referencedFields',
+            'declared_fields': 'declaredFields'
+        }
+
+        self._name = None
+        self._display_query_string = None
+        self._internal_query_string = None
+        self._category = None
+        self._referenced_fields = None
+        self._declared_fields = None
+        self._name = 'CREATE_VIEW'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/delete_command_descriptor.py
+++ b/src/oci/log_analytics/models/delete_command_descriptor.py
@@ -21,7 +21,7 @@ class DeleteCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this DeleteCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/delta_command_descriptor.py
+++ b/src/oci/log_analytics/models/delta_command_descriptor.py
@@ -21,7 +21,7 @@ class DeltaCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this DeltaCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/demo_mode_command_descriptor.py
+++ b/src/oci/log_analytics/models/demo_mode_command_descriptor.py
@@ -21,7 +21,7 @@ class DemoModeCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this DemoModeCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/distinct_command_descriptor.py
+++ b/src/oci/log_analytics/models/distinct_command_descriptor.py
@@ -21,7 +21,7 @@ class DistinctCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this DistinctCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/estimate_recall_data_size_details.py
+++ b/src/oci/log_analytics/models/estimate_recall_data_size_details.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EstimateRecallDataSizeDetails(object):
+    """
+    This is the input used to estimate the size of data to be recalled
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EstimateRecallDataSizeDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param time_data_started:
+            The value to assign to the time_data_started property of this EstimateRecallDataSizeDetails.
+        :type time_data_started: datetime
+
+        :param time_data_ended:
+            The value to assign to the time_data_ended property of this EstimateRecallDataSizeDetails.
+        :type time_data_ended: datetime
+
+        """
+        self.swagger_types = {
+            'time_data_started': 'datetime',
+            'time_data_ended': 'datetime'
+        }
+
+        self.attribute_map = {
+            'time_data_started': 'timeDataStarted',
+            'time_data_ended': 'timeDataEnded'
+        }
+
+        self._time_data_started = None
+        self._time_data_ended = None
+
+    @property
+    def time_data_started(self):
+        """
+        **[Required]** Gets the time_data_started of this EstimateRecallDataSizeDetails.
+        This is the start of the time range for the data to be recalled
+
+
+        :return: The time_data_started of this EstimateRecallDataSizeDetails.
+        :rtype: datetime
+        """
+        return self._time_data_started
+
+    @time_data_started.setter
+    def time_data_started(self, time_data_started):
+        """
+        Sets the time_data_started of this EstimateRecallDataSizeDetails.
+        This is the start of the time range for the data to be recalled
+
+
+        :param time_data_started: The time_data_started of this EstimateRecallDataSizeDetails.
+        :type: datetime
+        """
+        self._time_data_started = time_data_started
+
+    @property
+    def time_data_ended(self):
+        """
+        **[Required]** Gets the time_data_ended of this EstimateRecallDataSizeDetails.
+        This is the end of the time range for the data to be recalled
+
+
+        :return: The time_data_ended of this EstimateRecallDataSizeDetails.
+        :rtype: datetime
+        """
+        return self._time_data_ended
+
+    @time_data_ended.setter
+    def time_data_ended(self, time_data_ended):
+        """
+        Sets the time_data_ended of this EstimateRecallDataSizeDetails.
+        This is the end of the time range for the data to be recalled
+
+
+        :param time_data_ended: The time_data_ended of this EstimateRecallDataSizeDetails.
+        :type: datetime
+        """
+        self._time_data_ended = time_data_ended
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/estimate_recall_data_size_result.py
+++ b/src/oci/log_analytics/models/estimate_recall_data_size_result.py
@@ -1,0 +1,167 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EstimateRecallDataSizeResult(object):
+    """
+    This is the size and time range of data to be recalled
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EstimateRecallDataSizeResult object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param time_data_ended:
+            The value to assign to the time_data_ended property of this EstimateRecallDataSizeResult.
+        :type time_data_ended: datetime
+
+        :param time_data_started:
+            The value to assign to the time_data_started property of this EstimateRecallDataSizeResult.
+        :type time_data_started: datetime
+
+        :param size_in_bytes:
+            The value to assign to the size_in_bytes property of this EstimateRecallDataSizeResult.
+        :type size_in_bytes: int
+
+        :param is_overlapping_with_existing_recalls:
+            The value to assign to the is_overlapping_with_existing_recalls property of this EstimateRecallDataSizeResult.
+        :type is_overlapping_with_existing_recalls: bool
+
+        """
+        self.swagger_types = {
+            'time_data_ended': 'datetime',
+            'time_data_started': 'datetime',
+            'size_in_bytes': 'int',
+            'is_overlapping_with_existing_recalls': 'bool'
+        }
+
+        self.attribute_map = {
+            'time_data_ended': 'timeDataEnded',
+            'time_data_started': 'timeDataStarted',
+            'size_in_bytes': 'sizeInBytes',
+            'is_overlapping_with_existing_recalls': 'isOverlappingWithExistingRecalls'
+        }
+
+        self._time_data_ended = None
+        self._time_data_started = None
+        self._size_in_bytes = None
+        self._is_overlapping_with_existing_recalls = None
+
+    @property
+    def time_data_ended(self):
+        """
+        **[Required]** Gets the time_data_ended of this EstimateRecallDataSizeResult.
+        This is the end of the time range of data to be recalled.  timeDataStarted and timeDataEnded delineate
+        the time range of the archived data to be recalled.  They may not be exact the same as the
+        parameters in the request input (EstimateRecallDataSizeDetails).
+
+
+        :return: The time_data_ended of this EstimateRecallDataSizeResult.
+        :rtype: datetime
+        """
+        return self._time_data_ended
+
+    @time_data_ended.setter
+    def time_data_ended(self, time_data_ended):
+        """
+        Sets the time_data_ended of this EstimateRecallDataSizeResult.
+        This is the end of the time range of data to be recalled.  timeDataStarted and timeDataEnded delineate
+        the time range of the archived data to be recalled.  They may not be exact the same as the
+        parameters in the request input (EstimateRecallDataSizeDetails).
+
+
+        :param time_data_ended: The time_data_ended of this EstimateRecallDataSizeResult.
+        :type: datetime
+        """
+        self._time_data_ended = time_data_ended
+
+    @property
+    def time_data_started(self):
+        """
+        **[Required]** Gets the time_data_started of this EstimateRecallDataSizeResult.
+        This is the start of the time range of data to be recalled
+
+
+        :return: The time_data_started of this EstimateRecallDataSizeResult.
+        :rtype: datetime
+        """
+        return self._time_data_started
+
+    @time_data_started.setter
+    def time_data_started(self, time_data_started):
+        """
+        Sets the time_data_started of this EstimateRecallDataSizeResult.
+        This is the start of the time range of data to be recalled
+
+
+        :param time_data_started: The time_data_started of this EstimateRecallDataSizeResult.
+        :type: datetime
+        """
+        self._time_data_started = time_data_started
+
+    @property
+    def size_in_bytes(self):
+        """
+        **[Required]** Gets the size_in_bytes of this EstimateRecallDataSizeResult.
+        This is the size in bytes
+
+
+        :return: The size_in_bytes of this EstimateRecallDataSizeResult.
+        :rtype: int
+        """
+        return self._size_in_bytes
+
+    @size_in_bytes.setter
+    def size_in_bytes(self, size_in_bytes):
+        """
+        Sets the size_in_bytes of this EstimateRecallDataSizeResult.
+        This is the size in bytes
+
+
+        :param size_in_bytes: The size_in_bytes of this EstimateRecallDataSizeResult.
+        :type: int
+        """
+        self._size_in_bytes = size_in_bytes
+
+    @property
+    def is_overlapping_with_existing_recalls(self):
+        """
+        Gets the is_overlapping_with_existing_recalls of this EstimateRecallDataSizeResult.
+        This indicates if the time range of data to be recalled overlaps with existing recalled data
+
+
+        :return: The is_overlapping_with_existing_recalls of this EstimateRecallDataSizeResult.
+        :rtype: bool
+        """
+        return self._is_overlapping_with_existing_recalls
+
+    @is_overlapping_with_existing_recalls.setter
+    def is_overlapping_with_existing_recalls(self, is_overlapping_with_existing_recalls):
+        """
+        Sets the is_overlapping_with_existing_recalls of this EstimateRecallDataSizeResult.
+        This indicates if the time range of data to be recalled overlaps with existing recalled data
+
+
+        :param is_overlapping_with_existing_recalls: The is_overlapping_with_existing_recalls of this EstimateRecallDataSizeResult.
+        :type: bool
+        """
+        self._is_overlapping_with_existing_recalls = is_overlapping_with_existing_recalls
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/estimate_release_data_size_details.py
+++ b/src/oci/log_analytics/models/estimate_release_data_size_details.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EstimateReleaseDataSizeDetails(object):
+    """
+    This is the input used to estimate the size of data to be released
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EstimateReleaseDataSizeDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param time_data_started:
+            The value to assign to the time_data_started property of this EstimateReleaseDataSizeDetails.
+        :type time_data_started: datetime
+
+        :param time_data_ended:
+            The value to assign to the time_data_ended property of this EstimateReleaseDataSizeDetails.
+        :type time_data_ended: datetime
+
+        """
+        self.swagger_types = {
+            'time_data_started': 'datetime',
+            'time_data_ended': 'datetime'
+        }
+
+        self.attribute_map = {
+            'time_data_started': 'timeDataStarted',
+            'time_data_ended': 'timeDataEnded'
+        }
+
+        self._time_data_started = None
+        self._time_data_ended = None
+
+    @property
+    def time_data_started(self):
+        """
+        **[Required]** Gets the time_data_started of this EstimateReleaseDataSizeDetails.
+        This is the start of the time range for the data to be released
+
+
+        :return: The time_data_started of this EstimateReleaseDataSizeDetails.
+        :rtype: datetime
+        """
+        return self._time_data_started
+
+    @time_data_started.setter
+    def time_data_started(self, time_data_started):
+        """
+        Sets the time_data_started of this EstimateReleaseDataSizeDetails.
+        This is the start of the time range for the data to be released
+
+
+        :param time_data_started: The time_data_started of this EstimateReleaseDataSizeDetails.
+        :type: datetime
+        """
+        self._time_data_started = time_data_started
+
+    @property
+    def time_data_ended(self):
+        """
+        **[Required]** Gets the time_data_ended of this EstimateReleaseDataSizeDetails.
+        This is the end of the time range for the data to be released
+
+
+        :return: The time_data_ended of this EstimateReleaseDataSizeDetails.
+        :rtype: datetime
+        """
+        return self._time_data_ended
+
+    @time_data_ended.setter
+    def time_data_ended(self, time_data_ended):
+        """
+        Sets the time_data_ended of this EstimateReleaseDataSizeDetails.
+        This is the end of the time range for the data to be released
+
+
+        :param time_data_ended: The time_data_ended of this EstimateReleaseDataSizeDetails.
+        :type: datetime
+        """
+        self._time_data_ended = time_data_ended
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/estimate_release_data_size_result.py
+++ b/src/oci/log_analytics/models/estimate_release_data_size_result.py
@@ -1,0 +1,136 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EstimateReleaseDataSizeResult(object):
+    """
+    This is the size and time range of data to be released
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EstimateReleaseDataSizeResult object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param time_data_ended:
+            The value to assign to the time_data_ended property of this EstimateReleaseDataSizeResult.
+        :type time_data_ended: datetime
+
+        :param time_data_started:
+            The value to assign to the time_data_started property of this EstimateReleaseDataSizeResult.
+        :type time_data_started: datetime
+
+        :param size_in_bytes:
+            The value to assign to the size_in_bytes property of this EstimateReleaseDataSizeResult.
+        :type size_in_bytes: int
+
+        """
+        self.swagger_types = {
+            'time_data_ended': 'datetime',
+            'time_data_started': 'datetime',
+            'size_in_bytes': 'int'
+        }
+
+        self.attribute_map = {
+            'time_data_ended': 'timeDataEnded',
+            'time_data_started': 'timeDataStarted',
+            'size_in_bytes': 'sizeInBytes'
+        }
+
+        self._time_data_ended = None
+        self._time_data_started = None
+        self._size_in_bytes = None
+
+    @property
+    def time_data_ended(self):
+        """
+        **[Required]** Gets the time_data_ended of this EstimateReleaseDataSizeResult.
+        This is the end of the time range of data to be released.  timeDataStarted and timeDataEnded delineate
+        the time range of the recalled data to be released.  They may not be exact the same as the
+        parameters in the request input (EstimateReleaseDataSizeDetails).
+
+
+        :return: The time_data_ended of this EstimateReleaseDataSizeResult.
+        :rtype: datetime
+        """
+        return self._time_data_ended
+
+    @time_data_ended.setter
+    def time_data_ended(self, time_data_ended):
+        """
+        Sets the time_data_ended of this EstimateReleaseDataSizeResult.
+        This is the end of the time range of data to be released.  timeDataStarted and timeDataEnded delineate
+        the time range of the recalled data to be released.  They may not be exact the same as the
+        parameters in the request input (EstimateReleaseDataSizeDetails).
+
+
+        :param time_data_ended: The time_data_ended of this EstimateReleaseDataSizeResult.
+        :type: datetime
+        """
+        self._time_data_ended = time_data_ended
+
+    @property
+    def time_data_started(self):
+        """
+        **[Required]** Gets the time_data_started of this EstimateReleaseDataSizeResult.
+        This is the start of the time range of data to be released
+
+
+        :return: The time_data_started of this EstimateReleaseDataSizeResult.
+        :rtype: datetime
+        """
+        return self._time_data_started
+
+    @time_data_started.setter
+    def time_data_started(self, time_data_started):
+        """
+        Sets the time_data_started of this EstimateReleaseDataSizeResult.
+        This is the start of the time range of data to be released
+
+
+        :param time_data_started: The time_data_started of this EstimateReleaseDataSizeResult.
+        :type: datetime
+        """
+        self._time_data_started = time_data_started
+
+    @property
+    def size_in_bytes(self):
+        """
+        **[Required]** Gets the size_in_bytes of this EstimateReleaseDataSizeResult.
+        This is the size in bytes
+
+
+        :return: The size_in_bytes of this EstimateReleaseDataSizeResult.
+        :rtype: int
+        """
+        return self._size_in_bytes
+
+    @size_in_bytes.setter
+    def size_in_bytes(self, size_in_bytes):
+        """
+        Sets the size_in_bytes of this EstimateReleaseDataSizeResult.
+        This is the size in bytes
+
+
+        :param size_in_bytes: The size_in_bytes of this EstimateReleaseDataSizeResult.
+        :type: int
+        """
+        self._size_in_bytes = size_in_bytes
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/eval_command_descriptor.py
+++ b/src/oci/log_analytics/models/eval_command_descriptor.py
@@ -21,7 +21,7 @@ class EvalCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this EvalCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/event_stats_command_descriptor.py
+++ b/src/oci/log_analytics/models/event_stats_command_descriptor.py
@@ -21,7 +21,7 @@ class EventStatsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this EventStatsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/event_type.py
+++ b/src/oci/log_analytics/models/event_type.py
@@ -1,0 +1,163 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EventType(object):
+    """
+    The event type.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EventType object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param event_type_name:
+            The value to assign to the event_type_name property of this EventType.
+        :type event_type_name: str
+
+        :param spec_version:
+            The value to assign to the spec_version property of this EventType.
+        :type spec_version: str
+
+        :param is_enabled:
+            The value to assign to the is_enabled property of this EventType.
+        :type is_enabled: bool
+
+        :param is_system:
+            The value to assign to the is_system property of this EventType.
+        :type is_system: bool
+
+        """
+        self.swagger_types = {
+            'event_type_name': 'str',
+            'spec_version': 'str',
+            'is_enabled': 'bool',
+            'is_system': 'bool'
+        }
+
+        self.attribute_map = {
+            'event_type_name': 'eventTypeName',
+            'spec_version': 'specVersion',
+            'is_enabled': 'isEnabled',
+            'is_system': 'isSystem'
+        }
+
+        self._event_type_name = None
+        self._spec_version = None
+        self._is_enabled = None
+        self._is_system = None
+
+    @property
+    def event_type_name(self):
+        """
+        Gets the event_type_name of this EventType.
+        The name of the event type.
+
+
+        :return: The event_type_name of this EventType.
+        :rtype: str
+        """
+        return self._event_type_name
+
+    @event_type_name.setter
+    def event_type_name(self, event_type_name):
+        """
+        Sets the event_type_name of this EventType.
+        The name of the event type.
+
+
+        :param event_type_name: The event_type_name of this EventType.
+        :type: str
+        """
+        self._event_type_name = event_type_name
+
+    @property
+    def spec_version(self):
+        """
+        Gets the spec_version of this EventType.
+        The version.
+
+
+        :return: The spec_version of this EventType.
+        :rtype: str
+        """
+        return self._spec_version
+
+    @spec_version.setter
+    def spec_version(self, spec_version):
+        """
+        Sets the spec_version of this EventType.
+        The version.
+
+
+        :param spec_version: The spec_version of this EventType.
+        :type: str
+        """
+        self._spec_version = spec_version
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this EventType.
+        A flag indicating whether or not the event type is enabled.
+
+
+        :return: The is_enabled of this EventType.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this EventType.
+        A flag indicating whether or not the event type is enabled.
+
+
+        :param is_enabled: The is_enabled of this EventType.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
+
+    @property
+    def is_system(self):
+        """
+        Gets the is_system of this EventType.
+        A flag indicating whether or not the event type is user defined.
+
+
+        :return: The is_system of this EventType.
+        :rtype: bool
+        """
+        return self._is_system
+
+    @is_system.setter
+    def is_system(self, is_system):
+        """
+        Sets the is_system of this EventType.
+        A flag indicating whether or not the event type is user defined.
+
+
+        :param is_system: The is_system of this EventType.
+        :type: bool
+        """
+        self._is_system = is_system
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/extract_command_descriptor.py
+++ b/src/oci/log_analytics/models/extract_command_descriptor.py
@@ -21,7 +21,7 @@ class ExtractCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this ExtractCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/field.py
+++ b/src/oci/log_analytics/models/field.py
@@ -61,6 +61,10 @@ class Field(AbstractField):
             The value to assign to the filter_query_string property of this Field.
         :type filter_query_string: str
 
+        :param unit_type:
+            The value to assign to the unit_type property of this Field.
+        :type unit_type: str
+
         """
         self.swagger_types = {
             'name': 'str',
@@ -72,7 +76,8 @@ class Field(AbstractField):
             'is_groupable': 'bool',
             'is_duration': 'bool',
             'alias': 'str',
-            'filter_query_string': 'str'
+            'filter_query_string': 'str',
+            'unit_type': 'str'
         }
 
         self.attribute_map = {
@@ -85,7 +90,8 @@ class Field(AbstractField):
             'is_groupable': 'isGroupable',
             'is_duration': 'isDuration',
             'alias': 'alias',
-            'filter_query_string': 'filterQueryString'
+            'filter_query_string': 'filterQueryString',
+            'unit_type': 'unitType'
         }
 
         self._name = None
@@ -98,6 +104,7 @@ class Field(AbstractField):
         self._is_duration = None
         self._alias = None
         self._filter_query_string = None
+        self._unit_type = None
         self._name = 'FIELD'
 
     def __repr__(self):

--- a/src/oci/log_analytics/models/field_summary_command_descriptor.py
+++ b/src/oci/log_analytics/models/field_summary_command_descriptor.py
@@ -21,7 +21,7 @@ class FieldSummaryCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this FieldSummaryCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/fields_add_remove_field.py
+++ b/src/oci/log_analytics/models/fields_add_remove_field.py
@@ -71,6 +71,10 @@ class FieldsAddRemoveField(AbstractField):
             The value to assign to the filter_query_string property of this FieldsAddRemoveField.
         :type filter_query_string: str
 
+        :param unit_type:
+            The value to assign to the unit_type property of this FieldsAddRemoveField.
+        :type unit_type: str
+
         :param operation:
             The value to assign to the operation property of this FieldsAddRemoveField.
             Allowed values for this property are: "ADD", "REMOVE", 'UNKNOWN_ENUM_VALUE'.
@@ -89,6 +93,7 @@ class FieldsAddRemoveField(AbstractField):
             'is_duration': 'bool',
             'alias': 'str',
             'filter_query_string': 'str',
+            'unit_type': 'str',
             'operation': 'str'
         }
 
@@ -103,6 +108,7 @@ class FieldsAddRemoveField(AbstractField):
             'is_duration': 'isDuration',
             'alias': 'alias',
             'filter_query_string': 'filterQueryString',
+            'unit_type': 'unitType',
             'operation': 'operation'
         }
 
@@ -116,6 +122,7 @@ class FieldsAddRemoveField(AbstractField):
         self._is_duration = None
         self._alias = None
         self._filter_query_string = None
+        self._unit_type = None
         self._operation = None
         self._name = 'FIELDS'
 

--- a/src/oci/log_analytics/models/fields_command_descriptor.py
+++ b/src/oci/log_analytics/models/fields_command_descriptor.py
@@ -21,7 +21,7 @@ class FieldsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this FieldsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/function_field.py
+++ b/src/oci/log_analytics/models/function_field.py
@@ -61,6 +61,10 @@ class FunctionField(AbstractField):
             The value to assign to the filter_query_string property of this FunctionField.
         :type filter_query_string: str
 
+        :param unit_type:
+            The value to assign to the unit_type property of this FunctionField.
+        :type unit_type: str
+
         :param function:
             The value to assign to the function property of this FunctionField.
         :type function: str
@@ -81,6 +85,7 @@ class FunctionField(AbstractField):
             'is_duration': 'bool',
             'alias': 'str',
             'filter_query_string': 'str',
+            'unit_type': 'str',
             'function': 'str',
             'arguments': 'list[Argument]'
         }
@@ -96,6 +101,7 @@ class FunctionField(AbstractField):
             'is_duration': 'isDuration',
             'alias': 'alias',
             'filter_query_string': 'filterQueryString',
+            'unit_type': 'unitType',
             'function': 'function',
             'arguments': 'arguments'
         }
@@ -110,6 +116,7 @@ class FunctionField(AbstractField):
         self._is_duration = None
         self._alias = None
         self._filter_query_string = None
+        self._unit_type = None
         self._function = None
         self._arguments = None
         self._name = 'FUNCTION'

--- a/src/oci/log_analytics/models/head_command_descriptor.py
+++ b/src/oci/log_analytics/models/head_command_descriptor.py
@@ -21,7 +21,7 @@ class HeadCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this HeadCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/highlight_command_descriptor.py
+++ b/src/oci/log_analytics/models/highlight_command_descriptor.py
@@ -21,7 +21,7 @@ class HighlightCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this HighlightCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/highlight_groups_command_descriptor.py
+++ b/src/oci/log_analytics/models/highlight_groups_command_descriptor.py
@@ -1,0 +1,239 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .abstract_command_descriptor import AbstractCommandDescriptor
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class HighlightGroupsCommandDescriptor(AbstractCommandDescriptor):
+    """
+    Command descriptor for querylanguage HIGHLIGHTGROUPS command.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new HighlightGroupsCommandDescriptor object with values from keyword arguments. The default value of the :py:attr:`~oci.log_analytics.models.HighlightGroupsCommandDescriptor.name` attribute
+        of this class is ``HIGHLIGHT_GROUPS`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this HighlightGroupsCommandDescriptor.
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+        :type name: str
+
+        :param display_query_string:
+            The value to assign to the display_query_string property of this HighlightGroupsCommandDescriptor.
+        :type display_query_string: str
+
+        :param internal_query_string:
+            The value to assign to the internal_query_string property of this HighlightGroupsCommandDescriptor.
+        :type internal_query_string: str
+
+        :param category:
+            The value to assign to the category property of this HighlightGroupsCommandDescriptor.
+        :type category: str
+
+        :param referenced_fields:
+            The value to assign to the referenced_fields property of this HighlightGroupsCommandDescriptor.
+        :type referenced_fields: list[oci.log_analytics.models.AbstractField]
+
+        :param declared_fields:
+            The value to assign to the declared_fields property of this HighlightGroupsCommandDescriptor.
+        :type declared_fields: list[oci.log_analytics.models.AbstractField]
+
+        :param color:
+            The value to assign to the color property of this HighlightGroupsCommandDescriptor.
+        :type color: str
+
+        :param priority:
+            The value to assign to the priority property of this HighlightGroupsCommandDescriptor.
+        :type priority: str
+
+        :param fields:
+            The value to assign to the fields property of this HighlightGroupsCommandDescriptor.
+        :type fields: list[str]
+
+        :param keywords:
+            The value to assign to the keywords property of this HighlightGroupsCommandDescriptor.
+        :type keywords: list[str]
+
+        :param sub_queries:
+            The value to assign to the sub_queries property of this HighlightGroupsCommandDescriptor.
+        :type sub_queries: list[oci.log_analytics.models.ParseQueryOutput]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'display_query_string': 'str',
+            'internal_query_string': 'str',
+            'category': 'str',
+            'referenced_fields': 'list[AbstractField]',
+            'declared_fields': 'list[AbstractField]',
+            'color': 'str',
+            'priority': 'str',
+            'fields': 'list[str]',
+            'keywords': 'list[str]',
+            'sub_queries': 'list[ParseQueryOutput]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'display_query_string': 'displayQueryString',
+            'internal_query_string': 'internalQueryString',
+            'category': 'category',
+            'referenced_fields': 'referencedFields',
+            'declared_fields': 'declaredFields',
+            'color': 'color',
+            'priority': 'priority',
+            'fields': 'fields',
+            'keywords': 'keywords',
+            'sub_queries': 'subQueries'
+        }
+
+        self._name = None
+        self._display_query_string = None
+        self._internal_query_string = None
+        self._category = None
+        self._referenced_fields = None
+        self._declared_fields = None
+        self._color = None
+        self._priority = None
+        self._fields = None
+        self._keywords = None
+        self._sub_queries = None
+        self._name = 'HIGHLIGHT_GROUPS'
+
+    @property
+    def color(self):
+        """
+        Gets the color of this HighlightGroupsCommandDescriptor.
+        User specified color to highlight matches with if found.
+
+
+        :return: The color of this HighlightGroupsCommandDescriptor.
+        :rtype: str
+        """
+        return self._color
+
+    @color.setter
+    def color(self, color):
+        """
+        Sets the color of this HighlightGroupsCommandDescriptor.
+        User specified color to highlight matches with if found.
+
+
+        :param color: The color of this HighlightGroupsCommandDescriptor.
+        :type: str
+        """
+        self._color = color
+
+    @property
+    def priority(self):
+        """
+        Gets the priority of this HighlightGroupsCommandDescriptor.
+        User specified priority assigned to highlighted matches if found.
+
+
+        :return: The priority of this HighlightGroupsCommandDescriptor.
+        :rtype: str
+        """
+        return self._priority
+
+    @priority.setter
+    def priority(self, priority):
+        """
+        Sets the priority of this HighlightGroupsCommandDescriptor.
+        User specified priority assigned to highlighted matches if found.
+
+
+        :param priority: The priority of this HighlightGroupsCommandDescriptor.
+        :type: str
+        """
+        self._priority = priority
+
+    @property
+    def fields(self):
+        """
+        Gets the fields of this HighlightGroupsCommandDescriptor.
+        List of fields to search for terms or phrases to highlight.
+
+
+        :return: The fields of this HighlightGroupsCommandDescriptor.
+        :rtype: list[str]
+        """
+        return self._fields
+
+    @fields.setter
+    def fields(self, fields):
+        """
+        Sets the fields of this HighlightGroupsCommandDescriptor.
+        List of fields to search for terms or phrases to highlight.
+
+
+        :param fields: The fields of this HighlightGroupsCommandDescriptor.
+        :type: list[str]
+        """
+        self._fields = fields
+
+    @property
+    def keywords(self):
+        """
+        Gets the keywords of this HighlightGroupsCommandDescriptor.
+        List of terms or phrases to highlight if found.
+
+
+        :return: The keywords of this HighlightGroupsCommandDescriptor.
+        :rtype: list[str]
+        """
+        return self._keywords
+
+    @keywords.setter
+    def keywords(self, keywords):
+        """
+        Sets the keywords of this HighlightGroupsCommandDescriptor.
+        List of terms or phrases to highlight if found.
+
+
+        :param keywords: The keywords of this HighlightGroupsCommandDescriptor.
+        :type: list[str]
+        """
+        self._keywords = keywords
+
+    @property
+    def sub_queries(self):
+        """
+        Gets the sub_queries of this HighlightGroupsCommandDescriptor.
+        List of subQueries specified as highlightgroups command arguments
+
+
+        :return: The sub_queries of this HighlightGroupsCommandDescriptor.
+        :rtype: list[oci.log_analytics.models.ParseQueryOutput]
+        """
+        return self._sub_queries
+
+    @sub_queries.setter
+    def sub_queries(self, sub_queries):
+        """
+        Sets the sub_queries of this HighlightGroupsCommandDescriptor.
+        List of subQueries specified as highlightgroups command arguments
+
+
+        :param sub_queries: The sub_queries of this HighlightGroupsCommandDescriptor.
+        :type: list[oci.log_analytics.models.ParseQueryOutput]
+        """
+        self._sub_queries = sub_queries
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/highlight_rows_command_descriptor.py
+++ b/src/oci/log_analytics/models/highlight_rows_command_descriptor.py
@@ -21,7 +21,7 @@ class HighlightRowsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this HighlightRowsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:
@@ -44,6 +44,10 @@ class HighlightRowsCommandDescriptor(AbstractCommandDescriptor):
             The value to assign to the declared_fields property of this HighlightRowsCommandDescriptor.
         :type declared_fields: list[oci.log_analytics.models.AbstractField]
 
+        :param color:
+            The value to assign to the color property of this HighlightRowsCommandDescriptor.
+        :type color: str
+
         :param keywords:
             The value to assign to the keywords property of this HighlightRowsCommandDescriptor.
         :type keywords: list[str]
@@ -56,6 +60,7 @@ class HighlightRowsCommandDescriptor(AbstractCommandDescriptor):
             'category': 'str',
             'referenced_fields': 'list[AbstractField]',
             'declared_fields': 'list[AbstractField]',
+            'color': 'str',
             'keywords': 'list[str]'
         }
 
@@ -66,6 +71,7 @@ class HighlightRowsCommandDescriptor(AbstractCommandDescriptor):
             'category': 'category',
             'referenced_fields': 'referencedFields',
             'declared_fields': 'declaredFields',
+            'color': 'color',
             'keywords': 'keywords'
         }
 
@@ -75,8 +81,33 @@ class HighlightRowsCommandDescriptor(AbstractCommandDescriptor):
         self._category = None
         self._referenced_fields = None
         self._declared_fields = None
+        self._color = None
         self._keywords = None
         self._name = 'HIGHLIGHT_ROWS'
+
+    @property
+    def color(self):
+        """
+        Gets the color of this HighlightRowsCommandDescriptor.
+        User specified color to highlight matches with if found.
+
+
+        :return: The color of this HighlightRowsCommandDescriptor.
+        :rtype: str
+        """
+        return self._color
+
+    @color.setter
+    def color(self, color):
+        """
+        Sets the color of this HighlightRowsCommandDescriptor.
+        User specified color to highlight matches with if found.
+
+
+        :param color: The color of this HighlightRowsCommandDescriptor.
+        :type: str
+        """
+        self._color = color
 
     @property
     def keywords(self):

--- a/src/oci/log_analytics/models/link_command_descriptor.py
+++ b/src/oci/log_analytics/models/link_command_descriptor.py
@@ -21,7 +21,7 @@ class LinkCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this LinkCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/link_details_command_descriptor.py
+++ b/src/oci/log_analytics/models/link_details_command_descriptor.py
@@ -21,7 +21,7 @@ class LinkDetailsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this LinkDetailsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/log_analytics_config_work_request.py
+++ b/src/oci/log_analytics/models/log_analytics_config_work_request.py
@@ -21,6 +21,18 @@ class LogAnalyticsConfigWorkRequest(object):
     #: This constant has a value of "DELETE_ASSOCIATIONS"
     OPERATION_TYPE_DELETE_ASSOCIATIONS = "DELETE_ASSOCIATIONS"
 
+    #: A constant which can be used with the operation_type property of a LogAnalyticsConfigWorkRequest.
+    #: This constant has a value of "APPEND_LOOKUP_DATA"
+    OPERATION_TYPE_APPEND_LOOKUP_DATA = "APPEND_LOOKUP_DATA"
+
+    #: A constant which can be used with the operation_type property of a LogAnalyticsConfigWorkRequest.
+    #: This constant has a value of "UPDATE_LOOKUP_DATA"
+    OPERATION_TYPE_UPDATE_LOOKUP_DATA = "UPDATE_LOOKUP_DATA"
+
+    #: A constant which can be used with the operation_type property of a LogAnalyticsConfigWorkRequest.
+    #: This constant has a value of "DELETE_LOOKUP"
+    OPERATION_TYPE_DELETE_LOOKUP = "DELETE_LOOKUP"
+
     #: A constant which can be used with the lifecycle_state property of a LogAnalyticsConfigWorkRequest.
     #: This constant has a value of "ACCEPTED"
     LIFECYCLE_STATE_ACCEPTED = "ACCEPTED"
@@ -52,7 +64,7 @@ class LogAnalyticsConfigWorkRequest(object):
 
         :param operation_type:
             The value to assign to the operation_type property of this LogAnalyticsConfigWorkRequest.
-            Allowed values for this property are: "CREATE_ASSOCIATIONS", "DELETE_ASSOCIATIONS", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATE_ASSOCIATIONS", "DELETE_ASSOCIATIONS", "APPEND_LOOKUP_DATA", "UPDATE_LOOKUP_DATA", "DELETE_LOOKUP", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type operation_type: str
 
@@ -171,7 +183,7 @@ class LogAnalyticsConfigWorkRequest(object):
         Gets the operation_type of this LogAnalyticsConfigWorkRequest.
         operation type
 
-        Allowed values for this property are: "CREATE_ASSOCIATIONS", "DELETE_ASSOCIATIONS", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATE_ASSOCIATIONS", "DELETE_ASSOCIATIONS", "APPEND_LOOKUP_DATA", "UPDATE_LOOKUP_DATA", "DELETE_LOOKUP", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -190,7 +202,7 @@ class LogAnalyticsConfigWorkRequest(object):
         :param operation_type: The operation_type of this LogAnalyticsConfigWorkRequest.
         :type: str
         """
-        allowed_values = ["CREATE_ASSOCIATIONS", "DELETE_ASSOCIATIONS"]
+        allowed_values = ["CREATE_ASSOCIATIONS", "DELETE_ASSOCIATIONS", "APPEND_LOOKUP_DATA", "UPDATE_LOOKUP_DATA", "DELETE_LOOKUP"]
         if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
             operation_type = 'UNKNOWN_ENUM_VALUE'
         self._operation_type = operation_type

--- a/src/oci/log_analytics/models/log_analytics_config_work_request_payload.py
+++ b/src/oci/log_analytics/models/log_analytics_config_work_request_payload.py
@@ -30,22 +30,29 @@ class LogAnalyticsConfigWorkRequestPayload(object):
             The value to assign to the lookup_reference property of this LogAnalyticsConfigWorkRequestPayload.
         :type lookup_reference: int
 
+        :param lookup_reference_string:
+            The value to assign to the lookup_reference_string property of this LogAnalyticsConfigWorkRequestPayload.
+        :type lookup_reference_string: str
+
         """
         self.swagger_types = {
             'source_name': 'str',
             'entity_id': 'str',
-            'lookup_reference': 'int'
+            'lookup_reference': 'int',
+            'lookup_reference_string': 'str'
         }
 
         self.attribute_map = {
             'source_name': 'sourceName',
             'entity_id': 'entityId',
-            'lookup_reference': 'lookupReference'
+            'lookup_reference': 'lookupReference',
+            'lookup_reference_string': 'lookupReferenceString'
         }
 
         self._source_name = None
         self._entity_id = None
         self._lookup_reference = None
+        self._lookup_reference_string = None
 
     @property
     def source_name(self):
@@ -118,6 +125,30 @@ class LogAnalyticsConfigWorkRequestPayload(object):
         :type: int
         """
         self._lookup_reference = lookup_reference
+
+    @property
+    def lookup_reference_string(self):
+        """
+        Gets the lookup_reference_string of this LogAnalyticsConfigWorkRequestPayload.
+        lookupReference
+
+
+        :return: The lookup_reference_string of this LogAnalyticsConfigWorkRequestPayload.
+        :rtype: str
+        """
+        return self._lookup_reference_string
+
+    @lookup_reference_string.setter
+    def lookup_reference_string(self, lookup_reference_string):
+        """
+        Sets the lookup_reference_string of this LogAnalyticsConfigWorkRequestPayload.
+        lookupReference
+
+
+        :param lookup_reference_string: The lookup_reference_string of this LogAnalyticsConfigWorkRequestPayload.
+        :type: str
+        """
+        self._lookup_reference_string = lookup_reference_string
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/log_analytics/models/log_analytics_config_work_request_summary.py
+++ b/src/oci/log_analytics/models/log_analytics_config_work_request_summary.py
@@ -21,6 +21,18 @@ class LogAnalyticsConfigWorkRequestSummary(object):
     #: This constant has a value of "DELETE_ASSOCIATIONS"
     OPERATION_TYPE_DELETE_ASSOCIATIONS = "DELETE_ASSOCIATIONS"
 
+    #: A constant which can be used with the operation_type property of a LogAnalyticsConfigWorkRequestSummary.
+    #: This constant has a value of "APPEND_LOOKUP_DATA"
+    OPERATION_TYPE_APPEND_LOOKUP_DATA = "APPEND_LOOKUP_DATA"
+
+    #: A constant which can be used with the operation_type property of a LogAnalyticsConfigWorkRequestSummary.
+    #: This constant has a value of "UPDATE_LOOKUP_DATA"
+    OPERATION_TYPE_UPDATE_LOOKUP_DATA = "UPDATE_LOOKUP_DATA"
+
+    #: A constant which can be used with the operation_type property of a LogAnalyticsConfigWorkRequestSummary.
+    #: This constant has a value of "DELETE_LOOKUP"
+    OPERATION_TYPE_DELETE_LOOKUP = "DELETE_LOOKUP"
+
     #: A constant which can be used with the lifecycle_state property of a LogAnalyticsConfigWorkRequestSummary.
     #: This constant has a value of "ACCEPTED"
     LIFECYCLE_STATE_ACCEPTED = "ACCEPTED"
@@ -52,7 +64,7 @@ class LogAnalyticsConfigWorkRequestSummary(object):
 
         :param operation_type:
             The value to assign to the operation_type property of this LogAnalyticsConfigWorkRequestSummary.
-            Allowed values for this property are: "CREATE_ASSOCIATIONS", "DELETE_ASSOCIATIONS", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATE_ASSOCIATIONS", "DELETE_ASSOCIATIONS", "APPEND_LOOKUP_DATA", "UPDATE_LOOKUP_DATA", "DELETE_LOOKUP", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type operation_type: str
 
@@ -157,7 +169,7 @@ class LogAnalyticsConfigWorkRequestSummary(object):
         Gets the operation_type of this LogAnalyticsConfigWorkRequestSummary.
         operation type
 
-        Allowed values for this property are: "CREATE_ASSOCIATIONS", "DELETE_ASSOCIATIONS", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATE_ASSOCIATIONS", "DELETE_ASSOCIATIONS", "APPEND_LOOKUP_DATA", "UPDATE_LOOKUP_DATA", "DELETE_LOOKUP", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -176,7 +188,7 @@ class LogAnalyticsConfigWorkRequestSummary(object):
         :param operation_type: The operation_type of this LogAnalyticsConfigWorkRequestSummary.
         :type: str
         """
-        allowed_values = ["CREATE_ASSOCIATIONS", "DELETE_ASSOCIATIONS"]
+        allowed_values = ["CREATE_ASSOCIATIONS", "DELETE_ASSOCIATIONS", "APPEND_LOOKUP_DATA", "UPDATE_LOOKUP_DATA", "DELETE_LOOKUP"]
         if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
             operation_type = 'UNKNOWN_ENUM_VALUE'
         self._operation_type = operation_type

--- a/src/oci/log_analytics/models/log_analytics_entity.py
+++ b/src/oci/log_analytics/models/log_analytics_entity.py
@@ -206,7 +206,7 @@ class LogAnalyticsEntity(object):
     def name(self):
         """
         **[Required]** Gets the name of this LogAnalyticsEntity.
-        Log analytics entity name. The name must be unique, within the tenancy, and cannot be changed.
+        Log analytics entity name.
 
 
         :return: The name of this LogAnalyticsEntity.
@@ -218,7 +218,7 @@ class LogAnalyticsEntity(object):
     def name(self, name):
         """
         Sets the name of this LogAnalyticsEntity.
-        Log analytics entity name. The name must be unique, within the tenancy, and cannot be changed.
+        Log analytics entity name.
 
 
         :param name: The name of this LogAnalyticsEntity.

--- a/src/oci/log_analytics/models/log_analytics_entity_summary.py
+++ b/src/oci/log_analytics/models/log_analytics_entity_summary.py
@@ -178,7 +178,7 @@ class LogAnalyticsEntitySummary(object):
     def name(self):
         """
         **[Required]** Gets the name of this LogAnalyticsEntitySummary.
-        Log analytics entity name. The name must be unique, within the tenancy, and cannot be changed.
+        Log analytics entity name.
 
 
         :return: The name of this LogAnalyticsEntitySummary.
@@ -190,7 +190,7 @@ class LogAnalyticsEntitySummary(object):
     def name(self, name):
         """
         Sets the name of this LogAnalyticsEntitySummary.
-        Log analytics entity name. The name must be unique, within the tenancy, and cannot be changed.
+        Log analytics entity name.
 
 
         :param name: The name of this LogAnalyticsEntitySummary.

--- a/src/oci/log_analytics/models/log_analytics_entity_type.py
+++ b/src/oci/log_analytics/models/log_analytics_entity_type.py
@@ -213,7 +213,7 @@ class LogAnalyticsEntityType(object):
     def cloud_type(self):
         """
         **[Required]** Gets the cloud_type of this LogAnalyticsEntityType.
-        Nature of log analytics entity type.
+        Log analytics entity type group. That can be CLOUD (OCI) or NON_CLOUD otherwise.
 
         Allowed values for this property are: "CLOUD", "NON_CLOUD", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -228,7 +228,7 @@ class LogAnalyticsEntityType(object):
     def cloud_type(self, cloud_type):
         """
         Sets the cloud_type of this LogAnalyticsEntityType.
-        Nature of log analytics entity type.
+        Log analytics entity type group. That can be CLOUD (OCI) or NON_CLOUD otherwise.
 
 
         :param cloud_type: The cloud_type of this LogAnalyticsEntityType.
@@ -267,7 +267,7 @@ class LogAnalyticsEntityType(object):
     def lifecycle_state(self):
         """
         **[Required]** Gets the lifecycle_state of this LogAnalyticsEntityType.
-        The current state of the log analytics entity.
+        The current lifecycle state of the log analytics entity.
 
         Allowed values for this property are: "ACTIVE", "DELETED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -282,7 +282,7 @@ class LogAnalyticsEntityType(object):
     def lifecycle_state(self, lifecycle_state):
         """
         Sets the lifecycle_state of this LogAnalyticsEntityType.
-        The current state of the log analytics entity.
+        The current lifecycle state of the log analytics entity.
 
 
         :param lifecycle_state: The lifecycle_state of this LogAnalyticsEntityType.

--- a/src/oci/log_analytics/models/log_analytics_entity_type_summary.py
+++ b/src/oci/log_analytics/models/log_analytics_entity_type_summary.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class LogAnalyticsEntityTypeSummary(object):
     """
-    Summary of an log analytics entity type.
+    Summary of a log analytics entity type.
     """
 
     #: A constant which can be used with the cloud_type property of a LogAnalyticsEntityTypeSummary.
@@ -171,7 +171,7 @@ class LogAnalyticsEntityTypeSummary(object):
     def cloud_type(self):
         """
         **[Required]** Gets the cloud_type of this LogAnalyticsEntityTypeSummary.
-        Nature of log analytics entity type.
+        Log analytics entity type group. This can be CLOUD (OCI) or NON_CLOUD otherwise.
 
         Allowed values for this property are: "CLOUD", "NON_CLOUD", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -186,7 +186,7 @@ class LogAnalyticsEntityTypeSummary(object):
     def cloud_type(self, cloud_type):
         """
         Sets the cloud_type of this LogAnalyticsEntityTypeSummary.
-        Nature of log analytics entity type.
+        Log analytics entity type group. This can be CLOUD (OCI) or NON_CLOUD otherwise.
 
 
         :param cloud_type: The cloud_type of this LogAnalyticsEntityTypeSummary.
@@ -201,7 +201,7 @@ class LogAnalyticsEntityTypeSummary(object):
     def lifecycle_state(self):
         """
         **[Required]** Gets the lifecycle_state of this LogAnalyticsEntityTypeSummary.
-        The current state of the log analytics entity
+        The current lifecycle state of the log analytics entity type.
 
         Allowed values for this property are: "ACTIVE", "DELETED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -216,7 +216,7 @@ class LogAnalyticsEntityTypeSummary(object):
     def lifecycle_state(self, lifecycle_state):
         """
         Sets the lifecycle_state of this LogAnalyticsEntityTypeSummary.
-        The current state of the log analytics entity
+        The current lifecycle state of the log analytics entity type.
 
 
         :param lifecycle_state: The lifecycle_state of this LogAnalyticsEntityTypeSummary.

--- a/src/oci/log_analytics/models/log_analytics_lookup.py
+++ b/src/oci/log_analytics/models/log_analytics_lookup.py
@@ -13,6 +13,14 @@ class LogAnalyticsLookup(object):
     LogAnalyticsLookup
     """
 
+    #: A constant which can be used with the type property of a LogAnalyticsLookup.
+    #: This constant has a value of "Lookup"
+    TYPE_LOOKUP = "Lookup"
+
+    #: A constant which can be used with the type property of a LogAnalyticsLookup.
+    #: This constant has a value of "Dictionary"
+    TYPE_DICTIONARY = "Dictionary"
+
     def __init__(self, **kwargs):
         """
         Initializes a new LogAnalyticsLookup object with values from keyword arguments.
@@ -41,6 +49,16 @@ class LogAnalyticsLookup(object):
         :param lookup_reference:
             The value to assign to the lookup_reference property of this LogAnalyticsLookup.
         :type lookup_reference: int
+
+        :param lookup_reference_string:
+            The value to assign to the lookup_reference_string property of this LogAnalyticsLookup.
+        :type lookup_reference_string: str
+
+        :param type:
+            The value to assign to the type property of this LogAnalyticsLookup.
+            Allowed values for this property are: "Lookup", "Dictionary", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type type: str
 
         :param name:
             The value to assign to the name property of this LogAnalyticsLookup.
@@ -78,6 +96,8 @@ class LogAnalyticsLookup(object):
             'edit_version': 'int',
             'fields': 'list[LookupField]',
             'lookup_reference': 'int',
+            'lookup_reference_string': 'str',
+            'type': 'str',
             'name': 'str',
             'is_built_in': 'int',
             'is_hidden': 'bool',
@@ -94,6 +114,8 @@ class LogAnalyticsLookup(object):
             'edit_version': 'editVersion',
             'fields': 'fields',
             'lookup_reference': 'lookupReference',
+            'lookup_reference_string': 'lookupReferenceString',
+            'type': 'type',
             'name': 'name',
             'is_built_in': 'isBuiltIn',
             'is_hidden': 'isHidden',
@@ -109,6 +131,8 @@ class LogAnalyticsLookup(object):
         self._edit_version = None
         self._fields = None
         self._lookup_reference = None
+        self._lookup_reference_string = None
+        self._type = None
         self._name = None
         self._is_built_in = None
         self._is_hidden = None
@@ -241,7 +265,7 @@ class LogAnalyticsLookup(object):
     def lookup_reference(self):
         """
         Gets the lookup_reference of this LogAnalyticsLookup.
-        lookupReference
+        The lookup reference as an integer.
 
 
         :return: The lookup_reference of this LogAnalyticsLookup.
@@ -253,13 +277,67 @@ class LogAnalyticsLookup(object):
     def lookup_reference(self, lookup_reference):
         """
         Sets the lookup_reference of this LogAnalyticsLookup.
-        lookupReference
+        The lookup reference as an integer.
 
 
         :param lookup_reference: The lookup_reference of this LogAnalyticsLookup.
         :type: int
         """
         self._lookup_reference = lookup_reference
+
+    @property
+    def lookup_reference_string(self):
+        """
+        Gets the lookup_reference_string of this LogAnalyticsLookup.
+        The lookup reference as a string.
+
+
+        :return: The lookup_reference_string of this LogAnalyticsLookup.
+        :rtype: str
+        """
+        return self._lookup_reference_string
+
+    @lookup_reference_string.setter
+    def lookup_reference_string(self, lookup_reference_string):
+        """
+        Sets the lookup_reference_string of this LogAnalyticsLookup.
+        The lookup reference as a string.
+
+
+        :param lookup_reference_string: The lookup_reference_string of this LogAnalyticsLookup.
+        :type: str
+        """
+        self._lookup_reference_string = lookup_reference_string
+
+    @property
+    def type(self):
+        """
+        Gets the type of this LogAnalyticsLookup.
+        The lookup type.  Valid values are LOOKUP or DICTIONARY.
+
+        Allowed values for this property are: "Lookup", "Dictionary", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The type of this LogAnalyticsLookup.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this LogAnalyticsLookup.
+        The lookup type.  Valid values are LOOKUP or DICTIONARY.
+
+
+        :param type: The type of this LogAnalyticsLookup.
+        :type: str
+        """
+        allowed_values = ["Lookup", "Dictionary"]
+        if not value_allowed_none_or_none_sentinel(type, allowed_values):
+            type = 'UNKNOWN_ENUM_VALUE'
+        self._type = type
 
     @property
     def name(self):

--- a/src/oci/log_analytics/models/log_analytics_lookup_collection.py
+++ b/src/oci/log_analytics/models/log_analytics_lookup_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class LogAnalyticsLookupCollection(object):
+    """
+    LogAnalytics Lookup Collection
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new LogAnalyticsLookupCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this LogAnalyticsLookupCollection.
+        :type items: list[oci.log_analytics.models.LogAnalyticsLookup]
+
+        """
+        self.swagger_types = {
+            'items': 'list[LogAnalyticsLookup]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        Gets the items of this LogAnalyticsLookupCollection.
+        list of fields
+
+
+        :return: The items of this LogAnalyticsLookupCollection.
+        :rtype: list[oci.log_analytics.models.LogAnalyticsLookup]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this LogAnalyticsLookupCollection.
+        list of fields
+
+
+        :param items: The items of this LogAnalyticsLookupCollection.
+        :type: list[oci.log_analytics.models.LogAnalyticsLookup]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/log_analytics_lookup_fields.py
+++ b/src/oci/log_analytics/models/log_analytics_lookup_fields.py
@@ -1,0 +1,256 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class LogAnalyticsLookupFields(object):
+    """
+    LogAnalyticsLookupFields
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new LogAnalyticsLookupFields object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param common_field_name:
+            The value to assign to the common_field_name property of this LogAnalyticsLookupFields.
+        :type common_field_name: str
+
+        :param default_match_value:
+            The value to assign to the default_match_value property of this LogAnalyticsLookupFields.
+        :type default_match_value: str
+
+        :param display_name:
+            The value to assign to the display_name property of this LogAnalyticsLookupFields.
+        :type display_name: str
+
+        :param is_common_field:
+            The value to assign to the is_common_field property of this LogAnalyticsLookupFields.
+        :type is_common_field: bool
+
+        :param match_operator:
+            The value to assign to the match_operator property of this LogAnalyticsLookupFields.
+        :type match_operator: str
+
+        :param name:
+            The value to assign to the name property of this LogAnalyticsLookupFields.
+        :type name: str
+
+        :param position:
+            The value to assign to the position property of this LogAnalyticsLookupFields.
+        :type position: int
+
+        """
+        self.swagger_types = {
+            'common_field_name': 'str',
+            'default_match_value': 'str',
+            'display_name': 'str',
+            'is_common_field': 'bool',
+            'match_operator': 'str',
+            'name': 'str',
+            'position': 'int'
+        }
+
+        self.attribute_map = {
+            'common_field_name': 'commonFieldName',
+            'default_match_value': 'defaultMatchValue',
+            'display_name': 'displayName',
+            'is_common_field': 'isCommonField',
+            'match_operator': 'matchOperator',
+            'name': 'name',
+            'position': 'position'
+        }
+
+        self._common_field_name = None
+        self._default_match_value = None
+        self._display_name = None
+        self._is_common_field = None
+        self._match_operator = None
+        self._name = None
+        self._position = None
+
+    @property
+    def common_field_name(self):
+        """
+        Gets the common_field_name of this LogAnalyticsLookupFields.
+        The common field name.
+
+
+        :return: The common_field_name of this LogAnalyticsLookupFields.
+        :rtype: str
+        """
+        return self._common_field_name
+
+    @common_field_name.setter
+    def common_field_name(self, common_field_name):
+        """
+        Sets the common_field_name of this LogAnalyticsLookupFields.
+        The common field name.
+
+
+        :param common_field_name: The common_field_name of this LogAnalyticsLookupFields.
+        :type: str
+        """
+        self._common_field_name = common_field_name
+
+    @property
+    def default_match_value(self):
+        """
+        Gets the default_match_value of this LogAnalyticsLookupFields.
+        The default match value.
+
+
+        :return: The default_match_value of this LogAnalyticsLookupFields.
+        :rtype: str
+        """
+        return self._default_match_value
+
+    @default_match_value.setter
+    def default_match_value(self, default_match_value):
+        """
+        Sets the default_match_value of this LogAnalyticsLookupFields.
+        The default match value.
+
+
+        :param default_match_value: The default_match_value of this LogAnalyticsLookupFields.
+        :type: str
+        """
+        self._default_match_value = default_match_value
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this LogAnalyticsLookupFields.
+        The display name.
+
+
+        :return: The display_name of this LogAnalyticsLookupFields.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this LogAnalyticsLookupFields.
+        The display name.
+
+
+        :param display_name: The display_name of this LogAnalyticsLookupFields.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def is_common_field(self):
+        """
+        Gets the is_common_field of this LogAnalyticsLookupFields.
+        A flag indicating whether or not the field is a common field.
+
+
+        :return: The is_common_field of this LogAnalyticsLookupFields.
+        :rtype: bool
+        """
+        return self._is_common_field
+
+    @is_common_field.setter
+    def is_common_field(self, is_common_field):
+        """
+        Sets the is_common_field of this LogAnalyticsLookupFields.
+        A flag indicating whether or not the field is a common field.
+
+
+        :param is_common_field: The is_common_field of this LogAnalyticsLookupFields.
+        :type: bool
+        """
+        self._is_common_field = is_common_field
+
+    @property
+    def match_operator(self):
+        """
+        Gets the match_operator of this LogAnalyticsLookupFields.
+        The match operator.
+
+
+        :return: The match_operator of this LogAnalyticsLookupFields.
+        :rtype: str
+        """
+        return self._match_operator
+
+    @match_operator.setter
+    def match_operator(self, match_operator):
+        """
+        Sets the match_operator of this LogAnalyticsLookupFields.
+        The match operator.
+
+
+        :param match_operator: The match_operator of this LogAnalyticsLookupFields.
+        :type: str
+        """
+        self._match_operator = match_operator
+
+    @property
+    def name(self):
+        """
+        Gets the name of this LogAnalyticsLookupFields.
+        The field name.
+
+
+        :return: The name of this LogAnalyticsLookupFields.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this LogAnalyticsLookupFields.
+        The field name.
+
+
+        :param name: The name of this LogAnalyticsLookupFields.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def position(self):
+        """
+        Gets the position of this LogAnalyticsLookupFields.
+        The position.
+
+
+        :return: The position of this LogAnalyticsLookupFields.
+        :rtype: int
+        """
+        return self._position
+
+    @position.setter
+    def position(self, position):
+        """
+        Sets the position of this LogAnalyticsLookupFields.
+        The position.
+
+
+        :param position: The position of this LogAnalyticsLookupFields.
+        :type: int
+        """
+        self._position = position
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/log_analytics_object_collection_rule.py
+++ b/src/oci/log_analytics/models/log_analytics_object_collection_rule.py
@@ -33,6 +33,10 @@ class LogAnalyticsObjectCollectionRule(object):
     #: This constant has a value of "DELETED"
     LIFECYCLE_STATE_DELETED = "DELETED"
 
+    #: A constant which can be used with the lifecycle_state property of a LogAnalyticsObjectCollectionRule.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new LogAnalyticsObjectCollectionRule object with values from keyword arguments.
@@ -98,7 +102,7 @@ class LogAnalyticsObjectCollectionRule(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this LogAnalyticsObjectCollectionRule.
-            Allowed values for this property are: "ACTIVE", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ACTIVE", "DELETED", "INACTIVE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -113,6 +117,10 @@ class LogAnalyticsObjectCollectionRule(object):
         :param time_updated:
             The value to assign to the time_updated property of this LogAnalyticsObjectCollectionRule.
         :type time_updated: datetime
+
+        :param is_enabled:
+            The value to assign to the is_enabled property of this LogAnalyticsObjectCollectionRule.
+        :type is_enabled: bool
 
         :param defined_tags:
             The value to assign to the defined_tags property of this LogAnalyticsObjectCollectionRule.
@@ -142,6 +150,7 @@ class LogAnalyticsObjectCollectionRule(object):
             'lifecycle_details': 'str',
             'time_created': 'datetime',
             'time_updated': 'datetime',
+            'is_enabled': 'bool',
             'defined_tags': 'dict(str, dict(str, object))',
             'freeform_tags': 'dict(str, str)'
         }
@@ -165,6 +174,7 @@ class LogAnalyticsObjectCollectionRule(object):
             'lifecycle_details': 'lifecycleDetails',
             'time_created': 'timeCreated',
             'time_updated': 'timeUpdated',
+            'is_enabled': 'isEnabled',
             'defined_tags': 'definedTags',
             'freeform_tags': 'freeformTags'
         }
@@ -187,6 +197,7 @@ class LogAnalyticsObjectCollectionRule(object):
         self._lifecycle_details = None
         self._time_created = None
         self._time_updated = None
+        self._is_enabled = None
         self._defined_tags = None
         self._freeform_tags = None
 
@@ -348,8 +359,7 @@ class LogAnalyticsObjectCollectionRule(object):
     def collection_type(self):
         """
         **[Required]** Gets the collection_type of this LogAnalyticsObjectCollectionRule.
-        The type of collection.
-        Supported collection types: LIVE, HISTORIC, HISTORIC_LIVE
+        The type of log collection.
 
         Allowed values for this property are: "LIVE", "HISTORIC", "HISTORIC_LIVE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -364,8 +374,7 @@ class LogAnalyticsObjectCollectionRule(object):
     def collection_type(self, collection_type):
         """
         Sets the collection_type of this LogAnalyticsObjectCollectionRule.
-        The type of collection.
-        Supported collection types: LIVE, HISTORIC, HISTORIC_LIVE
+        The type of log collection.
 
 
         :param collection_type: The collection_type of this LogAnalyticsObjectCollectionRule.
@@ -382,7 +391,7 @@ class LogAnalyticsObjectCollectionRule(object):
         **[Required]** Gets the poll_since of this LogAnalyticsObjectCollectionRule.
         The oldest time of the file in the bucket to consider for collection.
         Accepted values are: BEGINNING or CURRENT_TIME or RFC3339 formatted datetime string.
-        When collectionType is LIVE, specifying pollSince value other than CURRENT_TIME will result in error.
+        Use this for HISTORIC or HISTORIC_LIVE collection types. When collectionType is LIVE, specifying pollSince value other than CURRENT_TIME will result in error.
 
 
         :return: The poll_since of this LogAnalyticsObjectCollectionRule.
@@ -396,7 +405,7 @@ class LogAnalyticsObjectCollectionRule(object):
         Sets the poll_since of this LogAnalyticsObjectCollectionRule.
         The oldest time of the file in the bucket to consider for collection.
         Accepted values are: BEGINNING or CURRENT_TIME or RFC3339 formatted datetime string.
-        When collectionType is LIVE, specifying pollSince value other than CURRENT_TIME will result in error.
+        Use this for HISTORIC or HISTORIC_LIVE collection types. When collectionType is LIVE, specifying pollSince value other than CURRENT_TIME will result in error.
 
 
         :param poll_since: The poll_since of this LogAnalyticsObjectCollectionRule.
@@ -408,9 +417,9 @@ class LogAnalyticsObjectCollectionRule(object):
     def poll_till(self):
         """
         Gets the poll_till of this LogAnalyticsObjectCollectionRule.
-        The oldest time of the file in the bucket to consider for collection.
+        The newest time of the file in the bucket to consider for collection.
         Accepted values are: CURRENT_TIME or RFC3339 formatted datetime string.
-        When collectionType is LIVE, specifying pollTill will result in error.
+        Use this for HISTORIC collection type. When collectionType is LIVE or HISTORIC_LIVE, specifying pollTill will result in error.
 
 
         :return: The poll_till of this LogAnalyticsObjectCollectionRule.
@@ -422,9 +431,9 @@ class LogAnalyticsObjectCollectionRule(object):
     def poll_till(self, poll_till):
         """
         Sets the poll_till of this LogAnalyticsObjectCollectionRule.
-        The oldest time of the file in the bucket to consider for collection.
+        The newest time of the file in the bucket to consider for collection.
         Accepted values are: CURRENT_TIME or RFC3339 formatted datetime string.
-        When collectionType is LIVE, specifying pollTill will result in error.
+        Use this for HISTORIC collection type. When collectionType is LIVE or HISTORIC_LIVE, specifying pollTill will result in error.
 
 
         :param poll_till: The poll_till of this LogAnalyticsObjectCollectionRule.
@@ -509,7 +518,7 @@ class LogAnalyticsObjectCollectionRule(object):
         """
         Gets the char_encoding of this LogAnalyticsObjectCollectionRule.
         An optional character encoding to aid in detecting the character encoding of the contents of the objects while processing.
-        It is recommended to set this value as ISO_8589_1 when configuring content of the objects having more numeric characters,
+        It is recommended to set this value as ISO_8859_1 when configuring content of the objects having more numeric characters,
         and very few alphabets.
         For e.g. this applies when configuring VCN Flow Logs.
 
@@ -524,7 +533,7 @@ class LogAnalyticsObjectCollectionRule(object):
         """
         Sets the char_encoding of this LogAnalyticsObjectCollectionRule.
         An optional character encoding to aid in detecting the character encoding of the contents of the objects while processing.
-        It is recommended to set this value as ISO_8589_1 when configuring content of the objects having more numeric characters,
+        It is recommended to set this value as ISO_8859_1 when configuring content of the objects having more numeric characters,
         and very few alphabets.
         For e.g. this applies when configuring VCN Flow Logs.
 
@@ -568,7 +577,7 @@ class LogAnalyticsObjectCollectionRule(object):
         **[Required]** Gets the lifecycle_state of this LogAnalyticsObjectCollectionRule.
         The current state of the rule.
 
-        Allowed values for this property are: "ACTIVE", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ACTIVE", "DELETED", "INACTIVE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -587,7 +596,7 @@ class LogAnalyticsObjectCollectionRule(object):
         :param lifecycle_state: The lifecycle_state of this LogAnalyticsObjectCollectionRule.
         :type: str
         """
-        allowed_values = ["ACTIVE", "DELETED"]
+        allowed_values = ["ACTIVE", "DELETED", "INACTIVE"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
@@ -663,6 +672,30 @@ class LogAnalyticsObjectCollectionRule(object):
         :type: datetime
         """
         self._time_updated = time_updated
+
+    @property
+    def is_enabled(self):
+        """
+        **[Required]** Gets the is_enabled of this LogAnalyticsObjectCollectionRule.
+        Whether or not this rule is currently enabled.
+
+
+        :return: The is_enabled of this LogAnalyticsObjectCollectionRule.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this LogAnalyticsObjectCollectionRule.
+        Whether or not this rule is currently enabled.
+
+
+        :param is_enabled: The is_enabled of this LogAnalyticsObjectCollectionRule.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
 
     @property
     def defined_tags(self):

--- a/src/oci/log_analytics/models/log_analytics_object_collection_rule_collection.py
+++ b/src/oci/log_analytics/models/log_analytics_object_collection_rule_collection.py
@@ -37,7 +37,7 @@ class LogAnalyticsObjectCollectionRuleCollection(object):
     def items(self):
         """
         **[Required]** Gets the items of this LogAnalyticsObjectCollectionRuleCollection.
-        list of LogAnalyticsObjectCollectionRuleSummary objects.
+        List of LogAnalyticsObjectCollectionRuleSummary objects.
 
 
         :return: The items of this LogAnalyticsObjectCollectionRuleCollection.
@@ -49,7 +49,7 @@ class LogAnalyticsObjectCollectionRuleCollection(object):
     def items(self, items):
         """
         Sets the items of this LogAnalyticsObjectCollectionRuleCollection.
-        list of LogAnalyticsObjectCollectionRuleSummary objects.
+        List of LogAnalyticsObjectCollectionRuleSummary objects.
 
 
         :param items: The items of this LogAnalyticsObjectCollectionRuleCollection.

--- a/src/oci/log_analytics/models/log_analytics_object_collection_rule_summary.py
+++ b/src/oci/log_analytics/models/log_analytics_object_collection_rule_summary.py
@@ -25,6 +25,18 @@ class LogAnalyticsObjectCollectionRuleSummary(object):
     #: This constant has a value of "HISTORIC_LIVE"
     COLLECTION_TYPE_HISTORIC_LIVE = "HISTORIC_LIVE"
 
+    #: A constant which can be used with the lifecycle_state property of a LogAnalyticsObjectCollectionRuleSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a LogAnalyticsObjectCollectionRuleSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a LogAnalyticsObjectCollectionRuleSummary.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new LogAnalyticsObjectCollectionRuleSummary object with values from keyword arguments.
@@ -62,6 +74,8 @@ class LogAnalyticsObjectCollectionRuleSummary(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this LogAnalyticsObjectCollectionRuleSummary.
+            Allowed values for this property are: "ACTIVE", "DELETED", "INACTIVE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
         :param lifecycle_details:
@@ -75,6 +89,10 @@ class LogAnalyticsObjectCollectionRuleSummary(object):
         :param time_updated:
             The value to assign to the time_updated property of this LogAnalyticsObjectCollectionRuleSummary.
         :type time_updated: datetime
+
+        :param is_enabled:
+            The value to assign to the is_enabled property of this LogAnalyticsObjectCollectionRuleSummary.
+        :type is_enabled: bool
 
         :param defined_tags:
             The value to assign to the defined_tags property of this LogAnalyticsObjectCollectionRuleSummary.
@@ -97,6 +115,7 @@ class LogAnalyticsObjectCollectionRuleSummary(object):
             'lifecycle_details': 'str',
             'time_created': 'datetime',
             'time_updated': 'datetime',
+            'is_enabled': 'bool',
             'defined_tags': 'dict(str, dict(str, object))',
             'freeform_tags': 'dict(str, str)'
         }
@@ -113,6 +132,7 @@ class LogAnalyticsObjectCollectionRuleSummary(object):
             'lifecycle_details': 'lifecycleDetails',
             'time_created': 'timeCreated',
             'time_updated': 'timeUpdated',
+            'is_enabled': 'isEnabled',
             'defined_tags': 'definedTags',
             'freeform_tags': 'freeformTags'
         }
@@ -128,6 +148,7 @@ class LogAnalyticsObjectCollectionRuleSummary(object):
         self._lifecycle_details = None
         self._time_created = None
         self._time_updated = None
+        self._is_enabled = None
         self._defined_tags = None
         self._freeform_tags = None
 
@@ -289,8 +310,7 @@ class LogAnalyticsObjectCollectionRuleSummary(object):
     def collection_type(self):
         """
         **[Required]** Gets the collection_type of this LogAnalyticsObjectCollectionRuleSummary.
-        The type of collection.
-        Supported collection types: LIVE, HISTORIC, HISTORIC_LIVE
+        The type of log collection.
 
         Allowed values for this property are: "LIVE", "HISTORIC", "HISTORIC_LIVE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -305,8 +325,7 @@ class LogAnalyticsObjectCollectionRuleSummary(object):
     def collection_type(self, collection_type):
         """
         Sets the collection_type of this LogAnalyticsObjectCollectionRuleSummary.
-        The type of collection.
-        Supported collection types: LIVE, HISTORIC, HISTORIC_LIVE
+        The type of log collection.
 
 
         :param collection_type: The collection_type of this LogAnalyticsObjectCollectionRuleSummary.
@@ -322,6 +341,9 @@ class LogAnalyticsObjectCollectionRuleSummary(object):
         """
         **[Required]** Gets the lifecycle_state of this LogAnalyticsObjectCollectionRuleSummary.
         The current state of the rule.
+
+        Allowed values for this property are: "ACTIVE", "DELETED", "INACTIVE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
         :return: The lifecycle_state of this LogAnalyticsObjectCollectionRuleSummary.
@@ -339,6 +361,9 @@ class LogAnalyticsObjectCollectionRuleSummary(object):
         :param lifecycle_state: The lifecycle_state of this LogAnalyticsObjectCollectionRuleSummary.
         :type: str
         """
+        allowed_values = ["ACTIVE", "DELETED", "INACTIVE"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
 
     @property
@@ -412,6 +437,30 @@ class LogAnalyticsObjectCollectionRuleSummary(object):
         :type: datetime
         """
         self._time_updated = time_updated
+
+    @property
+    def is_enabled(self):
+        """
+        **[Required]** Gets the is_enabled of this LogAnalyticsObjectCollectionRuleSummary.
+        Whether or not this rule is currently enabled.
+
+
+        :return: The is_enabled of this LogAnalyticsObjectCollectionRuleSummary.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this LogAnalyticsObjectCollectionRuleSummary.
+        Whether or not this rule is currently enabled.
+
+
+        :param is_enabled: The is_enabled of this LogAnalyticsObjectCollectionRuleSummary.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
 
     @property
     def defined_tags(self):

--- a/src/oci/log_analytics/models/log_analytics_source.py
+++ b/src/oci/log_analytics/models/log_analytics_source.py
@@ -158,6 +158,10 @@ class LogAnalyticsSource(object):
             The value to assign to the time_updated property of this LogAnalyticsSource.
         :type time_updated: datetime
 
+        :param event_types:
+            The value to assign to the event_types property of this LogAnalyticsSource.
+        :type event_types: list[oci.log_analytics.models.EventType]
+
         """
         self.swagger_types = {
             'label_conditions': 'list[LogAnalyticsSourceLabelCondition]',
@@ -194,7 +198,8 @@ class LogAnalyticsSource(object):
             'entity_types': 'list[LogAnalyticsSourceEntityType]',
             'is_timezone_override': 'bool',
             'user_parsers': 'list[LogAnalyticsParser]',
-            'time_updated': 'datetime'
+            'time_updated': 'datetime',
+            'event_types': 'list[EventType]'
         }
 
         self.attribute_map = {
@@ -232,7 +237,8 @@ class LogAnalyticsSource(object):
             'entity_types': 'entityTypes',
             'is_timezone_override': 'isTimezoneOverride',
             'user_parsers': 'userParsers',
-            'time_updated': 'timeUpdated'
+            'time_updated': 'timeUpdated',
+            'event_types': 'eventTypes'
         }
 
         self._label_conditions = None
@@ -270,6 +276,7 @@ class LogAnalyticsSource(object):
         self._is_timezone_override = None
         self._user_parsers = None
         self._time_updated = None
+        self._event_types = None
 
     @property
     def label_conditions(self):
@@ -1110,6 +1117,30 @@ class LogAnalyticsSource(object):
         :type: datetime
         """
         self._time_updated = time_updated
+
+    @property
+    def event_types(self):
+        """
+        Gets the event_types of this LogAnalyticsSource.
+        An array of event types.
+
+
+        :return: The event_types of this LogAnalyticsSource.
+        :rtype: list[oci.log_analytics.models.EventType]
+        """
+        return self._event_types
+
+    @event_types.setter
+    def event_types(self, event_types):
+        """
+        Sets the event_types of this LogAnalyticsSource.
+        An array of event types.
+
+
+        :param event_types: The event_types of this LogAnalyticsSource.
+        :type: list[oci.log_analytics.models.EventType]
+        """
+        self._event_types = event_types
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/log_analytics/models/log_analytics_warning.py
+++ b/src/oci/log_analytics/models/log_analytics_warning.py
@@ -1,0 +1,849 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class LogAnalyticsWarning(object):
+    """
+    LogAnalyticsWarning
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new LogAnalyticsWarning object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param agent_id:
+            The value to assign to the agent_id property of this LogAnalyticsWarning.
+        :type agent_id: str
+
+        :param host_name:
+            The value to assign to the host_name property of this LogAnalyticsWarning.
+        :type host_name: str
+
+        :param rule_display_name:
+            The value to assign to the rule_display_name property of this LogAnalyticsWarning.
+        :type rule_display_name: str
+
+        :param source_name:
+            The value to assign to the source_name property of this LogAnalyticsWarning.
+        :type source_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this LogAnalyticsWarning.
+        :type compartment_id: str
+
+        :param source_display_name:
+            The value to assign to the source_display_name property of this LogAnalyticsWarning.
+        :type source_display_name: str
+
+        :param entity_name:
+            The value to assign to the entity_name property of this LogAnalyticsWarning.
+        :type entity_name: str
+
+        :param time_collected:
+            The value to assign to the time_collected property of this LogAnalyticsWarning.
+        :type time_collected: datetime
+
+        :param warning_id:
+            The value to assign to the warning_id property of this LogAnalyticsWarning.
+        :type warning_id: str
+
+        :param time_of_initial_warning:
+            The value to assign to the time_of_initial_warning property of this LogAnalyticsWarning.
+        :type time_of_initial_warning: datetime
+
+        :param is_active:
+            The value to assign to the is_active property of this LogAnalyticsWarning.
+        :type is_active: bool
+
+        :param is_suppressed:
+            The value to assign to the is_suppressed property of this LogAnalyticsWarning.
+        :type is_suppressed: bool
+
+        :param time_of_latest_warning:
+            The value to assign to the time_of_latest_warning property of this LogAnalyticsWarning.
+        :type time_of_latest_warning: datetime
+
+        :param warning_level:
+            The value to assign to the warning_level property of this LogAnalyticsWarning.
+        :type warning_level: str
+
+        :param warning_message:
+            The value to assign to the warning_message property of this LogAnalyticsWarning.
+        :type warning_message: str
+
+        :param pattern_id:
+            The value to assign to the pattern_id property of this LogAnalyticsWarning.
+        :type pattern_id: str
+
+        :param pattern_text:
+            The value to assign to the pattern_text property of this LogAnalyticsWarning.
+        :type pattern_text: str
+
+        :param rule_id:
+            The value to assign to the rule_id property of this LogAnalyticsWarning.
+        :type rule_id: str
+
+        :param source_id:
+            The value to assign to the source_id property of this LogAnalyticsWarning.
+        :type source_id: str
+
+        :param suppressed_by:
+            The value to assign to the suppressed_by property of this LogAnalyticsWarning.
+        :type suppressed_by: str
+
+        :param entity_id:
+            The value to assign to the entity_id property of this LogAnalyticsWarning.
+        :type entity_id: str
+
+        :param entity_type:
+            The value to assign to the entity_type property of this LogAnalyticsWarning.
+        :type entity_type: str
+
+        :param entity_type_display_name:
+            The value to assign to the entity_type_display_name property of this LogAnalyticsWarning.
+        :type entity_type_display_name: str
+
+        :param type_display_name:
+            The value to assign to the type_display_name property of this LogAnalyticsWarning.
+        :type type_display_name: str
+
+        :param type_name:
+            The value to assign to the type_name property of this LogAnalyticsWarning.
+        :type type_name: str
+
+        :param severity:
+            The value to assign to the severity property of this LogAnalyticsWarning.
+        :type severity: int
+
+        """
+        self.swagger_types = {
+            'agent_id': 'str',
+            'host_name': 'str',
+            'rule_display_name': 'str',
+            'source_name': 'str',
+            'compartment_id': 'str',
+            'source_display_name': 'str',
+            'entity_name': 'str',
+            'time_collected': 'datetime',
+            'warning_id': 'str',
+            'time_of_initial_warning': 'datetime',
+            'is_active': 'bool',
+            'is_suppressed': 'bool',
+            'time_of_latest_warning': 'datetime',
+            'warning_level': 'str',
+            'warning_message': 'str',
+            'pattern_id': 'str',
+            'pattern_text': 'str',
+            'rule_id': 'str',
+            'source_id': 'str',
+            'suppressed_by': 'str',
+            'entity_id': 'str',
+            'entity_type': 'str',
+            'entity_type_display_name': 'str',
+            'type_display_name': 'str',
+            'type_name': 'str',
+            'severity': 'int'
+        }
+
+        self.attribute_map = {
+            'agent_id': 'agentId',
+            'host_name': 'hostName',
+            'rule_display_name': 'ruleDisplayName',
+            'source_name': 'sourceName',
+            'compartment_id': 'compartmentId',
+            'source_display_name': 'sourceDisplayName',
+            'entity_name': 'entityName',
+            'time_collected': 'timeCollected',
+            'warning_id': 'warningId',
+            'time_of_initial_warning': 'timeOfInitialWarning',
+            'is_active': 'isActive',
+            'is_suppressed': 'isSuppressed',
+            'time_of_latest_warning': 'timeOfLatestWarning',
+            'warning_level': 'warningLevel',
+            'warning_message': 'warningMessage',
+            'pattern_id': 'patternId',
+            'pattern_text': 'patternText',
+            'rule_id': 'ruleId',
+            'source_id': 'sourceId',
+            'suppressed_by': 'suppressedBy',
+            'entity_id': 'entityId',
+            'entity_type': 'entityType',
+            'entity_type_display_name': 'entityTypeDisplayName',
+            'type_display_name': 'typeDisplayName',
+            'type_name': 'typeName',
+            'severity': 'severity'
+        }
+
+        self._agent_id = None
+        self._host_name = None
+        self._rule_display_name = None
+        self._source_name = None
+        self._compartment_id = None
+        self._source_display_name = None
+        self._entity_name = None
+        self._time_collected = None
+        self._warning_id = None
+        self._time_of_initial_warning = None
+        self._is_active = None
+        self._is_suppressed = None
+        self._time_of_latest_warning = None
+        self._warning_level = None
+        self._warning_message = None
+        self._pattern_id = None
+        self._pattern_text = None
+        self._rule_id = None
+        self._source_id = None
+        self._suppressed_by = None
+        self._entity_id = None
+        self._entity_type = None
+        self._entity_type_display_name = None
+        self._type_display_name = None
+        self._type_name = None
+        self._severity = None
+
+    @property
+    def agent_id(self):
+        """
+        Gets the agent_id of this LogAnalyticsWarning.
+        The unique identifier of the agent associated with the warning
+
+
+        :return: The agent_id of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._agent_id
+
+    @agent_id.setter
+    def agent_id(self, agent_id):
+        """
+        Sets the agent_id of this LogAnalyticsWarning.
+        The unique identifier of the agent associated with the warning
+
+
+        :param agent_id: The agent_id of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._agent_id = agent_id
+
+    @property
+    def host_name(self):
+        """
+        Gets the host_name of this LogAnalyticsWarning.
+        The host containing the agent associated with the warning
+
+
+        :return: The host_name of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._host_name
+
+    @host_name.setter
+    def host_name(self, host_name):
+        """
+        Sets the host_name of this LogAnalyticsWarning.
+        The host containing the agent associated with the warning
+
+
+        :param host_name: The host_name of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._host_name = host_name
+
+    @property
+    def rule_display_name(self):
+        """
+        Gets the rule_display_name of this LogAnalyticsWarning.
+        The display name of the rule which triggered the warning
+
+
+        :return: The rule_display_name of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._rule_display_name
+
+    @rule_display_name.setter
+    def rule_display_name(self, rule_display_name):
+        """
+        Sets the rule_display_name of this LogAnalyticsWarning.
+        The display name of the rule which triggered the warning
+
+
+        :param rule_display_name: The rule_display_name of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._rule_display_name = rule_display_name
+
+    @property
+    def source_name(self):
+        """
+        Gets the source_name of this LogAnalyticsWarning.
+        The name of the source associated with the warning
+
+
+        :return: The source_name of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._source_name
+
+    @source_name.setter
+    def source_name(self, source_name):
+        """
+        Sets the source_name of this LogAnalyticsWarning.
+        The name of the source associated with the warning
+
+
+        :param source_name: The source_name of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._source_name = source_name
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this LogAnalyticsWarning.
+        The entity compartment ID.
+
+
+        :return: The compartment_id of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this LogAnalyticsWarning.
+        The entity compartment ID.
+
+
+        :param compartment_id: The compartment_id of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def source_display_name(self):
+        """
+        Gets the source_display_name of this LogAnalyticsWarning.
+        The display name of the source associated with the warning
+
+
+        :return: The source_display_name of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._source_display_name
+
+    @source_display_name.setter
+    def source_display_name(self, source_display_name):
+        """
+        Sets the source_display_name of this LogAnalyticsWarning.
+        The display name of the source associated with the warning
+
+
+        :param source_display_name: The source_display_name of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._source_display_name = source_display_name
+
+    @property
+    def entity_name(self):
+        """
+        Gets the entity_name of this LogAnalyticsWarning.
+        The name of the entity associated with the warning
+
+
+        :return: The entity_name of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._entity_name
+
+    @entity_name.setter
+    def entity_name(self, entity_name):
+        """
+        Sets the entity_name of this LogAnalyticsWarning.
+        The name of the entity associated with the warning
+
+
+        :param entity_name: The entity_name of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._entity_name = entity_name
+
+    @property
+    def time_collected(self):
+        """
+        Gets the time_collected of this LogAnalyticsWarning.
+        The time at which the warning was most recently collected
+
+
+        :return: The time_collected of this LogAnalyticsWarning.
+        :rtype: datetime
+        """
+        return self._time_collected
+
+    @time_collected.setter
+    def time_collected(self, time_collected):
+        """
+        Sets the time_collected of this LogAnalyticsWarning.
+        The time at which the warning was most recently collected
+
+
+        :param time_collected: The time_collected of this LogAnalyticsWarning.
+        :type: datetime
+        """
+        self._time_collected = time_collected
+
+    @property
+    def warning_id(self):
+        """
+        Gets the warning_id of this LogAnalyticsWarning.
+        The unique identifier of the warning
+
+
+        :return: The warning_id of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._warning_id
+
+    @warning_id.setter
+    def warning_id(self, warning_id):
+        """
+        Sets the warning_id of this LogAnalyticsWarning.
+        The unique identifier of the warning
+
+
+        :param warning_id: The warning_id of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._warning_id = warning_id
+
+    @property
+    def time_of_initial_warning(self):
+        """
+        Gets the time_of_initial_warning of this LogAnalyticsWarning.
+        The date at which the warning was initially triggered
+
+
+        :return: The time_of_initial_warning of this LogAnalyticsWarning.
+        :rtype: datetime
+        """
+        return self._time_of_initial_warning
+
+    @time_of_initial_warning.setter
+    def time_of_initial_warning(self, time_of_initial_warning):
+        """
+        Sets the time_of_initial_warning of this LogAnalyticsWarning.
+        The date at which the warning was initially triggered
+
+
+        :param time_of_initial_warning: The time_of_initial_warning of this LogAnalyticsWarning.
+        :type: datetime
+        """
+        self._time_of_initial_warning = time_of_initial_warning
+
+    @property
+    def is_active(self):
+        """
+        Gets the is_active of this LogAnalyticsWarning.
+        A flag indicating if the warning is currently active
+
+
+        :return: The is_active of this LogAnalyticsWarning.
+        :rtype: bool
+        """
+        return self._is_active
+
+    @is_active.setter
+    def is_active(self, is_active):
+        """
+        Sets the is_active of this LogAnalyticsWarning.
+        A flag indicating if the warning is currently active
+
+
+        :param is_active: The is_active of this LogAnalyticsWarning.
+        :type: bool
+        """
+        self._is_active = is_active
+
+    @property
+    def is_suppressed(self):
+        """
+        Gets the is_suppressed of this LogAnalyticsWarning.
+        A flag indicating if the warning is currently suppressed
+
+
+        :return: The is_suppressed of this LogAnalyticsWarning.
+        :rtype: bool
+        """
+        return self._is_suppressed
+
+    @is_suppressed.setter
+    def is_suppressed(self, is_suppressed):
+        """
+        Sets the is_suppressed of this LogAnalyticsWarning.
+        A flag indicating if the warning is currently suppressed
+
+
+        :param is_suppressed: The is_suppressed of this LogAnalyticsWarning.
+        :type: bool
+        """
+        self._is_suppressed = is_suppressed
+
+    @property
+    def time_of_latest_warning(self):
+        """
+        Gets the time_of_latest_warning of this LogAnalyticsWarning.
+        The most recent date on which the warning was triggered
+
+
+        :return: The time_of_latest_warning of this LogAnalyticsWarning.
+        :rtype: datetime
+        """
+        return self._time_of_latest_warning
+
+    @time_of_latest_warning.setter
+    def time_of_latest_warning(self, time_of_latest_warning):
+        """
+        Sets the time_of_latest_warning of this LogAnalyticsWarning.
+        The most recent date on which the warning was triggered
+
+
+        :param time_of_latest_warning: The time_of_latest_warning of this LogAnalyticsWarning.
+        :type: datetime
+        """
+        self._time_of_latest_warning = time_of_latest_warning
+
+    @property
+    def warning_level(self):
+        """
+        Gets the warning_level of this LogAnalyticsWarning.
+        The warning level - either pattern, rule, or source.
+
+
+        :return: The warning_level of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._warning_level
+
+    @warning_level.setter
+    def warning_level(self, warning_level):
+        """
+        Sets the warning_level of this LogAnalyticsWarning.
+        The warning level - either pattern, rule, or source.
+
+
+        :param warning_level: The warning_level of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._warning_level = warning_level
+
+    @property
+    def warning_message(self):
+        """
+        Gets the warning_message of this LogAnalyticsWarning.
+        A description of the warning intended for the consumer of the warning.  It will
+        usually detail the cause of the warning, may suggest a remedy, and can contain any
+        other relevant information the consumer might find useful
+
+
+        :return: The warning_message of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._warning_message
+
+    @warning_message.setter
+    def warning_message(self, warning_message):
+        """
+        Sets the warning_message of this LogAnalyticsWarning.
+        A description of the warning intended for the consumer of the warning.  It will
+        usually detail the cause of the warning, may suggest a remedy, and can contain any
+        other relevant information the consumer might find useful
+
+
+        :param warning_message: The warning_message of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._warning_message = warning_message
+
+    @property
+    def pattern_id(self):
+        """
+        Gets the pattern_id of this LogAnalyticsWarning.
+        The unique identifier of the warning pattern
+
+
+        :return: The pattern_id of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._pattern_id
+
+    @pattern_id.setter
+    def pattern_id(self, pattern_id):
+        """
+        Sets the pattern_id of this LogAnalyticsWarning.
+        The unique identifier of the warning pattern
+
+
+        :param pattern_id: The pattern_id of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._pattern_id = pattern_id
+
+    @property
+    def pattern_text(self):
+        """
+        Gets the pattern_text of this LogAnalyticsWarning.
+        The text of the pattern used by the warning
+
+
+        :return: The pattern_text of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._pattern_text
+
+    @pattern_text.setter
+    def pattern_text(self, pattern_text):
+        """
+        Sets the pattern_text of this LogAnalyticsWarning.
+        The text of the pattern used by the warning
+
+
+        :param pattern_text: The pattern_text of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._pattern_text = pattern_text
+
+    @property
+    def rule_id(self):
+        """
+        Gets the rule_id of this LogAnalyticsWarning.
+        The unique identifier of the rule associated with the warning
+
+
+        :return: The rule_id of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._rule_id
+
+    @rule_id.setter
+    def rule_id(self, rule_id):
+        """
+        Sets the rule_id of this LogAnalyticsWarning.
+        The unique identifier of the rule associated with the warning
+
+
+        :param rule_id: The rule_id of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._rule_id = rule_id
+
+    @property
+    def source_id(self):
+        """
+        Gets the source_id of this LogAnalyticsWarning.
+        The unique identifier of the source associated with the warning
+
+
+        :return: The source_id of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._source_id
+
+    @source_id.setter
+    def source_id(self, source_id):
+        """
+        Sets the source_id of this LogAnalyticsWarning.
+        The unique identifier of the source associated with the warning
+
+
+        :param source_id: The source_id of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._source_id = source_id
+
+    @property
+    def suppressed_by(self):
+        """
+        Gets the suppressed_by of this LogAnalyticsWarning.
+        The user who suppressed the warning, or empty if the warning is not suppressed
+
+
+        :return: The suppressed_by of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._suppressed_by
+
+    @suppressed_by.setter
+    def suppressed_by(self, suppressed_by):
+        """
+        Sets the suppressed_by of this LogAnalyticsWarning.
+        The user who suppressed the warning, or empty if the warning is not suppressed
+
+
+        :param suppressed_by: The suppressed_by of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._suppressed_by = suppressed_by
+
+    @property
+    def entity_id(self):
+        """
+        Gets the entity_id of this LogAnalyticsWarning.
+        The unique identifier of the entity associated with the warning
+
+
+        :return: The entity_id of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._entity_id
+
+    @entity_id.setter
+    def entity_id(self, entity_id):
+        """
+        Sets the entity_id of this LogAnalyticsWarning.
+        The unique identifier of the entity associated with the warning
+
+
+        :param entity_id: The entity_id of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._entity_id = entity_id
+
+    @property
+    def entity_type(self):
+        """
+        Gets the entity_type of this LogAnalyticsWarning.
+        The type of the entity associated with the warning
+
+
+        :return: The entity_type of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._entity_type
+
+    @entity_type.setter
+    def entity_type(self, entity_type):
+        """
+        Sets the entity_type of this LogAnalyticsWarning.
+        The type of the entity associated with the warning
+
+
+        :param entity_type: The entity_type of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._entity_type = entity_type
+
+    @property
+    def entity_type_display_name(self):
+        """
+        Gets the entity_type_display_name of this LogAnalyticsWarning.
+        The display name of the entity type associated with the warning
+
+
+        :return: The entity_type_display_name of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._entity_type_display_name
+
+    @entity_type_display_name.setter
+    def entity_type_display_name(self, entity_type_display_name):
+        """
+        Sets the entity_type_display_name of this LogAnalyticsWarning.
+        The display name of the entity type associated with the warning
+
+
+        :param entity_type_display_name: The entity_type_display_name of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._entity_type_display_name = entity_type_display_name
+
+    @property
+    def type_display_name(self):
+        """
+        Gets the type_display_name of this LogAnalyticsWarning.
+        The display name of the warning type
+
+
+        :return: The type_display_name of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._type_display_name
+
+    @type_display_name.setter
+    def type_display_name(self, type_display_name):
+        """
+        Sets the type_display_name of this LogAnalyticsWarning.
+        The display name of the warning type
+
+
+        :param type_display_name: The type_display_name of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._type_display_name = type_display_name
+
+    @property
+    def type_name(self):
+        """
+        Gets the type_name of this LogAnalyticsWarning.
+        The internal name of the warning
+
+
+        :return: The type_name of this LogAnalyticsWarning.
+        :rtype: str
+        """
+        return self._type_name
+
+    @type_name.setter
+    def type_name(self, type_name):
+        """
+        Sets the type_name of this LogAnalyticsWarning.
+        The internal name of the warning
+
+
+        :param type_name: The type_name of this LogAnalyticsWarning.
+        :type: str
+        """
+        self._type_name = type_name
+
+    @property
+    def severity(self):
+        """
+        Gets the severity of this LogAnalyticsWarning.
+        The warning severity
+
+
+        :return: The severity of this LogAnalyticsWarning.
+        :rtype: int
+        """
+        return self._severity
+
+    @severity.setter
+    def severity(self, severity):
+        """
+        Sets the severity of this LogAnalyticsWarning.
+        The warning severity
+
+
+        :param severity: The severity of this LogAnalyticsWarning.
+        :type: int
+        """
+        self._severity = severity
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/log_analytics_warning_collection.py
+++ b/src/oci/log_analytics/models/log_analytics_warning_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class LogAnalyticsWarningCollection(object):
+    """
+    A collection of warnings.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new LogAnalyticsWarningCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this LogAnalyticsWarningCollection.
+        :type items: list[oci.log_analytics.models.LogAnalyticsWarning]
+
+        """
+        self.swagger_types = {
+            'items': 'list[LogAnalyticsWarning]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        Gets the items of this LogAnalyticsWarningCollection.
+        A collection of LogAnalyticsWarnings
+
+
+        :return: The items of this LogAnalyticsWarningCollection.
+        :rtype: list[oci.log_analytics.models.LogAnalyticsWarning]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this LogAnalyticsWarningCollection.
+        A collection of LogAnalyticsWarnings
+
+
+        :param items: The items of this LogAnalyticsWarningCollection.
+        :type: list[oci.log_analytics.models.LogAnalyticsWarning]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/lookup_command_descriptor.py
+++ b/src/oci/log_analytics/models/lookup_command_descriptor.py
@@ -21,7 +21,7 @@ class LookupCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this LookupCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/macro_command_descriptor.py
+++ b/src/oci/log_analytics/models/macro_command_descriptor.py
@@ -21,7 +21,7 @@ class MacroCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this MacroCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/map_command_descriptor.py
+++ b/src/oci/log_analytics/models/map_command_descriptor.py
@@ -1,0 +1,84 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .abstract_command_descriptor import AbstractCommandDescriptor
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class MapCommandDescriptor(AbstractCommandDescriptor):
+    """
+    Command descriptor for querylanguage MAP command.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new MapCommandDescriptor object with values from keyword arguments. The default value of the :py:attr:`~oci.log_analytics.models.MapCommandDescriptor.name` attribute
+        of this class is ``MAP`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this MapCommandDescriptor.
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+        :type name: str
+
+        :param display_query_string:
+            The value to assign to the display_query_string property of this MapCommandDescriptor.
+        :type display_query_string: str
+
+        :param internal_query_string:
+            The value to assign to the internal_query_string property of this MapCommandDescriptor.
+        :type internal_query_string: str
+
+        :param category:
+            The value to assign to the category property of this MapCommandDescriptor.
+        :type category: str
+
+        :param referenced_fields:
+            The value to assign to the referenced_fields property of this MapCommandDescriptor.
+        :type referenced_fields: list[oci.log_analytics.models.AbstractField]
+
+        :param declared_fields:
+            The value to assign to the declared_fields property of this MapCommandDescriptor.
+        :type declared_fields: list[oci.log_analytics.models.AbstractField]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'display_query_string': 'str',
+            'internal_query_string': 'str',
+            'category': 'str',
+            'referenced_fields': 'list[AbstractField]',
+            'declared_fields': 'list[AbstractField]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'display_query_string': 'displayQueryString',
+            'internal_query_string': 'internalQueryString',
+            'category': 'category',
+            'referenced_fields': 'referencedFields',
+            'declared_fields': 'declaredFields'
+        }
+
+        self._name = None
+        self._display_query_string = None
+        self._internal_query_string = None
+        self._category = None
+        self._referenced_fields = None
+        self._declared_fields = None
+        self._name = 'MAP'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/metric_extraction.py
+++ b/src/oci/log_analytics/models/metric_extraction.py
@@ -1,0 +1,176 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class MetricExtraction(object):
+    """
+    Specify metric extraction for SAVED_SEARCH scheduled task execution
+    to post to OCI Monitoring.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new MetricExtraction object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this MetricExtraction.
+        :type compartment_id: str
+
+        :param namespace:
+            The value to assign to the namespace property of this MetricExtraction.
+        :type namespace: str
+
+        :param metric_name:
+            The value to assign to the metric_name property of this MetricExtraction.
+        :type metric_name: str
+
+        :param resource_group:
+            The value to assign to the resource_group property of this MetricExtraction.
+        :type resource_group: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'namespace': 'str',
+            'metric_name': 'str',
+            'resource_group': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'namespace': 'namespace',
+            'metric_name': 'metricName',
+            'resource_group': 'resourceGroup'
+        }
+
+        self._compartment_id = None
+        self._namespace = None
+        self._metric_name = None
+        self._resource_group = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this MetricExtraction.
+        The compartment OCID (/iaas/Content/General/Concepts/identifiers.htm) of the extracted metric.
+
+
+        :return: The compartment_id of this MetricExtraction.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this MetricExtraction.
+        The compartment OCID (/iaas/Content/General/Concepts/identifiers.htm) of the extracted metric.
+
+
+        :param compartment_id: The compartment_id of this MetricExtraction.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def namespace(self):
+        """
+        **[Required]** Gets the namespace of this MetricExtraction.
+        The namespace of the extracted metric.
+        A valid value starts with an alphabetical character and includes only
+        alphanumeric characters and underscores (_).
+
+
+        :return: The namespace of this MetricExtraction.
+        :rtype: str
+        """
+        return self._namespace
+
+    @namespace.setter
+    def namespace(self, namespace):
+        """
+        Sets the namespace of this MetricExtraction.
+        The namespace of the extracted metric.
+        A valid value starts with an alphabetical character and includes only
+        alphanumeric characters and underscores (_).
+
+
+        :param namespace: The namespace of this MetricExtraction.
+        :type: str
+        """
+        self._namespace = namespace
+
+    @property
+    def metric_name(self):
+        """
+        **[Required]** Gets the metric_name of this MetricExtraction.
+        The metric name of the extracted metric.
+        A valid value starts with an alphabetical character and includes only
+        alphanumeric characters, periods (.), underscores (_), hyphens (-), and dollar signs ($).
+
+
+        :return: The metric_name of this MetricExtraction.
+        :rtype: str
+        """
+        return self._metric_name
+
+    @metric_name.setter
+    def metric_name(self, metric_name):
+        """
+        Sets the metric_name of this MetricExtraction.
+        The metric name of the extracted metric.
+        A valid value starts with an alphabetical character and includes only
+        alphanumeric characters, periods (.), underscores (_), hyphens (-), and dollar signs ($).
+
+
+        :param metric_name: The metric_name of this MetricExtraction.
+        :type: str
+        """
+        self._metric_name = metric_name
+
+    @property
+    def resource_group(self):
+        """
+        Gets the resource_group of this MetricExtraction.
+        The resourceGroup of the extracted metric.
+        A valid value starts with an alphabetical character and includes only
+        alphanumeric characters, periods (.), underscores (_), hyphens (-), and dollar signs ($).
+
+
+        :return: The resource_group of this MetricExtraction.
+        :rtype: str
+        """
+        return self._resource_group
+
+    @resource_group.setter
+    def resource_group(self, resource_group):
+        """
+        Sets the resource_group of this MetricExtraction.
+        The resourceGroup of the extracted metric.
+        A valid value starts with an alphabetical character and includes only
+        alphanumeric characters, periods (.), underscores (_), hyphens (-), and dollar signs ($).
+
+
+        :param resource_group: The resource_group of this MetricExtraction.
+        :type: str
+        """
+        self._resource_group = resource_group
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/multi_search_command_descriptor.py
+++ b/src/oci/log_analytics/models/multi_search_command_descriptor.py
@@ -21,7 +21,7 @@ class MultiSearchCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this MultiSearchCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/nlp_command_descriptor.py
+++ b/src/oci/log_analytics/models/nlp_command_descriptor.py
@@ -1,0 +1,84 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .abstract_command_descriptor import AbstractCommandDescriptor
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class NlpCommandDescriptor(AbstractCommandDescriptor):
+    """
+    Command descriptor for querylanguage NLP command.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new NlpCommandDescriptor object with values from keyword arguments. The default value of the :py:attr:`~oci.log_analytics.models.NlpCommandDescriptor.name` attribute
+        of this class is ``NLP`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this NlpCommandDescriptor.
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+        :type name: str
+
+        :param display_query_string:
+            The value to assign to the display_query_string property of this NlpCommandDescriptor.
+        :type display_query_string: str
+
+        :param internal_query_string:
+            The value to assign to the internal_query_string property of this NlpCommandDescriptor.
+        :type internal_query_string: str
+
+        :param category:
+            The value to assign to the category property of this NlpCommandDescriptor.
+        :type category: str
+
+        :param referenced_fields:
+            The value to assign to the referenced_fields property of this NlpCommandDescriptor.
+        :type referenced_fields: list[oci.log_analytics.models.AbstractField]
+
+        :param declared_fields:
+            The value to assign to the declared_fields property of this NlpCommandDescriptor.
+        :type declared_fields: list[oci.log_analytics.models.AbstractField]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'display_query_string': 'str',
+            'internal_query_string': 'str',
+            'category': 'str',
+            'referenced_fields': 'list[AbstractField]',
+            'declared_fields': 'list[AbstractField]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'display_query_string': 'displayQueryString',
+            'internal_query_string': 'internalQueryString',
+            'category': 'category',
+            'referenced_fields': 'referencedFields',
+            'declared_fields': 'declaredFields'
+        }
+
+        self._name = None
+        self._display_query_string = None
+        self._internal_query_string = None
+        self._category = None
+        self._referenced_fields = None
+        self._declared_fields = None
+        self._name = 'NLP'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/parsed_content.py
+++ b/src/oci/log_analytics/models/parsed_content.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ParsedContent(object):
     """
-    Parsed Content
+    Parsed representation of the log file.
     """
 
     def __init__(self, **kwargs):
@@ -72,7 +72,7 @@ class ParsedContent(object):
     def field_names(self):
         """
         Gets the field_names of this ParsedContent.
-        Field names
+        List of field names.
 
 
         :return: The field_names of this ParsedContent.
@@ -84,7 +84,7 @@ class ParsedContent(object):
     def field_names(self, field_names):
         """
         Sets the field_names of this ParsedContent.
-        Field names
+        List of field names.
 
 
         :param field_names: The field_names of this ParsedContent.
@@ -96,7 +96,7 @@ class ParsedContent(object):
     def field_display_names(self):
         """
         Gets the field_display_names of this ParsedContent.
-        Display names for fields
+        List of field display names.
 
 
         :return: The field_display_names of this ParsedContent.
@@ -108,7 +108,7 @@ class ParsedContent(object):
     def field_display_names(self, field_display_names):
         """
         Sets the field_display_names of this ParsedContent.
-        Display names for fields
+        List of field display names.
 
 
         :param field_display_names: The field_display_names of this ParsedContent.
@@ -120,7 +120,7 @@ class ParsedContent(object):
     def parsed_field_values(self):
         """
         Gets the parsed_field_values of this ParsedContent.
-        Parsed field values
+        Parsed field values.
 
 
         :return: The parsed_field_values of this ParsedContent.
@@ -132,7 +132,7 @@ class ParsedContent(object):
     def parsed_field_values(self, parsed_field_values):
         """
         Sets the parsed_field_values of this ParsedContent.
-        Parsed field values
+        Parsed field values.
 
 
         :param parsed_field_values: The parsed_field_values of this ParsedContent.
@@ -144,7 +144,7 @@ class ParsedContent(object):
     def log_content(self):
         """
         Gets the log_content of this ParsedContent.
-        Sample log entries picked up from the given file for validation
+        Sample log entries picked up from the given file for validation.
 
 
         :return: The log_content of this ParsedContent.
@@ -156,7 +156,7 @@ class ParsedContent(object):
     def log_content(self, log_content):
         """
         Sets the log_content of this ParsedContent.
-        Sample log entries picked up from the given file for validation
+        Sample log entries picked up from the given file for validation.
 
 
         :param log_content: The log_content of this ParsedContent.
@@ -168,7 +168,7 @@ class ParsedContent(object):
     def sample_size(self):
         """
         Gets the sample_size of this ParsedContent.
-        Sample Size taken for validation
+        Sample Size taken for validation.
 
 
         :return: The sample_size of this ParsedContent.
@@ -180,7 +180,7 @@ class ParsedContent(object):
     def sample_size(self, sample_size):
         """
         Sets the sample_size of this ParsedContent.
-        Sample Size taken for validation
+        Sample Size taken for validation.
 
 
         :param sample_size: The sample_size of this ParsedContent.
@@ -192,7 +192,7 @@ class ParsedContent(object):
     def match_status(self):
         """
         Gets the match_status of this ParsedContent.
-        Match Status
+        Match Status.
 
 
         :return: The match_status of this ParsedContent.
@@ -204,7 +204,7 @@ class ParsedContent(object):
     def match_status(self, match_status):
         """
         Sets the match_status of this ParsedContent.
-        Match Status
+        Match Status.
 
 
         :param match_status: The match_status of this ParsedContent.

--- a/src/oci/log_analytics/models/parsed_field.py
+++ b/src/oci/log_analytics/models/parsed_field.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ParsedField(object):
     """
-    Parsed field response
+    Parsed field response.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,7 @@ class ParsedField(object):
     def log_content(self):
         """
         Gets the log_content of this ParsedField.
-        Sample log entries picked up from the given file for validation
+        Sample log entries picked up from the given file for validation.
 
 
         :return: The log_content of this ParsedField.
@@ -56,7 +56,7 @@ class ParsedField(object):
     def log_content(self, log_content):
         """
         Sets the log_content of this ParsedField.
-        Sample log entries picked up from the given file for validation
+        Sample log entries picked up from the given file for validation.
 
 
         :param log_content: The log_content of this ParsedField.
@@ -68,7 +68,7 @@ class ParsedField(object):
     def field_values(self):
         """
         Gets the field_values of this ParsedField.
-        Field Values
+        List of field Values.
 
 
         :return: The field_values of this ParsedField.
@@ -80,7 +80,7 @@ class ParsedField(object):
     def field_values(self, field_values):
         """
         Sets the field_values of this ParsedField.
-        Field Values
+        List of field Values.
 
 
         :param field_values: The field_values of this ParsedField.

--- a/src/oci/log_analytics/models/property_override.py
+++ b/src/oci/log_analytics/models/property_override.py
@@ -60,7 +60,7 @@ class PropertyOverride(object):
     def match_type(self):
         """
         Gets the match_type of this PropertyOverride.
-        Match Type. Accepted values are: contains
+        Match Type. Accepted values are: contains.
 
 
         :return: The match_type of this PropertyOverride.
@@ -72,7 +72,7 @@ class PropertyOverride(object):
     def match_type(self, match_type):
         """
         Sets the match_type of this PropertyOverride.
-        Match Type. Accepted values are: contains
+        Match Type. Accepted values are: contains.
 
 
         :param match_type: The match_type of this PropertyOverride.
@@ -132,7 +132,7 @@ class PropertyOverride(object):
     def property_value(self):
         """
         Gets the property_value of this PropertyOverride.
-        Value.
+        Value of the property.
 
 
         :return: The property_value of this PropertyOverride.
@@ -144,7 +144,7 @@ class PropertyOverride(object):
     def property_value(self, property_value):
         """
         Sets the property_value of this PropertyOverride.
-        Value.
+        Value of the property.
 
 
         :param property_value: The property_value of this PropertyOverride.

--- a/src/oci/log_analytics/models/recalled_data.py
+++ b/src/oci/log_analytics/models/recalled_data.py
@@ -1,0 +1,243 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class RecalledData(object):
+    """
+    This is the information about recalled data
+    """
+
+    #: A constant which can be used with the status property of a RecalledData.
+    #: This constant has a value of "RECALLED"
+    STATUS_RECALLED = "RECALLED"
+
+    #: A constant which can be used with the status property of a RecalledData.
+    #: This constant has a value of "PENDING"
+    STATUS_PENDING = "PENDING"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new RecalledData object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param time_data_ended:
+            The value to assign to the time_data_ended property of this RecalledData.
+        :type time_data_ended: datetime
+
+        :param time_data_started:
+            The value to assign to the time_data_started property of this RecalledData.
+        :type time_data_started: datetime
+
+        :param time_started:
+            The value to assign to the time_started property of this RecalledData.
+        :type time_started: datetime
+
+        :param status:
+            The value to assign to the status property of this RecalledData.
+            Allowed values for this property are: "RECALLED", "PENDING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type status: str
+
+        :param recall_count:
+            The value to assign to the recall_count property of this RecalledData.
+        :type recall_count: int
+
+        :param storage_usage_in_bytes:
+            The value to assign to the storage_usage_in_bytes property of this RecalledData.
+        :type storage_usage_in_bytes: int
+
+        """
+        self.swagger_types = {
+            'time_data_ended': 'datetime',
+            'time_data_started': 'datetime',
+            'time_started': 'datetime',
+            'status': 'str',
+            'recall_count': 'int',
+            'storage_usage_in_bytes': 'int'
+        }
+
+        self.attribute_map = {
+            'time_data_ended': 'timeDataEnded',
+            'time_data_started': 'timeDataStarted',
+            'time_started': 'timeStarted',
+            'status': 'status',
+            'recall_count': 'recallCount',
+            'storage_usage_in_bytes': 'storageUsageInBytes'
+        }
+
+        self._time_data_ended = None
+        self._time_data_started = None
+        self._time_started = None
+        self._status = None
+        self._recall_count = None
+        self._storage_usage_in_bytes = None
+
+    @property
+    def time_data_ended(self):
+        """
+        **[Required]** Gets the time_data_ended of this RecalledData.
+        This is the end of the time range of the related data
+
+
+        :return: The time_data_ended of this RecalledData.
+        :rtype: datetime
+        """
+        return self._time_data_ended
+
+    @time_data_ended.setter
+    def time_data_ended(self, time_data_ended):
+        """
+        Sets the time_data_ended of this RecalledData.
+        This is the end of the time range of the related data
+
+
+        :param time_data_ended: The time_data_ended of this RecalledData.
+        :type: datetime
+        """
+        self._time_data_ended = time_data_ended
+
+    @property
+    def time_data_started(self):
+        """
+        **[Required]** Gets the time_data_started of this RecalledData.
+        This is the start of the time range of the related data
+
+
+        :return: The time_data_started of this RecalledData.
+        :rtype: datetime
+        """
+        return self._time_data_started
+
+    @time_data_started.setter
+    def time_data_started(self, time_data_started):
+        """
+        Sets the time_data_started of this RecalledData.
+        This is the start of the time range of the related data
+
+
+        :param time_data_started: The time_data_started of this RecalledData.
+        :type: datetime
+        """
+        self._time_data_started = time_data_started
+
+    @property
+    def time_started(self):
+        """
+        **[Required]** Gets the time_started of this RecalledData.
+        This is the time when the first recall operation was started for this RecalledData
+
+
+        :return: The time_started of this RecalledData.
+        :rtype: datetime
+        """
+        return self._time_started
+
+    @time_started.setter
+    def time_started(self, time_started):
+        """
+        Sets the time_started of this RecalledData.
+        This is the time when the first recall operation was started for this RecalledData
+
+
+        :param time_started: The time_started of this RecalledData.
+        :type: datetime
+        """
+        self._time_started = time_started
+
+    @property
+    def status(self):
+        """
+        **[Required]** Gets the status of this RecalledData.
+        This is the status of the recall
+
+        Allowed values for this property are: "RECALLED", "PENDING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The status of this RecalledData.
+        :rtype: str
+        """
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        """
+        Sets the status of this RecalledData.
+        This is the status of the recall
+
+
+        :param status: The status of this RecalledData.
+        :type: str
+        """
+        allowed_values = ["RECALLED", "PENDING"]
+        if not value_allowed_none_or_none_sentinel(status, allowed_values):
+            status = 'UNKNOWN_ENUM_VALUE'
+        self._status = status
+
+    @property
+    def recall_count(self):
+        """
+        **[Required]** Gets the recall_count of this RecalledData.
+        This is the number of recall operations for this recall.  Note one RecalledData can be merged from the results
+        of several recall operations if the time duration of the results of the recall operations overlap.
+
+
+        :return: The recall_count of this RecalledData.
+        :rtype: int
+        """
+        return self._recall_count
+
+    @recall_count.setter
+    def recall_count(self, recall_count):
+        """
+        Sets the recall_count of this RecalledData.
+        This is the number of recall operations for this recall.  Note one RecalledData can be merged from the results
+        of several recall operations if the time duration of the results of the recall operations overlap.
+
+
+        :param recall_count: The recall_count of this RecalledData.
+        :type: int
+        """
+        self._recall_count = recall_count
+
+    @property
+    def storage_usage_in_bytes(self):
+        """
+        **[Required]** Gets the storage_usage_in_bytes of this RecalledData.
+        This is the size in bytes
+
+
+        :return: The storage_usage_in_bytes of this RecalledData.
+        :rtype: int
+        """
+        return self._storage_usage_in_bytes
+
+    @storage_usage_in_bytes.setter
+    def storage_usage_in_bytes(self, storage_usage_in_bytes):
+        """
+        Sets the storage_usage_in_bytes of this RecalledData.
+        This is the size in bytes
+
+
+        :param storage_usage_in_bytes: The storage_usage_in_bytes of this RecalledData.
+        :type: int
+        """
+        self._storage_usage_in_bytes = storage_usage_in_bytes
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/recalled_data_collection.py
+++ b/src/oci/log_analytics/models/recalled_data_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class RecalledDataCollection(object):
+    """
+    This is the list of recalled data
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new RecalledDataCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this RecalledDataCollection.
+        :type items: list[oci.log_analytics.models.RecalledData]
+
+        """
+        self.swagger_types = {
+            'items': 'list[RecalledData]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this RecalledDataCollection.
+        This is the array of recalled data
+
+
+        :return: The items of this RecalledDataCollection.
+        :rtype: list[oci.log_analytics.models.RecalledData]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this RecalledDataCollection.
+        This is the array of recalled data
+
+
+        :param items: The items of this RecalledDataCollection.
+        :type: list[oci.log_analytics.models.RecalledData]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/regex_command_descriptor.py
+++ b/src/oci/log_analytics/models/regex_command_descriptor.py
@@ -21,7 +21,7 @@ class RegexCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this RegexCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/remove_entity_associations_details.py
+++ b/src/oci/log_analytics/models/remove_entity_associations_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class RemoveEntityAssociationsDetails(object):
     """
-    Information about the associations to be deleted between entity and other existing entities.
+    Information about the associations to be deleted between source entity and other existing destination entities.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/log_analytics/models/rename_command_descriptor.py
+++ b/src/oci/log_analytics/models/rename_command_descriptor.py
@@ -21,7 +21,7 @@ class RenameCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this RenameCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/scheduled_task.py
+++ b/src/oci/log_analytics/models/scheduled_task.py
@@ -13,6 +13,14 @@ class ScheduledTask(object):
     Log analytics scheduled task resource.
     """
 
+    #: A constant which can be used with the kind property of a ScheduledTask.
+    #: This constant has a value of "ACCELERATION"
+    KIND_ACCELERATION = "ACCELERATION"
+
+    #: A constant which can be used with the kind property of a ScheduledTask.
+    #: This constant has a value of "STANDARD"
+    KIND_STANDARD = "STANDARD"
+
     #: A constant which can be used with the task_type property of a ScheduledTask.
     #: This constant has a value of "SAVED_SEARCH"
     TASK_TYPE_SAVED_SEARCH = "SAVED_SEARCH"
@@ -55,8 +63,18 @@ class ScheduledTask(object):
 
     def __init__(self, **kwargs):
         """
-        Initializes a new ScheduledTask object with values from keyword arguments.
+        Initializes a new ScheduledTask object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.log_analytics.models.StandardTask`
+
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param kind:
+            The value to assign to the kind property of this ScheduledTask.
+            Allowed values for this property are: "ACCELERATION", "STANDARD", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type kind: str
 
         :param id:
             The value to assign to the id property of this ScheduledTask.
@@ -122,6 +140,7 @@ class ScheduledTask(object):
 
         """
         self.swagger_types = {
+            'kind': 'str',
             'id': 'str',
             'display_name': 'str',
             'task_type': 'str',
@@ -139,6 +158,7 @@ class ScheduledTask(object):
         }
 
         self.attribute_map = {
+            'kind': 'kind',
             'id': 'id',
             'display_name': 'displayName',
             'task_type': 'taskType',
@@ -155,6 +175,7 @@ class ScheduledTask(object):
             'defined_tags': 'definedTags'
         }
 
+        self._kind = None
         self._id = None
         self._display_name = None
         self._task_type = None
@@ -169,6 +190,49 @@ class ScheduledTask(object):
         self._lifecycle_state = None
         self._freeform_tags = None
         self._defined_tags = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['kind']
+
+        if type == 'STANDARD':
+            return 'StandardTask'
+        else:
+            return 'ScheduledTask'
+
+    @property
+    def kind(self):
+        """
+        **[Required]** Gets the kind of this ScheduledTask.
+        Discriminator.
+
+        Allowed values for this property are: "ACCELERATION", "STANDARD", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The kind of this ScheduledTask.
+        :rtype: str
+        """
+        return self._kind
+
+    @kind.setter
+    def kind(self, kind):
+        """
+        Sets the kind of this ScheduledTask.
+        Discriminator.
+
+
+        :param kind: The kind of this ScheduledTask.
+        :type: str
+        """
+        allowed_values = ["ACCELERATION", "STANDARD"]
+        if not value_allowed_none_or_none_sentinel(kind, allowed_values):
+            kind = 'UNKNOWN_ENUM_VALUE'
+        self._kind = kind
 
     @property
     def id(self):

--- a/src/oci/log_analytics/models/scheduled_task_summary.py
+++ b/src/oci/log_analytics/models/scheduled_task_summary.py
@@ -45,6 +45,14 @@ class ScheduledTaskSummary(object):
     #: This constant has a value of "BLOCKED"
     TASK_STATUS_BLOCKED = "BLOCKED"
 
+    #: A constant which can be used with the last_execution_status property of a ScheduledTaskSummary.
+    #: This constant has a value of "FAILED"
+    LAST_EXECUTION_STATUS_FAILED = "FAILED"
+
+    #: A constant which can be used with the last_execution_status property of a ScheduledTaskSummary.
+    #: This constant has a value of "SUCCEEDED"
+    LAST_EXECUTION_STATUS_SUCCEEDED = "SUCCEEDED"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ScheduledTaskSummary object with values from keyword arguments.
@@ -98,6 +106,16 @@ class ScheduledTaskSummary(object):
             The value to assign to the defined_tags property of this ScheduledTaskSummary.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param last_execution_status:
+            The value to assign to the last_execution_status property of this ScheduledTaskSummary.
+            Allowed values for this property are: "FAILED", "SUCCEEDED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type last_execution_status: str
+
+        :param time_last_executed:
+            The value to assign to the time_last_executed property of this ScheduledTaskSummary.
+        :type time_last_executed: datetime
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -110,7 +128,9 @@ class ScheduledTaskSummary(object):
             'work_request_id': 'str',
             'display_name': 'str',
             'freeform_tags': 'dict(str, str)',
-            'defined_tags': 'dict(str, dict(str, object))'
+            'defined_tags': 'dict(str, dict(str, object))',
+            'last_execution_status': 'str',
+            'time_last_executed': 'datetime'
         }
 
         self.attribute_map = {
@@ -124,7 +144,9 @@ class ScheduledTaskSummary(object):
             'work_request_id': 'workRequestId',
             'display_name': 'displayName',
             'freeform_tags': 'freeformTags',
-            'defined_tags': 'definedTags'
+            'defined_tags': 'definedTags',
+            'last_execution_status': 'lastExecutionStatus',
+            'time_last_executed': 'timeLastExecuted'
         }
 
         self._id = None
@@ -138,6 +160,8 @@ class ScheduledTaskSummary(object):
         self._display_name = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._last_execution_status = None
+        self._time_last_executed = None
 
     @property
     def id(self):
@@ -436,6 +460,60 @@ class ScheduledTaskSummary(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def last_execution_status(self):
+        """
+        Gets the last_execution_status of this ScheduledTaskSummary.
+        The most recent task execution status.
+
+        Allowed values for this property are: "FAILED", "SUCCEEDED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The last_execution_status of this ScheduledTaskSummary.
+        :rtype: str
+        """
+        return self._last_execution_status
+
+    @last_execution_status.setter
+    def last_execution_status(self, last_execution_status):
+        """
+        Sets the last_execution_status of this ScheduledTaskSummary.
+        The most recent task execution status.
+
+
+        :param last_execution_status: The last_execution_status of this ScheduledTaskSummary.
+        :type: str
+        """
+        allowed_values = ["FAILED", "SUCCEEDED"]
+        if not value_allowed_none_or_none_sentinel(last_execution_status, allowed_values):
+            last_execution_status = 'UNKNOWN_ENUM_VALUE'
+        self._last_execution_status = last_execution_status
+
+    @property
+    def time_last_executed(self):
+        """
+        Gets the time_last_executed of this ScheduledTaskSummary.
+        The date and time the scheduled task last executed, in the format defined by RFC3339.
+
+
+        :return: The time_last_executed of this ScheduledTaskSummary.
+        :rtype: datetime
+        """
+        return self._time_last_executed
+
+    @time_last_executed.setter
+    def time_last_executed(self, time_last_executed):
+        """
+        Sets the time_last_executed of this ScheduledTaskSummary.
+        The date and time the scheduled task last executed, in the format defined by RFC3339.
+
+
+        :param time_last_executed: The time_last_executed of this ScheduledTaskSummary.
+        :type: datetime
+        """
+        self._time_last_executed = time_last_executed
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/log_analytics/models/search_command_descriptor.py
+++ b/src/oci/log_analytics/models/search_command_descriptor.py
@@ -21,7 +21,7 @@ class SearchCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this SearchCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/search_lookup_command_descriptor.py
+++ b/src/oci/log_analytics/models/search_lookup_command_descriptor.py
@@ -21,7 +21,7 @@ class SearchLookupCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this SearchLookupCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/sort_command_descriptor.py
+++ b/src/oci/log_analytics/models/sort_command_descriptor.py
@@ -21,7 +21,7 @@ class SortCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this SortCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/sort_field.py
+++ b/src/oci/log_analytics/models/sort_field.py
@@ -71,6 +71,10 @@ class SortField(AbstractField):
             The value to assign to the filter_query_string property of this SortField.
         :type filter_query_string: str
 
+        :param unit_type:
+            The value to assign to the unit_type property of this SortField.
+        :type unit_type: str
+
         :param direction:
             The value to assign to the direction property of this SortField.
             Allowed values for this property are: "ASCENDING", "DESCENDING", 'UNKNOWN_ENUM_VALUE'.
@@ -89,6 +93,7 @@ class SortField(AbstractField):
             'is_duration': 'bool',
             'alias': 'str',
             'filter_query_string': 'str',
+            'unit_type': 'str',
             'direction': 'str'
         }
 
@@ -103,6 +108,7 @@ class SortField(AbstractField):
             'is_duration': 'isDuration',
             'alias': 'alias',
             'filter_query_string': 'filterQueryString',
+            'unit_type': 'unitType',
             'direction': 'direction'
         }
 
@@ -116,6 +122,7 @@ class SortField(AbstractField):
         self._is_duration = None
         self._alias = None
         self._filter_query_string = None
+        self._unit_type = None
         self._direction = None
         self._name = 'SORT'
 

--- a/src/oci/log_analytics/models/source_mapping_response.py
+++ b/src/oci/log_analytics/models/source_mapping_response.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class SourceMappingResponse(object):
     """
-    Response object containing match status and parsed representation of log data
+    Response object containing match status and parsed representation of log data.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +37,7 @@ class SourceMappingResponse(object):
     def parsed_response(self):
         """
         **[Required]** Gets the parsed_response of this SourceMappingResponse.
-        Parsed representation of the log file
+        Parsed representation of the log file.
 
 
         :return: The parsed_response of this SourceMappingResponse.
@@ -49,7 +49,7 @@ class SourceMappingResponse(object):
     def parsed_response(self, parsed_response):
         """
         Sets the parsed_response of this SourceMappingResponse.
-        Parsed representation of the log file
+        Parsed representation of the log file.
 
 
         :param parsed_response: The parsed_response of this SourceMappingResponse.

--- a/src/oci/log_analytics/models/standard_task.py
+++ b/src/oci/log_analytics/models/standard_task.py
@@ -1,0 +1,232 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .scheduled_task import ScheduledTask
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class StandardTask(ScheduledTask):
+    """
+    Log analytics scheduled task resource.
+    """
+
+    #: A constant which can be used with the last_execution_status property of a StandardTask.
+    #: This constant has a value of "FAILED"
+    LAST_EXECUTION_STATUS_FAILED = "FAILED"
+
+    #: A constant which can be used with the last_execution_status property of a StandardTask.
+    #: This constant has a value of "SUCCEEDED"
+    LAST_EXECUTION_STATUS_SUCCEEDED = "SUCCEEDED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new StandardTask object with values from keyword arguments. The default value of the :py:attr:`~oci.log_analytics.models.StandardTask.kind` attribute
+        of this class is ``STANDARD`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param kind:
+            The value to assign to the kind property of this StandardTask.
+            Allowed values for this property are: "ACCELERATION", "STANDARD", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type kind: str
+
+        :param id:
+            The value to assign to the id property of this StandardTask.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this StandardTask.
+        :type display_name: str
+
+        :param task_type:
+            The value to assign to the task_type property of this StandardTask.
+            Allowed values for this property are: "SAVED_SEARCH", "ACCELERATION", "PURGE", "ACCELERATION_MAINTENANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type task_type: str
+
+        :param schedules:
+            The value to assign to the schedules property of this StandardTask.
+        :type schedules: list[oci.log_analytics.models.Schedule]
+
+        :param action:
+            The value to assign to the action property of this StandardTask.
+        :type action: oci.log_analytics.models.Action
+
+        :param task_status:
+            The value to assign to the task_status property of this StandardTask.
+            Allowed values for this property are: "READY", "PAUSED", "COMPLETED", "BLOCKED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type task_status: str
+
+        :param work_request_id:
+            The value to assign to the work_request_id property of this StandardTask.
+        :type work_request_id: str
+
+        :param num_occurrences:
+            The value to assign to the num_occurrences property of this StandardTask.
+        :type num_occurrences: int
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this StandardTask.
+        :type compartment_id: str
+
+        :param time_created:
+            The value to assign to the time_created property of this StandardTask.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this StandardTask.
+        :type time_updated: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this StandardTask.
+            Allowed values for this property are: "ACTIVE", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this StandardTask.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this StandardTask.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param last_execution_status:
+            The value to assign to the last_execution_status property of this StandardTask.
+            Allowed values for this property are: "FAILED", "SUCCEEDED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type last_execution_status: str
+
+        :param time_last_executed:
+            The value to assign to the time_last_executed property of this StandardTask.
+        :type time_last_executed: datetime
+
+        """
+        self.swagger_types = {
+            'kind': 'str',
+            'id': 'str',
+            'display_name': 'str',
+            'task_type': 'str',
+            'schedules': 'list[Schedule]',
+            'action': 'Action',
+            'task_status': 'str',
+            'work_request_id': 'str',
+            'num_occurrences': 'int',
+            'compartment_id': 'str',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'lifecycle_state': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'last_execution_status': 'str',
+            'time_last_executed': 'datetime'
+        }
+
+        self.attribute_map = {
+            'kind': 'kind',
+            'id': 'id',
+            'display_name': 'displayName',
+            'task_type': 'taskType',
+            'schedules': 'schedules',
+            'action': 'action',
+            'task_status': 'taskStatus',
+            'work_request_id': 'workRequestId',
+            'num_occurrences': 'numOccurrences',
+            'compartment_id': 'compartmentId',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'lifecycle_state': 'lifecycleState',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'last_execution_status': 'lastExecutionStatus',
+            'time_last_executed': 'timeLastExecuted'
+        }
+
+        self._kind = None
+        self._id = None
+        self._display_name = None
+        self._task_type = None
+        self._schedules = None
+        self._action = None
+        self._task_status = None
+        self._work_request_id = None
+        self._num_occurrences = None
+        self._compartment_id = None
+        self._time_created = None
+        self._time_updated = None
+        self._lifecycle_state = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._last_execution_status = None
+        self._time_last_executed = None
+        self._kind = 'STANDARD'
+
+    @property
+    def last_execution_status(self):
+        """
+        Gets the last_execution_status of this StandardTask.
+        The most recent task execution status.
+
+        Allowed values for this property are: "FAILED", "SUCCEEDED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The last_execution_status of this StandardTask.
+        :rtype: str
+        """
+        return self._last_execution_status
+
+    @last_execution_status.setter
+    def last_execution_status(self, last_execution_status):
+        """
+        Sets the last_execution_status of this StandardTask.
+        The most recent task execution status.
+
+
+        :param last_execution_status: The last_execution_status of this StandardTask.
+        :type: str
+        """
+        allowed_values = ["FAILED", "SUCCEEDED"]
+        if not value_allowed_none_or_none_sentinel(last_execution_status, allowed_values):
+            last_execution_status = 'UNKNOWN_ENUM_VALUE'
+        self._last_execution_status = last_execution_status
+
+    @property
+    def time_last_executed(self):
+        """
+        Gets the time_last_executed of this StandardTask.
+        The date and time the scheduled task last executed, in the format defined by RFC3339.
+
+
+        :return: The time_last_executed of this StandardTask.
+        :rtype: datetime
+        """
+        return self._time_last_executed
+
+    @time_last_executed.setter
+    def time_last_executed(self, time_last_executed):
+        """
+        Sets the time_last_executed of this StandardTask.
+        The date and time the scheduled task last executed, in the format defined by RFC3339.
+
+
+        :param time_last_executed: The time_last_executed of this StandardTask.
+        :type: datetime
+        """
+        self._time_last_executed = time_last_executed
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/stats_command_descriptor.py
+++ b/src/oci/log_analytics/models/stats_command_descriptor.py
@@ -21,7 +21,7 @@ class StatsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this StatsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/stream_action.py
+++ b/src/oci/log_analytics/models/stream_action.py
@@ -28,19 +28,26 @@ class StreamAction(Action):
             The value to assign to the saved_search_id property of this StreamAction.
         :type saved_search_id: str
 
+        :param metric_extraction:
+            The value to assign to the metric_extraction property of this StreamAction.
+        :type metric_extraction: oci.log_analytics.models.MetricExtraction
+
         """
         self.swagger_types = {
             'type': 'str',
-            'saved_search_id': 'str'
+            'saved_search_id': 'str',
+            'metric_extraction': 'MetricExtraction'
         }
 
         self.attribute_map = {
             'type': 'type',
-            'saved_search_id': 'savedSearchId'
+            'saved_search_id': 'savedSearchId',
+            'metric_extraction': 'metricExtraction'
         }
 
         self._type = None
         self._saved_search_id = None
+        self._metric_extraction = None
         self._type = 'STREAM'
 
     @property
@@ -66,6 +73,26 @@ class StreamAction(Action):
         :type: str
         """
         self._saved_search_id = saved_search_id
+
+    @property
+    def metric_extraction(self):
+        """
+        Gets the metric_extraction of this StreamAction.
+
+        :return: The metric_extraction of this StreamAction.
+        :rtype: oci.log_analytics.models.MetricExtraction
+        """
+        return self._metric_extraction
+
+    @metric_extraction.setter
+    def metric_extraction(self, metric_extraction):
+        """
+        Sets the metric_extraction of this StreamAction.
+
+        :param metric_extraction: The metric_extraction of this StreamAction.
+        :type: oci.log_analytics.models.MetricExtraction
+        """
+        self._metric_extraction = metric_extraction
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/log_analytics/models/tail_command_descriptor.py
+++ b/src/oci/log_analytics/models/tail_command_descriptor.py
@@ -21,7 +21,7 @@ class TailCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this TailCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/time_compare_command_descriptor.py
+++ b/src/oci/log_analytics/models/time_compare_command_descriptor.py
@@ -21,7 +21,7 @@ class TimeCompareCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this TimeCompareCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/time_stats_command_descriptor.py
+++ b/src/oci/log_analytics/models/time_stats_command_descriptor.py
@@ -21,7 +21,7 @@ class TimeStatsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this TimeStatsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/top_command_descriptor.py
+++ b/src/oci/log_analytics/models/top_command_descriptor.py
@@ -21,7 +21,7 @@ class TopCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this TopCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/update_log_analytics_entity_details.py
+++ b/src/oci/log_analytics/models/update_log_analytics_entity_details.py
@@ -79,7 +79,7 @@ class UpdateLogAnalyticsEntityDetails(object):
     def name(self):
         """
         Gets the name of this UpdateLogAnalyticsEntityDetails.
-        Log analytics entity name. The name must be unique, within the tenancy, and cannot be changed.
+        Log analytics entity name.
 
 
         :return: The name of this UpdateLogAnalyticsEntityDetails.
@@ -91,7 +91,7 @@ class UpdateLogAnalyticsEntityDetails(object):
     def name(self, name):
         """
         Sets the name of this UpdateLogAnalyticsEntityDetails.
-        Log analytics entity name. The name must be unique, within the tenancy, and cannot be changed.
+        Log analytics entity name.
 
 
         :param name: The name of this UpdateLogAnalyticsEntityDetails.

--- a/src/oci/log_analytics/models/update_log_analytics_object_collection_rule_details.py
+++ b/src/oci/log_analytics/models/update_log_analytics_object_collection_rule_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateLogAnalyticsObjectCollectionRuleDetails(object):
     """
-    To update the attributes of an Object Storage based collection rule.
+    Configuration of the collection rule to be updated.
     """
 
     def __init__(self, **kwargs):
@@ -38,6 +38,10 @@ class UpdateLogAnalyticsObjectCollectionRuleDetails(object):
             The value to assign to the char_encoding property of this UpdateLogAnalyticsObjectCollectionRuleDetails.
         :type char_encoding: str
 
+        :param is_enabled:
+            The value to assign to the is_enabled property of this UpdateLogAnalyticsObjectCollectionRuleDetails.
+        :type is_enabled: bool
+
         :param overrides:
             The value to assign to the overrides property of this UpdateLogAnalyticsObjectCollectionRuleDetails.
         :type overrides: dict(str, list[PropertyOverride])
@@ -57,6 +61,7 @@ class UpdateLogAnalyticsObjectCollectionRuleDetails(object):
             'log_source_name': 'str',
             'entity_id': 'str',
             'char_encoding': 'str',
+            'is_enabled': 'bool',
             'overrides': 'dict(str, list[PropertyOverride])',
             'defined_tags': 'dict(str, dict(str, object))',
             'freeform_tags': 'dict(str, str)'
@@ -68,6 +73,7 @@ class UpdateLogAnalyticsObjectCollectionRuleDetails(object):
             'log_source_name': 'logSourceName',
             'entity_id': 'entityId',
             'char_encoding': 'charEncoding',
+            'is_enabled': 'isEnabled',
             'overrides': 'overrides',
             'defined_tags': 'definedTags',
             'freeform_tags': 'freeformTags'
@@ -78,6 +84,7 @@ class UpdateLogAnalyticsObjectCollectionRuleDetails(object):
         self._log_source_name = None
         self._entity_id = None
         self._char_encoding = None
+        self._is_enabled = None
         self._overrides = None
         self._defined_tags = None
         self._freeform_tags = None
@@ -185,7 +192,7 @@ class UpdateLogAnalyticsObjectCollectionRuleDetails(object):
         """
         Gets the char_encoding of this UpdateLogAnalyticsObjectCollectionRuleDetails.
         An optional character encoding to aid in detecting the character encoding of the contents of the objects while processing.
-        It is recommended to set this value as ISO_8589_1 when configuring content of the objects having more numeric characters,
+        It is recommended to set this value as ISO_8859_1 when configuring content of the objects having more numeric characters,
         and very few alphabets.
         For e.g. this applies when configuring VCN Flow Logs.
 
@@ -200,7 +207,7 @@ class UpdateLogAnalyticsObjectCollectionRuleDetails(object):
         """
         Sets the char_encoding of this UpdateLogAnalyticsObjectCollectionRuleDetails.
         An optional character encoding to aid in detecting the character encoding of the contents of the objects while processing.
-        It is recommended to set this value as ISO_8589_1 when configuring content of the objects having more numeric characters,
+        It is recommended to set this value as ISO_8859_1 when configuring content of the objects having more numeric characters,
         and very few alphabets.
         For e.g. this applies when configuring VCN Flow Logs.
 
@@ -209,6 +216,30 @@ class UpdateLogAnalyticsObjectCollectionRuleDetails(object):
         :type: str
         """
         self._char_encoding = char_encoding
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this UpdateLogAnalyticsObjectCollectionRuleDetails.
+        Whether or not this rule is currently enabled.
+
+
+        :return: The is_enabled of this UpdateLogAnalyticsObjectCollectionRuleDetails.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this UpdateLogAnalyticsObjectCollectionRuleDetails.
+        Whether or not this rule is currently enabled.
+
+
+        :param is_enabled: The is_enabled of this UpdateLogAnalyticsObjectCollectionRuleDetails.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
 
     @property
     def overrides(self):

--- a/src/oci/log_analytics/models/update_lookup_metadata_details.py
+++ b/src/oci/log_analytics/models/update_lookup_metadata_details.py
@@ -1,0 +1,163 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateLookupMetadataDetails(object):
+    """
+    UpdateLookupMetadataDetails
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateLookupMetadataDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param default_match_value:
+            The value to assign to the default_match_value property of this UpdateLookupMetadataDetails.
+        :type default_match_value: str
+
+        :param description:
+            The value to assign to the description property of this UpdateLookupMetadataDetails.
+        :type description: str
+
+        :param fields:
+            The value to assign to the fields property of this UpdateLookupMetadataDetails.
+        :type fields: list[oci.log_analytics.models.LogAnalyticsLookupFields]
+
+        :param max_matches:
+            The value to assign to the max_matches property of this UpdateLookupMetadataDetails.
+        :type max_matches: int
+
+        """
+        self.swagger_types = {
+            'default_match_value': 'str',
+            'description': 'str',
+            'fields': 'list[LogAnalyticsLookupFields]',
+            'max_matches': 'int'
+        }
+
+        self.attribute_map = {
+            'default_match_value': 'defaultMatchValue',
+            'description': 'description',
+            'fields': 'fields',
+            'max_matches': 'maxMatches'
+        }
+
+        self._default_match_value = None
+        self._description = None
+        self._fields = None
+        self._max_matches = None
+
+    @property
+    def default_match_value(self):
+        """
+        Gets the default_match_value of this UpdateLookupMetadataDetails.
+        The default match value.
+
+
+        :return: The default_match_value of this UpdateLookupMetadataDetails.
+        :rtype: str
+        """
+        return self._default_match_value
+
+    @default_match_value.setter
+    def default_match_value(self, default_match_value):
+        """
+        Sets the default_match_value of this UpdateLookupMetadataDetails.
+        The default match value.
+
+
+        :param default_match_value: The default_match_value of this UpdateLookupMetadataDetails.
+        :type: str
+        """
+        self._default_match_value = default_match_value
+
+    @property
+    def description(self):
+        """
+        Gets the description of this UpdateLookupMetadataDetails.
+        The lookup description.
+
+
+        :return: The description of this UpdateLookupMetadataDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this UpdateLookupMetadataDetails.
+        The lookup description.
+
+
+        :param description: The description of this UpdateLookupMetadataDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def fields(self):
+        """
+        Gets the fields of this UpdateLookupMetadataDetails.
+        The lookup fields.
+
+
+        :return: The fields of this UpdateLookupMetadataDetails.
+        :rtype: list[oci.log_analytics.models.LogAnalyticsLookupFields]
+        """
+        return self._fields
+
+    @fields.setter
+    def fields(self, fields):
+        """
+        Sets the fields of this UpdateLookupMetadataDetails.
+        The lookup fields.
+
+
+        :param fields: The fields of this UpdateLookupMetadataDetails.
+        :type: list[oci.log_analytics.models.LogAnalyticsLookupFields]
+        """
+        self._fields = fields
+
+    @property
+    def max_matches(self):
+        """
+        Gets the max_matches of this UpdateLookupMetadataDetails.
+        The maximum number of matches.
+
+
+        :return: The max_matches of this UpdateLookupMetadataDetails.
+        :rtype: int
+        """
+        return self._max_matches
+
+    @max_matches.setter
+    def max_matches(self, max_matches):
+        """
+        Sets the max_matches of this UpdateLookupMetadataDetails.
+        The maximum number of matches.
+
+
+        :param max_matches: The max_matches of this UpdateLookupMetadataDetails.
+        :type: int
+        """
+        self._max_matches = max_matches
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/update_scheduled_task_details.py
+++ b/src/oci/log_analytics/models/update_scheduled_task_details.py
@@ -13,10 +13,27 @@ class UpdateScheduledTaskDetails(object):
     The details for updating a schedule task.
     """
 
+    #: A constant which can be used with the kind property of a UpdateScheduledTaskDetails.
+    #: This constant has a value of "ACCELERATION"
+    KIND_ACCELERATION = "ACCELERATION"
+
+    #: A constant which can be used with the kind property of a UpdateScheduledTaskDetails.
+    #: This constant has a value of "STANDARD"
+    KIND_STANDARD = "STANDARD"
+
     def __init__(self, **kwargs):
         """
-        Initializes a new UpdateScheduledTaskDetails object with values from keyword arguments.
+        Initializes a new UpdateScheduledTaskDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.log_analytics.models.UpdateStandardTaskDetails`
+
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param kind:
+            The value to assign to the kind property of this UpdateScheduledTaskDetails.
+            Allowed values for this property are: "ACCELERATION", "STANDARD"
+        :type kind: str
 
         :param display_name:
             The value to assign to the display_name property of this UpdateScheduledTaskDetails.
@@ -36,6 +53,7 @@ class UpdateScheduledTaskDetails(object):
 
         """
         self.swagger_types = {
+            'kind': 'str',
             'display_name': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
@@ -43,16 +61,63 @@ class UpdateScheduledTaskDetails(object):
         }
 
         self.attribute_map = {
+            'kind': 'kind',
             'display_name': 'displayName',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'schedules': 'schedules'
         }
 
+        self._kind = None
         self._display_name = None
         self._freeform_tags = None
         self._defined_tags = None
         self._schedules = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['kind']
+
+        if type == 'STANDARD':
+            return 'UpdateStandardTaskDetails'
+        else:
+            return 'UpdateScheduledTaskDetails'
+
+    @property
+    def kind(self):
+        """
+        **[Required]** Gets the kind of this UpdateScheduledTaskDetails.
+        Discriminator.
+
+        Allowed values for this property are: "ACCELERATION", "STANDARD"
+
+
+        :return: The kind of this UpdateScheduledTaskDetails.
+        :rtype: str
+        """
+        return self._kind
+
+    @kind.setter
+    def kind(self, kind):
+        """
+        Sets the kind of this UpdateScheduledTaskDetails.
+        Discriminator.
+
+
+        :param kind: The kind of this UpdateScheduledTaskDetails.
+        :type: str
+        """
+        allowed_values = ["ACCELERATION", "STANDARD"]
+        if not value_allowed_none_or_none_sentinel(kind, allowed_values):
+            raise ValueError(
+                "Invalid value for `kind`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._kind = kind
 
     @property
     def display_name(self):
@@ -140,7 +205,8 @@ class UpdateScheduledTaskDetails(object):
     def schedules(self):
         """
         Gets the schedules of this UpdateScheduledTaskDetails.
-        Schedules may be updated for task types SAVED_SEARCH and PURGE
+        Schedules may be updated for task types SAVED_SEARCH and PURGE.
+        Note there may only be a single schedule for SAVED_SEARCH and PURGE scheduled tasks.
 
 
         :return: The schedules of this UpdateScheduledTaskDetails.
@@ -152,7 +218,8 @@ class UpdateScheduledTaskDetails(object):
     def schedules(self, schedules):
         """
         Sets the schedules of this UpdateScheduledTaskDetails.
-        Schedules may be updated for task types SAVED_SEARCH and PURGE
+        Schedules may be updated for task types SAVED_SEARCH and PURGE.
+        Note there may only be a single schedule for SAVED_SEARCH and PURGE scheduled tasks.
 
 
         :param schedules: The schedules of this UpdateScheduledTaskDetails.

--- a/src/oci/log_analytics/models/update_standard_task_details.py
+++ b/src/oci/log_analytics/models/update_standard_task_details.py
@@ -1,0 +1,104 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .update_scheduled_task_details import UpdateScheduledTaskDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateStandardTaskDetails(UpdateScheduledTaskDetails):
+    """
+    The details for updating a schedule task.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateStandardTaskDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.log_analytics.models.UpdateStandardTaskDetails.kind` attribute
+        of this class is ``STANDARD`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param kind:
+            The value to assign to the kind property of this UpdateStandardTaskDetails.
+            Allowed values for this property are: "ACCELERATION", "STANDARD"
+        :type kind: str
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateStandardTaskDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateStandardTaskDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateStandardTaskDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param schedules:
+            The value to assign to the schedules property of this UpdateStandardTaskDetails.
+        :type schedules: list[oci.log_analytics.models.Schedule]
+
+        :param action:
+            The value to assign to the action property of this UpdateStandardTaskDetails.
+        :type action: oci.log_analytics.models.Action
+
+        """
+        self.swagger_types = {
+            'kind': 'str',
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'schedules': 'list[Schedule]',
+            'action': 'Action'
+        }
+
+        self.attribute_map = {
+            'kind': 'kind',
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'schedules': 'schedules',
+            'action': 'action'
+        }
+
+        self._kind = None
+        self._display_name = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._schedules = None
+        self._action = None
+        self._kind = 'STANDARD'
+
+    @property
+    def action(self):
+        """
+        Gets the action of this UpdateStandardTaskDetails.
+
+        :return: The action of this UpdateStandardTaskDetails.
+        :rtype: oci.log_analytics.models.Action
+        """
+        return self._action
+
+    @action.setter
+    def action(self, action):
+        """
+        Sets the action of this UpdateStandardTaskDetails.
+
+        :param action: The action of this UpdateStandardTaskDetails.
+        :type: oci.log_analytics.models.Action
+        """
+        self._action = action
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/upload.py
+++ b/src/oci/log_analytics/models/upload.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class Upload(object):
     """
-    Upload is a container that can be used to optionally put all the relevant and related on-demand upload based log files.
+    Upload is a container that can be used to put all the relevant and related on-demand upload based log files together.
     """
 
     def __init__(self, **kwargs):
@@ -79,7 +79,7 @@ class Upload(object):
     def reference(self):
         """
         **[Required]** Gets the reference of this Upload.
-        Unique internal identifier to refer to the upload container
+        Unique internal identifier to refer the upload container.
 
 
         :return: The reference of this Upload.
@@ -91,7 +91,7 @@ class Upload(object):
     def reference(self, reference):
         """
         Sets the reference of this Upload.
-        Unique internal identifier to refer to the upload container
+        Unique internal identifier to refer the upload container.
 
 
         :param reference: The reference of this Upload.
@@ -103,7 +103,7 @@ class Upload(object):
     def name(self):
         """
         **[Required]** Gets the name of this Upload.
-        The name of the upload container
+        The name of the upload container.
 
 
         :return: The name of this Upload.
@@ -115,7 +115,7 @@ class Upload(object):
     def name(self, name):
         """
         Sets the name of this Upload.
-        The name of the upload container
+        The name of the upload container.
 
 
         :param name: The name of this Upload.
@@ -127,7 +127,7 @@ class Upload(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this Upload.
-        The time when this upload container is created. An RFC3339 formatted datetime string
+        The time when this upload container is created. An RFC3339 formatted datetime string.
 
 
         :return: The time_created of this Upload.
@@ -139,7 +139,7 @@ class Upload(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Upload.
-        The time when this upload container is created. An RFC3339 formatted datetime string
+        The time when this upload container is created. An RFC3339 formatted datetime string.
 
 
         :param time_created: The time_created of this Upload.
@@ -151,7 +151,7 @@ class Upload(object):
     def time_updated(self):
         """
         Gets the time_updated of this Upload.
-        The latest time when this upload container is modified. An RFC3339 formatted datetime string
+        The latest time when this upload container is modified. An RFC3339 formatted datetime string.
 
 
         :return: The time_updated of this Upload.
@@ -163,7 +163,7 @@ class Upload(object):
     def time_updated(self, time_updated):
         """
         Sets the time_updated of this Upload.
-        The latest time when this upload container is modified. An RFC3339 formatted datetime string
+        The latest time when this upload container is modified. An RFC3339 formatted datetime string.
 
 
         :param time_updated: The time_updated of this Upload.
@@ -175,7 +175,7 @@ class Upload(object):
     def time_earliest_log_entry(self):
         """
         Gets the time_earliest_log_entry of this Upload.
-        This time represents the earliest time of the log entry in this container. An RFC3339 formatted datetime string
+        This time represents the earliest time of the log entry in this container. An RFC3339 formatted datetime string.
 
 
         :return: The time_earliest_log_entry of this Upload.
@@ -187,7 +187,7 @@ class Upload(object):
     def time_earliest_log_entry(self, time_earliest_log_entry):
         """
         Sets the time_earliest_log_entry of this Upload.
-        This time represents the earliest time of the log entry in this container. An RFC3339 formatted datetime string
+        This time represents the earliest time of the log entry in this container. An RFC3339 formatted datetime string.
 
 
         :param time_earliest_log_entry: The time_earliest_log_entry of this Upload.
@@ -199,7 +199,7 @@ class Upload(object):
     def time_latest_log_entry(self):
         """
         Gets the time_latest_log_entry of this Upload.
-        This time represents the latest time of the log entry in this container. An RFC3339 formatted datetime string
+        This time represents the latest time of the log entry in this container. An RFC3339 formatted datetime string.
 
 
         :return: The time_latest_log_entry of this Upload.
@@ -211,7 +211,7 @@ class Upload(object):
     def time_latest_log_entry(self, time_latest_log_entry):
         """
         Sets the time_latest_log_entry of this Upload.
-        This time represents the latest time of the log entry in this container. An RFC3339 formatted datetime string
+        This time represents the latest time of the log entry in this container. An RFC3339 formatted datetime string.
 
 
         :param time_latest_log_entry: The time_latest_log_entry of this Upload.

--- a/src/oci/log_analytics/models/upload_file_status.py
+++ b/src/oci/log_analytics/models/upload_file_status.py
@@ -44,7 +44,7 @@ class UploadFileStatus(object):
     def file_name(self):
         """
         Gets the file_name of this UploadFileStatus.
-        Name of the file
+        Name of the file.
 
 
         :return: The file_name of this UploadFileStatus.
@@ -56,7 +56,7 @@ class UploadFileStatus(object):
     def file_name(self, file_name):
         """
         Sets the file_name of this UploadFileStatus.
-        Name of the file
+        Name of the file.
 
 
         :param file_name: The file_name of this UploadFileStatus.
@@ -68,7 +68,7 @@ class UploadFileStatus(object):
     def is_valid(self):
         """
         Gets the is_valid of this UploadFileStatus.
-        Is Valid flag
+        Is Valid flag.
 
 
         :return: The is_valid of this UploadFileStatus.
@@ -80,7 +80,7 @@ class UploadFileStatus(object):
     def is_valid(self, is_valid):
         """
         Sets the is_valid of this UploadFileStatus.
-        Is Valid flag
+        Is Valid flag.
 
 
         :param is_valid: The is_valid of this UploadFileStatus.

--- a/src/oci/log_analytics/models/upload_file_summary.py
+++ b/src/oci/log_analytics/models/upload_file_summary.py
@@ -149,7 +149,7 @@ class UploadFileSummary(object):
     def reference(self):
         """
         **[Required]** Gets the reference of this UploadFileSummary.
-        Unique internal identifier to refer to upload file
+        Unique internal identifier to refer upload file.
 
 
         :return: The reference of this UploadFileSummary.
@@ -161,7 +161,7 @@ class UploadFileSummary(object):
     def reference(self, reference):
         """
         Sets the reference of this UploadFileSummary.
-        Unique internal identifier to refer to upload file
+        Unique internal identifier to refer upload file.
 
 
         :param reference: The reference of this UploadFileSummary.
@@ -251,7 +251,7 @@ class UploadFileSummary(object):
     def chunks_consumed(self):
         """
         Gets the chunks_consumed of this UploadFileSummary.
-        Number of chunks processed
+        Number of chunks processed.
 
 
         :return: The chunks_consumed of this UploadFileSummary.
@@ -263,7 +263,7 @@ class UploadFileSummary(object):
     def chunks_consumed(self, chunks_consumed):
         """
         Sets the chunks_consumed of this UploadFileSummary.
-        Number of chunks processed
+        Number of chunks processed.
 
 
         :param chunks_consumed: The chunks_consumed of this UploadFileSummary.
@@ -275,7 +275,7 @@ class UploadFileSummary(object):
     def chunks_success(self):
         """
         Gets the chunks_success of this UploadFileSummary.
-        Number of chunks processed successfully
+        Number of chunks processed successfully.
 
 
         :return: The chunks_success of this UploadFileSummary.
@@ -287,7 +287,7 @@ class UploadFileSummary(object):
     def chunks_success(self, chunks_success):
         """
         Sets the chunks_success of this UploadFileSummary.
-        Number of chunks processed successfully
+        Number of chunks processed successfully.
 
 
         :param chunks_success: The chunks_success of this UploadFileSummary.
@@ -299,7 +299,7 @@ class UploadFileSummary(object):
     def chunks_fail(self):
         """
         Gets the chunks_fail of this UploadFileSummary.
-        Number of chunks failed processing
+        Number of chunks failed processing.
 
 
         :return: The chunks_fail of this UploadFileSummary.
@@ -311,7 +311,7 @@ class UploadFileSummary(object):
     def chunks_fail(self, chunks_fail):
         """
         Sets the chunks_fail of this UploadFileSummary.
-        Number of chunks failed processing
+        Number of chunks failed processing.
 
 
         :param chunks_fail: The chunks_fail of this UploadFileSummary.
@@ -323,7 +323,7 @@ class UploadFileSummary(object):
     def time_started(self):
         """
         Gets the time_started of this UploadFileSummary.
-        The time when this file processing started
+        The time when this file processing started.
 
 
         :return: The time_started of this UploadFileSummary.
@@ -335,7 +335,7 @@ class UploadFileSummary(object):
     def time_started(self, time_started):
         """
         Sets the time_started of this UploadFileSummary.
-        The time when this file processing started
+        The time when this file processing started.
 
 
         :param time_started: The time_started of this UploadFileSummary.
@@ -347,7 +347,7 @@ class UploadFileSummary(object):
     def source_name(self):
         """
         Gets the source_name of this UploadFileSummary.
-        Name of the log source used for processing this file
+        Name of the log source used for processing this file.
 
 
         :return: The source_name of this UploadFileSummary.
@@ -359,7 +359,7 @@ class UploadFileSummary(object):
     def source_name(self, source_name):
         """
         Sets the source_name of this UploadFileSummary.
-        Name of the log source used for processing this file
+        Name of the log source used for processing this file.
 
 
         :param source_name: The source_name of this UploadFileSummary.
@@ -371,7 +371,7 @@ class UploadFileSummary(object):
     def entity_type(self):
         """
         Gets the entity_type of this UploadFileSummary.
-        Name of the entity type
+        Name of the entity type.
 
 
         :return: The entity_type of this UploadFileSummary.
@@ -383,7 +383,7 @@ class UploadFileSummary(object):
     def entity_type(self, entity_type):
         """
         Sets the entity_type of this UploadFileSummary.
-        Name of the entity type
+        Name of the entity type.
 
 
         :param entity_type: The entity_type of this UploadFileSummary.
@@ -419,7 +419,7 @@ class UploadFileSummary(object):
     def log_namespace(self):
         """
         Gets the log_namespace of this UploadFileSummary.
-        Log namespace associated with the file.
+        (Deprecated) Name of the log namespace associated with the file.
 
 
         :return: The log_namespace of this UploadFileSummary.
@@ -431,7 +431,7 @@ class UploadFileSummary(object):
     def log_namespace(self, log_namespace):
         """
         Sets the log_namespace of this UploadFileSummary.
-        Log namespace associated with the file.
+        (Deprecated) Name of the log namespace associated with the file.
 
 
         :param log_namespace: The log_namespace of this UploadFileSummary.
@@ -467,7 +467,7 @@ class UploadFileSummary(object):
     def log_group_name(self):
         """
         Gets the log_group_name of this UploadFileSummary.
-        Log group name associated with the file.
+        Name of the log group associated with the file.
 
 
         :return: The log_group_name of this UploadFileSummary.
@@ -479,7 +479,7 @@ class UploadFileSummary(object):
     def log_group_name(self, log_group_name):
         """
         Sets the log_group_name of this UploadFileSummary.
-        Log group name associated with the file.
+        Name of the log group associated with the file.
 
 
         :param log_group_name: The log_group_name of this UploadFileSummary.
@@ -491,7 +491,7 @@ class UploadFileSummary(object):
     def failure_details(self):
         """
         Gets the failure_details of this UploadFileSummary.
-        The details about upload processing failure
+        The details about upload processing failure.
 
 
         :return: The failure_details of this UploadFileSummary.
@@ -503,7 +503,7 @@ class UploadFileSummary(object):
     def failure_details(self, failure_details):
         """
         Sets the failure_details of this UploadFileSummary.
-        The details about upload processing failure
+        The details about upload processing failure.
 
 
         :param failure_details: The failure_details of this UploadFileSummary.

--- a/src/oci/log_analytics/models/upload_summary.py
+++ b/src/oci/log_analytics/models/upload_summary.py
@@ -79,7 +79,7 @@ class UploadSummary(object):
     def reference(self):
         """
         **[Required]** Gets the reference of this UploadSummary.
-        Unique internal identifier to refer to the upload container
+        Unique internal identifier to refer the upload container.
 
 
         :return: The reference of this UploadSummary.
@@ -91,7 +91,7 @@ class UploadSummary(object):
     def reference(self, reference):
         """
         Sets the reference of this UploadSummary.
-        Unique internal identifier to refer to the upload container
+        Unique internal identifier to refer the upload container.
 
 
         :param reference: The reference of this UploadSummary.
@@ -103,7 +103,7 @@ class UploadSummary(object):
     def name(self):
         """
         **[Required]** Gets the name of this UploadSummary.
-        The name of the upload container
+        The name of the upload container.
 
 
         :return: The name of this UploadSummary.
@@ -115,7 +115,7 @@ class UploadSummary(object):
     def name(self, name):
         """
         Sets the name of this UploadSummary.
-        The name of the upload container
+        The name of the upload container.
 
 
         :param name: The name of this UploadSummary.
@@ -127,7 +127,7 @@ class UploadSummary(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this UploadSummary.
-        The time when this upload container is created. An RFC3339 formatted datetime string
+        The time when this upload container is created. An RFC3339 formatted datetime string.
 
 
         :return: The time_created of this UploadSummary.
@@ -139,7 +139,7 @@ class UploadSummary(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this UploadSummary.
-        The time when this upload container is created. An RFC3339 formatted datetime string
+        The time when this upload container is created. An RFC3339 formatted datetime string.
 
 
         :param time_created: The time_created of this UploadSummary.
@@ -151,7 +151,7 @@ class UploadSummary(object):
     def time_updated(self):
         """
         Gets the time_updated of this UploadSummary.
-        The latest time when this upload container is modified. An RFC3339 formatted datetime string
+        The latest time when this upload container is modified. An RFC3339 formatted datetime string.
 
 
         :return: The time_updated of this UploadSummary.
@@ -163,7 +163,7 @@ class UploadSummary(object):
     def time_updated(self, time_updated):
         """
         Sets the time_updated of this UploadSummary.
-        The latest time when this upload container is modified. An RFC3339 formatted datetime string
+        The latest time when this upload container is modified. An RFC3339 formatted datetime string.
 
 
         :param time_updated: The time_updated of this UploadSummary.
@@ -175,7 +175,7 @@ class UploadSummary(object):
     def time_earliest_log_entry(self):
         """
         Gets the time_earliest_log_entry of this UploadSummary.
-        This time represents the earliest time of the log entry in this container. An RFC3339 formatted datetime string
+        This time represents the earliest time of the log entry in this container. An RFC3339 formatted datetime string.
 
 
         :return: The time_earliest_log_entry of this UploadSummary.
@@ -187,7 +187,7 @@ class UploadSummary(object):
     def time_earliest_log_entry(self, time_earliest_log_entry):
         """
         Sets the time_earliest_log_entry of this UploadSummary.
-        This time represents the earliest time of the log entry in this container. An RFC3339 formatted datetime string
+        This time represents the earliest time of the log entry in this container. An RFC3339 formatted datetime string.
 
 
         :param time_earliest_log_entry: The time_earliest_log_entry of this UploadSummary.
@@ -199,7 +199,7 @@ class UploadSummary(object):
     def time_latest_log_entry(self):
         """
         Gets the time_latest_log_entry of this UploadSummary.
-        This time represents the latest time of the log entry in this container. An RFC3339 formatted datetime string
+        This time represents the latest time of the log entry in this container. An RFC3339 formatted datetime string.
 
 
         :return: The time_latest_log_entry of this UploadSummary.
@@ -211,7 +211,7 @@ class UploadSummary(object):
     def time_latest_log_entry(self, time_latest_log_entry):
         """
         Sets the time_latest_log_entry of this UploadSummary.
-        This time represents the latest time of the log entry in this container. An RFC3339 formatted datetime string
+        This time represents the latest time of the log entry in this container. An RFC3339 formatted datetime string.
 
 
         :param time_latest_log_entry: The time_latest_log_entry of this UploadSummary.

--- a/src/oci/log_analytics/models/upload_warning_collection.py
+++ b/src/oci/log_analytics/models/upload_warning_collection.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UploadWarningCollection(object):
     """
-    Collection of UploadFileSummary objects.
+    Collection of UploadWarningSummary objects.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/log_analytics/models/upload_warning_summary.py
+++ b/src/oci/log_analytics/models/upload_warning_summary.py
@@ -58,7 +58,7 @@ class UploadWarningSummary(object):
     def reference(self):
         """
         **[Required]** Gets the reference of this UploadWarningSummary.
-        Unique internal identifier to refer to upload warning
+        Unique internal identifier to refer upload warning.
 
 
         :return: The reference of this UploadWarningSummary.
@@ -70,7 +70,7 @@ class UploadWarningSummary(object):
     def reference(self, reference):
         """
         Sets the reference of this UploadWarningSummary.
-        Unique internal identifier to refer to upload warning
+        Unique internal identifier to refer upload warning.
 
 
         :param reference: The reference of this UploadWarningSummary.
@@ -82,7 +82,7 @@ class UploadWarningSummary(object):
     def status(self):
         """
         Gets the status of this UploadWarningSummary.
-        Status of the upload. Ex - Failed
+        Status of the upload. Ex - Failed.
 
 
         :return: The status of this UploadWarningSummary.
@@ -94,7 +94,7 @@ class UploadWarningSummary(object):
     def status(self, status):
         """
         Sets the status of this UploadWarningSummary.
-        Status of the upload. Ex - Failed
+        Status of the upload. Ex - Failed.
 
 
         :param status: The status of this UploadWarningSummary.
@@ -106,7 +106,7 @@ class UploadWarningSummary(object):
     def time_started(self):
         """
         Gets the time_started of this UploadWarningSummary.
-        The time when the upload processing started
+        The time when the upload processing started.
 
 
         :return: The time_started of this UploadWarningSummary.
@@ -118,7 +118,7 @@ class UploadWarningSummary(object):
     def time_started(self, time_started):
         """
         Sets the time_started of this UploadWarningSummary.
-        The time when the upload processing started
+        The time when the upload processing started.
 
 
         :param time_started: The time_started of this UploadWarningSummary.
@@ -130,7 +130,7 @@ class UploadWarningSummary(object):
     def error_message(self):
         """
         Gets the error_message of this UploadWarningSummary.
-        The details about upload processing failure
+        The details about upload processing failure.
 
 
         :return: The error_message of this UploadWarningSummary.
@@ -142,7 +142,7 @@ class UploadWarningSummary(object):
     def error_message(self, error_message):
         """
         Sets the error_message of this UploadWarningSummary.
-        The details about upload processing failure
+        The details about upload processing failure.
 
 
         :param error_message: The error_message of this UploadWarningSummary.

--- a/src/oci/log_analytics/models/warning_reference_details.py
+++ b/src/oci/log_analytics/models/warning_reference_details.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class WarningReferenceDetails(object):
+    """
+    A list of LogAnalyticsWarning references.  Used as input to APIs which operate on a
+    list.  For example, the suppress warning API accepts a list of warning references
+    and will suppress all warnings in the input list.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new WarningReferenceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param warning_references:
+            The value to assign to the warning_references property of this WarningReferenceDetails.
+        :type warning_references: list[str]
+
+        """
+        self.swagger_types = {
+            'warning_references': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'warning_references': 'warningReferences'
+        }
+
+        self._warning_references = None
+
+    @property
+    def warning_references(self):
+        """
+        Gets the warning_references of this WarningReferenceDetails.
+        A list of LogAnalyticsWarning references.  Used as input to APIs which operate on a
+        list.  For example, the suppress warning API accepts a list of warning references
+        and will suppress all warnings in the input list.
+
+
+        :return: The warning_references of this WarningReferenceDetails.
+        :rtype: list[str]
+        """
+        return self._warning_references
+
+    @warning_references.setter
+    def warning_references(self, warning_references):
+        """
+        Sets the warning_references of this WarningReferenceDetails.
+        A list of LogAnalyticsWarning references.  Used as input to APIs which operate on a
+        list.  For example, the suppress warning API accepts a list of warning references
+        and will suppress all warnings in the input list.
+
+
+        :param warning_references: The warning_references of this WarningReferenceDetails.
+        :type: list[str]
+        """
+        self._warning_references = warning_references
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/models/where_command_descriptor.py
+++ b/src/oci/log_analytics/models/where_command_descriptor.py
@@ -21,7 +21,7 @@ class WhereCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this WhereCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/management_dashboard/dashx_apis_client.py
+++ b/src/oci/management_dashboard/dashx_apis_client.py
@@ -79,7 +79,7 @@ class DashxApisClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20200901',
-            'service_endpoint_template': 'https://managementdashboards.{region}.oci.{secondLevelDomain}',
+            'service_endpoint_template': 'https://managementdashboard.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("dashx_apis", config, signer, management_dashboard_type_mapping, **base_client_init_kwargs)

--- a/src/oci/sch/models/__init__.py
+++ b/src/oci/sch/models/__init__.py
@@ -9,6 +9,7 @@ from .create_service_connector_details import CreateServiceConnectorDetails
 from .functions_target_details import FunctionsTargetDetails
 from .log_rule_task_details import LogRuleTaskDetails
 from .log_source import LogSource
+from .logging_analytics_target_details import LoggingAnalyticsTargetDetails
 from .logging_source_details import LoggingSourceDetails
 from .monitoring_target_details import MonitoringTargetDetails
 from .notifications_target_details import NotificationsTargetDetails
@@ -36,6 +37,7 @@ sch_type_mapping = {
     "FunctionsTargetDetails": FunctionsTargetDetails,
     "LogRuleTaskDetails": LogRuleTaskDetails,
     "LogSource": LogSource,
+    "LoggingAnalyticsTargetDetails": LoggingAnalyticsTargetDetails,
     "LoggingSourceDetails": LoggingSourceDetails,
     "MonitoringTargetDetails": MonitoringTargetDetails,
     "NotificationsTargetDetails": NotificationsTargetDetails,

--- a/src/oci/sch/models/functions_target_details.py
+++ b/src/oci/sch/models/functions_target_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class FunctionsTargetDetails(TargetDetails):
     """
-    The function target.
+    The function used for the Functions target.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class FunctionsTargetDetails(TargetDetails):
 
         :param kind:
             The value to assign to the kind property of this FunctionsTargetDetails.
-            Allowed values for this property are: "streaming", "objectStorage", "monitoring", "functions", "notifications"
+            Allowed values for this property are: "functions", "loggingAnalytics", "monitoring", "notifications", "objectStorage", "streaming"
         :type kind: str
 
         :param function_id:

--- a/src/oci/sch/models/logging_analytics_target_details.py
+++ b/src/oci/sch/models/logging_analytics_target_details.py
@@ -1,0 +1,84 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .target_details import TargetDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class LoggingAnalyticsTargetDetails(TargetDetails):
+    """
+    The log group used for the Logging Analytics target.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new LoggingAnalyticsTargetDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.sch.models.LoggingAnalyticsTargetDetails.kind` attribute
+        of this class is ``loggingAnalytics`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param kind:
+            The value to assign to the kind property of this LoggingAnalyticsTargetDetails.
+            Allowed values for this property are: "functions", "loggingAnalytics", "monitoring", "notifications", "objectStorage", "streaming"
+        :type kind: str
+
+        :param log_group_id:
+            The value to assign to the log_group_id property of this LoggingAnalyticsTargetDetails.
+        :type log_group_id: str
+
+        """
+        self.swagger_types = {
+            'kind': 'str',
+            'log_group_id': 'str'
+        }
+
+        self.attribute_map = {
+            'kind': 'kind',
+            'log_group_id': 'logGroupId'
+        }
+
+        self._kind = None
+        self._log_group_id = None
+        self._kind = 'loggingAnalytics'
+
+    @property
+    def log_group_id(self):
+        """
+        **[Required]** Gets the log_group_id of this LoggingAnalyticsTargetDetails.
+        The `OCID`__ of the Logging Analytics log group.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The log_group_id of this LoggingAnalyticsTargetDetails.
+        :rtype: str
+        """
+        return self._log_group_id
+
+    @log_group_id.setter
+    def log_group_id(self, log_group_id):
+        """
+        Sets the log_group_id of this LoggingAnalyticsTargetDetails.
+        The `OCID`__ of the Logging Analytics log group.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param log_group_id: The log_group_id of this LoggingAnalyticsTargetDetails.
+        :type: str
+        """
+        self._log_group_id = log_group_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/sch/models/monitoring_target_details.py
+++ b/src/oci/sch/models/monitoring_target_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class MonitoringTargetDetails(TargetDetails):
     """
-    The monitoring target.
+    The metric and metric namespace used for the Monitoring target.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class MonitoringTargetDetails(TargetDetails):
 
         :param kind:
             The value to assign to the kind property of this MonitoringTargetDetails.
-            Allowed values for this property are: "streaming", "objectStorage", "monitoring", "functions", "notifications"
+            Allowed values for this property are: "functions", "loggingAnalytics", "monitoring", "notifications", "objectStorage", "streaming"
         :type kind: str
 
         :param compartment_id:

--- a/src/oci/sch/models/notifications_target_details.py
+++ b/src/oci/sch/models/notifications_target_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class NotificationsTargetDetails(TargetDetails):
     """
-    The notifications target.
+    The topic used for the Notifications target.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class NotificationsTargetDetails(TargetDetails):
 
         :param kind:
             The value to assign to the kind property of this NotificationsTargetDetails.
-            Allowed values for this property are: "streaming", "objectStorage", "monitoring", "functions", "notifications"
+            Allowed values for this property are: "functions", "loggingAnalytics", "monitoring", "notifications", "objectStorage", "streaming"
         :type kind: str
 
         :param topic_id:

--- a/src/oci/sch/models/object_storage_target_details.py
+++ b/src/oci/sch/models/object_storage_target_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ObjectStorageTargetDetails(TargetDetails):
     """
-    The object storage target.
+    The bucket used for the Object Storage target.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class ObjectStorageTargetDetails(TargetDetails):
 
         :param kind:
             The value to assign to the kind property of this ObjectStorageTargetDetails.
-            Allowed values for this property are: "streaming", "objectStorage", "monitoring", "functions", "notifications"
+            Allowed values for this property are: "functions", "loggingAnalytics", "monitoring", "notifications", "objectStorage", "streaming"
         :type kind: str
 
         :param namespace:
@@ -36,25 +36,39 @@ class ObjectStorageTargetDetails(TargetDetails):
             The value to assign to the object_name_prefix property of this ObjectStorageTargetDetails.
         :type object_name_prefix: str
 
+        :param batch_rollover_size_in_mbs:
+            The value to assign to the batch_rollover_size_in_mbs property of this ObjectStorageTargetDetails.
+        :type batch_rollover_size_in_mbs: int
+
+        :param batch_rollover_time_in_ms:
+            The value to assign to the batch_rollover_time_in_ms property of this ObjectStorageTargetDetails.
+        :type batch_rollover_time_in_ms: int
+
         """
         self.swagger_types = {
             'kind': 'str',
             'namespace': 'str',
             'bucket_name': 'str',
-            'object_name_prefix': 'str'
+            'object_name_prefix': 'str',
+            'batch_rollover_size_in_mbs': 'int',
+            'batch_rollover_time_in_ms': 'int'
         }
 
         self.attribute_map = {
             'kind': 'kind',
             'namespace': 'namespace',
             'bucket_name': 'bucketName',
-            'object_name_prefix': 'objectNamePrefix'
+            'object_name_prefix': 'objectNamePrefix',
+            'batch_rollover_size_in_mbs': 'batchRolloverSizeInMBs',
+            'batch_rollover_time_in_ms': 'batchRolloverTimeInMs'
         }
 
         self._kind = None
         self._namespace = None
         self._bucket_name = None
         self._object_name_prefix = None
+        self._batch_rollover_size_in_mbs = None
+        self._batch_rollover_time_in_ms = None
         self._kind = 'objectStorage'
 
     @property
@@ -128,6 +142,54 @@ class ObjectStorageTargetDetails(TargetDetails):
         :type: str
         """
         self._object_name_prefix = object_name_prefix
+
+    @property
+    def batch_rollover_size_in_mbs(self):
+        """
+        Gets the batch_rollover_size_in_mbs of this ObjectStorageTargetDetails.
+        The batch rollover size in megabytes.
+
+
+        :return: The batch_rollover_size_in_mbs of this ObjectStorageTargetDetails.
+        :rtype: int
+        """
+        return self._batch_rollover_size_in_mbs
+
+    @batch_rollover_size_in_mbs.setter
+    def batch_rollover_size_in_mbs(self, batch_rollover_size_in_mbs):
+        """
+        Sets the batch_rollover_size_in_mbs of this ObjectStorageTargetDetails.
+        The batch rollover size in megabytes.
+
+
+        :param batch_rollover_size_in_mbs: The batch_rollover_size_in_mbs of this ObjectStorageTargetDetails.
+        :type: int
+        """
+        self._batch_rollover_size_in_mbs = batch_rollover_size_in_mbs
+
+    @property
+    def batch_rollover_time_in_ms(self):
+        """
+        Gets the batch_rollover_time_in_ms of this ObjectStorageTargetDetails.
+        The batch rollover time in milliseconds.
+
+
+        :return: The batch_rollover_time_in_ms of this ObjectStorageTargetDetails.
+        :rtype: int
+        """
+        return self._batch_rollover_time_in_ms
+
+    @batch_rollover_time_in_ms.setter
+    def batch_rollover_time_in_ms(self, batch_rollover_time_in_ms):
+        """
+        Sets the batch_rollover_time_in_ms of this ObjectStorageTargetDetails.
+        The batch rollover time in milliseconds.
+
+
+        :param batch_rollover_time_in_ms: The batch_rollover_time_in_ms of this ObjectStorageTargetDetails.
+        :type: int
+        """
+        self._batch_rollover_time_in_ms = batch_rollover_time_in_ms
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/sch/models/streaming_target_details.py
+++ b/src/oci/sch/models/streaming_target_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class StreamingTargetDetails(TargetDetails):
     """
-    The streaming target.
+    The stream used for the Streaming target.
     """
 
     def __init__(self, **kwargs):
@@ -21,7 +21,7 @@ class StreamingTargetDetails(TargetDetails):
 
         :param kind:
             The value to assign to the kind property of this StreamingTargetDetails.
-            Allowed values for this property are: "streaming", "objectStorage", "monitoring", "functions", "notifications"
+            Allowed values for this property are: "functions", "loggingAnalytics", "monitoring", "notifications", "objectStorage", "streaming"
         :type kind: str
 
         :param stream_id:

--- a/src/oci/sch/models/target_details.py
+++ b/src/oci/sch/models/target_details.py
@@ -19,24 +19,28 @@ class TargetDetails(object):
     """
 
     #: A constant which can be used with the kind property of a TargetDetails.
-    #: This constant has a value of "streaming"
-    KIND_STREAMING = "streaming"
+    #: This constant has a value of "functions"
+    KIND_FUNCTIONS = "functions"
 
     #: A constant which can be used with the kind property of a TargetDetails.
-    #: This constant has a value of "objectStorage"
-    KIND_OBJECT_STORAGE = "objectStorage"
+    #: This constant has a value of "loggingAnalytics"
+    KIND_LOGGING_ANALYTICS = "loggingAnalytics"
 
     #: A constant which can be used with the kind property of a TargetDetails.
     #: This constant has a value of "monitoring"
     KIND_MONITORING = "monitoring"
 
     #: A constant which can be used with the kind property of a TargetDetails.
-    #: This constant has a value of "functions"
-    KIND_FUNCTIONS = "functions"
-
-    #: A constant which can be used with the kind property of a TargetDetails.
     #: This constant has a value of "notifications"
     KIND_NOTIFICATIONS = "notifications"
+
+    #: A constant which can be used with the kind property of a TargetDetails.
+    #: This constant has a value of "objectStorage"
+    KIND_OBJECT_STORAGE = "objectStorage"
+
+    #: A constant which can be used with the kind property of a TargetDetails.
+    #: This constant has a value of "streaming"
+    KIND_STREAMING = "streaming"
 
     def __init__(self, **kwargs):
         """
@@ -47,13 +51,14 @@ class TargetDetails(object):
         * :class:`~oci.sch.models.ObjectStorageTargetDetails`
         * :class:`~oci.sch.models.MonitoringTargetDetails`
         * :class:`~oci.sch.models.FunctionsTargetDetails`
+        * :class:`~oci.sch.models.LoggingAnalyticsTargetDetails`
         * :class:`~oci.sch.models.StreamingTargetDetails`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param kind:
             The value to assign to the kind property of this TargetDetails.
-            Allowed values for this property are: "streaming", "objectStorage", "monitoring", "functions", "notifications", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "functions", "loggingAnalytics", "monitoring", "notifications", "objectStorage", "streaming", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type kind: str
 
@@ -88,6 +93,9 @@ class TargetDetails(object):
         if type == 'functions':
             return 'FunctionsTargetDetails'
 
+        if type == 'loggingAnalytics':
+            return 'LoggingAnalyticsTargetDetails'
+
         if type == 'streaming':
             return 'StreamingTargetDetails'
         else:
@@ -99,7 +107,7 @@ class TargetDetails(object):
         **[Required]** Gets the kind of this TargetDetails.
         The type descriminator.
 
-        Allowed values for this property are: "streaming", "objectStorage", "monitoring", "functions", "notifications", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "functions", "loggingAnalytics", "monitoring", "notifications", "objectStorage", "streaming", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -118,7 +126,7 @@ class TargetDetails(object):
         :param kind: The kind of this TargetDetails.
         :type: str
         """
-        allowed_values = ["streaming", "objectStorage", "monitoring", "functions", "notifications"]
+        allowed_values = ["functions", "loggingAnalytics", "monitoring", "notifications", "objectStorage", "streaming"]
         if not value_allowed_none_or_none_sentinel(kind, allowed_values):
             kind = 'UNKNOWN_ENUM_VALUE'
         self._kind = kind

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.27.0"
+__version__ = "2.28.0"


### PR DESCRIPTION
## Added

* Support for Logging Analytics as a target in the Service Connector Hub service

* Support for lookups, agent collection warnings, task commands, and data archive/recall in the Logging Analytics service

## Fixed

* Fixed a bug in the endpoint used for the Management Dashboard service

## Breaking

* A new required property `kind` is added to the models `UpdateScheduledTaskDetails` and `ScheduledTask` in the Log Analytics service

* The allowed values for parameter `sort_by` are restricted for methods `list_meta_source_types`, `list_parser_functions`, `list_parser_meta_plugins`, `list_source_label_operators`, `list_source_meta_functions` in the Log Analytics service. For more information please see the documentation for [LogAnalyticsClient](https://docs.oracle.com/en-us/iaas/tools/python/latest/api/log_analytics/client/oci.log_analytics.LogAnalyticsClient.html#loganalyticsclient)
